### PR TITLE
fix: ignore comments when parsing `Expression`.

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Fix ignoring comments in expressions [#23](https://github.com/stjude-rust-labs/wdl/pull/23).
+* Fix ignoring comments in expressions ([#23](https://github.com/stjude-rust-labs/wdl/pull/23)).
 
 ## 0.1.0 — 12-17-2023
 

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix ignoring comments in expressions [#23](https://github.com/stjude-rust-labs/wdl/pull/23).
+
 ## 0.1.0 — 12-17-2023
 
 ### Added

--- a/wdl-ast/src/v1/document/workflow/execution/statement/call/body.rs
+++ b/wdl-ast/src/v1/document/workflow/execution/statement/call/body.rs
@@ -73,10 +73,7 @@ impl TryFrom<Pair<'_, grammar::v1::Rule>> for Body {
         for node in nodes {
             let inner = node
                 .into_inner()
-                .filter(|node| {
-                    !matches!(node.as_rule(), Rule::WHITESPACE)
-                        && !matches!(node.as_rule(), Rule::COMMENT)
-                })
+                .filter(|node| !matches!(node.as_rule(), Rule::WHITESPACE | Rule::COMMENT))
                 .collect::<Vec<_>>();
 
             if inner.len() != 1 && inner.len() != 2 {


### PR DESCRIPTION
This commit fixes the incorrect filter when iterating over the pairs provided to the `parse` function for `Expression`.

Fixes #21.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your changes are squashed into a single commit (unless there is a _really_
      good, articulated reason as to why there shouldn be more than one).

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/