### PR TITLE
feat(wdl-gauntlet): ENTER THE ARENA

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,9 +41,8 @@ Rule specific checks:
       `wdl-grammar/src/v1/lint.rs`.
 - [ ] You have added a test that covers every possible setting for the rule 
       within the file where the rule is implemented.
-- [ ] You have run `wdl-gauntlet --refresh` to ensure that all of the rules
-      added/removed are now reflected in the baseline configuration file
-      (`Gauntlet.toml`).
+- [ ] You have run `wdl-gauntlet --refresh` to ensure that there are no unintended
+      changes to the baseline configuration file (`Gauntlet.toml`).
 - [ ] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the rules
       added/removed are now reflected in the baseline configuration file
       (`Arena.toml`).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,6 +44,9 @@ Rule specific checks:
 - [ ] You have run `wdl-gauntlet --refresh` to ensure that all of the rules
       added/removed are now reflected in the baseline configuration file
       (`Gauntlet.toml`).
+- [ ] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the rules
+      added/removed are now reflected in the baseline configuration file
+      (`Arena.toml`).
 
 END SECTION -->
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,10 +53,16 @@ jobs:
 
   gauntlet:
     runs-on: ubuntu-22.04
-    env:
-      CACHE_DIR: ~/.config/wdl-grammar
     steps:
       - uses: actions/checkout@v3
       - name: Update Rust
         run: rustup update nightly && rustup default nightly
       - run: cargo run --release --bin wdl-gauntlet
+
+  arena:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update Rust
+        run: rustup update nightly && rustup default nightly
+      - run: cargo run --release --bin wdl-gauntlet -- --arena

--- a/Arena.toml
+++ b/Arena.toml
@@ -10,7 +10,7 @@ commit_hash = "7dd6c4c7c8c9fc6dcd4eb5ff8f3262cd26d5e7cc"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
-commit_hash = "d67ec17bdf8436c0fff3360cd55bbdfc1dada383"
+commit_hash = "e88a97791c101676773f635e4d92f645d5a1535a"
 
 [[concerns]]
 kind = "LintWarning"
@@ -239,16 +239,6 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 
 [[concerns]]
 kind = "LintWarning"
-document = "stjudecloud/workflows:/data_structures/read_group.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (48:6-48:25)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/data_structures/read_group.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (96:6-96:20)"
-
-[[concerns]]
-kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (119:17-119:29)"
 
@@ -380,36 +370,6 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (478:20-478:54)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (479:19-479:45)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (485:19-485:49)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (491:19-491:48)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (497:19-497:53)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (503:19-503:49)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (509:30-509:49)"
 
 [[concerns]]
@@ -435,112 +395,7 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (517:16-517:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (518:16-518:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (519:16-519:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (520:16-520:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (521:16-521:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (522:16-522:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (526:16-526:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (535:15-535:47)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (536:15-536:52)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (537:15-537:47)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (538:15-538:49)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (539:15-539:46)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (53:16-53:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (540:15-540:50)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (541:15-541:55)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (542:15-542:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (543:13-543:25)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (544:13-544:23)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (547:13-547:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (548:13-548:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (549:13-549:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (54:16-54:37)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -555,37 +410,12 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (552:13-552:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (553:13-553:28)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (554:13-554:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (556:13-556:38)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (557:13-557:38)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (559:13-559:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (55:16-55:51)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -600,127 +430,12 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (568:13-568:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (569:13-569:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (56:16-56:45)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (570:13-570:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (571:13-571:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (572:13-572:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (573:13-573:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (57:16-57:50)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (580:13-580:34)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (581:13-581:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (582:13-582:41)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (583:13-583:41)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (584:13-584:47)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (585:13-585:45)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (586:13-586:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (587:13-587:38)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (588:13-588:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (589:13-589:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (58:16-58:50)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (590:13-590:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (595:13-595:40)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (598:13-598:42)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (599:13-599:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (602:13-602:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (60:13-60:34)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -731,11 +446,6 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (62:13-62:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (64:13-64:26)"
 
 [[concerns]]
 kind = "LintWarning"

--- a/Arena.toml
+++ b/Arena.toml
@@ -1,8 +1,166 @@
 version = "v1"
 
+[repositories."ENCODE-DCC/chip-seq-pipeline2"]
+identifier = "ENCODE-DCC/chip-seq-pipeline2"
+commit_hash = "26eeda81a0540dc793fc69b0c390d232ca7ca50a"
+
+[repositories."getwilds/ww-fastq-to-cram"]
+identifier = "getwilds/ww-fastq-to-cram"
+commit_hash = "7dd6c4c7c8c9fc6dcd4eb5ff8f3262cd26d5e7cc"
+
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
 commit_hash = "2970ed4ffec95cbc3c94b3e85543d46c4e730f71"
+
+[[concerns]]
+kind = "LintWarning"
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/compare_md5sum.wdl"
+message = "[v1::W001::[Spacing, Style]::Low] trailing space (10:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/compare_md5sum.wdl"
+message = "[v1::W001::[Spacing, Style]::Low] trailing space (68:66)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/compare_md5sum.wdl"
+message = "[v1::W003::[Completeness]::Medium] missing parameter meta within task: files (5:6-5:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/compare_md5sum.wdl"
+message = "[v1::W003::[Completeness]::Medium] missing parameter meta within task: labels (4:6-4:26)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/compare_md5sum.wdl"
+message = "[v1::W003::[Completeness]::Medium] missing parameter meta within task: ref_files (6:6-6:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/compare_md5sum.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (2:6-2:20)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W001::[Spacing, Style]::Low] trailing space (133:46)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W001::[Spacing, Style]::Low] trailing space (182:63)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W001::[Spacing, Style]::Low] trailing space (34:105)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W001::[Spacing, Style]::Low] trailing space (57:13)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W001::[Spacing, Style]::Low] trailing space (8:42)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W003::[Completeness]::Medium] extraneous parameter meta within task: crai (203:5-203:9)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W003::[Completeness]::Medium] extraneous parameter meta within task: cram (202:5-202:9)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W003::[Completeness]::Medium] extraneous parameter meta within task: unmapped_bam (129:5-129:17)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W003::[Completeness]::Medium] extraneous parameter meta within task: validation (165:5-165:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W003::[Completeness]::Medium] extraneous parameter meta within workflow: unmapped_cram_indexes (75:5-75:26)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W003::[Completeness]::Medium] extraneous parameter meta within workflow: unmapped_crams (74:5-74:19)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W003::[Completeness]::Medium] extraneous parameter meta within workflow: validation (76:5-76:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (10:15-10:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (134:6-134:18)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (170:6-170:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (23:10-23:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (83:6-83:24)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (85:17-85:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (86:17-86:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (9:15-9:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W007::[Spacing, Style]::Low] missing newline at the end of the file (205:2-205:2)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W010::[Style]::Low] double pound signs are reserved for preamble comments (21:1-21:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W010::[Style]::Low] double pound signs are reserved for preamble comments (5:1-5:24)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "[v1::W010::[Style]::Low] double pound signs are reserved for preamble comments (80:1-80:22)"
 
 [[concerns]]
 kind = "LintWarning"

--- a/Arena.toml
+++ b/Arena.toml
@@ -1,0 +1,1015 @@
+version = "v1"
+
+[repositories."stjudecloud/workflows"]
+identifier = "stjudecloud/workflows"
+commit_hash = "2970ed4ffec95cbc3c94b3e85543d46c4e730f71"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (124:10-124:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (71:6-71:45)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (147:6-147:24)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (32:12-32:14)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (33:13-33:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (34:13-34:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (35:13-35:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (36:13-36:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (37:13-37:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (38:13-38:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (39:13-39:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (40:13-40:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (41:10-41:12)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (42:13-42:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (43:13-43:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (44:13-44:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (45:13-45:15)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (48:6-48:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/data_structures/read_group.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (96:6-96:20)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/cellranger.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (119:17-119:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/cellranger.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (120:17-120:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/cellranger.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (82:14-82:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/cellranger.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (83:14-83:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/cellranger.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (87:14-87:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (139:11-139:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (140:11-140:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (149:12-149:18)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (150:12-150:18)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (166:14-166:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (167:15-167:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (71:11-71:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/fq.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (72:11-72:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/gatk4.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (107:14-107:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/gatk4.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (108:14-108:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/gatk4.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (109:21-109:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/gatk4.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (249:14-249:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/gatk4.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (250:14-250:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/gatk4.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (62:14-62:35)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/kraken2.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (347:11-347:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/kraken2.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (348:11-348:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/librarian.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (30:11-30:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/md5sum.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (36:14-36:20)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/picard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (121:15-121:39)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/picard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (327:14-327:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/picard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (422:14-422:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/picard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (483:14-483:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/sambamba.wdl"
+message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (2:1-2:2)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/sambamba.wdl"
+message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (3:1-3:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/sambamba.wdl"
+message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (4:1-4:50)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (478:20-478:47)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (479:19-479:41)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (485:19-485:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (491:19-491:43)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (497:19-497:46)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (503:19-503:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (509:30-509:46)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (510:28-510:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (511:27-511:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (512:24-512:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (513:24-513:48)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (514:24-514:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (515:16-515:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (516:16-516:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (517:16-517:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (518:16-518:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (519:16-519:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (520:16-520:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (521:16-521:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (522:16-522:26)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (523:16-523:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (524:16-524:37)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (525:16-525:38)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (526:16-526:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (527:16-527:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (528:16-528:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (529:16-529:35)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (530:16-530:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (531:16-531:26)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (532:16-532:37)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (533:16-533:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (535:15-535:41)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (536:15-536:45)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (537:15-537:41)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (538:15-538:42)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (539:15-539:42)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (53:16-53:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (540:15-540:43)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (541:15-541:47)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (542:15-542:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (543:13-543:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (544:13-544:22)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (545:13-545:26)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (546:13-546:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (547:13-547:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (548:13-548:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (549:13-549:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (54:16-54:34)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (550:13-550:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (551:13-551:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (552:13-552:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (553:13-553:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (554:13-554:26)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (555:13-555:40)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (556:13-556:34)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (557:13-557:34)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (558:13-558:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (559:13-559:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (55:16-55:46)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (560:13-560:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (561:13-561:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (562:13-562:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (563:13-563:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (564:13-564:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (565:13-565:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (566:13-566:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (567:13-567:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (568:13-568:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (569:13-569:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (56:16-56:40)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (570:13-570:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (571:13-571:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (572:13-572:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (573:13-573:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (574:13-574:34)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (575:13-575:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (576:13-576:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (577:13-577:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (578:13-578:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (579:13-579:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (57:16-57:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (580:13-580:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (581:13-581:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (582:13-582:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (583:13-583:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (584:13-584:42)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (585:13-585:40)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (586:13-586:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (587:13-587:34)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (588:13-588:24)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (589:13-589:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (58:16-58:44)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (590:13-590:26)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (591:13-591:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (592:13-592:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (593:13-593:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (594:13-594:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (595:13-595:37)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (596:13-596:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (597:13-597:34)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (598:13-598:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (599:13-599:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (600:13-600:35)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (601:13-601:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (602:13-602:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (60:13-60:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (61:13-61:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (62:13-62:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (63:13-63:34)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (64:13-64:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (816:9-816:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (817:9-817:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (818:9-818:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/util.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (24:17-24:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/util.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (413:14-413:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/util.wdl"
+message = "[v1::W011::[Spacing, Style]::Low] more than one empty line (563:1-563:1)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/tools/util.wdl"
+message = "[v1::W011::[Spacing, Style]::Low] more than one empty line (595:1-595:1)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
+message = "[v1::W003::[Completeness]::Medium] missing parameter meta within task: array_lengths (118:9-118:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (49:21-49:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (50:22-50:28)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (570:11-570:35)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/bwa-db-build.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (26:17-26:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (103:15-103:24)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (104:15-104:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (106:21-106:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (41:16-41:32)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (42:16-42:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (43:16-43:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (44:17-44:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (45:17-45:37)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (46:23-46:36)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (47:23-47:37)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W007::[Spacing, Style]::Low] missing newline at the end of the file (108:2-108:2)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (1:1-1:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
+message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (2:1-2:50)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (125:14-125:21)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/star-db-build.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (33:17-33:33)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/reference/star-db-build.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (34:17-34:24)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (44:14-44:23)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (45:14-45:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
+message = "[v1::W007::[Spacing, Style]::Low] multiple empty lines at the end of file (126:1-127:1)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
+message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (1:1-1:31)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
+message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (2:1-2:50)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (59:17-59:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (60:17-60:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (83:21-83:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (84:21-84:27)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (90:17-90:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (91:17-91:29)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W011::[Spacing, Style]::Low] more than one empty line (43:1-43:1)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (104:14-104:30)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (105:14-105:25)"
+
+[[concerns]]
+kind = "LintWarning"
+document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (109:14-109:25)"

--- a/Arena.toml
+++ b/Arena.toml
@@ -10,7 +10,7 @@ commit_hash = "7dd6c4c7c8c9fc6dcd4eb5ff8f3262cd26d5e7cc"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
-commit_hash = "2970ed4ffec95cbc3c94b3e85543d46c4e730f71"
+commit_hash = "d67ec17bdf8436c0fff3360cd55bbdfc1dada383"
 
 [[concerns]]
 kind = "LintWarning"
@@ -165,17 +165,7 @@ message = "[v1::W010::[Style]::Low] double pound signs are reserved for preamble
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (124:10-124:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (71:6-71:45)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/data_structures/read_group.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (147:6-147:24)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -335,11 +325,6 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (109:21-109:44)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (249:14-249:23)"
 
 [[concerns]]
@@ -394,568 +379,363 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 
 [[concerns]]
 kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/sambamba.wdl"
-message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (2:1-2:2)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/sambamba.wdl"
-message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (3:1-3:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/sambamba.wdl"
-message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (4:1-4:50)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (478:20-478:47)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (479:19-479:41)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (485:19-485:44)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (491:19-491:43)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (497:19-497:46)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (503:19-503:44)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (509:30-509:46)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (510:28-510:44)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (511:27-511:44)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (512:24-512:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (513:24-513:48)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (514:24-514:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (515:16-515:33)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (516:16-516:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (517:16-517:33)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (518:16-518:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (519:16-519:30)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (520:16-520:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (521:16-521:28)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (522:16-522:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (523:16-523:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (524:16-524:37)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (525:16-525:38)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (526:16-526:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (527:16-527:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (528:16-528:44)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (529:16-529:35)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (530:16-530:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (531:16-531:26)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (532:16-532:37)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (533:16-533:27)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (535:15-535:41)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (536:15-536:45)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (537:15-537:41)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (538:15-538:42)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (539:15-539:42)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (53:16-53:32)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (540:15-540:43)"
-
-[[concerns]]
-kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (541:15-541:47)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (478:20-478:54)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (542:15-542:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (479:19-479:45)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (543:13-543:23)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (485:19-485:49)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (544:13-544:22)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (491:19-491:48)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (545:13-545:26)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (497:19-497:53)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (546:13-546:33)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (503:19-503:49)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (547:13-547:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (509:30-509:49)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (548:13-548:32)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (510:28-510:47)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (549:13-549:31)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (512:24-512:39)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (54:16-54:34)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (513:24-513:53)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (550:13-550:31)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (514:24-514:39)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (551:13-551:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (517:16-517:36)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (552:13-552:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (518:16-518:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (553:13-553:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (519:16-519:32)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (554:13-554:26)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (520:16-520:29)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (555:13-555:40)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (521:16-521:31)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (556:13-556:34)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (522:16-522:28)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (557:13-557:34)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (526:16-526:35)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (558:13-558:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (535:15-535:47)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (559:13-559:31)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (536:15-536:52)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (55:16-55:46)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (537:15-537:47)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (560:13-560:21)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (538:15-538:49)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (561:13-561:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (539:15-539:46)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (562:13-562:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (53:16-53:35)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (563:13-563:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (540:15-540:50)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (564:13-564:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (541:15-541:55)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (565:13-565:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (542:15-542:29)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (566:13-566:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (543:13-543:25)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (567:13-567:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (544:13-544:23)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (568:13-568:31)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (547:13-547:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (569:13-569:32)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (548:13-548:35)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (56:16-56:40)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (549:13-549:35)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (570:13-570:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (54:16-54:37)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (571:13-571:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (550:13-550:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (572:13-572:28)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (551:13-551:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (573:13-573:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (552:13-552:32)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (574:13-574:34)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (553:13-553:28)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (575:13-575:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (554:13-554:29)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (576:13-576:23)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (556:13-556:38)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (577:13-577:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (557:13-557:38)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (578:13-578:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (559:13-559:35)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (579:13-579:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (55:16-55:51)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (57:16-57:44)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (562:13-562:27)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (580:13-580:31)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (563:13-563:27)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (581:13-581:33)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (568:13-568:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (582:13-582:36)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (569:13-569:36)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (583:13-583:36)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (56:16-56:45)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (584:13-584:42)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (570:13-570:30)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (585:13-585:40)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (571:13-571:32)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (586:13-586:31)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (572:13-572:32)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (587:13-587:34)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (573:13-573:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (588:13-588:24)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (57:16-57:50)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (589:13-589:31)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (580:13-580:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (58:16-58:44)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (581:13-581:36)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (590:13-590:26)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (582:13-582:41)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (591:13-591:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (583:13-583:41)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (592:13-592:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (584:13-584:47)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (593:13-593:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (585:13-585:45)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (594:13-594:32)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (586:13-586:35)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (595:13-595:37)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (587:13-587:38)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (596:13-596:36)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (588:13-588:27)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (597:13-597:34)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (589:13-589:35)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (598:13-598:36)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (58:16-58:50)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (599:13-599:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (590:13-590:29)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (600:13-600:35)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (595:13-595:40)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (601:13-601:36)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (598:13-598:42)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (602:13-602:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (599:13-599:32)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (60:13-60:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (602:13-602:29)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (61:13-61:32)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (60:13-60:34)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (62:13-62:28)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (61:13-61:36)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (63:13-63:34)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (62:13-62:31)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (64:13-64:25)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (64:13-64:26)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -984,21 +764,6 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 
 [[concerns]]
 kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/util.wdl"
-message = "[v1::W011::[Spacing, Style]::Low] more than one empty line (563:1-563:1)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/tools/util.wdl"
-message = "[v1::W011::[Spacing, Style]::Low] more than one empty line (595:1-595:1)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
-message = "[v1::W003::[Completeness]::Medium] missing parameter meta within task: array_lengths (118:9-118:33)"
-
-[[concerns]]
-kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (49:21-49:27)"
 
@@ -1020,67 +785,37 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (103:15-103:24)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (101:15-101:24)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (104:15-104:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (102:15-102:30)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (106:21-106:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (39:16-39:32)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (41:16-41:32)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (40:16-40:29)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (42:16-42:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (41:16-41:30)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (43:16-43:30)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (42:17-42:36)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (44:17-44:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (45:17-45:37)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (46:23-46:36)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (47:23-47:37)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W007::[Spacing, Style]::Low] missing newline at the end of the file (108:2-108:2)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (1:1-1:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
-message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (2:1-2:50)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (43:17-43:37)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -1100,27 +835,17 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (44:14-44:23)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (42:14-42:23)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (45:14-45:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (43:14-43:29)"
 
 [[concerns]]
 kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "[v1::W007::[Spacing, Style]::Low] multiple empty lines at the end of file (126:1-127:1)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (1:1-1:31)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "[v1::W010::[Style]::Low] preamble comment without a double pound sign (2:1-2:50)"
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (58:17-58:29)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -1130,7 +855,7 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (60:17-60:29)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (82:21-82:27)"
 
 [[concerns]]
 kind = "LintWarning"
@@ -1140,22 +865,12 @@ message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (84:21-84:27)"
+message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (89:17-89:29)"
 
 [[concerns]]
 kind = "LintWarning"
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (90:17-90:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
-message = "[v1::W006::[Naming, Style, Clarity]::Medium] identifier must be snake case (91:17-91:29)"
-
-[[concerns]]
-kind = "LintWarning"
-document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
-message = "[v1::W011::[Spacing, Style]::Low] more than one empty line (43:1-43:1)"
 
 [[concerns]]
 kind = "LintWarning"

--- a/wdl-gauntlet/CHANGELOG.md
+++ b/wdl-gauntlet/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Core goal of crate is changed: **The goal of (new) `wdl-gauntlet` is to ensure the parsing of syntactically valid WDLs never regresses.**
-* `LintWarnings` are ignored
+* Core goal of crate is split in two:
+  * **The goal of** (base) **`wdl-gauntlet` is to ensure the parsing of syntactically valid WDLs never regresses.**
+  * **The goal of `wdl-gauntlet --arena` is to test lint rules against WDL "in the wild".**
+* `LintWarnings` are ignored (when there is no `--arena` flag)
 * uses `libgit2` (via the `git2` crate) instead of the GitHub REST API (via `octocrab` and `reqwest` crates)
 * no more persistent cache (Now uses `temp-dir`)
 
 ### Added
 
+* The `--arena` flag and `Arena.toml` for lint rule testing
 * more test repos!
 * test repos are tracked at specific commits
 

--- a/wdl-gauntlet/Cargo.toml
+++ b/wdl-gauntlet/Cargo.toml
@@ -22,6 +22,6 @@ serde_with.workspace = true
 temp-dir = "0.1.13"
 tokio.workspace = true
 toml.workspace = true
-wdl-ast = { path = "../wdl-ast" }
-wdl-core = { path = "../wdl-core" }
-wdl-grammar = { path = "../wdl-grammar" }
+wdl-ast = { path = "../wdl-ast", version = "0.1.0" }
+wdl-core = { path = "../wdl-core", version = "0.1.0" }
+wdl-grammar = { path = "../wdl-grammar", version = "0.2.0" }

--- a/wdl-gauntlet/Cargo.toml
+++ b/wdl-gauntlet/Cargo.toml
@@ -8,8 +8,6 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-recursion = "1.0.5"
-chrono = "0.4.31"
 clap.workspace = true
 colored.workspace = true
 dirs = "5.0.1"
@@ -24,7 +22,6 @@ serde_with.workspace = true
 temp-dir = "0.1.13"
 tokio.workspace = true
 toml.workspace = true
-urlencoding = "2.1.3"
-wdl-ast = { path = "../wdl-ast", version = "0.1.0" }
-wdl-core = { path = "../wdl-core", version = "0.1.0" }
-wdl-grammar = { path = "../wdl-grammar", version = "0.2.0" }
+wdl-ast = { path = "../wdl-ast" }
+wdl-core = { path = "../wdl-core" }
+wdl-grammar = { path = "../wdl-grammar" }

--- a/wdl-gauntlet/src/config.rs
+++ b/wdl-gauntlet/src/config.rs
@@ -15,11 +15,10 @@ pub mod reportable_concern;
 pub use inner::Inner;
 pub use reportable_concern::ReportableConcern;
 
-/// The default directory name for the `wdl-grammar` configuration file and
-/// cache.
-const DEFAULT_CONFIG_DIR: &str = "wdl-grammar";
+/// The default directory name for the `wdl-gauntlet` configuration file
+const DEFAULT_CONFIG_DIR: &str = "wdl-gauntlet";
 
-/// The default name for the `wdl-grammar` configuration file.
+/// The default name for the `wdl-gauntlet` configuration file.
 const DEFAULT_CONFIG_FILE: &str = "Gauntlet.toml";
 
 /// An error related to a [`Config`].

--- a/wdl-gauntlet/src/config.rs
+++ b/wdl-gauntlet/src/config.rs
@@ -21,6 +21,9 @@ const DEFAULT_CONFIG_DIR: &str = "wdl-gauntlet";
 /// The default name for the `wdl-gauntlet` configuration file.
 const DEFAULT_CONFIG_FILE: &str = "Gauntlet.toml";
 
+/// The default name for the `wdl-gauntlet` configuration file.
+const DEFAULT_ARENA_CONFIG_FILE: &str = "Arena.toml";
+
 /// An error related to a [`Config`].
 #[derive(Debug)]
 pub enum Error {
@@ -82,18 +85,25 @@ impl Config {
     ///   within the current working directory, that is returned.
     /// * Otherwise, the default configuration directory is searched for a file
     ///   matching the default configuration file name.
+    /// * Presence of the `--arena` flag will change the default configuration
+    ///   file name.
     ///
     /// **Note:** the file may not actually exist—it is up to the consumer to
     /// check if the file exists before acting on it.
-    pub fn default_path() -> PathBuf {
+    pub fn default_path(arena: bool) -> PathBuf {
         let mut path = std::env::current_dir().expect("cannot locate working directory");
-        path.push(DEFAULT_CONFIG_FILE);
+        let filename = if arena {
+            DEFAULT_ARENA_CONFIG_FILE
+        } else {
+            DEFAULT_CONFIG_FILE
+        };
+        path.push(filename);
         if path.exists() {
             return path;
         }
 
         let mut path = default_config_dir();
-        path.push(DEFAULT_CONFIG_FILE);
+        path.push(filename);
         path
     }
 

--- a/wdl-gauntlet/src/config.rs
+++ b/wdl-gauntlet/src/config.rs
@@ -21,7 +21,7 @@ const DEFAULT_CONFIG_DIR: &str = "wdl-gauntlet";
 /// The default name for the `wdl-gauntlet` configuration file.
 const DEFAULT_CONFIG_FILE: &str = "Gauntlet.toml";
 
-/// The default name for the `wdl-gauntlet` configuration file.
+/// The default name for the `wdl-gauntlet --arena` configuration file.
 const DEFAULT_ARENA_CONFIG_FILE: &str = "Arena.toml";
 
 /// An error related to a [`Config`].

--- a/wdl-gauntlet/src/lib.rs
+++ b/wdl-gauntlet/src/lib.rs
@@ -227,6 +227,9 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                     if let Some(these_concerns) = these_concerns {
                         detected_concerns.extend(these_concerns.into_inner().iter().filter_map(
                             |concern| {
+                                // from_concern() will return `None` if the concern is not
+                                // of the right type (based on the value of `args.arena`)
+                                // in which case filter_map() will drop it.
                                 ReportableConcern::from_concern(
                                     document_identifier.to_string(),
                                     concern.clone(),
@@ -242,6 +245,9 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         if let Some(these_concerns) = these_concerns {
                             detected_concerns.extend(
                                 these_concerns.into_inner().iter().filter_map(|concern| {
+                                    // from_concern() will return `None` if the concern is not
+                                    // of the right type (based on the value of `args.arena`)
+                                    // in which case filter_map() will drop it.
                                     ReportableConcern::from_concern(
                                         document_identifier.to_string(),
                                         concern.clone(),

--- a/wdl-gauntlet/src/lib.rs
+++ b/wdl-gauntlet/src/lib.rs
@@ -225,26 +225,30 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .map_err(Error::GrammarV1)?
                         .into_parts();
                     if let Some(these_concerns) = these_concerns {
-                        detected_concerns.extend(these_concerns.into_inner().iter().filter_map(|concern| {
-                            ReportableConcern::from_concern(
-                                document_identifier.to_string(),
-                                concern.clone(),
-                                args.arena,
-                            )
-                        }));
+                        detected_concerns.extend(these_concerns.into_inner().iter().filter_map(
+                            |concern| {
+                                ReportableConcern::from_concern(
+                                    document_identifier.to_string(),
+                                    concern.clone(),
+                                    args.arena,
+                                )
+                            },
+                        ));
                     }
 
                     if let Some(pt) = pt {
                         let (_, these_concerns) =
                             ast::v1::parse(pt).map_err(Error::AstV1)?.into_parts();
                         if let Some(these_concerns) = these_concerns {
-                            detected_concerns.extend(these_concerns.into_inner().iter().filter_map(|concern| {
-                                ReportableConcern::from_concern(
-                                    document_identifier.to_string(),
-                                    concern.clone(),
-                                    args.arena,
-                                )
-                            }));
+                            detected_concerns.extend(
+                                these_concerns.into_inner().iter().filter_map(|concern| {
+                                    ReportableConcern::from_concern(
+                                        document_identifier.to_string(),
+                                        concern.clone(),
+                                        args.arena,
+                                    )
+                                }),
+                            );
                         }
                     }
 

--- a/wdl-gauntlet/src/lib.rs
+++ b/wdl-gauntlet/src/lib.rs
@@ -1,4 +1,4 @@
-//! `wdl-grammar gauntlet`
+//! `wdl-gauntlet`
 
 #![feature(let_chains)]
 #![warn(missing_docs)]
@@ -103,7 +103,7 @@ pub struct Args {
     #[arg(short, long)]
     pub filter: Option<Vec<String>>,
 
-    /// Enables logging for all modules (not just `wdl-grammar`).
+    /// Enables logging for all modules (not just `wdl-gauntlet`).
     #[arg(short, long)]
     pub log_all_modules: bool,
 
@@ -125,10 +125,6 @@ pub struct Args {
     /// time. The difference in disk space usage should be negligible.
     #[arg(long)]
     pub refresh: bool,
-
-    /// Skips the retreiving of remote objects.
-    #[arg(long)]
-    pub skip_remote: bool,
 
     /// Displays warnings as part of the report output.
     #[arg(long)]

--- a/wdl-gauntlet/src/repository.rs
+++ b/wdl-gauntlet/src/repository.rs
@@ -70,13 +70,6 @@ impl Repository {
             .join(identifier.organization())
             .join(identifier.name());
 
-        // Ensure the root directory exists.
-        if !repo_root.exists() {
-            info!("creating repository root directory: {:?}", repo_root);
-            std::fs::create_dir_all(&repo_root)
-                .expect("failed to create repository root directory");
-        }
-
         info!("cloning repository: {:?}", identifier);
         let mut fo = FetchOptions::new();
         fo.depth(FETCH_DEPTH);
@@ -132,12 +125,6 @@ impl Repository {
         let repo_root = root
             .join(self.identifier.organization())
             .join(self.identifier.name());
-        // Ensure repo_root exists.
-        if !repo_root.exists() {
-            info!("creating repository root directory: {:?}", repo_root);
-            std::fs::create_dir_all(&repo_root)
-                .expect("failed to create repository root directory");
-        }
 
         let git_repo = match git2::Repository::open(&repo_root) {
             Ok(repo) => {
@@ -206,11 +193,7 @@ impl Repository {
             .join(self.identifier.organization())
             .join(self.identifier.name());
 
-        // Try to delete the current repository.
-        // SAFETY: It shouldn't matter if this succeeds or fails.
-        let _ = std::fs::remove_dir_all(&repo_root);
-
-        // [Re-]Clone the repository.
+        // Clone the repository.
         info!("cloning repository: {:?}", self.identifier);
         let mut fo = FetchOptions::new();
         fo.depth(FETCH_DEPTH);

--- a/wdl-gauntlet/src/repository/work_dir.rs
+++ b/wdl-gauntlet/src/repository/work_dir.rs
@@ -48,12 +48,7 @@ impl WorkDir {
     /// By a guarantee of [`Repository::new()`], the added repository will
     /// _always_ have `Some(commit_hash)`.
     pub fn add_by_identifier(&mut self, identifier: &Identifier) {
-        let repository = Repository::new(
-            identifier.clone(),
-            None,
-            &self
-                .root(),
-        );
+        let repository = Repository::new(identifier.clone(), None, &self.root());
 
         self.repositories.insert(identifier.clone(), repository);
     }

--- a/wdl-gauntlet/src/repository/work_dir.rs
+++ b/wdl-gauntlet/src/repository/work_dir.rs
@@ -52,10 +52,7 @@ impl WorkDir {
             identifier.clone(),
             None,
             &self
-                .root
-                .path()
-                .join(identifier.organization())
-                .join(identifier.name()),
+                .root(),
         );
 
         self.repositories.insert(identifier.clone(), repository);

--- a/wdl-gauntlet/src/repository/work_dir.rs
+++ b/wdl-gauntlet/src/repository/work_dir.rs
@@ -48,7 +48,7 @@ impl WorkDir {
     /// By a guarantee of [`Repository::new()`], the added repository will
     /// _always_ have `Some(commit_hash)`.
     pub fn add_by_identifier(&mut self, identifier: &Identifier) {
-        let repository = Repository::new(identifier.clone(), None, &self.root());
+        let repository = Repository::new(identifier.clone(), None, self.root());
 
         self.repositories.insert(identifier.clone(), repository);
     }


### PR DESCRIPTION
**The goal of `THE ARENA` is to ensure new lints produce sane warnings for WDL "in the wild".**

New `--arena` flag for `wdl-gauntlet` that ignores all syntax errors (`ParseError` or `ValidationFailure`) and instead just reports `LintWarning`. This comes with it's own config file, `Arena.toml`.

Arena has been seeded with 3 repos and their warnings, but that's probably worth revisiting. My process for these 3 was simple elimination starting from `Gauntlet.toml`. I ran `--arena` on each of those 13 repos and excluded anything that returned an overwhelming number of Warnings. That was 10 of the 13 😬 .

While testing out arena on some of the test repos I've already logged issues (#50) with existing warnings.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
