### PR TITLE
feat: add lint warning for newline_eof

### DIFF
--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -3057,6 +3057,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (47:14-47:26)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "biowdl/tasks:deconstructsigs.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (66:2-66:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "biowdl/tasks:deepvariant.wdl"
 message = "[v1::W002::Style/Medium] curly command found (45:5-59:6)"
 
@@ -3312,6 +3317,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (89:16-89:27)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "biowdl/tasks:delly.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (126:2-126:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "biowdl/tasks:duphold.wdl"
 message = "[v1::W002::Style/Medium] curly command found (38:5-47:6)"
 
@@ -3439,6 +3449,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (48:14-48:29)"
 kind = "LintWarning"
 document = "biowdl/tasks:extractSigPredictHRD.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (49:14-49:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "biowdl/tasks:extractSigPredictHRD.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (71:2-71:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -3577,6 +3592,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (94:21-94:30)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "biowdl/tasks:fastp.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (124:2-124:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "biowdl/tasks:fastqFilter.wdl"
 message = "[v1::W002::Style/Medium] curly command found (37:5-45:6)"
 
@@ -3609,6 +3629,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (33:13-33:24)"
 kind = "LintWarning"
 document = "biowdl/tasks:fastqFilter.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (34:16-34:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "biowdl/tasks:fastqFilter.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (66:2-66:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -11772,6 +11797,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (999:16-999:27)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "biowdl/tasks:picard.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (1222:2-1222:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "biowdl/tasks:prepareShiny.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (58:1-58:8)"
 
@@ -17187,578 +17217,8 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (2:10-2:27)"
 
 [[concerns]]
 kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: allc_tar (921:8-921:21)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: allc_uniq_reads_stats (991:9-991:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: bam (647:9-647:17)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: bam (697:9-697:17)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: bam (798:8-798:16)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: bam_and_index_tar (854:9-854:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: chrom_size_path (923:8-923:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: chromatin_contact_stats (990:9-990:37)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: chromosome_sizes (322:9-322:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: compress_level (859:9-859:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: dedup_stats (989:9-989:25)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (168:5-168:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (250:9-250:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (326:9-326:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (415:9-415:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (487:9-487:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (548:9-548:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (651:9-651:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (702:9-702:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (748:9-748:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (802:8-802:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (861:9-861:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (927:8-927:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (996:9-996:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (252:9-252:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (325:9-325:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (414:9-414:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (486:9-486:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (547:9-547:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (650:9-650:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (701:9-701:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (747:9-747:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (801:8-801:77)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (864:9-864:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (926:8-926:77)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker (995:9-995:78)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker_image (167:5-167:80)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: fastq_input_read1 (162:5-162:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: fastq_input_read2 (163:5-163:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: genome_base (863:9-863:49)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: genome_fa (321:9-321:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: genome_fa (543:9-543:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: genome_fa (855:9-855:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: hisat3n_bam_tar (410:9-410:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: hisat3n_stats (986:9-986:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (169:5-169:22)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (251:9-251:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (327:9-327:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (416:9-416:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (488:9-488:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (549:9-549:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (652:9-652:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (703:9-703:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (749:9-749:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (803:8-803:25)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (862:9-862:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (928:8-928:25)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (997:9-997:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: min_read_length (248:9-248:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: min_read_length (411:9-411:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: min_read_length (483:9-483:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: name_sorted_bam (744:9-744:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: num_downstr_bases (858:9-858:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: num_upstr_bases (857:9-857:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: num_upstr_bases (929:8-929:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (165:5-165:20)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (241:9-241:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (323:9-323:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (412:9-412:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (484:9-484:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (545:9-545:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (648:9-648:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (699:9-699:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (745:9-745:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (799:8-799:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (856:9-856:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (924:8-924:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (993:9-993:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r1_adapter (242:9-242:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r1_hisat3n_stats (987:9-987:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r1_left_cut (244:9-244:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r1_right_cut (245:9-245:25)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r1_trimmed_tar (318:9-318:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r2_adapter (243:9-243:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r2_hisat3n_stats (988:9-988:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r2_left_cut (246:9-246:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r2_right_cut (247:9-247:25)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: r2_trimmed_tar (319:9-319:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: random_primer_indexes (164:5-164:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: split_bam (698:9-698:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: split_fq_tar (542:9-542:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: tarred_demultiplexed_fastqs (240:9-240:41)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: tarred_index_files (320:9-320:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: tarred_index_files (544:9-544:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: tbi_tar (922:8-922:20)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: trimmed_stats (985:9-985:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: unique_reads_cgn_extraction_tbi (992:9-992:45)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: unmapped_fastq_tar (482:9-482:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: chromosome_sizes (13:9-13:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: compress_level (24:9-24:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: fastq_input_read1 (6:9-6:38)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: fastq_input_read2 (7:9-7:38)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: genome_fa (12:9-12:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: min_read_length (21:9-21:33)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: num_downstr_bases (23:9-23:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: num_upstr_bases (22:9-22:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: plate_id (9:9-9:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: r1_adapter (15:9-15:56)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: r1_left_cut (17:9-17:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: r1_right_cut (18:9-18:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: r2_adapter (16:9-16:56)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: r2_left_cut (19:9-19:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: r2_right_cut (20:9-20:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: random_primer_indexes (8:9-8:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:beta-pipelines/skylab/m3c/CondensedSnm3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: tarred_index_files (11:9-11:32)"
+document = "broadinstitute/warp:beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (55:2-55:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -19087,6 +18547,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (12:10-12:39)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (360:2-360:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: callset_name (13:5-13:24)"
 
@@ -19437,6 +18902,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:44)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (231:1-232:1)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: annotations_to_keep_command (19:5-19:40)"
 
@@ -19494,6 +18964,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (64:2-64:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -21162,6 +20637,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (7:10-7:29)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (103:2-103:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (103:1-103:2)"
 
@@ -21579,6 +21059,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (419:8-419:26)"
 kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (7:10-7:37)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (448:4-448:4)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -22519,6 +22004,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (46:10-46:28)"
 kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (47:10-47:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (259:1-260:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -23479,6 +22969,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (61:6-61:30)"
 kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (81:6-81:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:pipelines/skylab/build_indices/BuildIndices.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (197:1-198:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -24804,146 +24299,6 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (87:8-87:23)"
 kind = "LintWarning"
 document = "broadinstitute/warp:pipelines/skylab/smartseq2_single_sample/SmartSeq2SingleSample.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W001::Style/Low] line contains only whitespace (22:1-22:2)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: chromosome_sizes (135:5-135:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (140:5-140:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: disk_size (60:5-60:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker_image (139:5-139:80)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: docker_image (59:5-59:80)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: fastq_input_read1 (54:5-54:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: fastq_input_read2 (55:5-55:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: genome_fa (136:5-136:19)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mapping_yaml (133:5-133:22)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (141:5-141:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: mem_size (61:5-61:22)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (137:5-137:20)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: plate_id (57:5-57:20)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: random_primer_indexes (56:5-56:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: snakefile (134:5-134:19)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: tarred_demultiplexed_fastqs (131:5-131:37)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within task: tarred_index_files (132:5-132:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: chromosome_sizes (17:5-17:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: fastq_input_read1 (7:5-7:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: fastq_input_read2 (8:5-8:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: genome_fa (18:5-18:19)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: mapping_yaml (15:5-15:22)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: output_basename (11:5-11:38)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: plate_id (10:5-10:20)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: random_primer_indexes (9:5-9:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: snakefile (16:5-16:19)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:pipelines/skylab/snM3C/snM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: tarred_index_files (14:5-14:28)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -26497,6 +25852,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:38)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:projects/optimus/CreateOptimusAdapterMetadata.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (235:1-236:1)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:projects/optimus/CreateOptimusAdapterObjects.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: bam (12:5-12:14)"
 
@@ -26552,6 +25912,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:37)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:projects/optimus/CreateOptimusAdapterObjects.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (130:1-131:1)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:projects/optimus/MergeOptimusLooms.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: library (15:5-15:19)"
 
@@ -26589,6 +25954,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:projects/optimus/MergeOptimusLooms.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (7:10-7:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:projects/optimus/MergeOptimusLooms.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (46:1-47:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -26754,6 +26124,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (15:10-15:19)"
 kind = "LintWarning"
 document = "broadinstitute/warp:projects/smartseq2/CreateSs2AdapterObjects.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:projects/smartseq2/CreateSs2AdapterObjects.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (141:1-142:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -27757,6 +27132,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (99:6-99:16)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:projects/tasks/AdapterTasks.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (761:2-761:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:projects/tasks/CreateReferenceMetadata.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: input_type (15:5-15:22)"
 
@@ -27784,6 +27164,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:projects/tasks/CreateReferenceMetadata.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:projects/tasks/CreateReferenceMetadata.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (67:1-68:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -28007,6 +27392,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (96:6-96:22)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:scripts/BuildAFComparisonTable.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (287:2-287:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:scripts/FilterAFComparisonTable.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within task: table (21:3-21:13)"
 
@@ -28024,6 +27414,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (19:6-19:31)"
 kind = "LintWarning"
 document = "broadinstitute/warp:scripts/FilterAFComparisonTable.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (4:10-4:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:scripts/FilterAFComparisonTable.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (78:2-78:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -28217,8 +27612,18 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (7:14-7:22)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:scripts/RemoveBadSitesByID.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (299:2-299:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:structs/imputation/ImputationStructs.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (8:7-8:12)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:structs/imputation/ImputationStructs.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (10:2-10:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -28894,6 +28299,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (63:11-63:26)"
 kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/BamToCram.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:19)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/BamToCram.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (70:1-71:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -31192,6 +30602,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (876:9-876:17)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/ImputationTasks.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (904:2-904:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/InternalArraysTasks.wdl"
 message = "[v1::W002::Style/Medium] curly command found (148:3-153:4)"
 
@@ -31767,6 +31182,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (82:6-82:33)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/InternalArraysTasks.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (552:2-552:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/InternalImputationTasks.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (140:1-140:8)"
 
@@ -31864,6 +31284,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (3:6-3:29)"
 kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/InternalImputationTasks.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (60:6-60:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/InternalImputationTasks.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (155:2-155:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -34957,6 +34382,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (992:6-992:37)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/RNAWithUMIsTasks.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (1039:2-1039:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/UMIAwareDuplicateMarking.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (70:1-70:2)"
 
@@ -35392,6 +34822,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (8:10-8:37)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (413:2-413:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/UltimaGenomicsWholeGenomeGermlineQC.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: agg_bam (8:5-8:17)"
 
@@ -35449,6 +34884,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (115:10-115:16)"
 kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/UltimaGenomicsWholeGenomeGermlineQC.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:45)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/UltimaGenomicsWholeGenomeGermlineQC.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (132:2-132:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -35719,6 +35159,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (225:6-225:25)"
 kind = "LintWarning"
 document = "broadinstitute/warp:tasks/broad/Utilities.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (77:6-77:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:tasks/broad/Utilities.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (301:2-301:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -36862,6 +36307,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (3:6-3:23)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tasks/skylab/MergeSortBam.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (62:1-63:1)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tasks/skylab/Metrics.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (114:1-114:4)"
 
@@ -37407,6 +36857,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (91:6-91:28)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tasks/skylab/Picard.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (434:1-435:1)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tasks/skylab/RSEM.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (18:1-18:2)"
 
@@ -37434,6 +36889,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within task: i
 kind = "LintWarning"
 document = "broadinstitute/warp:tasks/skylab/RSEM.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (3:6-3:20)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:tasks/skylab/RSEM.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (68:1-69:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -38042,6 +37502,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (48:10-48:21)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tasks/skylab/sample_fastq.14.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (121:1-122:1)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "[v1::W002::Style/Medium] curly command found (27:5-29:6)"
 
@@ -38084,6 +37549,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (22:6-22:26)"
 kind = "LintWarning"
 document = "broadinstitute/warp:tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (3:10-3:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (38:2-38:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -38512,6 +37982,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (3:6-3:25)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:tests/skylab/smartseq2_single_nucleus/pr/ValidateSmartSeq2SingleNucleus.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (40:2-40:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:tests/skylab/smartseq2_single_nucleus/pr/test_smartseq2_single_nucleus_PR.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: adapter_list (21:5-21:22)"
 
@@ -38687,6 +38162,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (41:10-41:29)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyArrays.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (78:1-79:1)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyCheckFingerprint.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: done (31:5-31:18)"
 
@@ -38714,6 +38194,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyCheckFingerprint.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (22:10-22:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyCheckFingerprint.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (55:1-56:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -38917,6 +38402,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (3:10-3:36)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyExternalReprocessing.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (40:2-40:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyGDCSomaticSingleSample.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: done (17:5-17:18)"
 
@@ -38954,6 +38444,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyGDCSomaticSingleSample.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:38)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyGDCSomaticSingleSample.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (40:1-41:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -39079,6 +38574,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyGvcf.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:20)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyGvcf.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (33:2-33:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -39432,6 +38932,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (22:10-22:26)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyImputation.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (177:2-177:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyJointGenotyping.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (78:1-78:2)"
 
@@ -39514,6 +39019,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (84:6-84:25)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyJointGenotyping.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (8:10-8:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyJointGenotyping.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (101:2-101:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -39677,6 +39187,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:36)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyMultiSampleSmartSeq2.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (31:2-31:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (23:1-23:2)"
 
@@ -39709,6 +39224,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:49)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (31:2-31:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -39814,6 +39334,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (8:14-8:31)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyMultiome.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:14-9:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyMultiome.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (72:2-72:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -39932,6 +39457,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (4:10-4:23)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyNA12878.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (90:2-90:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyOptimus.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (16:1-16:4)"
 
@@ -40004,6 +39534,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (8:10-8:19)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyOptimus.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:20)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyOptimus.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (48:2-48:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -40144,6 +39679,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (185:6-185:50)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyRNAWithUMIs.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyRNAWithUMIs.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (213:2-213:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -40297,6 +39837,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:20)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifySlideSeq.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (57:2-57:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifySmartSeq2SingleSample.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: done (18:5-18:18)"
 
@@ -40347,6 +39892,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:37)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifySmartSeq2SingleSample.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (47:2-47:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifySomaticSingleSample.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: test_crai (15:5-15:19)"
 
@@ -40379,6 +39929,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifySomaticSingleSample.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (6:10-6:35)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifySomaticSingleSample.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (45:1-46:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -40464,6 +40019,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (70:6-70:25)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (8:10-8:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyUltimaGenomicsJointGenotyping.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (87:2-87:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -40747,6 +40307,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (22:10-22:28)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/VerifyValidateChip.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (96:2-96:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/VerifyscATAC.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (11:1-11:4)"
 
@@ -40782,18 +40347,8 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:22)"
 
 [[concerns]]
 kind = "LintWarning"
-document = "broadinstitute/warp:verification/VerifysnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: done (11:9-11:22)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/VerifysnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: test_mapping_summary (8:9-8:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/VerifysnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: truth_mapping_summary (9:9-9:35)"
+document = "broadinstitute/warp:verification/VerifyscATAC.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (29:2-29:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -40814,6 +40369,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/Verifysnm3C.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (5:10-5:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/Verifysnm3C.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (19:2-19:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -41262,6 +40822,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (8:10-8:20)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestArrays.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (296:2-296:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (103:1-103:36)"
 
@@ -41467,6 +41032,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:38)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (209:2-209:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (109:1-109:36)"
 
@@ -41657,6 +41227,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:41)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (188:2-188:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestCheckFingerprint.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (41:1-41:2)"
 
@@ -41817,6 +41392,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:30)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestCheckFingerprint.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (125:2-125:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestCramToUnmappedBams.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (32:1-32:2)"
 
@@ -41929,6 +41509,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestCramToUnmappedBams.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestCramToUnmappedBams.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (100:2-100:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -42132,6 +41717,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (10:10-10:31)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestExomeReprocessing.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (210:2-210:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestExternalExomeReprocessing.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (118:1-118:36)"
 
@@ -42287,6 +41877,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (8:10-8:39)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestExternalExomeReprocessing.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (153:2-153:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (126:1-126:36)"
 
@@ -42434,6 +42029,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:45)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (158:2-158:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -42609,6 +42209,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:47)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (146:2-146:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -42877,6 +42482,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:37)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestIlluminaGenotypingArray.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (213:2-213:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestImputation.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (108:1-108:2)"
 
@@ -43079,6 +42689,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (34:14-34:26)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestImputation.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:24)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestImputation.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (169:2-169:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -43402,6 +43017,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:29)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestJointGenotyping.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (215:2-215:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestMultiSampleArrays.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (31:1-31:2)"
 
@@ -43504,6 +43124,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestMultiSampleArrays.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestMultiSampleArrays.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (93:2-93:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -43727,6 +43352,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:34)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestMultiSampleSmartSeq2.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (134:2-134:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (41:1-41:2)"
 
@@ -43894,6 +43524,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (19:21-19:39)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:47)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (122:2-122:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -44159,6 +43794,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (44:14-44:31)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestMultiome.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:22)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestMultiome.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (206:2-206:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -44562,6 +44202,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (8:10-8:33)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (214:2-214:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestReblockGVCF.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (35:1-35:2)"
 
@@ -44684,6 +44329,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestReblockGVCF.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestReblockGVCF.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (107:2-107:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -44834,6 +44484,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (14:20-14:28)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestSlideSeq.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:22)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestSlideSeq.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (143:2-143:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -45039,6 +44694,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (27:13-27:19)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestSmartSeq2SingleSample.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:35)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestSmartSeq2SingleSample.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (154:2-154:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -45297,6 +44957,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:43)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestUltimaGenomicsJointGenotyping.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (185:2-185:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (33:1-33:2)"
 
@@ -45424,6 +45089,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:47)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (141:2-141:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -45584,6 +45254,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:47)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (170:2-170:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -45827,6 +45502,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:26)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestValidateChip.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (193:2-193:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestVariantCalling.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (107:1-107:2)"
 
@@ -46024,6 +45704,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (32:15-32:41)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestVariantCalling.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestVariantCalling.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (143:2-143:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -46332,6 +46017,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:37)"
 
 [[concerns]]
 kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/TestWholeGenomeReprocessing.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (200:2-200:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/TestscATAC.wdl"
 message = "[v1::W001::Style/Low] line contains only whitespace (31:1-31:2)"
 
@@ -46452,118 +46142,8 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:20)"
 
 [[concerns]]
 kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] line contains only whitespace (34:1-34:2)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] line contains only whitespace (47:1-47:2)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] line contains only whitespace (50:1-50:4)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] line contains only whitespace (61:1-61:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] line contains only whitespace (64:1-64:4)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] line contains only whitespace (74:1-74:2)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] trailing space (78:15)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W001::Style/Low] trailing space (97:64)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: chromosome_sizes (20:7-20:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: fastq_input_read1 (12:7-12:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: fastq_input_read2 (13:7-13:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: genome_fa (21:7-21:21)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: google_account_vault_path (28:7-28:39)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: mapping_yaml (18:7-18:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: output_basename (16:7-16:40)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: plate_id (15:7-15:22)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: random_primer_indexes (14:7-14:33)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: results_path (25:7-25:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: snakefile (19:7-19:21)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: tarred_index_files (17:7-17:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: truth_path (24:7-24:24)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: update_truth (26:7-26:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "broadinstitute/warp:verification/test-wdls/TestsnM3C.wdl"
-message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: vault_token_path (27:7-27:30)"
+document = "broadinstitute/warp:verification/test-wdls/TestscATAC.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (115:2-115:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -46759,6 +46339,11 @@ message = "[v1::W006::Naming/Low] identifier must be snake case (25:11-25:23)"
 kind = "LintWarning"
 document = "broadinstitute/warp:verification/test-wdls/Testsnm3C.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (9:10-9:19)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "broadinstitute/warp:verification/test-wdls/Testsnm3C.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (124:2-124:2)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -47677,6 +47262,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 
 [[concerns]]
 kind = "LintWarning"
+document = "chanzuckerberg/czid-workflows:workflows/benchmark/long-read-mngs-benchmark.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (230:2-230:2)"
+
+[[concerns]]
+kind = "LintWarning"
 document = "chanzuckerberg/czid-workflows:workflows/benchmark/mngs-benchmark-tasks.wdl"
 message = "[v1::W001::Style/Low] trailing space (12:20)"
 
@@ -48174,6 +47764,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "chanzuckerberg/czid-workflows:workflows/benchmark/short-read-mngs-benchmark.wdl"
 message = "[v1::W003::Completeness/Medium] missing parameter meta within workflow: taxon_counts_run_2 (14:9-14:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "chanzuckerberg/czid-workflows:workflows/benchmark/short-read-mngs-benchmark.wdl"
+message = "[v1::W007::Spacing/Low] multiple empty lines at the end of file (234:1-235:1)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -49324,6 +48919,11 @@ message = "[v1::W003::Completeness/Medium] missing parameter meta within workflo
 kind = "LintWarning"
 document = "chanzuckerberg/czid-workflows:workflows/diamond/diamond.wdl"
 message = "[v1::W006::Naming/Low] identifier must be snake case (27:6-27:16)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "chanzuckerberg/czid-workflows:workflows/diamond/diamond.wdl"
+message = "[v1::W007::Spacing/Low] missing newline at the end of the file (48:2-48:2)"
 
 [[concerns]]
 kind = "LintWarning"

--- a/RULES.md
+++ b/RULES.md
@@ -23,6 +23,7 @@ repository. Note that the information may be out of sync with released packages.
 | `mixed_indentation`       | `v1::W004` | Style        | [`wdl-grammar`][wdl-grammar-lints] |
 | `missing_runtime_block`   | `v1::W005` | Completeness | [`wdl-grammar`][wdl-grammar-lints] |
 | `snake_case`              | `v1::W006` | Naming       | [`wdl-grammar`][wdl-grammar-lints] |
+| `newline_eof`             | `v1::W007` | Spacing      | [`wdl-grammar`][wdl-grammar-lints] |
 
 [wdl-ast-lints]: https://docs.rs/wdl-ast/latest/wdl_ast/v1/index.html#lint-rules
 [wdl-ast-validation]: https://docs.rs/wdl-ast/latest/wdl_ast/v1/index.html#validation-rules

--- a/wdl-core/src/concern/lint/group.rs
+++ b/wdl-core/src/concern/lint/group.rs
@@ -12,6 +12,9 @@ pub enum Group {
     /// Rules associated with the names of WDL elements.
     Naming,
 
+    /// Rules associated with the whitespace in a document.
+    Spacing,
+
     /// Rules associated with the style of a document.
     Style,
 
@@ -26,6 +29,7 @@ impl std::fmt::Display for Group {
         match self {
             Group::Completeness => write!(f, "Completeness"),
             Group::Naming => write!(f, "Naming"),
+            Group::Spacing => write!(f, "Spacing"),
             Group::Style => write!(f, "Style"),
             Group::Pedantic => write!(f, "Pedantic"),
         }

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   @markjschreiber).
 * Adds the `snake_case` rule that ensures all tasks, workflows, and variables
   are snakecase (#13, contributed by @simojoe).
+* Adds the `newline_eof` rule for tasks (#18, contributed by @simojoe).
 
 ## 0.2.0 - 12-17-2023
 

--- a/wdl-grammar/src/v1.rs
+++ b/wdl-grammar/src/v1.rs
@@ -22,6 +22,7 @@
 //! | `mixed_indentation`     | `v1::W004` | Style        | [Link](lint::MixedIndentation)    |
 //! | `missing_runtime_block` | `v1::W005` | Completeness | [Link](lint::MissingRuntimeBlock) |
 //! | `snake_case`            | `v1::W006` | Naming       | [Link](lint::SnakeCase)           |
+//! | `newline_eof`           | `v1::W007` | Spacing      | [Link](lint::NewlineEOF)          |
 
 use pest::iterators::Pair;
 use pest::Parser as _;
@@ -121,7 +122,8 @@ pub type Result<'a> = wdl_core::parse::Result<Pair<'a, crate::v1::Rule>>;
 ///         cpu: 1
 ///         memory: "2GiB"
 ///     }
-/// }"#,
+/// }
+/// "#,
 /// )
 /// .unwrap();
 ///

--- a/wdl-grammar/src/v1/lint.rs
+++ b/wdl-grammar/src/v1/lint.rs
@@ -4,12 +4,14 @@ use pest::iterators::Pair;
 
 mod missing_runtime_block;
 mod mixed_indentation;
+mod newline_eof;
 mod no_curly_commands;
 mod snake_case;
 mod whitespace;
 
 pub use missing_runtime_block::MissingRuntimeBlock;
 pub use mixed_indentation::MixedIndentation;
+pub use newline_eof::NewlineEOF;
 pub use no_curly_commands::NoCurlyCommands;
 pub use snake_case::SnakeCase;
 pub use whitespace::Whitespace;
@@ -27,5 +29,7 @@ pub fn rules<'a>() -> Vec<Box<dyn wdl_core::concern::lint::Rule<&'a Pair<'a, cra
         Box::new(MissingRuntimeBlock),
         // v1::W006
         Box::new(SnakeCase),
+        // v1::W007
+        Box::new(NewlineEOF),
     ]
 }

--- a/wdl-grammar/src/v1/lint/newline_eof.rs
+++ b/wdl-grammar/src/v1/lint/newline_eof.rs
@@ -1,0 +1,163 @@
+//! WDL files must end with a newline.
+
+use std::collections::VecDeque;
+
+use nonempty::NonEmpty;
+use pest::iterators::Pair;
+use wdl_core::concern::code;
+use wdl_core::concern::lint;
+use wdl_core::concern::lint::Group;
+use wdl_core::concern::lint::Rule;
+use wdl_core::concern::Code;
+use wdl_core::file::Location;
+use wdl_core::Version;
+
+use crate::v1;
+
+/// Detects missing newline at the EOF
+#[derive(Debug)]
+pub struct NewlineEOF;
+
+impl<'a> NewlineEOF {
+    /// Creates a warning for a file not ending with a newline
+    fn missing_newline_at_eof(&self, location: Location) -> lint::Warning
+    where
+        Self: Rule<&'a Pair<'a, v1::Rule>>,
+    {
+        // SAFETY: this error is written so that it will always unwrap.
+        lint::warning::Builder::default()
+            .code(self.code())
+            .level(lint::Level::Low)
+            .group(self.group())
+            .push_location(location)
+            .subject("missing newline at the end of the file")
+            .body("There should always be a newline at the end of a WDL file.")
+            .fix("Add a newline at the end of the file.")
+            .try_build()
+            .unwrap()
+    }
+
+    /// Creates a warning for a file ending with more than one newline
+    fn no_empty_line_at_eof(&self, location: Location) -> lint::Warning
+    where
+        Self: Rule<&'a Pair<'a, v1::Rule>>,
+    {
+        // SAFETY: this error is written so that it will always unwrap.
+        lint::warning::Builder::default()
+            .code(self.code())
+            .level(lint::Level::Low)
+            .group(self.group())
+            .push_location(location)
+            .subject("multiple empty lines at the end of file")
+            .body("There should only be one newline at the end of a WDL file.")
+            .fix("Remove all but one empty line at the end of the file.")
+            .try_build()
+            .unwrap()
+    }
+}
+
+impl<'a> Rule<&'a Pair<'a, v1::Rule>> for NewlineEOF {
+    fn code(&self) -> Code {
+        // SAFETY: this manually crafted to unwrap successfully every time.
+        Code::try_new(code::Kind::Warning, Version::V1, 7).unwrap()
+    }
+
+    fn group(&self) -> Group {
+        Group::Spacing
+    }
+
+    fn check(&self, tree: &'a Pair<'_, v1::Rule>) -> lint::Result {
+        let mut warnings: VecDeque<_> = VecDeque::new();
+
+        let mut iter = tree.clone().into_inner().rev();
+
+        if let (Some(node_eof), Some(node1), Some(node2)) = (iter.next(), iter.next(), iter.next())
+        {
+            if node1.as_str() != "\n" {
+                let location =
+                    Location::try_from(node_eof.as_span()).map_err(lint::Error::Location)?;
+                warnings.push_back(self.missing_newline_at_eof(location))
+            }
+
+            if node1.as_str() == "\n" && node2.as_str() == "\n" {
+                let location =
+                    Location::try_from(node1.as_span()).map_err(lint::Error::Location)?;
+                warnings.push_back(self.no_empty_line_at_eof(location))
+            }
+        }
+
+        match warnings.pop_front() {
+            Some(front) => {
+                let mut results = NonEmpty::new(front);
+                results.extend(warnings);
+                Ok(Some(results))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pest::Parser as _;
+    use wdl_core::concern::lint::Rule as _;
+
+    use super::*;
+    use crate::v1::parse::Parser;
+    use crate::v1::Rule;
+
+    #[test]
+    fn it_catches_no_trailing_newline() -> Result<(), Box<dyn std::error::Error>> {
+        let tree = Parser::parse(
+            Rule::document,
+            r#"version 1.0
+workflow test {}"#,
+        )?
+        .next()
+        .unwrap();
+
+        let warnings = NewlineEOF.check(&tree)?.unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings.first().to_string(),
+            "[v1::W007::Spacing/Low] missing newline at the end of the file (2:17-2:17)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn it_catches_an_empty_newline_eof() -> Result<(), Box<dyn std::error::Error>> {
+        let tree = Parser::parse(
+            Rule::document,
+            r#"version 1.0
+workflow test {}
+
+"#,
+        )?
+        .next()
+        .unwrap();
+
+        let warnings = NewlineEOF.check(&tree)?.unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings.first().to_string(),
+            "[v1::W007::Spacing/Low] multiple empty lines at the end of file (3:1-4:1)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn it_ignores_a_correctly_formatted_eof() -> Result<(), Box<dyn std::error::Error>> {
+        let tree = Parser::parse(
+            Rule::document,
+            r#"version 1.0
+workflow test {}
+"#,
+        )?
+        .next()
+        .unwrap();
+
+        assert!(NewlineEOF.check(&tree)?.is_none());
+        Ok(())
+    }
+}


### PR DESCRIPTION
This pull request adds a new rule to `wdl`.

- **Rule Name**: `newline_eof`
- **Rule Kind**: Lint warning
- **Rule Code**: `v1::W007`
- **Packages**: `wdl-grammar`

This rule is currently written as to avoid missing newline at the end of WDL files.

My interpretation of the rule is that a WDL file should not end with an empty line (double newline symbols), but the rule description is not explicit about that (or the opposite situation). 

The implementation currently checks two things :
- there is at least one newline at the end of the file
- there is at most one newline at the end of file

Let me know if this implementation is not suitable

Before submitting this PR, please make sure:

- [X] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [X] Your code builds clean without any errors or warnings.
- [X] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [X] Your commit messages follow the [conventional commit] style.
- [ ] Your changes are squashed into a single commit (unless there is a _really_
      good, articulated reason as to why there shouldn be more than one).

Rule specific checks:

- [X] You have added the rule as an entry within the the package-specific rule
      tables (`wdl-ast/src/v1.rs` for AST-based rules and 
      `wdl-grammar/src/v1.rs` for parse tree-based rules).
- [X] You have added the rule as an entry within the the global rule
      table at `RULES.md`.
- [X] You have added the rule to the appropriate `fn rules()`.
    - Validation rules added to `wdl-ast` should be added to `fn rules()` within 
      `wdl-ast/src/v1/validation.rs`.
    - Lint rules added to `wdl-ast` should be added to `fn rules()` within `wdl-ast/src/v1/lint.rs`.
    - Validation rules added to `wdl-grammar` should be added to `fn rules()` within 
      `wdl-grammar/src/v1/validation.rs`.
    - Lint rules added to `wdl-grammar` should be added to `fn rules()` within 
      `wdl-grammar/src/v1/lint.rs`.
- [X] You have added a test that covers every possible setting for the rule 
      within the file where the rule is implemented.
