### PR TITLE
feat: implement parsing of struct definitions in experimental parser.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ Before submitting this PR, please make sure:
       ["keep a changelog"] for more information).
 - [ ] Your commit messages follow the [conventional commit] style.
 - [ ] Your changes are squashed into a single commit (unless there is a _really_
-      good, articulated reason as to why there shouldn be more than one).
+      good, articulated reason as to why there should be more than one).
 
 Rule specific checks:
 
@@ -66,7 +66,7 @@ Before submitting this PR, please make sure:
       ["keep a changelog"] for more information).
 - [ ] Your commit messages follow the [conventional commit] style.
 - [ ] Your changes are squashed into a single commit (unless there is a _really_
-      good, articulated reason as to why there shouldn be more than one).
+      good, articulated reason as to why there should be more than one).
 
 END SECTION -->
 

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Adds support for parsing struct definitions to the experimental parser;
+  requires the `experimental` feature to be activated ([#38](https://github.com/stjude-rust-labs/wdl/pull/38)).
 * Adds a new experimental `SyntaxTree` representation; requires the 
   `experimental` feature to be activated ([#36](https://github.com/stjude-rust-labs/wdl/pull/36)).
 * Adds an `experimental` module containing the start of a new

--- a/wdl-grammar/src/experimental/grammar.rs
+++ b/wdl-grammar/src/experimental/grammar.rs
@@ -17,9 +17,21 @@ mod macros {
     ///
     /// Returns an error if the token is not the specified token.
     macro_rules! expected {
-        ($p:ident, $m:ident, $t:expr) => {
-            if let Err(e) = $p.expect($t) {
-                return Err(($m, e));
+        ($parser:ident, $marker:ident, $token:expr) => {
+            if let Err(e) = $parser.expect($token) {
+                return Err(($marker, e));
+            }
+        };
+    }
+
+    /// A macro for expecting the next token be a particular token and
+    /// providing an alternative name for the expected item.
+    ///
+    /// Returns an error if the token is not the specified token.
+    macro_rules! expected_with_name {
+        ($parser:ident, $marker:ident, $token:expr, $expected:literal) => {
+            if let Err(e) = $parser.expect_with_name($token, $expected) {
+                return Err(($marker, e));
             }
         };
     }
@@ -28,17 +40,18 @@ mod macros {
     ///
     /// Returns an error if the given function returns an error.
     macro_rules! expected_fn {
-        ($p:ident, $m:ident, $f:ident) => {
-            let inner = $p.start();
-            if let Err((inner, e)) = $f($p, inner) {
-                inner.abandon($p);
-                return Err(($m, e));
+        ($parser:ident, $marker:ident, $func:ident) => {
+            let inner = $parser.start();
+            if let Err((inner, e)) = $func($parser, inner) {
+                inner.abandon($parser);
+                return Err(($marker, e));
             }
         };
     }
 
     pub(crate) use expected;
     pub(crate) use expected_fn;
+    pub(crate) use expected_with_name;
 }
 
 /// Parses a WDL document.

--- a/wdl-grammar/src/experimental/grammar.rs
+++ b/wdl-grammar/src/experimental/grammar.rs
@@ -12,6 +12,35 @@ use crate::experimental::lexer::VersionStatementToken;
 
 pub mod v1;
 
+mod macros {
+    /// A macro for expecting the next token be a particular token.
+    ///
+    /// Returns an error if the token is not the specified token.
+    macro_rules! expected {
+        ($p:ident, $m:ident, $t:expr) => {
+            if let Err(e) = $p.expect($t) {
+                return Err(($m, e));
+            }
+        };
+    }
+
+    /// A macro for expecting that a given function parses the next node.
+    ///
+    /// Returns an error if the given function returns an error.
+    macro_rules! expected_fn {
+        ($p:ident, $m:ident, $f:ident) => {
+            let inner = $p.start();
+            if let Err((inner, e)) = $f($p, inner) {
+                inner.abandon($p);
+                return Err(($m, e));
+            }
+        };
+    }
+
+    pub(crate) use expected;
+    pub(crate) use expected_fn;
+}
+
 /// Parses a WDL document.
 ///
 /// Returns the parser events that result from parsing the document.

--- a/wdl-grammar/src/experimental/grammar/v1.rs
+++ b/wdl-grammar/src/experimental/grammar/v1.rs
@@ -1,14 +1,274 @@
 //! Module for the V1 grammar functions.
 
-use crate::experimental::lexer;
+use super::macros::expected;
+use super::macros::expected_fn;
+use crate::experimental::lexer::v1::Token;
+use crate::experimental::lexer::TokenSet;
 use crate::experimental::parser;
+use crate::experimental::parser::Error;
+use crate::experimental::parser::Marker;
+use crate::experimental::parser::ParserToken;
+use crate::experimental::tree::SyntaxKind;
 
 /// The parser type for the V1 grammar.
-pub type Parser<'a> = parser::Parser<'a, lexer::v1::Token>;
+pub type Parser<'a> = parser::Parser<'a, Token>;
+
+/// The expected set of tokens at the top-level of a WDL document.
+const TOP_EXPECTED_SET: TokenSet = TokenSet::new(&[
+    Token::ImportKeyword as u8,
+    Token::StructKeyword as u8,
+    Token::TaskKeyword as u8,
+    Token::WorkflowKeyword as u8,
+]);
+
+/// The recovery set for top-level.
+const TOP_RECOVERY_SET: TokenSet = TOP_EXPECTED_SET;
+
+/// A set of tokens for primitive types.
+const PRIMITIVE_TYPE_SET: TokenSet = TokenSet::new(&[
+    Token::BooleanTypeKeyword as u8,
+    Token::IntTypeKeyword as u8,
+    Token::FloatTypeKeyword as u8,
+    Token::StringTypeKeyword as u8,
+    Token::FileTypeKeyword as u8,
+]);
+
+/// A set of tokens for all types.
+const TYPE_SET: TokenSet = PRIMITIVE_TYPE_SET.union(TokenSet::new(&[
+    Token::MapTypeKeyword as u8,
+    Token::ArrayTypeKeyword as u8,
+    Token::PairTypeKeyword as u8,
+    Token::ObjectTypeKeyword as u8,
+    Token::Ident as u8,
+]));
+
+/// The expected set of tokens in a struct definition of a WDL document.
+const STRUCT_ITEM_EXPECTED_SET: TokenSet = TYPE_SET;
+
+/// The recovery set for struct items.
+const STRUCT_ITEM_RECOVERY_SET: TokenSet =
+    STRUCT_ITEM_EXPECTED_SET.union(TokenSet::new(&[Token::CloseBrace as u8]));
+
+/// The expected set of tokens in a task definition of a WDL document.
+const TASK_ITEM_EXPECTED_SET: TokenSet = TYPE_SET.union(TokenSet::new(&[
+    Token::InputKeyword as u8,
+    Token::CommandKeyword as u8,
+    Token::OutputKeyword as u8,
+    Token::RuntimeKeyword as u8,
+    Token::MetaKeyword as u8,
+    Token::ParameterMetaKeyword as u8,
+]));
+
+/// The recovery set for task items.
+const TASK_ITEM_RECOVERY_SET: TokenSet =
+    TASK_ITEM_EXPECTED_SET.union(TokenSet::new(&[Token::CloseBrace as u8]));
+
+/// The recovery set for workflow items.
+const WORKFLOW_ITEM_RECOVERY_SET: TokenSet = TYPE_SET.union(TokenSet::new(&[
+    Token::InputKeyword as u8,
+    Token::OutputKeyword as u8,
+    Token::MetaKeyword as u8,
+    Token::ParameterMetaKeyword as u8,
+    Token::IfKeyword as u8,
+    Token::ScatterKeyword as u8,
+    Token::CallKeyword as u8,
+]));
+
+/// A token set used to parse a delimited set of things until a closing brace.
+const UNTIL_CLOSE_BRACE: TokenSet = TokenSet::new(&[Token::CloseBrace as u8]);
 
 /// Parses the top-level items of a V1 document.
 ///
 /// It is expected that the version statement has already been parsed.
-pub fn items(_parser: &mut Parser<'_>) {
-    // TODO: parse the top-level items
+pub fn items(parser: &mut Parser<'_>) {
+    while parser.peek().is_some() {
+        let marker = parser.start();
+        if let Err((marker, e)) = item(parser, marker) {
+            parser.error(e);
+            parser.recover(TOP_RECOVERY_SET);
+            marker.abandon(parser);
+        }
+    }
+}
+
+/// Parses a single top-level item in a WDL document.
+fn item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    match parser.peek() {
+        Some((Token::ImportKeyword, _)) => import_statement(parser, marker),
+        Some((Token::StructKeyword, _)) => struct_definition(parser, marker),
+        Some((Token::TaskKeyword, _)) => task_definition(parser, marker),
+        Some((Token::WorkflowKeyword, _)) => workflow_definition(parser, marker),
+        found => {
+            let (found, span) = found
+                .map(|(t, s)| (Some(t.into_raw()), s))
+                .unwrap_or_else(|| (None, parser.span()));
+            Err((
+                marker,
+                Error::Expected {
+                    expected: TOP_EXPECTED_SET,
+                    found,
+                    span,
+                    describe: Token::describe,
+                },
+            ))
+        }
+    }
+}
+
+/// Parses an import statement.
+fn import_statement(parser: &mut Parser<'_>, _marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::ImportKeyword);
+    todo!("parse import statements")
+}
+
+/// Parses a name (i.e. identifier) for a struct, task, or workflow definition.
+fn name(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    expected!(parser, marker, Token::Ident);
+    marker.complete(parser, SyntaxKind::NameNode);
+    Ok(())
+}
+
+/// Parses a struct definition.
+fn struct_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::StructKeyword);
+    expected_fn!(parser, marker, name);
+    expected!(parser, marker, Token::OpenBrace);
+    parser.delimited(
+        None,
+        UNTIL_CLOSE_BRACE,
+        STRUCT_ITEM_RECOVERY_SET,
+        |parser, marker| {
+            unbound_decl(parser, marker)?;
+            Ok(true)
+        },
+    );
+    expected!(parser, marker, Token::CloseBrace);
+    marker.complete(parser, SyntaxKind::StructDefinitionNode);
+    Ok(())
+}
+
+/// Parses a task definition.
+fn task_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::TaskKeyword);
+    expected_fn!(parser, marker, name);
+    expected!(parser, marker, Token::OpenBrace);
+    parser.delimited(
+        None,
+        UNTIL_CLOSE_BRACE,
+        TASK_ITEM_RECOVERY_SET,
+        |_parser, _marker| todo!("parse task items"),
+    );
+    expected!(parser, marker, Token::CloseBrace);
+    marker.complete(parser, SyntaxKind::TaskDefinitionNode);
+    Ok(())
+}
+
+/// Parses a workflow definition.
+fn workflow_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::WorkflowKeyword);
+    expected_fn!(parser, marker, name);
+    expected!(parser, marker, Token::OpenBrace);
+    parser.delimited(
+        None,
+        UNTIL_CLOSE_BRACE,
+        WORKFLOW_ITEM_RECOVERY_SET,
+        |_parser, _marker| todo!("parse workflow items"),
+    );
+    expected!(parser, marker, Token::CloseBrace);
+    Ok(())
+}
+
+/// Parses an unbound declaration.
+fn unbound_decl(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    expected_fn!(parser, marker, ty);
+    expected!(parser, marker, Token::Ident);
+    marker.complete(parser, SyntaxKind::UnboundDeclNode);
+    Ok(())
+}
+
+/// Parses a type used in a declaration.
+fn ty(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    match parser.peek() {
+        Some((Token::MapTypeKeyword, _)) => map(parser, marker),
+        Some((Token::ArrayTypeKeyword, _)) => array(parser, marker),
+        Some((Token::PairTypeKeyword, _)) => pair(parser, marker),
+        Some((Token::ObjectTypeKeyword, _)) => object(parser, marker),
+        Some((Token::Ident, _)) => type_ref(parser, marker),
+        Some((t, _)) if PRIMITIVE_TYPE_SET.contains(t.into_raw()) => primitive(parser, marker),
+        found => {
+            let (found, span) = found
+                .map(|(t, s)| (Some(t.into_raw()), s))
+                .unwrap_or_else(|| (None, parser.span()));
+            Err((
+                marker,
+                Error::Expected {
+                    expected: TYPE_SET,
+                    found,
+                    span,
+                    describe: Token::describe,
+                },
+            ))
+        }
+    }
+}
+
+/// Parses a map type used in a declaration.
+fn map(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::MapTypeKeyword);
+    expected!(parser, marker, Token::OpenBracket);
+    expected_fn!(parser, marker, primitive);
+    expected!(parser, marker, Token::Comma);
+    expected_fn!(parser, marker, ty);
+    expected!(parser, marker, Token::CloseBracket);
+    parser.next_if(Token::QuestionMark);
+    marker.complete(parser, SyntaxKind::MapTypeNode);
+    Ok(())
+}
+
+/// Parses a array type used in a declaration.
+fn array(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::ArrayTypeKeyword);
+    expected!(parser, marker, Token::OpenBracket);
+    expected_fn!(parser, marker, ty);
+    expected!(parser, marker, Token::CloseBracket);
+    parser.next_if(Token::QuestionMark);
+    marker.complete(parser, SyntaxKind::ArrayTypeNode);
+    Ok(())
+}
+
+/// Parses a pair type used in a declaration.
+fn pair(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::PairTypeKeyword);
+    expected!(parser, marker, Token::OpenBracket);
+    expected_fn!(parser, marker, ty);
+    expected!(parser, marker, Token::Comma);
+    expected_fn!(parser, marker, ty);
+    expected!(parser, marker, Token::CloseBracket);
+    parser.next_if(Token::QuestionMark);
+    marker.complete(parser, SyntaxKind::PairTypeNode);
+    Ok(())
+}
+
+/// Parses an object type used in a declaration.
+fn object(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::ObjectTypeKeyword);
+    parser.next_if(Token::QuestionMark);
+    marker.complete(parser, SyntaxKind::ObjectTypeNode);
+    Ok(())
+}
+
+/// Parses a type reference used in a declaration.
+fn type_ref(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require(Token::Ident);
+    parser.next_if(Token::QuestionMark);
+    marker.complete(parser, SyntaxKind::TypeRefNode);
+    Ok(())
+}
+
+/// Parses a primitive type used in a declaration.
+fn primitive(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
+    parser.require_in(PRIMITIVE_TYPE_SET);
+    parser.next_if(Token::QuestionMark);
+    marker.complete(parser, SyntaxKind::PrimitiveTypeNode);
+    Ok(())
 }

--- a/wdl-grammar/src/experimental/lexer.rs
+++ b/wdl-grammar/src/experimental/lexer.rs
@@ -213,10 +213,10 @@ impl<'a> ParserToken<'a> for VersionStatementToken {
 /// Represents a lexer error.
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Error {
-    /// An unexpected token was encountered.
+    /// An unknown token was encountered.
     #[default]
-    #[error("an unexpected token was encountered")]
-    UnexpectedToken,
+    #[error("an unknown token was encountered")]
+    UnknownToken,
 }
 
 /// The result type for the lexer.

--- a/wdl-grammar/src/experimental/parser.rs
+++ b/wdl-grammar/src/experimental/parser.rs
@@ -69,26 +69,23 @@ impl fmt::Display for Found {
     }
 }
 
-/// Utility type for displaying "expected" token sets in a parser expectation
-/// error.
-struct Expected {
-    /// The set of expected tokens.
-    set: TokenSet,
-    /// The function used to describe a raw token.
-    describe: fn(u8) -> &'static str,
+/// Utility type for displaying "expected" items in a parser expectation error.
+struct Expected<'a> {
+    /// The set of expected items.
+    items: &'a [&'static str],
 }
 
-impl Expected {
+impl<'a> Expected<'a> {
     /// Constructs a new `Expected`.
-    fn new(set: TokenSet, describe: fn(u8) -> &'static str) -> Self {
-        Self { set, describe }
+    fn new(items: &'a [&'static str]) -> Self {
+        Self { items }
     }
 }
 
-impl fmt::Display for Expected {
+impl fmt::Display for Expected<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let count = self.set.count();
-        for (i, token) in self.set.iter().enumerate() {
+        let count = self.items.len();
+        for (i, item) in self.items.iter().enumerate() {
             if i > 0 {
                 if count == 2 {
                     write!(f, " or ")?;
@@ -99,7 +96,7 @@ impl fmt::Display for Expected {
                 }
             }
 
-            write!(f, "{}", (self.describe)(token))?;
+            write!(f, "{item}")?;
         }
 
         Ok(())
@@ -118,11 +115,25 @@ pub enum Error {
         #[label(primary, "this is not a WDL token")]
         span: SourceSpan,
     },
-    /// An unexpected token was encountered when a single token was expected.
-    #[error("expected {expected}, but found {found}", expected = Expected::new(*.expected, *.describe), found = Found::new(*.found, *.describe))]
+    /// An unexpected token was encountered when a single item was expected.
+    #[error("expected {expected}, but found {found}", found = Found::new(*.found, *.describe))]
     Expected {
-        /// The expected token set.
-        expected: TokenSet,
+        /// The expected item.
+        expected: &'static str,
+        /// The found raw token (`None` for end of input).
+        found: Option<u8>,
+        /// The span of the found token.
+        #[label(primary, "unexpected {found}", found = Found::new(*.found, *.describe))]
+        span: SourceSpan,
+        /// The function used to describe the raw token.
+        describe: fn(u8) -> &'static str,
+    },
+    /// An unexpected token was encountered when one of multiple items was
+    /// expected.
+    #[error("expected {expected}, but found {found}", expected = Expected::new(.expected), found = Found::new(*.found, *.describe))]
+    ExpectedOneOf {
+        /// The expected items.
+        expected: &'static [&'static str],
         /// The found raw token (`None` for end of input).
         found: Option<u8>,
         /// The span of the found token.
@@ -378,10 +389,13 @@ where
     pub fn require_in(&mut self, tokens: TokenSet) {
         match self.next() {
             Some((t, _)) if tokens.contains(t.into_raw()) => {}
-            _ => panic!(
-                "expected {expected}",
-                expected = Expected::new(tokens, T::describe),
-            ),
+            found => {
+                let found = found.map(|(t, _)| t.into_raw());
+                panic!(
+                    "expected token {found}",
+                    found = Found::new(found, T::describe)
+                );
+            }
         }
     }
 
@@ -395,13 +409,38 @@ where
                 Ok(span)
             }
             Some((t, span)) => Err(Error::Expected {
-                expected: TokenSet::new(&[token.into_raw()]),
+                expected: T::describe(token.into_raw()),
                 found: Some(t.into_raw()),
                 span,
                 describe: T::describe,
             }),
             None => Err(Error::Expected {
-                expected: TokenSet::new(&[token.into_raw()]),
+                expected: T::describe(token.into_raw()),
+                found: None,
+                span: self.span(),
+                describe: T::describe,
+            }),
+        }
+    }
+
+    /// Expects the next token to be the given token, but uses
+    /// the provided name in the error.
+    ///
+    /// Returns an error if the token is not the given token.
+    pub fn expect_with_name(&mut self, token: T, name: &'static str) -> Result<SourceSpan, Error> {
+        match self.peek() {
+            Some((t, span)) if t == token => {
+                self.next();
+                Ok(span)
+            }
+            Some((t, span)) => Err(Error::Expected {
+                expected: name,
+                found: Some(t.into_raw()),
+                span,
+                describe: T::describe,
+            }),
+            None => Err(Error::Expected {
+                expected: name,
                 found: None,
                 span: self.span(),
                 describe: T::describe,
@@ -412,20 +451,24 @@ where
     /// Expects the next token to be in the given token set.
     ///
     /// Returns an error if the token is not the given set.
-    pub fn expect_in(&mut self, tokens: TokenSet) -> Result<(T, SourceSpan), Error> {
+    pub fn expect_in(
+        &mut self,
+        tokens: TokenSet,
+        expected: &'static [&'static str],
+    ) -> Result<(T, SourceSpan), Error> {
         match self.peek() {
             Some((t, span)) if tokens.contains(t.into_raw()) => {
                 self.next();
                 Ok((t, span))
             }
-            Some((t, span)) => Err(Error::Expected {
-                expected: tokens,
+            Some((t, span)) => Err(Error::ExpectedOneOf {
+                expected,
                 found: Some(t.into_raw()),
                 span,
                 describe: T::describe,
             }),
-            None => Err(Error::Expected {
-                expected: tokens,
+            None => Err(Error::ExpectedOneOf {
+                expected,
                 found: None,
                 span: self.span(),
                 describe: T::describe,

--- a/wdl-grammar/src/experimental/parser.rs
+++ b/wdl-grammar/src/experimental/parser.rs
@@ -372,6 +372,8 @@ where
 
     /// Requires that the current token is in the given token set.
     ///
+    /// # Panics
+    ///
     /// Panics if the token is not in the token set.
     pub fn require_in(&mut self, tokens: TokenSet) {
         match self.next() {

--- a/wdl-grammar/src/experimental/tree.rs
+++ b/wdl-grammar/src/experimental/tree.rs
@@ -177,8 +177,32 @@ pub enum SyntaxKind {
     Abandoned,
     /// Represents the WDL document root node.
     RootNode,
+    /// Represents a name node (for a struct, task, or workflow).
+    NameNode,
     /// Represents a version statement node.
     VersionStatementNode,
+    /// Represents an import statement node.
+    ImportStatementNode,
+    /// Represents a struct definition node.
+    StructDefinitionNode,
+    /// Represents a task definition node.
+    TaskDefinitionNode,
+    /// Represents a workflow definition node.
+    WorkflowDefinitionNode,
+    /// Represents an unbound declaration node.
+    UnboundDeclNode,
+    /// Represents a primitive type node.
+    PrimitiveTypeNode,
+    /// Represents a map type node.
+    MapTypeNode,
+    /// Represents an array type node.
+    ArrayTypeNode,
+    /// Represents a pair type node.
+    PairTypeNode,
+    /// Represents an object type node.
+    ObjectTypeNode,
+    /// Represents a type reference node.
+    TypeRefNode,
 
     // WARNING: this must always be the last variant.
     /// The exclusive maximum syntax kind value.

--- a/wdl-grammar/tests/parsing/missing-version/source.tree
+++ b/wdl-grammar/tests/parsing/missing-version/source.tree
@@ -1,3 +1,13 @@
-RootNode@0..50
+RootNode@0..64
   Comment@0..48 "# This is a test of a ..."
   Whitespace@48..50 "\n\n"
+  TaskDefinitionNode@50..63
+    TaskKeyword@50..54 "task"
+    NameNode@54..58
+      Whitespace@54..55 " "
+      Ident@55..58 "foo"
+    Whitespace@58..59 " "
+    OpenBrace@59..60 "{"
+    Whitespace@60..62 "\n\n"
+    CloseBrace@62..63 "}"
+  Whitespace@63..64 "\n"

--- a/wdl-grammar/tests/parsing/struct-definitions/source.tree
+++ b/wdl-grammar/tests/parsing/struct-definitions/source.tree
@@ -1,0 +1,437 @@
+RootNode@0..1072
+  Comment@0..39 "# This is a test of s ..."
+  Whitespace@39..41 "\n\n"
+  VersionStatementNode@41..52
+    VersionKeyword@41..48 "version"
+    Whitespace@48..49 " "
+    Version@49..52 "1.1"
+  Whitespace@52..54 "\n\n"
+  Comment@54..81 "# Test for an empty s ..."
+  Whitespace@81..82 "\n"
+  StructDefinitionNode@82..97
+    StructKeyword@82..88 "struct"
+    NameNode@88..94
+      Whitespace@88..89 " "
+      Ident@89..94 "Empty"
+    Whitespace@94..95 " "
+    OpenBrace@95..96 "{"
+    CloseBrace@96..97 "}"
+  Whitespace@97..99 "\n\n"
+  Comment@99..140 "# Test for a struct w ..."
+  Whitespace@140..141 "\n"
+  StructDefinitionNode@141..373
+    StructKeyword@141..147 "struct"
+    NameNode@147..162
+      Whitespace@147..148 " "
+      Ident@148..162 "PrimitiveTypes"
+    Whitespace@162..163 " "
+    OpenBrace@163..164 "{"
+    Whitespace@164..169 "\n    "
+    Comment@169..179 "# Booleans"
+    Whitespace@179..184 "\n    "
+    UnboundDeclNode@184..193
+      PrimitiveTypeNode@184..192
+        BooleanTypeKeyword@184..191 "Boolean"
+        Whitespace@191..192 " "
+      Ident@192..193 "a"
+    Whitespace@193..198 "\n    "
+    UnboundDeclNode@198..208
+      PrimitiveTypeNode@198..206
+        BooleanTypeKeyword@198..205 "Boolean"
+        QuestionMark@205..206 "?"
+      Whitespace@206..207 " "
+      Ident@207..208 "b"
+    Whitespace@208..214 "\n\n    "
+    Comment@214..220 "# Ints"
+    Whitespace@220..225 "\n    "
+    UnboundDeclNode@225..230
+      PrimitiveTypeNode@225..229
+        IntTypeKeyword@225..228 "Int"
+        Whitespace@228..229 " "
+      Ident@229..230 "c"
+    Whitespace@230..235 "\n    "
+    UnboundDeclNode@235..241
+      PrimitiveTypeNode@235..239
+        IntTypeKeyword@235..238 "Int"
+        QuestionMark@238..239 "?"
+      Whitespace@239..240 " "
+      Ident@240..241 "d"
+    Whitespace@241..251 "\n    \n    "
+    Comment@251..259 "# Floats"
+    Whitespace@259..264 "\n    "
+    UnboundDeclNode@264..271
+      PrimitiveTypeNode@264..270
+        FloatTypeKeyword@264..269 "Float"
+        Whitespace@269..270 " "
+      Ident@270..271 "e"
+    Whitespace@271..276 "\n    "
+    UnboundDeclNode@276..284
+      PrimitiveTypeNode@276..282
+        FloatTypeKeyword@276..281 "Float"
+        QuestionMark@281..282 "?"
+      Whitespace@282..283 " "
+      Ident@283..284 "f"
+    Whitespace@284..294 "\n    \n    "
+    Comment@294..303 "# Strings"
+    Whitespace@303..308 "\n    "
+    UnboundDeclNode@308..316
+      PrimitiveTypeNode@308..315
+        StringTypeKeyword@308..314 "String"
+        Whitespace@314..315 " "
+      Ident@315..316 "g"
+    Whitespace@316..321 "\n    "
+    UnboundDeclNode@321..330
+      PrimitiveTypeNode@321..328
+        StringTypeKeyword@321..327 "String"
+        QuestionMark@327..328 "?"
+      Whitespace@328..329 " "
+      Ident@329..330 "h"
+    Whitespace@330..340 "\n    \n    "
+    Comment@340..347 "# Files"
+    Whitespace@347..352 "\n    "
+    UnboundDeclNode@352..358
+      PrimitiveTypeNode@352..357
+        FileTypeKeyword@352..356 "File"
+        Whitespace@356..357 " "
+      Ident@357..358 "i"
+    Whitespace@358..363 "\n    "
+    UnboundDeclNode@363..370
+      PrimitiveTypeNode@363..368
+        FileTypeKeyword@363..367 "File"
+        QuestionMark@367..368 "?"
+      Whitespace@368..369 " "
+      Ident@369..370 "j"
+    Whitespace@370..372 "\n\n"
+    CloseBrace@372..373 "}"
+  Whitespace@373..375 "\n\n"
+  Comment@375..414 "# Test for a struct w ..."
+  Whitespace@414..415 "\n"
+  StructDefinitionNode@415..1071
+    StructKeyword@415..421 "struct"
+    NameNode@421..434
+      Whitespace@421..422 " "
+      Ident@422..434 "ComplexTypes"
+    Whitespace@434..435 " "
+    OpenBrace@435..436 "{"
+    Whitespace@436..441 "\n    "
+    Comment@441..447 "# Maps"
+    Whitespace@447..452 "\n    "
+    UnboundDeclNode@452..474
+      MapTypeNode@452..473
+        MapTypeKeyword@452..455 "Map"
+        OpenBracket@455..456 "["
+        PrimitiveTypeNode@456..463
+          BooleanTypeKeyword@456..463 "Boolean"
+        Comma@463..464 ","
+        PrimitiveTypeNode@464..471
+          Whitespace@464..465 " "
+          StringTypeKeyword@465..471 "String"
+        CloseBracket@471..472 "]"
+        Whitespace@472..473 " "
+      Ident@473..474 "a"
+    Whitespace@474..479 "\n    "
+    UnboundDeclNode@479..505
+      MapTypeNode@479..504
+        MapTypeKeyword@479..482 "Map"
+        OpenBracket@482..483 "["
+        PrimitiveTypeNode@483..487
+          IntTypeKeyword@483..486 "Int"
+          QuestionMark@486..487 "?"
+        Comma@487..488 ","
+        ArrayTypeNode@488..502
+          Whitespace@488..489 " "
+          ArrayTypeKeyword@489..494 "Array"
+          OpenBracket@494..495 "["
+          PrimitiveTypeNode@495..501
+            StringTypeKeyword@495..501 "String"
+          CloseBracket@501..502 "]"
+        CloseBracket@502..503 "]"
+        Whitespace@503..504 " "
+      Ident@504..505 "b"
+    Whitespace@505..510 "\n    "
+    UnboundDeclNode@510..555
+      MapTypeNode@510..554
+        MapTypeKeyword@510..513 "Map"
+        OpenBracket@513..514 "["
+        PrimitiveTypeNode@514..519
+          FloatTypeKeyword@514..519 "Float"
+        Comma@519..520 ","
+        MapTypeNode@520..552
+          Whitespace@520..521 " "
+          MapTypeKeyword@521..524 "Map"
+          OpenBracket@524..525 "["
+          PrimitiveTypeNode@525..531
+            StringTypeKeyword@525..531 "String"
+          Comma@531..532 ","
+          ArrayTypeNode@532..551
+            Whitespace@532..533 " "
+            ArrayTypeKeyword@533..538 "Array"
+            OpenBracket@538..539 "["
+            ArrayTypeNode@539..550
+              ArrayTypeKeyword@539..544 "Array"
+              OpenBracket@544..545 "["
+              PrimitiveTypeNode@545..549
+                FileTypeKeyword@545..549 "File"
+              CloseBracket@549..550 "]"
+            CloseBracket@550..551 "]"
+          CloseBracket@551..552 "]"
+        CloseBracket@552..553 "]"
+        Whitespace@553..554 " "
+      Ident@554..555 "c"
+    Whitespace@555..560 "\n    "
+    UnboundDeclNode@560..615
+      MapTypeNode@560..614
+        MapTypeKeyword@560..563 "Map"
+        OpenBracket@563..564 "["
+        PrimitiveTypeNode@564..570
+          StringTypeKeyword@564..570 "String"
+        Comma@570..571 ","
+        PairTypeNode@571..612
+          Whitespace@571..572 " "
+          PairTypeKeyword@572..576 "Pair"
+          OpenBracket@576..577 "["
+          ArrayTypeNode@577..590
+            ArrayTypeKeyword@577..582 "Array"
+            OpenBracket@582..583 "["
+            PrimitiveTypeNode@583..589
+              StringTypeKeyword@583..589 "String"
+            CloseBracket@589..590 "]"
+          Comma@590..591 ","
+          MapTypeNode@591..611
+            Whitespace@591..592 " "
+            MapTypeKeyword@592..595 "Map"
+            OpenBracket@595..596 "["
+            PrimitiveTypeNode@596..602
+              StringTypeKeyword@596..602 "String"
+            Comma@602..603 ","
+            PrimitiveTypeNode@603..610
+              Whitespace@603..604 " "
+              StringTypeKeyword@604..610 "String"
+            CloseBracket@610..611 "]"
+          CloseBracket@611..612 "]"
+        CloseBracket@612..613 "]"
+        Whitespace@613..614 " "
+      Ident@614..615 "d"
+    Whitespace@615..620 "\n    "
+    UnboundDeclNode@620..637
+      MapTypeNode@620..636
+        MapTypeKeyword@620..623 "Map"
+        OpenBracket@623..624 "["
+        PrimitiveTypeNode@624..628
+          FileTypeKeyword@624..628 "File"
+        Comma@628..629 ","
+        PrimitiveTypeNode@629..634
+          Whitespace@629..630 " "
+          FileTypeKeyword@630..634 "File"
+        CloseBracket@634..635 "]"
+        Whitespace@635..636 " "
+      Ident@636..637 "e"
+    Whitespace@637..643 "\n\n    "
+    Comment@643..651 "# Arrays"
+    Whitespace@651..656 "\n    "
+    UnboundDeclNode@656..672
+      ArrayTypeNode@656..671
+        ArrayTypeKeyword@656..661 "Array"
+        OpenBracket@661..662 "["
+        PrimitiveTypeNode@662..669
+          BooleanTypeKeyword@662..669 "Boolean"
+        CloseBracket@669..670 "]"
+        Whitespace@670..671 " "
+      Ident@671..672 "f"
+    Whitespace@672..677 "\n    "
+    UnboundDeclNode@677..698
+      ArrayTypeNode@677..697
+        ArrayTypeKeyword@677..682 "Array"
+        OpenBracket@682..683 "["
+        ArrayTypeNode@683..695
+          ArrayTypeKeyword@683..688 "Array"
+          OpenBracket@688..689 "["
+          PrimitiveTypeNode@689..694
+            FloatTypeKeyword@689..694 "Float"
+          CloseBracket@694..695 "]"
+        CloseBracket@695..696 "]"
+        Whitespace@696..697 " "
+      Ident@697..698 "g"
+    Whitespace@698..703 "\n    "
+    UnboundDeclNode@703..731
+      ArrayTypeNode@703..730
+        ArrayTypeKeyword@703..708 "Array"
+        OpenBracket@708..709 "["
+        MapTypeNode@709..728
+          MapTypeKeyword@709..712 "Map"
+          OpenBracket@712..713 "["
+          PrimitiveTypeNode@713..719
+            StringTypeKeyword@713..719 "String"
+          Comma@719..720 ","
+          ObjectTypeNode@720..727
+            Whitespace@720..721 " "
+            ObjectTypeKeyword@721..727 "Object"
+          CloseBracket@727..728 "]"
+        CloseBracket@728..729 "]"
+        Whitespace@729..730 " "
+      Ident@730..731 "h"
+    Whitespace@731..736 "\n    "
+    UnboundDeclNode@736..778
+      ArrayTypeNode@736..777
+        ArrayTypeKeyword@736..741 "Array"
+        OpenBracket@741..742 "["
+        ArrayTypeNode@742..775
+          ArrayTypeKeyword@742..747 "Array"
+          OpenBracket@747..748 "["
+          ArrayTypeNode@748..774
+            ArrayTypeKeyword@748..753 "Array"
+            OpenBracket@753..754 "["
+            ArrayTypeNode@754..773
+              ArrayTypeKeyword@754..759 "Array"
+              OpenBracket@759..760 "["
+              ArrayTypeNode@760..772
+                ArrayTypeKeyword@760..765 "Array"
+                OpenBracket@765..766 "["
+                PrimitiveTypeNode@766..771
+                  FileTypeKeyword@766..770 "File"
+                  QuestionMark@770..771 "?"
+                CloseBracket@771..772 "]"
+              CloseBracket@772..773 "]"
+            CloseBracket@773..774 "]"
+          CloseBracket@774..775 "]"
+        CloseBracket@775..776 "]"
+        Whitespace@776..777 " "
+      Ident@777..778 "i"
+    Whitespace@778..783 "\n    "
+    UnboundDeclNode@783..802
+      ArrayTypeNode@783..801
+        ArrayTypeKeyword@783..788 "Array"
+        OpenBracket@788..789 "["
+        TypeRefNode@789..799
+          Ident@789..799 "CustomType"
+        CloseBracket@799..800 "]"
+        Whitespace@800..801 " "
+      Ident@801..802 "j"
+    Whitespace@802..808 "\n\n    "
+    Comment@808..815 "# Pairs"
+    Whitespace@815..820 "\n    "
+    UnboundDeclNode@820..844
+      PairTypeNode@820..843
+        PairTypeKeyword@820..824 "Pair"
+        OpenBracket@824..825 "["
+        PrimitiveTypeNode@825..832
+          BooleanTypeKeyword@825..832 "Boolean"
+        Comma@832..833 ","
+        PrimitiveTypeNode@833..841
+          Whitespace@833..834 " "
+          BooleanTypeKeyword@834..841 "Boolean"
+        CloseBracket@841..842 "]"
+        Whitespace@842..843 " "
+      Ident@843..844 "k"
+    Whitespace@844..849 "\n    "
+    UnboundDeclNode@849..900
+      PairTypeNode@849..899
+        PairTypeKeyword@849..853 "Pair"
+        OpenBracket@853..854 "["
+        PairTypeNode@854..890
+          PairTypeKeyword@854..858 "Pair"
+          OpenBracket@858..859 "["
+          PairTypeNode@859..880
+            PairTypeKeyword@859..863 "Pair"
+            OpenBracket@863..864 "["
+            PrimitiveTypeNode@864..871
+              StringTypeKeyword@864..870 "String"
+              QuestionMark@870..871 "?"
+            Comma@871..872 ","
+            PrimitiveTypeNode@872..879
+              Whitespace@872..873 " "
+              StringTypeKeyword@873..879 "String"
+            CloseBracket@879..880 "]"
+          Comma@880..881 ","
+          TypeRefNode@881..889
+            Whitespace@881..882 " "
+            Ident@882..889 "Integer"
+          CloseBracket@889..890 "]"
+        Comma@890..891 ","
+        PrimitiveTypeNode@891..897
+          Whitespace@891..892 " "
+          FloatTypeKeyword@892..897 "Float"
+        CloseBracket@897..898 "]"
+        Whitespace@898..899 " "
+      Ident@899..900 "l"
+    Whitespace@900..905 "\n    "
+    UnboundDeclNode@905..953
+      PairTypeNode@905..952
+        PairTypeKeyword@905..909 "Pair"
+        OpenBracket@909..910 "["
+        MapTypeNode@910..944
+          MapTypeKeyword@910..913 "Map"
+          OpenBracket@913..914 "["
+          PrimitiveTypeNode@914..921
+            StringTypeKeyword@914..920 "String"
+            QuestionMark@920..921 "?"
+          Comma@921..922 ","
+          PairTypeNode@922..943
+            Whitespace@922..923 " "
+            PairTypeKeyword@923..927 "Pair"
+            OpenBracket@927..928 "["
+            PrimitiveTypeNode@928..934
+              StringTypeKeyword@928..934 "String"
+            Comma@934..935 ","
+            PrimitiveTypeNode@935..942
+              Whitespace@935..936 " "
+              StringTypeKeyword@936..942 "String"
+            CloseBracket@942..943 "]"
+          CloseBracket@943..944 "]"
+        Comma@944..945 ","
+        PrimitiveTypeNode@945..950
+          Whitespace@945..946 " "
+          IntTypeKeyword@946..949 "Int"
+          QuestionMark@949..950 "?"
+        CloseBracket@950..951 "]"
+        Whitespace@951..952 " "
+      Ident@952..953 "m"
+    Whitespace@953..958 "\n    "
+    UnboundDeclNode@958..995
+      PairTypeNode@958..994
+        PairTypeKeyword@958..962 "Pair"
+        OpenBracket@962..963 "["
+        ArrayTypeNode@963..976
+          ArrayTypeKeyword@963..968 "Array"
+          OpenBracket@968..969 "["
+          PrimitiveTypeNode@969..975
+            StringTypeKeyword@969..975 "String"
+          CloseBracket@975..976 "]"
+        Comma@976..977 ","
+        ArrayTypeNode@977..992
+          Whitespace@977..978 " "
+          ArrayTypeKeyword@978..983 "Array"
+          OpenBracket@983..984 "["
+          PrimitiveTypeNode@984..991
+            StringTypeKeyword@984..990 "String"
+            QuestionMark@990..991 "?"
+          CloseBracket@991..992 "]"
+        CloseBracket@992..993 "]"
+        Whitespace@993..994 " "
+      Ident@994..995 "n"
+    Whitespace@995..1001 "\n\n    "
+    Comment@1001..1009 "# Object"
+    Whitespace@1009..1014 "\n    "
+    UnboundDeclNode@1014..1022
+      ObjectTypeNode@1014..1021
+        ObjectTypeKeyword@1014..1020 "Object"
+        Whitespace@1020..1021 " "
+      Ident@1021..1022 "o"
+    Whitespace@1022..1028 "\n\n    "
+    Comment@1028..1042 "# Custom types"
+    Whitespace@1042..1047 "\n    "
+    UnboundDeclNode@1047..1055
+      TypeRefNode@1047..1054
+        Ident@1047..1053 "MyType"
+        Whitespace@1053..1054 " "
+      Ident@1054..1055 "p"
+    Whitespace@1055..1060 "\n    "
+    UnboundDeclNode@1060..1069
+      TypeRefNode@1060..1067
+        Ident@1060..1066 "MyType"
+        QuestionMark@1066..1067 "?"
+      Whitespace@1067..1068 " "
+      Ident@1068..1069 "q"
+    Whitespace@1069..1070 "\n"
+    CloseBrace@1070..1071 "}"
+  Whitespace@1071..1072 "\n"

--- a/wdl-grammar/tests/parsing/struct-definitions/source.wdl
+++ b/wdl-grammar/tests/parsing/struct-definitions/source.wdl
@@ -1,0 +1,60 @@
+# This is a test of struct definitions.
+
+version 1.1
+
+# Test for an empty struct.
+struct Empty {}
+
+# Test for a struct with primitive types.
+struct PrimitiveTypes {
+    # Booleans
+    Boolean a
+    Boolean? b
+
+    # Ints
+    Int c
+    Int? d
+    
+    # Floats
+    Float e
+    Float? f
+    
+    # Strings
+    String g
+    String? h
+    
+    # Files
+    File i
+    File? j
+
+}
+
+# Test for a struct with complex types.
+struct ComplexTypes {
+    # Maps
+    Map[Boolean, String] a
+    Map[Int?, Array[String]] b
+    Map[Float, Map[String, Array[Array[File]]]] c
+    Map[String, Pair[Array[String], Map[String, String]]] d
+    Map[File, File] e
+
+    # Arrays
+    Array[Boolean] f
+    Array[Array[Float]] g
+    Array[Map[String, Object]] h
+    Array[Array[Array[Array[Array[File?]]]]] i
+    Array[CustomType] j
+
+    # Pairs
+    Pair[Boolean, Boolean] k
+    Pair[Pair[Pair[String?, String], Integer], Float] l
+    Pair[Map[String?, Pair[String, String]], Int?] m
+    Pair[Array[String], Array[String?]] n
+
+    # Object
+    Object o
+
+    # Custom types
+    MyType p
+    MyType? q
+}

--- a/wdl-grammar/tests/parsing/struct-recovery/source.errors
+++ b/wdl-grammar/tests/parsing/struct-recovery/source.errors
@@ -6,7 +6,7 @@
    ·     ╰── this is not a WDL token
  7 │     String a
    ╰────
-  × expected identifier, `Array` keyword, `Boolean` keyword, `File` keyword, `Float` keyword, `Int` keyword, `Map` keyword, `Object` keyword, `Pair` keyword, or `String` keyword, but found `?`
+  × expected type, but found `?`
    ╭─[tests/parsing/struct-recovery/source.wdl:8:5]
  7 │     String a
  8 │     ?  # Unexpected token
@@ -14,8 +14,7 @@
    ·     ╰── unexpected `?`
  9 │     Float b
    ╰────
-  × expected identifier, `Array` keyword, `Boolean` keyword, `File` keyword, `Float` keyword, `Int` keyword, `Map` keyword, `Object` keyword, `Pair` keyword, or `String` keyword, but found `struct`
-  │ keyword
+  × expected type, but found `struct` keyword
     ╭─[tests/parsing/struct-recovery/source.wdl:10:5]
   9 │     Float b
  10 │     struct   # Unexpected keyword

--- a/wdl-grammar/tests/parsing/struct-recovery/source.errors
+++ b/wdl-grammar/tests/parsing/struct-recovery/source.errors
@@ -1,0 +1,25 @@
+  × an unknown token was encountered
+   ╭─[tests/parsing/struct-recovery/source.wdl:6:5]
+ 5 │ struct MyStruct {
+ 6 │     ; # Unknown token
+   ·     ┬
+   ·     ╰── this is not a WDL token
+ 7 │     String a
+   ╰────
+  × expected identifier, `Array` keyword, `Boolean` keyword, `File` keyword, `Float` keyword, `Int` keyword, `Map` keyword, `Object` keyword, `Pair` keyword, or `String` keyword, but found `?`
+   ╭─[tests/parsing/struct-recovery/source.wdl:8:5]
+ 7 │     String a
+ 8 │     ?  # Unexpected token
+   ·     ┬
+   ·     ╰── unexpected `?`
+ 9 │     Float b
+   ╰────
+  × expected identifier, `Array` keyword, `Boolean` keyword, `File` keyword, `Float` keyword, `Int` keyword, `Map` keyword, `Object` keyword, `Pair` keyword, or `String` keyword, but found `struct`
+  │ keyword
+    ╭─[tests/parsing/struct-recovery/source.wdl:10:5]
+  9 │     Float b
+ 10 │     struct   # Unexpected keyword
+    ·     ───┬──
+    ·        ╰── unexpected `struct` keyword
+ 11 │     Integer c
+    ╰────

--- a/wdl-grammar/tests/parsing/struct-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/struct-recovery/source.tree
@@ -1,0 +1,47 @@
+RootNode@0..226
+  Comment@0..71 "# This test ensures t ..."
+  Whitespace@71..73 "\n\n"
+  VersionStatementNode@73..84
+    VersionKeyword@73..80 "version"
+    Whitespace@80..81 " "
+    Version@81..84 "1.1"
+  Whitespace@84..86 "\n\n"
+  StructDefinitionNode@86..225
+    StructKeyword@86..92 "struct"
+    NameNode@92..101
+      Whitespace@92..93 " "
+      Ident@93..101 "MyStruct"
+    Whitespace@101..102 " "
+    OpenBrace@102..103 "{"
+    Whitespace@103..108 "\n    "
+    Whitespace@108..109 " "
+    Comment@109..124 "# Unknown token"
+    Whitespace@124..129 "\n    "
+    UnboundDeclNode@129..137
+      PrimitiveTypeNode@129..136
+        StringTypeKeyword@129..135 "String"
+        Whitespace@135..136 " "
+      Ident@136..137 "a"
+    Whitespace@137..142 "\n    "
+    QuestionMark@142..143 "?"
+    Whitespace@143..145 "  "
+    Comment@145..163 "# Unexpected token"
+    Whitespace@163..168 "\n    "
+    UnboundDeclNode@168..175
+      PrimitiveTypeNode@168..174
+        FloatTypeKeyword@168..173 "Float"
+        Whitespace@173..174 " "
+      Ident@174..175 "b"
+    Whitespace@175..180 "\n    "
+    StructKeyword@180..186 "struct"
+    Whitespace@186..189 "   "
+    Comment@189..209 "# Unexpected keyword"
+    Whitespace@209..214 "\n    "
+    UnboundDeclNode@214..223
+      TypeRefNode@214..222
+        Ident@214..221 "Integer"
+        Whitespace@221..222 " "
+      Ident@222..223 "c"
+    Whitespace@223..224 "\n"
+    CloseBrace@224..225 "}"
+  Whitespace@225..226 "\n"

--- a/wdl-grammar/tests/parsing/struct-recovery/source.wdl
+++ b/wdl-grammar/tests/parsing/struct-recovery/source.wdl
@@ -1,0 +1,12 @@
+# This test ensures that a struct definition can be parsed with errors.
+
+version 1.1
+
+struct MyStruct {
+    ; # Unknown token
+    String a
+    ?  # Unexpected token
+    Float b
+    struct   # Unexpected keyword
+    Integer c
+}

--- a/wdl-grammar/tests/parsing/top-recovery/source.errors
+++ b/wdl-grammar/tests/parsing/top-recovery/source.errors
@@ -1,0 +1,8 @@
+  × expected `import` keyword, `struct` keyword, `task` keyword, or `workflow` keyword, but found `Int` keyword
+    ╭─[tests/parsing/top-recovery/source.wdl:9:1]
+  8 │ 
+  9 │ Int i = 0
+    · ─┬─
+    ·  ╰── unexpected `Int` keyword
+ 10 │ 
+    ╰────

--- a/wdl-grammar/tests/parsing/top-recovery/source.errors
+++ b/wdl-grammar/tests/parsing/top-recovery/source.errors
@@ -1,4 +1,4 @@
-  × expected `import` keyword, `struct` keyword, `task` keyword, or `workflow` keyword, but found `Int` keyword
+  × expected import statement, struct definition, task definition, or workflow definition, but found `Int` keyword
     ╭─[tests/parsing/top-recovery/source.wdl:9:1]
   8 │ 
   9 │ Int i = 0

--- a/wdl-grammar/tests/parsing/top-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/top-recovery/source.tree
@@ -1,0 +1,48 @@
+RootNode@0..120
+  Comment@0..44 "# This is a test of t ..."
+  Whitespace@44..46 "\n\n"
+  VersionStatementNode@46..57
+    VersionKeyword@46..53 "version"
+    Whitespace@53..54 " "
+    Version@54..57 "1.1"
+  Whitespace@57..59 "\n\n"
+  StructDefinitionNode@59..84
+    StructKeyword@59..65 "struct"
+    NameNode@65..67
+      Whitespace@65..66 " "
+      Ident@66..67 "A"
+    Whitespace@67..68 " "
+    OpenBrace@68..69 "{"
+    Whitespace@69..74 "\n    "
+    UnboundDeclNode@74..82
+      PrimitiveTypeNode@74..81
+        StringTypeKeyword@74..80 "String"
+        Whitespace@80..81 " "
+      Ident@81..82 "x"
+    Whitespace@82..83 "\n"
+    CloseBrace@83..84 "}"
+  Whitespace@84..86 "\n\n"
+  IntTypeKeyword@86..89 "Int"
+  Whitespace@89..90 " "
+  Ident@90..91 "i"
+  Whitespace@91..92 " "
+  Assignment@92..93 "="
+  Whitespace@93..94 " "
+  Integer@94..95 "0"
+  Whitespace@95..97 "\n\n"
+  StructDefinitionNode@97..119
+    StructKeyword@97..103 "struct"
+    NameNode@103..105
+      Whitespace@103..104 " "
+      Ident@104..105 "B"
+    Whitespace@105..106 " "
+    OpenBrace@106..107 "{"
+    Whitespace@107..112 "\n    "
+    UnboundDeclNode@112..117
+      PrimitiveTypeNode@112..116
+        IntTypeKeyword@112..115 "Int"
+        Whitespace@115..116 " "
+      Ident@116..117 "y"
+    Whitespace@117..118 "\n"
+    CloseBrace@118..119 "}"
+  Whitespace@119..120 "\n"

--- a/wdl-grammar/tests/parsing/top-recovery/source.wdl
+++ b/wdl-grammar/tests/parsing/top-recovery/source.wdl
@@ -1,0 +1,13 @@
+# This is a test of top-level item recovery.
+
+version 1.1
+
+struct A {
+    String x
+}
+
+Int i = 0
+
+struct B {
+    Int y
+}

--- a/wdl-grammar/tests/parsing/unsupported-version/source.tree
+++ b/wdl-grammar/tests/parsing/unsupported-version/source.tree
@@ -1,7 +1,8 @@
-RootNode@0..62
+RootNode@0..63
   Comment@0..44 "# This is a test for  ..."
   Whitespace@44..46 "\n\n"
   VersionStatementNode@46..62
     VersionKeyword@46..53 "version"
     Whitespace@53..54 " "
     Version@54..62 "100000.0"
+  Whitespace@62..63 "\n"

--- a/wdl-grammar/tests/parsing/valid-version/source.tree
+++ b/wdl-grammar/tests/parsing/valid-version/source.tree
@@ -1,7 +1,8 @@
-RootNode@0..59
+RootNode@0..60
   Comment@0..46 "# This is a test of a ..."
   Whitespace@46..48 "\n\n"
   VersionStatementNode@48..59
     VersionKeyword@48..55 "version"
     Whitespace@55..56 " "
     Version@56..59 "1.1"
+  Whitespace@59..60 "\n"


### PR DESCRIPTION
This commit implements the parsing of WDL struct definitions in the experimental parser.

The `experimental` feature is still required to use the new parser.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your changes are squashed into a single commit (unless there is a _really_
      good, articulated reason as to why there should be more than one).