### PR TITLE
fix: fix placeholder option parsing in the experimental parser.

### DIFF
--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed parsing of placeholder options in the experimental parser such
+  that it can disambiguate between the `sep` option and a `sep` function
+  call ([#44](https://github.com/stjude-rust-labs/wdl/pull/44)).
+
 ### Added
 
 * Adds support for bound declarations and expressions in the experimental

--- a/wdl-grammar/src/experimental/grammar/v1.rs
+++ b/wdl-grammar/src/experimental/grammar/v1.rs
@@ -728,8 +728,8 @@ fn number(
 
 /// Parses a placeholder option.
 fn placeholder_option(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    match parser.peek() {
-        Some((Token::Ident, span)) => {
+    match parser.peek2() {
+        Some(((Token::Ident, span), (Token::Assignment, _))) => {
             let kind = match parser.source(span) {
                 "sep" => SyntaxKind::PlaceholderSepOptionNode,
                 "default" => SyntaxKind::PlaceholderDefaultOptionNode,
@@ -746,7 +746,8 @@ fn placeholder_option(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Ma
             marker.complete(parser, kind);
             Ok(())
         }
-        Some((t @ Token::TrueKeyword, _)) | Some((t @ Token::FalseKeyword, _)) => {
+        Some(((t @ Token::TrueKeyword, _), (Token::Assignment, _)))
+        | Some(((t @ Token::FalseKeyword, _), (Token::Assignment, _))) => {
             parser.next();
             expected!(parser, marker, Token::Assignment);
             expected_fn!(parser, marker, string);

--- a/wdl-grammar/src/experimental/lexer.rs
+++ b/wdl-grammar/src/experimental/lexer.rs
@@ -226,9 +226,10 @@ pub type LexerResult<T> = Result<T, Error>;
 ///
 /// A lexer produces a stream of tokens from a WDL source string.
 #[allow(missing_debug_implementations)]
+#[derive(Clone)]
 pub struct Lexer<'a, T>(logos::Lexer<'a, T>)
 where
-    T: Logos<'a>;
+    T: Logos<'a, Extras = ()>;
 
 impl<'a, T> Lexer<'a, T>
 where
@@ -269,8 +270,7 @@ where
     /// as the current lexer.
     pub fn morph<T2>(self) -> Lexer<'a, T2>
     where
-        T2: Logos<'a, Source = str, Error = Error>,
-        T::Extras: Into<T2::Extras>,
+        T2: Logos<'a, Source = str, Error = Error, Extras = ()> + Copy,
     {
         Lexer(self.0.morph())
     }
@@ -278,7 +278,7 @@ where
 
 impl<'a, T> Iterator for Lexer<'a, T>
 where
-    T: Logos<'a, Error = Error>,
+    T: Logos<'a, Error = Error, Extras = ()> + Copy,
 {
     type Item = (LexerResult<T>, SourceSpan);
 

--- a/wdl-grammar/tests/parsing/interpolation/source.tree
+++ b/wdl-grammar/tests/parsing/interpolation/source.tree
@@ -1,4 +1,4 @@
-RootNode@0..410
+RootNode@0..472
   Comment@0..41 "# This is a test of s ..."
   Whitespace@41..43 "\n\n"
   VersionStatementNode@43..54
@@ -6,7 +6,7 @@ RootNode@0..410
     Whitespace@50..51 " "
     Version@51..54 "1.1"
   Whitespace@54..56 "\n\n"
-  TaskDefinitionNode@56..409
+  TaskDefinitionNode@56..471
     TaskKeyword@56..60 "task"
     NameNode@60..65
       Whitespace@60..61 " "
@@ -217,7 +217,7 @@ RootNode@0..410
           CloseBrace@353..354 "}"
         DoubleQuote@354..355 "\""
       Whitespace@355..360 "\n    "
-    BoundDeclNode@360..408
+    BoundDeclNode@360..412
       PrimitiveTypeNode@360..367
         StringTypeKeyword@360..366 "String"
         Whitespace@366..367 " "
@@ -249,6 +249,48 @@ RootNode@0..410
             FalseKeyword@400..405 "false"
           CloseBrace@405..406 "}"
         DoubleQuote@406..407 "\""
-      Whitespace@407..408 "\n"
-    CloseBrace@408..409 "}"
-  Whitespace@409..410 "\n"
+      Whitespace@407..412 "\n    "
+    BoundDeclNode@412..470
+      PrimitiveTypeNode@412..419
+        StringTypeKeyword@412..418 "String"
+        Whitespace@418..419 " "
+      NameNode@419..420
+        Ident@419..420 "i"
+      Whitespace@420..421 " "
+      Assignment@421..422 "="
+      LiteralStringNode@422..448
+        Whitespace@422..423 " "
+        DoubleQuote@423..424 "\""
+        PlaceholderNode@424..447
+          PlaceholderOpen@424..426 "~{"
+          CallExprNode@426..446
+            NameReferenceNode@426..429
+              Ident@426..429 "sep"
+            OpenParen@429..430 "("
+            LiteralStringNode@430..434
+              SingleQuote@430..431 "'"
+              LiteralStringText@431..433 "\\n"
+              SingleQuote@433..434 "'"
+            Comma@434..435 ","
+            Whitespace@435..436 " "
+            LiteralArrayNode@436..445
+              OpenBracket@436..437 "["
+              LiteralIntegerNode@437..438
+                Integer@437..438 "1"
+              Comma@438..439 ","
+              Whitespace@439..440 " "
+              LiteralIntegerNode@440..441
+                Integer@440..441 "2"
+              Comma@441..442 ","
+              Whitespace@442..443 " "
+              LiteralIntegerNode@443..444
+                Integer@443..444 "3"
+              CloseBracket@444..445 "]"
+            CloseParen@445..446 ")"
+          CloseBrace@446..447 "}"
+        DoubleQuote@447..448 "\""
+      Whitespace@448..449 " "
+      Comment@449..469 "# Not a `sep` option"
+      Whitespace@469..470 "\n"
+    CloseBrace@470..471 "}"
+  Whitespace@471..472 "\n"

--- a/wdl-grammar/tests/parsing/interpolation/source.wdl
+++ b/wdl-grammar/tests/parsing/interpolation/source.wdl
@@ -12,4 +12,5 @@ task test {
     String f = "~{sep=" " [1, 2, 3]}"
     String g = "~{default="n/a" 1*2/2+1}"
     String h = "~{true="false" false="true" false}"
+    String i = "~{sep('\n', [1, 2, 3])}" # Not a `sep` option
 }


### PR DESCRIPTION
This commit fixes the parsing of placeholder options by adding a `peek2` method to check for an assignment token following the option identifier.

Without the assignment token present, it should treat the contents as an expression, such as a call to the `sep` function.

Currently `Lexer::peek` is retokenizing on every `peek` followed by `next`; a forthcoming PR will properly cache the result of `peek` so that re-tokenization will only ever occur for `peek2`, which will only be called for string placeholders.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your changes are squashed into a single commit (unless there is a _really_
      good, articulated reason as to why there should be more than one).

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/