### PR TITLE
fix: allow reserved names in the experimental parser.

### DIFF
--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed parsing of reserved identifiers and recovery in metadata sections
+  in the experimental parser ([#52](https://github.com/stjude-rust-labs/wdl/pull/52)).
 * Fixed parsing of empty inputs to a task call statement in the
   experimental parser ([#54](https://github.com/stjude-rust-labs/wdl/pull/54)).
 * Fixed parsing of postfix `+` qualifier on array types in the experimental 

--- a/wdl-grammar/src/experimental/grammar.rs
+++ b/wdl-grammar/src/experimental/grammar.rs
@@ -24,19 +24,13 @@ mod macros {
         };
     }
 
-    /// A macro for expecting the next token be a particular token and
-    /// providing an alternative name for the expected item.
+    /// A macro for expecting the next token be in the given token set.
     ///
     /// Returns an error if the token is not the specified token.
-    macro_rules! expected_with_name {
-        ($parser:ident, $marker:ident, $token:expr, $expected:literal) => {
-            if let Err(e) = $parser.expect_with_name($token, $expected) {
+    macro_rules! expected_in {
+        ($parser:ident, $marker:ident, $set:ident $(, $names:literal)+) => {
+            if let Err(e) = $parser.expect_in($set, &[$($names),+]) {
                 return Err(($marker, e));
-            }
-        };
-        ($parser:ident, $token:expr, $expected:literal) => {
-            if let Err(e) = $parser.expect_with_name($token, $expected) {
-                return Err((e));
             }
         };
     }
@@ -63,7 +57,7 @@ mod macros {
 
     pub(crate) use expected;
     pub(crate) use expected_fn;
-    pub(crate) use expected_with_name;
+    pub(crate) use expected_in;
 }
 
 /// A parser type used for parsing the document preamble.

--- a/wdl-grammar/src/experimental/grammar/v1.rs
+++ b/wdl-grammar/src/experimental/grammar/v1.rs
@@ -407,6 +407,7 @@ fn import_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mark
 
     if parser.next_if(Token::AsKeyword) {
         expected_in!(parser, marker, ANY_IDENT, "import namespace");
+        parser.update_last_token_kind(SyntaxKind::Ident);
     }
 
     while let Some((Token::AliasKeyword, _)) = parser.peek() {
@@ -421,8 +422,10 @@ fn import_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mark
 fn import_alias(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::AliasKeyword);
     expected_in!(parser, marker, ANY_IDENT, "source type name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     expected!(parser, marker, Token::AsKeyword);
     expected_in!(parser, marker, ANY_IDENT, "target type name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     marker.complete(parser, SyntaxKind::ImportAliasNode);
     Ok(())
 }
@@ -431,6 +434,7 @@ fn import_alias(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, 
 fn struct_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::StructKeyword);
     expected_in!(parser, marker, ANY_IDENT, "struct name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     braced!(parser, marker, |parser| {
         parser.delimited(
             None,
@@ -448,6 +452,7 @@ fn struct_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mar
 fn task_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::TaskKeyword);
     expected_in!(parser, marker, ANY_IDENT, "task name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     braced!(parser, marker, |parser| {
         parser.delimited(None, UNTIL_CLOSE_BRACE, TASK_ITEM_RECOVERY_SET, task_item);
         Ok(())
@@ -460,6 +465,7 @@ fn task_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marke
 fn workflow_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::WorkflowKeyword);
     expected_in!(parser, marker, ANY_IDENT, "workflow name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     braced!(parser, marker, |parser| {
         parser.delimited(
             None,
@@ -477,6 +483,7 @@ fn workflow_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (M
 fn unbound_decl(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_fn!(parser, marker, ty);
     expected_in!(parser, marker, ANY_IDENT, "declaration name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     marker.complete(parser, SyntaxKind::UnboundDeclNode);
     Ok(())
 }
@@ -680,6 +687,7 @@ fn input_section(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker,
 fn decl(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_fn!(parser, marker, ty);
     expected_in!(parser, marker, ANY_IDENT, "declaration name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
 
     let kind = if parser.next_if(Token::Assignment) {
         expected_fn!(parser, marker, expr);
@@ -931,6 +939,7 @@ fn runtime_section(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marke
 /// Parses a runtime item in a runtime section.
 fn runtime_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_in!(parser, marker, ANY_IDENT, "runtime key");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::RuntimeItemNode);
@@ -956,6 +965,7 @@ fn metadata_section(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mark
 /// Parses an item in a metadata object.
 fn metadata_object_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_in!(parser, marker, ANY_IDENT, "metadata key");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, metadata_value);
     marker.complete(parser, SyntaxKind::MetadataObjectItemNode);
@@ -1412,6 +1422,7 @@ fn parameter_metadata_section(
 fn bound_decl(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_fn!(parser, marker, ty);
     expected_in!(parser, marker, ANY_IDENT, "declaration name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     expected!(parser, marker, Token::Assignment);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::BoundDeclNode);
@@ -1440,6 +1451,7 @@ fn scatter_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mar
     parser.require(Token::ScatterKeyword);
     paren!(parser, marker, |parser| {
         parser.expect_in(ANY_IDENT, &["scatter variable name"])?;
+        parser.update_last_token_kind(SyntaxKind::Ident);
         parser.expect(Token::InKeyword)?;
         expected_fn!(parser, expr);
         Ok(())
@@ -1461,13 +1473,16 @@ fn scatter_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mar
 fn call_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::CallKeyword);
     expected_in!(parser, marker, ANY_IDENT, "task name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
 
     if parser.next_if(Token::Dot) {
         expected_in!(parser, marker, ANY_IDENT, "task name");
+        parser.update_last_token_kind(SyntaxKind::Ident);
     }
 
     if parser.next_if(Token::AsKeyword) {
         expected_in!(parser, marker, ANY_IDENT, "call output name");
+        parser.update_last_token_kind(SyntaxKind::Ident);
     }
 
     while let Some((Token::AfterKeyword, _)) = parser.peek() {
@@ -1496,6 +1511,7 @@ fn call_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker
 fn after_clause(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::AfterKeyword);
     expected_in!(parser, marker, ANY_IDENT, "task name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     marker.complete(parser, SyntaxKind::AfterClauseNode);
     Ok(())
 }
@@ -1503,6 +1519,7 @@ fn after_clause(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, 
 /// Parses a call input item.
 fn call_input_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_in!(parser, marker, ANY_IDENT, "call input key");
+    parser.update_last_token_kind(SyntaxKind::Ident);
 
     if parser.next_if(Token::Assignment) {
         expected_fn!(parser, marker, expr);
@@ -1761,6 +1778,7 @@ fn object(parser: &mut Parser<'_>, marker: Marker) -> Result<CompletedMarker, (M
 /// Parses a single item in a literal object.
 fn object_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_in!(parser, marker, ANY_IDENT, "object key");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::LiteralObjectItemNode);
@@ -1773,6 +1791,7 @@ fn literal_struct_or_name_ref(
     marker: Marker,
 ) -> Result<CompletedMarker, (Marker, Error)> {
     expected_in!(parser, marker, ANY_IDENT, "identifier");
+    parser.update_last_token_kind(SyntaxKind::Ident);
 
     if !matches!(parser.peek(), Some((Token::OpenBrace, _)) | None) {
         // This is actually a name reference.
@@ -1794,6 +1813,7 @@ fn literal_struct_or_name_ref(
 /// Parses a single item in a literal struct.
 fn literal_struct_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_in!(parser, marker, ANY_IDENT, "struct member name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::LiteralStructItemNode);
@@ -1841,6 +1861,7 @@ fn access_expr(
 ) -> Result<CompletedMarker, (Marker, Error)> {
     parser.require(Token::Dot);
     expected_in!(parser, marker, ANY_IDENT, "member name");
+    parser.update_last_token_kind(SyntaxKind::Ident);
     Ok(marker.complete(parser, SyntaxKind::AccessExprNode))
 }
 

--- a/wdl-grammar/src/experimental/grammar/v1.rs
+++ b/wdl-grammar/src/experimental/grammar/v1.rs
@@ -4,7 +4,7 @@ use miette::SourceSpan;
 
 use super::macros::expected;
 use super::macros::expected_fn;
-use crate::experimental::grammar::macros::expected_with_name;
+use crate::experimental::grammar::macros::expected_in;
 use crate::experimental::lexer::v1::BraceCommandToken;
 use crate::experimental::lexer::v1::DQStringToken;
 use crate::experimental::lexer::v1::HeredocCommandToken;
@@ -51,9 +51,6 @@ const PRIMITIVE_TYPE_SET: TokenSet = TokenSet::new(&[
     Token::FileTypeKeyword as u8,
 ]);
 
-/// The expected names of primitive types.
-const PRIMITIVE_TYPE_NAMES: &[&str] = &["Boolean", "Int", "Float", "String", "File"];
-
 /// A set of tokens for all types.
 const TYPE_EXPECTED_SET: TokenSet = PRIMITIVE_TYPE_SET.union(TokenSet::new(&[
     Token::MapTypeKeyword as u8,
@@ -77,7 +74,7 @@ const OUTPUT_ITEM_RECOVERY_SET: TokenSet =
 
 /// The recovery set for runtime items.
 const RUNTIME_SECTION_RECOVERY_SET: TokenSet =
-    TokenSet::new(&[Token::Ident as u8, Token::CloseBrace as u8]);
+    ANY_IDENT.union(TokenSet::new(&[Token::CloseBrace as u8]));
 
 /// The expected set of tokens in a task definition.
 const TASK_ITEM_EXPECTED_SET: TokenSet = TYPE_EXPECTED_SET.union(TokenSet::new(&[
@@ -141,11 +138,10 @@ const WORKFLOW_STATEMENT_RECOVERY_SET: TokenSet = TokenSet::new(&[
 ]);
 
 /// The recovery set for input items in a call statement.
-const CALL_INPUT_ITEM_RECOVERY_SET: TokenSet = TokenSet::new(&[
-    Token::Ident as u8,
+const CALL_INPUT_ITEM_RECOVERY_SET: TokenSet = ANY_IDENT.union(TokenSet::new(&[
     Token::Comma as u8,
     Token::CloseBrace as u8,
-]);
+]));
 
 /// The expected token set for metadata values.
 const METADATA_VALUE_EXPECTED_SET: TokenSet = TokenSet::new(&[
@@ -172,27 +168,23 @@ const METADATA_VALUE_EXPECTED_NAMES: &[&str] = &[
 
 /// The recovery set of tokens in a metadata section.
 const METADATA_SECTION_RECOVERY_SET: TokenSet =
-    METADATA_VALUE_EXPECTED_SET.union(TokenSet::new(&[
-        Token::Ident as u8,
+    ANY_IDENT.union(TokenSet::new(&[Token::CloseBrace as u8]));
+
+/// The recovery set of tokens in a metadata object.
+const METADATA_OBJECT_RECOVERY_SET: TokenSet =
+    METADATA_SECTION_RECOVERY_SET.union(TokenSet::new(&[
+        Token::Comma as u8,
         Token::CloseBrace as u8,
     ]));
 
-/// The recovery set of tokens in a metadata object.
-const METADATA_OBJECT_RECOVERY_SET: TokenSet = METADATA_VALUE_EXPECTED_SET.union(TokenSet::new(&[
-    Token::Ident as u8,
-    Token::Comma as u8,
-    Token::CloseBrace as u8,
-]));
-
 /// The recovery set of tokens in a metadata array.
-const METADATA_ARRAY_RECOVERY_SET: TokenSet = TokenSet::new(&[
-    Token::Ident as u8,
+const METADATA_ARRAY_RECOVERY_SET: TokenSet = METADATA_VALUE_EXPECTED_SET.union(TokenSet::new(&[
     Token::Comma as u8,
     Token::CloseBracket as u8,
-]);
+]));
 
 /// A token set for expression atoms.
-const ATOM_EXPECTED_SET: TokenSet = TokenSet::new(&[
+const ATOM_EXPECTED_SET: TokenSet = ANY_IDENT.union(TokenSet::new(&[
     Token::Integer as u8,
     Token::Float as u8,
     Token::TrueKeyword as u8,
@@ -203,9 +195,8 @@ const ATOM_EXPECTED_SET: TokenSet = TokenSet::new(&[
     Token::OpenBrace as u8,
     Token::OpenParen as u8,
     Token::ObjectKeyword as u8,
-    Token::Ident as u8,
     Token::IfKeyword as u8,
-]);
+]));
 
 /// A token set for prefix operators.
 ///
@@ -263,6 +254,48 @@ const UNTIL_CLOSE_BRACKET: TokenSet = TokenSet::new(&[Token::CloseBracket as u8]
 /// A token set used to parse a delimited set of things until a closing
 /// parenthesis.
 const UNTIL_CLOSE_PAREN: TokenSet = TokenSet::new(&[Token::CloseParen as u8]);
+
+/// Represents *any* identifier, including reserved keywords.
+const ANY_IDENT: TokenSet = TokenSet::new(&[
+    Token::Ident as u8,
+    Token::ArrayTypeKeyword as u8,
+    Token::BooleanTypeKeyword as u8,
+    Token::FileTypeKeyword as u8,
+    Token::FloatTypeKeyword as u8,
+    Token::IntTypeKeyword as u8,
+    Token::MapTypeKeyword as u8,
+    Token::NoneTypeKeyword as u8,
+    Token::ObjectTypeKeyword as u8,
+    Token::PairTypeKeyword as u8,
+    Token::StringTypeKeyword as u8,
+    Token::AfterKeyword as u8,
+    Token::AliasKeyword as u8,
+    Token::AsKeyword as u8,
+    Token::CallKeyword as u8,
+    Token::CommandKeyword as u8,
+    Token::ElseKeyword as u8,
+    Token::FalseKeyword as u8,
+    Token::IfKeyword as u8,
+    Token::InKeyword as u8,
+    Token::ImportKeyword as u8,
+    Token::InputKeyword as u8,
+    Token::MetaKeyword as u8,
+    Token::NullKeyword as u8,
+    Token::ObjectKeyword as u8,
+    Token::OutputKeyword as u8,
+    Token::ParameterMetaKeyword as u8,
+    Token::RuntimeKeyword as u8,
+    Token::ScatterKeyword as u8,
+    Token::StructKeyword as u8,
+    Token::TaskKeyword as u8,
+    Token::ThenKeyword as u8,
+    Token::TrueKeyword as u8,
+    Token::VersionKeyword as u8,
+    Token::WorkflowKeyword as u8,
+    Token::ReservedDirectoryTypeKeyword as u8,
+    Token::ReservedHintsKeyword as u8,
+    Token::ReservedRequirementsKeyword as u8,
+]);
 
 /// A helper for parsing matching tokens.
 fn matched<F>(parser: &mut Parser<'_>, open: Token, close: Token, cb: F) -> Result<(), Error>
@@ -373,7 +406,7 @@ fn import_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mark
     expected_fn!(parser, marker, string);
 
     if parser.next_if(Token::AsKeyword) {
-        expected!(parser, marker, Token::Ident);
+        expected_in!(parser, marker, ANY_IDENT, "import namespace");
     }
 
     while let Some((Token::AliasKeyword, _)) = parser.peek() {
@@ -387,24 +420,17 @@ fn import_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mark
 /// Parses an import alias.
 fn import_alias(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::AliasKeyword);
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "source type name");
     expected!(parser, marker, Token::AsKeyword);
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "target type name");
     marker.complete(parser, SyntaxKind::ImportAliasNode);
-    Ok(())
-}
-
-/// Parses a name (i.e. identifier) for a struct, task, or workflow definition.
-fn name(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    expected_with_name!(parser, marker, Token::Ident, "name");
-    marker.complete(parser, SyntaxKind::NameNode);
     Ok(())
 }
 
 /// Parses a struct definition.
 fn struct_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::StructKeyword);
-    expected_fn!(parser, marker, name);
+    expected_in!(parser, marker, ANY_IDENT, "struct name");
     braced!(parser, marker, |parser| {
         parser.delimited(
             None,
@@ -421,7 +447,7 @@ fn struct_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mar
 /// Parses a task definition.
 fn task_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::TaskKeyword);
-    expected_fn!(parser, marker, name);
+    expected_in!(parser, marker, ANY_IDENT, "task name");
     braced!(parser, marker, |parser| {
         parser.delimited(None, UNTIL_CLOSE_BRACE, TASK_ITEM_RECOVERY_SET, task_item);
         Ok(())
@@ -433,7 +459,7 @@ fn task_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marke
 /// Parses a workflow definition.
 fn workflow_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::WorkflowKeyword);
-    expected_fn!(parser, marker, name);
+    expected_in!(parser, marker, ANY_IDENT, "workflow name");
     braced!(parser, marker, |parser| {
         parser.delimited(
             None,
@@ -450,7 +476,7 @@ fn workflow_definition(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (M
 /// Parses an unbound declaration.
 fn unbound_decl(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_fn!(parser, marker, ty);
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "declaration name");
     marker.complete(parser, SyntaxKind::UnboundDeclNode);
     Ok(())
 }
@@ -548,10 +574,16 @@ fn type_ref(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Erro
 
 /// Parses a primitive type used in a declaration.
 fn primitive_type(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    if let Err(e) = parser.expect_in(PRIMITIVE_TYPE_SET, PRIMITIVE_TYPE_NAMES) {
-        return Err((marker, e));
-    }
-
+    expected_in!(
+        parser,
+        marker,
+        PRIMITIVE_TYPE_SET,
+        "Boolean",
+        "Int",
+        "Float",
+        "String",
+        "File"
+    );
     parser.next_if(Token::QuestionMark);
     marker.complete(parser, SyntaxKind::PrimitiveTypeNode);
     Ok(())
@@ -647,7 +679,7 @@ fn input_section(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker,
 /// Parses a declaration (either bound or unbound).
 fn decl(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_fn!(parser, marker, ty);
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "declaration name");
 
     let kind = if parser.next_if(Token::Assignment) {
         expected_fn!(parser, marker, expr);
@@ -898,7 +930,7 @@ fn runtime_section(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marke
 
 /// Parses a runtime item in a runtime section.
 fn runtime_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "runtime key");
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::RuntimeItemNode);
@@ -923,7 +955,7 @@ fn metadata_section(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mark
 
 /// Parses an item in a metadata object.
 fn metadata_object_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "metadata key");
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, metadata_value);
     marker.complete(parser, SyntaxKind::MetadataObjectItemNode);
@@ -1379,7 +1411,7 @@ fn parameter_metadata_section(
 /// Parses a bound declaration.
 fn bound_decl(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     expected_fn!(parser, marker, ty);
-    expected_fn!(parser, marker, name);
+    expected_in!(parser, marker, ANY_IDENT, "declaration name");
     expected!(parser, marker, Token::Assignment);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::BoundDeclNode);
@@ -1407,7 +1439,7 @@ fn conditional_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), 
 fn scatter_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::ScatterKeyword);
     paren!(parser, marker, |parser| {
-        expected_fn!(parser, name);
+        parser.expect_in(ANY_IDENT, &["scatter variable name"])?;
         parser.expect(Token::InKeyword)?;
         expected_fn!(parser, expr);
         Ok(())
@@ -1428,10 +1460,14 @@ fn scatter_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Mar
 /// Parses a call statement in a workflow.
 fn call_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::CallKeyword);
-    expected_fn!(parser, marker, qualified_name);
+    expected_in!(parser, marker, ANY_IDENT, "task name");
+
+    if parser.next_if(Token::Dot) {
+        expected_in!(parser, marker, ANY_IDENT, "task name");
+    }
 
     if parser.next_if(Token::AsKeyword) {
-        expected_fn!(parser, marker, name);
+        expected_in!(parser, marker, ANY_IDENT, "call output name");
     }
 
     while let Some((Token::AfterKeyword, _)) = parser.peek() {
@@ -1456,29 +1492,17 @@ fn call_statement(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker
     Ok(())
 }
 
-/// Parses a qualified name in a call statement.
-fn qualified_name(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    expected!(parser, marker, Token::Ident);
-
-    if parser.next_if(Token::Dot) {
-        expected!(parser, marker, Token::Ident);
-    }
-
-    marker.complete(parser, SyntaxKind::QualifiedNameNode);
-    Ok(())
-}
-
 /// Parses an `after` clause in a call statement.
 fn after_clause(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
     parser.require(Token::AfterKeyword);
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "task name");
     marker.complete(parser, SyntaxKind::AfterClauseNode);
     Ok(())
 }
 
 /// Parses a call input item.
 fn call_input_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "call input key");
 
     if parser.next_if(Token::Assignment) {
         expected_fn!(parser, marker, expr);
@@ -1634,8 +1658,8 @@ fn atom_expr(
         Token::OpenBrace => map(parser, marker),
         Token::OpenParen => pair_or_paren_expr(parser, marker),
         Token::ObjectKeyword => object(parser, marker),
-        Token::Ident => literal_struct_or_name_ref(parser, marker),
         Token::IfKeyword => if_expr(parser, marker),
+        t if ANY_IDENT.contains(t.into_raw()) => literal_struct_or_name_ref(parser, marker),
         _ => unreachable!(),
     }
 }
@@ -1736,7 +1760,7 @@ fn object(parser: &mut Parser<'_>, marker: Marker) -> Result<CompletedMarker, (M
 
 /// Parses a single item in a literal object.
 fn object_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "object key");
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::LiteralObjectItemNode);
@@ -1748,7 +1772,7 @@ fn literal_struct_or_name_ref(
     parser: &mut Parser<'_>,
     marker: Marker,
 ) -> Result<CompletedMarker, (Marker, Error)> {
-    parser.require(Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "identifier");
 
     if !matches!(parser.peek(), Some((Token::OpenBrace, _)) | None) {
         // This is actually a name reference.
@@ -1769,7 +1793,7 @@ fn literal_struct_or_name_ref(
 
 /// Parses a single item in a literal struct.
 fn literal_struct_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Error)> {
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "struct member name");
     expected!(parser, marker, Token::Colon);
     expected_fn!(parser, marker, expr);
     marker.complete(parser, SyntaxKind::LiteralStructItemNode);
@@ -1816,7 +1840,7 @@ fn access_expr(
     marker: Marker,
 ) -> Result<CompletedMarker, (Marker, Error)> {
     parser.require(Token::Dot);
-    expected!(parser, marker, Token::Ident);
+    expected_in!(parser, marker, ANY_IDENT, "member name");
     Ok(marker.complete(parser, SyntaxKind::AccessExprNode))
 }
 

--- a/wdl-grammar/src/experimental/parser.rs
+++ b/wdl-grammar/src/experimental/parser.rs
@@ -477,7 +477,7 @@ where
             .unwrap()
             .0
             .expect("should have peeked at a valid token");
-        while let Some((Ok(token), span)) = lexer.peek() {
+        while let Some((Ok(token), span)) = lexer.next() {
             if token.is_trivia() {
                 // Do not consume trivia here as we're between peeked tokens.
                 continue;

--- a/wdl-grammar/src/experimental/parser.rs
+++ b/wdl-grammar/src/experimental/parser.rs
@@ -746,6 +746,19 @@ where
         }
     }
 
+    /// Updates the syntax kind of the last token event.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last event was not a token.
+    pub fn update_last_token_kind(&mut self, new_kind: SyntaxKind) {
+        let last = self.events.last_mut().expect("expected a last event");
+        match last {
+            Event::Token { kind, .. } => *kind = new_kind,
+            _ => panic!("the last event is not a token"),
+        }
+    }
+
     /// Consumes any trivia tokens by adding them to the event list.
     fn consume_trivia(
         &mut self,

--- a/wdl-grammar/src/experimental/tree.rs
+++ b/wdl-grammar/src/experimental/tree.rs
@@ -185,10 +185,6 @@ pub enum SyntaxKind {
     Abandoned,
     /// Represents the WDL document root node.
     RootNode,
-    /// Represents a name node (for a struct, task, or workflow).
-    NameNode,
-    /// Represents a qualified name node (for a call statement).
-    QualifiedNameNode,
     /// Represents a version statement node.
     VersionStatementNode,
     /// Represents an import statement node.

--- a/wdl-grammar/tests/parsing/atoms/source.tree
+++ b/wdl-grammar/tests/parsing/atoms/source.tree
@@ -8,9 +8,8 @@ RootNode@0..602
   Whitespace@51..53 "\n\n"
   TaskDefinitionNode@53..601
     TaskKeyword@53..57 "task"
-    NameNode@57..62
-      Whitespace@57..58 " "
-      Ident@58..62 "test"
+    Whitespace@57..58 " "
+    Ident@58..62 "test"
     Whitespace@62..63 " "
     OpenBrace@63..64 "{"
     Whitespace@64..69 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..602
       PrimitiveTypeNode@69..73
         IntTypeKeyword@69..72 "Int"
         Whitespace@72..73 " "
-      NameNode@73..74
-        Ident@73..74 "a"
+      Ident@73..74 "a"
       Whitespace@74..75 " "
       Assignment@75..76 "="
       LiteralIntegerNode@76..78
@@ -30,8 +28,7 @@ RootNode@0..602
       PrimitiveTypeNode@83..89
         FloatTypeKeyword@83..88 "Float"
         Whitespace@88..89 " "
-      NameNode@89..90
-        Ident@89..90 "b"
+      Ident@89..90 "b"
       Whitespace@90..91 " "
       Assignment@91..92 "="
       LiteralFloatNode@92..97
@@ -42,8 +39,7 @@ RootNode@0..602
       PrimitiveTypeNode@102..110
         BooleanTypeKeyword@102..109 "Boolean"
         Whitespace@109..110 " "
-      NameNode@110..111
-        Ident@110..111 "c"
+      Ident@110..111 "c"
       Whitespace@111..112 " "
       Assignment@112..113 "="
       LiteralBooleanNode@113..118
@@ -54,8 +50,7 @@ RootNode@0..602
       PrimitiveTypeNode@123..131
         BooleanTypeKeyword@123..130 "Boolean"
         Whitespace@130..131 " "
-      NameNode@131..132
-        Ident@131..132 "d"
+      Ident@131..132 "d"
       Whitespace@132..133 " "
       Assignment@133..134 "="
       LiteralBooleanNode@134..140
@@ -66,8 +61,7 @@ RootNode@0..602
       PrimitiveTypeNode@145..152
         StringTypeKeyword@145..151 "String"
         Whitespace@151..152 " "
-      NameNode@152..153
-        Ident@152..153 "e"
+      Ident@152..153 "e"
       Whitespace@153..154 " "
       Assignment@154..155 "="
       LiteralStringNode@155..163
@@ -80,8 +74,7 @@ RootNode@0..602
       PrimitiveTypeNode@168..175
         StringTypeKeyword@168..174 "String"
         Whitespace@174..175 " "
-      NameNode@175..176
-        Ident@175..176 "f"
+      Ident@175..176 "f"
       Whitespace@176..177 " "
       Assignment@177..178 "="
       LiteralStringNode@178..186
@@ -98,8 +91,7 @@ RootNode@0..602
           IntTypeKeyword@197..200 "Int"
         CloseBracket@200..201 "]"
         Whitespace@201..202 " "
-      NameNode@202..203
-        Ident@202..203 "g"
+      Ident@202..203 "g"
       Whitespace@203..204 " "
       Assignment@204..205 "="
       LiteralArrayNode@205..215
@@ -129,8 +121,7 @@ RootNode@0..602
           StringTypeKeyword@234..240 "String"
         CloseBracket@240..241 "]"
         Whitespace@241..242 " "
-      NameNode@242..243
-        Ident@242..243 "h"
+      Ident@242..243 "h"
       Whitespace@243..244 " "
       Assignment@244..245 "="
       LiteralPairNode@245..258
@@ -162,8 +153,7 @@ RootNode@0..602
           CloseBracket@287..288 "]"
         CloseBracket@288..289 "]"
         Whitespace@289..290 " "
-      NameNode@290..291
-        Ident@290..291 "i"
+      Ident@290..291 "i"
       Whitespace@291..292 " "
       Assignment@292..293 "="
       LiteralMapNode@293..316
@@ -191,8 +181,7 @@ RootNode@0..602
       ObjectTypeNode@321..328
         ObjectTypeKeyword@321..327 "Object"
         Whitespace@327..328 " "
-      NameNode@328..329
-        Ident@328..329 "j"
+      Ident@328..329 "j"
       Whitespace@329..330 " "
       Assignment@330..331 "="
       LiteralObjectNode@331..369
@@ -232,8 +221,7 @@ RootNode@0..602
       TypeRefNode@374..383
         Ident@374..382 "MyStruct"
         Whitespace@382..383 " "
-      NameNode@383..384
-        Ident@383..384 "k"
+      Ident@383..384 "k"
       Whitespace@384..385 " "
       Assignment@385..386 "="
       LiteralStructNode@386..446
@@ -298,8 +286,7 @@ RootNode@0..602
       PrimitiveTypeNode@451..455
         IntTypeKeyword@451..454 "Int"
         Whitespace@454..455 " "
-      NameNode@455..456
-        Ident@455..456 "l"
+      Ident@455..456 "l"
       Whitespace@456..457 " "
       Assignment@457..458 "="
       IndexExprNode@458..463
@@ -315,8 +302,7 @@ RootNode@0..602
       PrimitiveTypeNode@468..472
         IntTypeKeyword@468..471 "Int"
         Whitespace@471..472 " "
-      NameNode@472..473
-        Ident@472..473 "m"
+      Ident@472..473 "m"
       Whitespace@473..474 " "
       Assignment@474..475 "="
       IfExprNode@475..507
@@ -356,8 +342,7 @@ RootNode@0..602
           IntTypeKeyword@513..516 "Int"
         CloseBracket@516..517 "]"
         Whitespace@517..518 " "
-      NameNode@518..519
-        Ident@518..519 "n"
+      Ident@518..519 "n"
       Whitespace@519..520 " "
       Assignment@520..521 "="
       LiteralArrayNode@521..524
@@ -377,8 +362,7 @@ RootNode@0..602
           StringTypeKeyword@541..547 "String"
         CloseBracket@547..548 "]"
         Whitespace@548..549 " "
-      NameNode@549..550
-        Ident@549..550 "o"
+      Ident@549..550 "o"
       Whitespace@550..551 " "
       Assignment@551..552 "="
       LiteralMapNode@552..555
@@ -390,8 +374,7 @@ RootNode@0..602
       TypeRefNode@560..564
         Ident@560..563 "Foo"
         Whitespace@563..564 " "
-      NameNode@564..565
-        Ident@564..565 "p"
+      Ident@564..565 "p"
       Whitespace@565..566 " "
       Assignment@566..567 "="
       LiteralStructNode@567..574
@@ -405,8 +388,7 @@ RootNode@0..602
       ObjectTypeNode@579..586
         ObjectTypeKeyword@579..585 "Object"
         Whitespace@585..586 " "
-      NameNode@586..587
-        Ident@586..587 "q"
+      Ident@586..587 "q"
       Whitespace@587..588 " "
       Assignment@588..589 "="
       LiteralObjectNode@589..599

--- a/wdl-grammar/tests/parsing/call-statements/source.tree
+++ b/wdl-grammar/tests/parsing/call-statements/source.tree
@@ -8,24 +8,21 @@ RootNode@0..425
   Whitespace@49..51 "\n\n"
   WorkflowDefinitionNode@51..424
     WorkflowKeyword@51..59 "workflow"
-    NameNode@59..64
-      Whitespace@59..60 " "
-      Ident@60..64 "test"
+    Whitespace@59..60 " "
+    Ident@60..64 "test"
     Whitespace@64..65 " "
     OpenBrace@65..66 "{"
     Whitespace@66..71 "\n    "
     CallStatementNode@71..90
       CallKeyword@71..75 "call"
-      QualifiedNameNode@75..90
-        Whitespace@75..76 " "
-        Ident@76..85 "no_params"
-        Whitespace@85..90 "\n    "
+      Whitespace@75..76 " "
+      Ident@76..85 "no_params"
+      Whitespace@85..90 "\n    "
     CallStatementNode@90..132
       CallKeyword@90..94 "call"
-      QualifiedNameNode@94..107
-        Whitespace@94..95 " "
-        Ident@95..106 "with_params"
-        Whitespace@106..107 " "
+      Whitespace@94..95 " "
+      Ident@95..106 "with_params"
+      Whitespace@106..107 " "
       OpenBrace@107..108 "{"
       Whitespace@108..109 " "
       InputKeyword@109..114 "input"
@@ -55,19 +52,17 @@ RootNode@0..425
     Whitespace@132..137 "\n    "
     CallStatementNode@137..161
       CallKeyword@137..141 "call"
-      QualifiedNameNode@141..156
-        Whitespace@141..142 " "
-        Ident@142..151 "qualified"
-        Dot@151..152 "."
-        Ident@152..156 "name"
+      Whitespace@141..142 " "
+      Ident@142..151 "qualified"
+      Dot@151..152 "."
+      Ident@152..156 "name"
       Whitespace@156..161 "\n    "
     CallStatementNode@161..213
       CallKeyword@161..165 "call"
-      QualifiedNameNode@165..180
-        Whitespace@165..166 " "
-        Ident@166..175 "qualified"
-        Dot@175..176 "."
-        Ident@176..180 "name"
+      Whitespace@165..166 " "
+      Ident@166..175 "qualified"
+      Dot@175..176 "."
+      Ident@176..180 "name"
       Whitespace@180..181 " "
       OpenBrace@181..182 "{"
       Whitespace@182..183 " "
@@ -106,25 +101,21 @@ RootNode@0..425
     Whitespace@213..218 "\n    "
     CallStatementNode@218..240
       CallKeyword@218..222 "call"
-      QualifiedNameNode@222..231
-        Whitespace@222..223 " "
-        Ident@223..230 "aliased"
-        Whitespace@230..231 " "
+      Whitespace@222..223 " "
+      Ident@223..230 "aliased"
+      Whitespace@230..231 " "
       AsKeyword@231..233 "as"
-      NameNode@233..235
-        Whitespace@233..234 " "
-        Ident@234..235 "x"
+      Whitespace@233..234 " "
+      Ident@234..235 "x"
       Whitespace@235..240 "\n    "
     CallStatementNode@240..268
       CallKeyword@240..244 "call"
-      QualifiedNameNode@244..253
-        Whitespace@244..245 " "
-        Ident@245..252 "aliased"
-        Whitespace@252..253 " "
+      Whitespace@244..245 " "
+      Ident@245..252 "aliased"
+      Whitespace@252..253 " "
       AsKeyword@253..255 "as"
-      NameNode@255..257
-        Whitespace@255..256 " "
-        Ident@256..257 "x"
+      Whitespace@255..256 " "
+      Ident@256..257 "x"
       Whitespace@257..258 " "
       OpenBrace@258..259 "{"
       Whitespace@259..260 " "
@@ -135,10 +126,9 @@ RootNode@0..425
     Whitespace@268..273 "\n    "
     CallStatementNode@273..300
       CallKeyword@273..277 "call"
-      QualifiedNameNode@277..280
-        Whitespace@277..278 " "
-        Ident@278..279 "f"
-        Whitespace@279..280 " "
+      Whitespace@277..278 " "
+      Ident@278..279 "f"
+      Whitespace@279..280 " "
       AfterClauseNode@280..287
         AfterKeyword@280..285 "after"
         Whitespace@285..286 " "
@@ -151,10 +141,9 @@ RootNode@0..425
       Whitespace@295..300 "\n    "
     CallStatementNode@300..340
       CallKeyword@300..304 "call"
-      QualifiedNameNode@304..307
-        Whitespace@304..305 " "
-        Ident@305..306 "f"
-        Whitespace@306..307 " "
+      Whitespace@304..305 " "
+      Ident@305..306 "f"
+      Whitespace@306..307 " "
       AfterClauseNode@307..314
         AfterKeyword@307..312 "after"
         Whitespace@312..313 " "
@@ -183,14 +172,12 @@ RootNode@0..425
     Whitespace@340..345 "\n    "
     CallStatementNode@345..369
       CallKeyword@345..349 "call"
-      QualifiedNameNode@349..352
-        Whitespace@349..350 " "
-        Ident@350..351 "f"
-        Whitespace@351..352 " "
+      Whitespace@349..350 " "
+      Ident@350..351 "f"
+      Whitespace@351..352 " "
       AsKeyword@352..354 "as"
-      NameNode@354..356
-        Whitespace@354..355 " "
-        Ident@355..356 "x"
+      Whitespace@354..355 " "
+      Ident@355..356 "x"
       Whitespace@356..357 " "
       AfterClauseNode@357..364
         AfterKeyword@357..362 "after"
@@ -199,14 +186,12 @@ RootNode@0..425
       Whitespace@364..369 "\n    "
     CallStatementNode@369..422
       CallKeyword@369..373 "call"
-      QualifiedNameNode@373..376
-        Whitespace@373..374 " "
-        Ident@374..375 "f"
-        Whitespace@375..376 " "
+      Whitespace@373..374 " "
+      Ident@374..375 "f"
+      Whitespace@375..376 " "
       AsKeyword@376..378 "as"
-      NameNode@378..380
-        Whitespace@378..379 " "
-        Ident@379..380 "x"
+      Whitespace@378..379 " "
+      Ident@379..380 "x"
       Whitespace@380..381 " "
       AfterClauseNode@381..388
         AfterKeyword@381..386 "after"

--- a/wdl-grammar/tests/parsing/command-sections/source.tree
+++ b/wdl-grammar/tests/parsing/command-sections/source.tree
@@ -8,9 +8,8 @@ RootNode@0..467
   Whitespace@50..52 "\n\n"
   TaskDefinitionNode@52..263
     TaskKeyword@52..56 "task"
-    NameNode@56..64
-      Whitespace@56..57 " "
-      Ident@57..64 "heredoc"
+    Whitespace@56..57 " "
+    Ident@57..64 "heredoc"
     Whitespace@64..65 " "
     OpenBrace@65..66 "{"
     Whitespace@66..71 "\n    "
@@ -51,9 +50,8 @@ RootNode@0..467
   Whitespace@263..265 "\n\n"
   TaskDefinitionNode@265..466
     TaskKeyword@265..269 "task"
-    NameNode@269..275
-      Whitespace@269..270 " "
-      Ident@270..275 "brace"
+    Whitespace@269..270 " "
+    Ident@270..275 "brace"
     Whitespace@275..276 " "
     OpenBrace@276..277 "{"
     Whitespace@277..282 "\n    "

--- a/wdl-grammar/tests/parsing/conditional-statements/source.tree
+++ b/wdl-grammar/tests/parsing/conditional-statements/source.tree
@@ -8,9 +8,8 @@ RootNode@0..331
   Whitespace@65..67 "\n\n"
   WorkflowDefinitionNode@67..330
     WorkflowKeyword@67..75 "workflow"
-    NameNode@75..80
-      Whitespace@75..76 " "
-      Ident@76..80 "test"
+    Whitespace@75..76 " "
+    Ident@76..80 "test"
     Whitespace@80..81 " "
     OpenBrace@81..82 "{"
     Whitespace@82..87 "\n    "
@@ -34,8 +33,7 @@ RootNode@0..331
           ScatterKeyword@128..135 "scatter"
           Whitespace@135..136 " "
           OpenParen@136..137 "("
-          NameNode@137..138
-            Ident@137..138 "x"
+          Ident@137..138 "x"
           Whitespace@138..139 " "
           InKeyword@139..141 "in"
           NameReferenceNode@141..143
@@ -55,10 +53,9 @@ RootNode@0..331
             Whitespace@172..193 "\n                    "
             CallStatementNode@193..216
               CallKeyword@193..197 "call"
-              QualifiedNameNode@197..216
-                Whitespace@197..198 " "
-                Ident@198..199 "z"
-                Whitespace@199..216 "\n                "
+              Whitespace@197..198 " "
+              Ident@198..199 "z"
+              Whitespace@199..216 "\n                "
             CloseBrace@216..217 "}"
           Whitespace@217..230 "\n            "
           CloseBrace@230..231 "}"
@@ -67,10 +64,9 @@ RootNode@0..331
       Whitespace@241..251 "\n\n        "
       CallStatementNode@251..283
         CallKeyword@251..255 "call"
-        QualifiedNameNode@255..258
-          Whitespace@255..256 " "
-          Ident@256..257 "z"
-          Whitespace@257..258 " "
+        Whitespace@255..256 " "
+        Ident@256..257 "z"
+        Whitespace@257..258 " "
         OpenBrace@258..259 "{"
         Whitespace@259..260 " "
         InputKeyword@260..265 "input"
@@ -90,10 +86,9 @@ RootNode@0..331
       Whitespace@283..292 "\n        "
       CallStatementNode@292..322
         CallKeyword@292..296 "call"
-        QualifiedNameNode@296..299
-          Whitespace@296..297 " "
-          Ident@297..298 "z"
-          Whitespace@298..299 " "
+        Whitespace@296..297 " "
+        Ident@297..298 "z"
+        Whitespace@298..299 " "
         OpenBrace@299..300 "{"
         Whitespace@300..301 " "
         InputKeyword@301..306 "input"

--- a/wdl-grammar/tests/parsing/empty-call/source.tree
+++ b/wdl-grammar/tests/parsing/empty-call/source.tree
@@ -8,18 +8,16 @@ RootNode@0..81
   Whitespace@47..49 "\n\n"
   WorkflowDefinitionNode@49..81
     WorkflowKeyword@49..57 "workflow"
-    NameNode@57..62
-      Whitespace@57..58 " "
-      Ident@58..62 "test"
+    Whitespace@57..58 " "
+    Ident@58..62 "test"
     Whitespace@62..63 " "
     OpenBrace@63..64 "{"
     Whitespace@64..69 "\n    "
     CallStatementNode@69..79
       CallKeyword@69..73 "call"
-      QualifiedNameNode@73..76
-        Whitespace@73..74 " "
-        Ident@74..75 "x"
-        Whitespace@75..76 " "
+      Whitespace@73..74 " "
+      Ident@74..75 "x"
+      Whitespace@75..76 " "
       OpenBrace@76..77 "{"
       Whitespace@77..78 " "
       CloseBrace@78..79 "}"

--- a/wdl-grammar/tests/parsing/escaped-newlines/source.tree
+++ b/wdl-grammar/tests/parsing/escaped-newlines/source.tree
@@ -8,9 +8,8 @@ RootNode@0..333
   Whitespace@82..84 "\n\n"
   TaskDefinitionNode@84..206
     TaskKeyword@84..88 "task"
-    NameNode@88..94
-      Whitespace@88..89 " "
-      Ident@89..94 "first"
+    Whitespace@88..89 " "
+    Ident@89..94 "first"
     Whitespace@94..95 " "
     OpenBrace@95..96 "{"
     Whitespace@96..101 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..333
       PrimitiveTypeNode@101..108
         StringTypeKeyword@101..107 "String"
         Whitespace@107..108 " "
-      NameNode@108..109
-        Ident@108..109 "x"
+      Ident@108..109 "x"
       Whitespace@109..110 " "
       Assignment@110..111 "="
       LiteralStringNode@111..128
@@ -39,9 +37,8 @@ RootNode@0..333
   Whitespace@206..208 "\n\n"
   TaskDefinitionNode@208..332
     TaskKeyword@208..212 "task"
-    NameNode@212..219
-      Whitespace@212..213 " "
-      Ident@213..219 "second"
+    Whitespace@212..213 " "
+    Ident@213..219 "second"
     Whitespace@219..220 " "
     OpenBrace@220..221 "{"
     Whitespace@221..226 "\n    "
@@ -49,8 +46,7 @@ RootNode@0..333
       PrimitiveTypeNode@226..233
         StringTypeKeyword@226..232 "String"
         Whitespace@232..233 " "
-      NameNode@233..234
-        Ident@233..234 "x"
+      Ident@233..234 "x"
       Whitespace@234..235 " "
       Assignment@235..236 "="
       LiteralStringNode@236..253

--- a/wdl-grammar/tests/parsing/infix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/infix-exprs/source.tree
@@ -8,9 +8,8 @@ RootNode@0..354
   Whitespace@41..43 "\n\n"
   TaskDefinitionNode@43..353
     TaskKeyword@43..47 "task"
-    NameNode@47..52
-      Whitespace@47..48 " "
-      Ident@48..52 "test"
+    Whitespace@47..48 " "
+    Ident@48..52 "test"
     Whitespace@52..53 " "
     OpenBrace@53..54 "{"
     Whitespace@54..59 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..354
       PrimitiveTypeNode@59..67
         BooleanTypeKeyword@59..66 "Boolean"
         Whitespace@66..67 " "
-      NameNode@67..68
-        Ident@67..68 "a"
+      Ident@67..68 "a"
       Whitespace@68..69 " "
       Assignment@69..70 "="
       LogicalOrExprNode@70..89
@@ -36,8 +34,7 @@ RootNode@0..354
       PrimitiveTypeNode@89..97
         BooleanTypeKeyword@89..96 "Boolean"
         Whitespace@96..97 " "
-      NameNode@97..98
-        Ident@97..98 "b"
+      Ident@97..98 "b"
       Whitespace@98..99 " "
       Assignment@99..100 "="
       LogicalAndExprNode@100..115
@@ -54,8 +51,7 @@ RootNode@0..354
       PrimitiveTypeNode@115..123
         BooleanTypeKeyword@115..122 "Boolean"
         Whitespace@122..123 " "
-      NameNode@123..124
-        Ident@123..124 "c"
+      Ident@123..124 "c"
       Whitespace@124..125 " "
       Assignment@125..126 "="
       EqualityExprNode@126..138
@@ -72,8 +68,7 @@ RootNode@0..354
       PrimitiveTypeNode@138..146
         BooleanTypeKeyword@138..145 "Boolean"
         Whitespace@145..146 " "
-      NameNode@146..147
-        Ident@146..147 "d"
+      Ident@146..147 "d"
       Whitespace@147..148 " "
       Assignment@148..149 "="
       InequalityExprNode@149..165
@@ -90,8 +85,7 @@ RootNode@0..354
       PrimitiveTypeNode@165..173
         BooleanTypeKeyword@165..172 "Boolean"
         Whitespace@172..173 " "
-      NameNode@173..174
-        Ident@173..174 "e"
+      Ident@173..174 "e"
       Whitespace@174..175 " "
       Assignment@175..176 "="
       LessExprNode@176..187
@@ -108,8 +102,7 @@ RootNode@0..354
       PrimitiveTypeNode@187..195
         BooleanTypeKeyword@187..194 "Boolean"
         Whitespace@194..195 " "
-      NameNode@195..196
-        Ident@195..196 "f"
+      Ident@195..196 "f"
       Whitespace@196..197 " "
       Assignment@197..198 "="
       LessEqualExprNode@198..210
@@ -126,8 +119,7 @@ RootNode@0..354
       PrimitiveTypeNode@210..218
         BooleanTypeKeyword@210..217 "Boolean"
         Whitespace@217..218 " "
-      NameNode@218..219
-        Ident@218..219 "g"
+      Ident@218..219 "g"
       Whitespace@219..220 " "
       Assignment@220..221 "="
       GreaterExprNode@221..232
@@ -144,8 +136,7 @@ RootNode@0..354
       PrimitiveTypeNode@232..240
         BooleanTypeKeyword@232..239 "Boolean"
         Whitespace@239..240 " "
-      NameNode@240..241
-        Ident@240..241 "h"
+      Ident@240..241 "h"
       Whitespace@241..242 " "
       Assignment@242..243 "="
       GreaterEqualExprNode@243..255
@@ -162,8 +153,7 @@ RootNode@0..354
       PrimitiveTypeNode@255..259
         IntTypeKeyword@255..258 "Int"
         Whitespace@258..259 " "
-      NameNode@259..260
-        Ident@259..260 "i"
+      Ident@259..260 "i"
       Whitespace@260..261 " "
       Assignment@261..262 "="
       AdditionExprNode@262..275
@@ -180,8 +170,7 @@ RootNode@0..354
       PrimitiveTypeNode@275..279
         IntTypeKeyword@275..278 "Int"
         Whitespace@278..279 " "
-      NameNode@279..280
-        Ident@279..280 "j"
+      Ident@279..280 "j"
       Whitespace@280..281 " "
       Assignment@281..282 "="
       SubtractionExprNode@282..296
@@ -200,8 +189,7 @@ RootNode@0..354
       PrimitiveTypeNode@296..300
         IntTypeKeyword@296..299 "Int"
         Whitespace@299..300 " "
-      NameNode@300..301
-        Ident@300..301 "k"
+      Ident@300..301 "k"
       Whitespace@301..302 " "
       Assignment@302..303 "="
       MultiplicationExprNode@303..316
@@ -218,8 +206,7 @@ RootNode@0..354
       PrimitiveTypeNode@316..320
         IntTypeKeyword@316..319 "Int"
         Whitespace@319..320 " "
-      NameNode@320..321
-        Ident@320..321 "l"
+      Ident@320..321 "l"
       Whitespace@321..322 " "
       Assignment@322..323 "="
       DivisionExprNode@323..336
@@ -236,8 +223,7 @@ RootNode@0..354
       PrimitiveTypeNode@336..340
         IntTypeKeyword@336..339 "Int"
         Whitespace@339..340 " "
-      NameNode@340..341
-        Ident@340..341 "m"
+      Ident@340..341 "m"
       Whitespace@341..342 " "
       Assignment@342..343 "="
       ModuloExprNode@343..352

--- a/wdl-grammar/tests/parsing/input-sections/source.tree
+++ b/wdl-grammar/tests/parsing/input-sections/source.tree
@@ -8,9 +8,8 @@ RootNode@0..374
   Whitespace@71..73 "\n\n"
   TaskDefinitionNode@73..200
     TaskKeyword@73..77 "task"
-    NameNode@77..79
-      Whitespace@77..78 " "
-      Ident@78..79 "t"
+    Whitespace@77..78 " "
+    Ident@78..79 "t"
     Whitespace@79..80 " "
     OpenBrace@80..81 "{"
     Whitespace@81..86 "\n    "
@@ -80,9 +79,8 @@ RootNode@0..374
   Whitespace@200..202 "\n\n"
   WorkflowDefinitionNode@202..373
     WorkflowKeyword@202..210 "workflow"
-    NameNode@210..212
-      Whitespace@210..211 " "
-      Ident@211..212 "w"
+    Whitespace@210..211 " "
+    Ident@211..212 "w"
     Whitespace@212..213 " "
     OpenBrace@213..214 "{"
     Whitespace@214..219 "\n    "

--- a/wdl-grammar/tests/parsing/interpolation/source.tree
+++ b/wdl-grammar/tests/parsing/interpolation/source.tree
@@ -8,9 +8,8 @@ RootNode@0..472
   Whitespace@54..56 "\n\n"
   TaskDefinitionNode@56..471
     TaskKeyword@56..60 "task"
-    NameNode@60..65
-      Whitespace@60..61 " "
-      Ident@61..65 "test"
+    Whitespace@60..61 " "
+    Ident@61..65 "test"
     Whitespace@65..66 " "
     OpenBrace@66..67 "{"
     Whitespace@67..72 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..472
       PrimitiveTypeNode@72..79
         StringTypeKeyword@72..78 "String"
         Whitespace@78..79 " "
-      NameNode@79..83
-        Ident@79..83 "name"
+      Ident@79..83 "name"
       Whitespace@83..84 " "
       Assignment@84..85 "="
       LiteralStringNode@85..93
@@ -32,8 +30,7 @@ RootNode@0..472
       PrimitiveTypeNode@98..105
         StringTypeKeyword@98..104 "String"
         Whitespace@104..105 " "
-      NameNode@105..106
-        Ident@105..106 "a"
+      Ident@105..106 "a"
       Whitespace@106..107 " "
       Assignment@107..108 "="
       LiteralStringNode@108..124
@@ -51,8 +48,7 @@ RootNode@0..472
       PrimitiveTypeNode@129..136
         StringTypeKeyword@129..135 "String"
         Whitespace@135..136 " "
-      NameNode@136..137
-        Ident@136..137 "b"
+      Ident@136..137 "b"
       Whitespace@137..138 " "
       Assignment@138..139 "="
       LiteralStringNode@139..156
@@ -70,8 +66,7 @@ RootNode@0..472
       PrimitiveTypeNode@161..168
         StringTypeKeyword@161..167 "String"
         Whitespace@167..168 " "
-      NameNode@168..169
-        Ident@168..169 "c"
+      Ident@168..169 "c"
       Whitespace@169..170 " "
       Assignment@170..171 "="
       LiteralStringNode@171..190
@@ -91,8 +86,7 @@ RootNode@0..472
       PrimitiveTypeNode@195..202
         StringTypeKeyword@195..201 "String"
         Whitespace@201..202 " "
-      NameNode@202..203
-        Ident@202..203 "d"
+      Ident@202..203 "d"
       Whitespace@203..204 " "
       Assignment@204..205 "="
       LiteralStringNode@205..224
@@ -112,8 +106,7 @@ RootNode@0..472
       PrimitiveTypeNode@229..236
         StringTypeKeyword@229..235 "String"
         Whitespace@235..236 " "
-      NameNode@236..237
-        Ident@236..237 "e"
+      Ident@236..237 "e"
       Whitespace@237..238 " "
       Assignment@238..239 "="
       LiteralStringNode@239..275
@@ -146,8 +139,7 @@ RootNode@0..472
       PrimitiveTypeNode@280..287
         StringTypeKeyword@280..286 "String"
         Whitespace@286..287 " "
-      NameNode@287..288
-        Ident@287..288 "f"
+      Ident@287..288 "f"
       Whitespace@288..289 " "
       Assignment@289..290 "="
       LiteralStringNode@290..313
@@ -183,8 +175,7 @@ RootNode@0..472
       PrimitiveTypeNode@318..325
         StringTypeKeyword@318..324 "String"
         Whitespace@324..325 " "
-      NameNode@325..326
-        Ident@325..326 "g"
+      Ident@325..326 "g"
       Whitespace@326..327 " "
       Assignment@327..328 "="
       LiteralStringNode@328..355
@@ -221,8 +212,7 @@ RootNode@0..472
       PrimitiveTypeNode@360..367
         StringTypeKeyword@360..366 "String"
         Whitespace@366..367 " "
-      NameNode@367..368
-        Ident@367..368 "h"
+      Ident@367..368 "h"
       Whitespace@368..369 " "
       Assignment@369..370 "="
       LiteralStringNode@370..407
@@ -254,8 +244,7 @@ RootNode@0..472
       PrimitiveTypeNode@412..419
         StringTypeKeyword@412..418 "String"
         Whitespace@418..419 " "
-      NameNode@419..420
-        Ident@419..420 "i"
+      Ident@419..420 "i"
       Whitespace@420..421 " "
       Assignment@421..422 "="
       LiteralStringNode@422..448

--- a/wdl-grammar/tests/parsing/metadata-recovery/source.errors
+++ b/wdl-grammar/tests/parsing/metadata-recovery/source.errors
@@ -1,0 +1,8 @@
+  × expected metadata key, but found integer
+   ╭─[tests/parsing/metadata-recovery/source.wdl:7:9]
+ 6 │     meta {
+ 7 │         1: 1
+   ·         ┬
+   ·         ╰── unexpected integer
+ 8 │         baz: "bar"
+   ╰────

--- a/wdl-grammar/tests/parsing/metadata-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/metadata-recovery/source.tree
@@ -1,0 +1,38 @@
+RootNode@0..124
+  Comment@0..46 "# This is a test of m ..."
+  Whitespace@46..48 "\n\n"
+  VersionStatementNode@48..59
+    VersionKeyword@48..55 "version"
+    Whitespace@55..56 " "
+    Version@56..59 "1.1"
+  Whitespace@59..61 "\n\n"
+  TaskDefinitionNode@61..123
+    TaskKeyword@61..65 "task"
+    Whitespace@65..66 " "
+    Ident@66..70 "test"
+    Whitespace@70..71 " "
+    OpenBrace@71..72 "{"
+    Whitespace@72..77 "\n    "
+    MetadataSectionNode@77..121
+      MetaKeyword@77..81 "meta"
+      Whitespace@81..82 " "
+      OpenBrace@82..83 "{"
+      Whitespace@83..92 "\n        "
+      Integer@92..93 "1"
+      Colon@93..94 ":"
+      Whitespace@94..95 " "
+      Integer@95..96 "1"
+      Whitespace@96..105 "\n        "
+      MetadataObjectItemNode@105..115
+        Ident@105..108 "baz"
+        Colon@108..109 ":"
+        LiteralStringNode@109..115
+          Whitespace@109..110 " "
+          DoubleQuote@110..111 "\""
+          LiteralStringText@111..114 "bar"
+          DoubleQuote@114..115 "\""
+      Whitespace@115..120 "\n    "
+      CloseBrace@120..121 "}"
+    Whitespace@121..122 "\n"
+    CloseBrace@122..123 "}"
+  Whitespace@123..124 "\n"

--- a/wdl-grammar/tests/parsing/metadata-recovery/source.wdl
+++ b/wdl-grammar/tests/parsing/metadata-recovery/source.wdl
@@ -1,0 +1,10 @@
+# This is a test of metadata section recovery.
+
+version 1.1
+
+task test {
+    meta {
+        1: 1
+        baz: "bar"
+    }
+}

--- a/wdl-grammar/tests/parsing/metadata/source.tree
+++ b/wdl-grammar/tests/parsing/metadata/source.tree
@@ -8,9 +8,8 @@ RootNode@0..2459
   Whitespace@77..79 "\n\n"
   TaskDefinitionNode@79..1267
     TaskKeyword@79..83 "task"
-    NameNode@83..88
-      Whitespace@83..84 " "
-      Ident@84..88 "test"
+    Whitespace@83..84 " "
+    Ident@84..88 "test"
     Whitespace@88..89 " "
     OpenBrace@89..90 "{"
     Whitespace@90..95 "\n    "
@@ -504,9 +503,8 @@ RootNode@0..2459
   Whitespace@1267..1269 "\n\n"
   WorkflowDefinitionNode@1269..2458
     WorkflowKeyword@1269..1277 "workflow"
-    NameNode@1277..1279
-      Whitespace@1277..1278 " "
-      Ident@1278..1279 "w"
+    Whitespace@1277..1278 " "
+    Ident@1278..1279 "w"
     Whitespace@1279..1280 " "
     OpenBrace@1280..1281 "{"
     Whitespace@1281..1286 "\n    "

--- a/wdl-grammar/tests/parsing/mismatched-brace/source.tree
+++ b/wdl-grammar/tests/parsing/mismatched-brace/source.tree
@@ -7,9 +7,8 @@ RootNode@0..83
     Version@49..52 "1.1"
   Whitespace@52..54 "\n\n"
   TaskKeyword@54..58 "task"
-  NameNode@58..63
-    Whitespace@58..59 " "
-    Ident@59..63 "test"
+  Whitespace@58..59 " "
+  Ident@59..63 "test"
   Whitespace@63..64 " "
   OpenBrace@64..65 "{"
   Whitespace@65..70 "\n    "

--- a/wdl-grammar/tests/parsing/mismatched-bracket/source.tree
+++ b/wdl-grammar/tests/parsing/mismatched-bracket/source.tree
@@ -8,9 +8,8 @@ RootNode@0..143
   Whitespace@54..56 "\n\n"
   StructDefinitionNode@56..143
     StructKeyword@56..62 "struct"
-    NameNode@62..67
-      Whitespace@62..63 " "
-      Ident@63..67 "test"
+    Whitespace@62..63 " "
+    Ident@63..67 "test"
     Whitespace@67..68 " "
     OpenBrace@68..69 "{"
     Whitespace@69..74 "\n    "

--- a/wdl-grammar/tests/parsing/missing-version/source.tree
+++ b/wdl-grammar/tests/parsing/missing-version/source.tree
@@ -3,9 +3,8 @@ RootNode@0..64
   Whitespace@48..50 "\n\n"
   TaskDefinitionNode@50..63
     TaskKeyword@50..54 "task"
-    NameNode@54..58
-      Whitespace@54..55 " "
-      Ident@55..58 "foo"
+    Whitespace@54..55 " "
+    Ident@55..58 "foo"
     Whitespace@58..59 " "
     OpenBrace@59..60 "{"
     Whitespace@60..62 "\n\n"

--- a/wdl-grammar/tests/parsing/name-ref/source.tree
+++ b/wdl-grammar/tests/parsing/name-ref/source.tree
@@ -8,9 +8,8 @@ RootNode@0..118
   Whitespace@51..53 "\n\n"
   TaskDefinitionNode@53..117
     TaskKeyword@53..57 "task"
-    NameNode@57..62
-      Whitespace@57..58 " "
-      Ident@58..62 "test"
+    Whitespace@57..58 " "
+    Ident@58..62 "test"
     Whitespace@62..63 " "
     OpenBrace@63..64 "{"
     Whitespace@64..69 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..118
       PrimitiveTypeNode@69..73
         IntTypeKeyword@69..72 "Int"
         Whitespace@72..73 " "
-      NameNode@73..74
-        Ident@73..74 "x"
+      Ident@73..74 "x"
       Whitespace@74..75 " "
       Assignment@75..76 "="
       LiteralIntegerNode@76..78
@@ -30,8 +28,7 @@ RootNode@0..118
       PrimitiveTypeNode@83..87
         IntTypeKeyword@83..86 "Int"
         Whitespace@86..87 " "
-      NameNode@87..88
-        Ident@87..88 "y"
+      Ident@87..88 "y"
       Whitespace@88..89 " "
       Assignment@89..90 "="
       NegationExprNode@90..98
@@ -44,8 +41,7 @@ RootNode@0..118
       PrimitiveTypeNode@98..102
         IntTypeKeyword@98..101 "Int"
         Whitespace@101..102 " "
-      NameNode@102..103
-        Ident@102..103 "z"
+      Ident@102..103 "z"
       Whitespace@103..104 " "
       Assignment@104..105 "="
       AdditionExprNode@105..116

--- a/wdl-grammar/tests/parsing/output-sections/source.tree
+++ b/wdl-grammar/tests/parsing/output-sections/source.tree
@@ -8,9 +8,8 @@ RootNode@0..415
   Whitespace@72..74 "\n\n"
   TaskDefinitionNode@74..241
     TaskKeyword@74..78 "task"
-    NameNode@78..80
-      Whitespace@78..79 " "
-      Ident@79..80 "t"
+    Whitespace@78..79 " "
+    Ident@79..80 "t"
     Whitespace@80..81 " "
     OpenBrace@81..82 "{"
     Whitespace@82..87 "\n    "
@@ -23,8 +22,7 @@ RootNode@0..415
         PrimitiveTypeNode@104..111
           StringTypeKeyword@104..110 "String"
           Whitespace@110..111 " "
-        NameNode@111..112
-          Ident@111..112 "a"
+        Ident@111..112 "a"
         Whitespace@112..113 " "
         Assignment@113..114 "="
         LiteralStringNode@114..123
@@ -37,8 +35,7 @@ RootNode@0..415
         PrimitiveTypeNode@132..136
           IntTypeKeyword@132..135 "Int"
           Whitespace@135..136 " "
-        NameNode@136..137
-          Ident@136..137 "b"
+        Ident@136..137 "b"
         Whitespace@137..138 " "
         Assignment@138..139 "="
         AdditionExprNode@139..154
@@ -55,8 +52,7 @@ RootNode@0..415
         PrimitiveTypeNode@154..161
           StringTypeKeyword@154..160 "String"
           Whitespace@160..161 " "
-        NameNode@161..162
-          Ident@161..162 "c"
+        Ident@161..162 "c"
         Whitespace@162..163 " "
         Assignment@163..164 "="
         LiteralStringNode@164..178
@@ -82,8 +78,7 @@ RootNode@0..415
             IntTypeKeyword@199..202 "Int"
           CloseBracket@202..203 "]"
           Whitespace@203..204 " "
-        NameNode@204..205
-          Ident@204..205 "d"
+        Ident@204..205 "d"
         Whitespace@205..206 " "
         Assignment@206..207 "="
         LiteralMapNode@207..233
@@ -129,9 +124,8 @@ RootNode@0..415
   Whitespace@241..243 "\n\n"
   WorkflowDefinitionNode@243..414
     WorkflowKeyword@243..251 "workflow"
-    NameNode@251..253
-      Whitespace@251..252 " "
-      Ident@252..253 "w"
+    Whitespace@251..252 " "
+    Ident@252..253 "w"
     Whitespace@253..254 " "
     OpenBrace@254..255 "{"
     Whitespace@255..260 "\n    "
@@ -144,8 +138,7 @@ RootNode@0..415
         PrimitiveTypeNode@277..284
           StringTypeKeyword@277..283 "String"
           Whitespace@283..284 " "
-        NameNode@284..285
-          Ident@284..285 "a"
+        Ident@284..285 "a"
         Whitespace@285..286 " "
         Assignment@286..287 "="
         LiteralStringNode@287..296
@@ -158,8 +151,7 @@ RootNode@0..415
         PrimitiveTypeNode@305..309
           IntTypeKeyword@305..308 "Int"
           Whitespace@308..309 " "
-        NameNode@309..310
-          Ident@309..310 "b"
+        Ident@309..310 "b"
         Whitespace@310..311 " "
         Assignment@311..312 "="
         AdditionExprNode@312..327
@@ -176,8 +168,7 @@ RootNode@0..415
         PrimitiveTypeNode@327..334
           StringTypeKeyword@327..333 "String"
           Whitespace@333..334 " "
-        NameNode@334..335
-          Ident@334..335 "c"
+        Ident@334..335 "c"
         Whitespace@335..336 " "
         Assignment@336..337 "="
         LiteralStringNode@337..351
@@ -203,8 +194,7 @@ RootNode@0..415
             IntTypeKeyword@372..375 "Int"
           CloseBracket@375..376 "]"
           Whitespace@376..377 " "
-        NameNode@377..378
-          Ident@377..378 "d"
+        Ident@377..378 "d"
         Whitespace@378..379 " "
         Assignment@379..380 "="
         LiteralMapNode@380..406

--- a/wdl-grammar/tests/parsing/placeholder-in-metadata/source.tree
+++ b/wdl-grammar/tests/parsing/placeholder-in-metadata/source.tree
@@ -8,9 +8,8 @@ RootNode@0..143
   Whitespace@67..69 "\n\n"
   TaskDefinitionNode@69..142
     TaskKeyword@69..73 "task"
-    NameNode@73..78
-      Whitespace@73..74 " "
-      Ident@74..78 "test"
+    Whitespace@73..74 " "
+    Ident@74..78 "test"
     Whitespace@78..79 " "
     OpenBrace@79..80 "{"
     Whitespace@80..85 "\n    "

--- a/wdl-grammar/tests/parsing/postfix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/postfix-exprs/source.tree
@@ -8,9 +8,8 @@ RootNode@0..324
   Whitespace@52..54 "\n\n"
   TaskDefinitionNode@54..324
     TaskKeyword@54..58 "task"
-    NameNode@58..63
-      Whitespace@58..59 " "
-      Ident@59..63 "test"
+    Whitespace@58..59 " "
+    Ident@59..63 "test"
     Whitespace@63..64 " "
     OpenBrace@64..65 "{"
     Whitespace@65..70 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..324
       PrimitiveTypeNode@70..74
         IntTypeKeyword@70..73 "Int"
         Whitespace@73..74 " "
-      NameNode@74..75
-        Ident@74..75 "a"
+      Ident@74..75 "a"
       Whitespace@75..76 " "
       Assignment@76..77 "="
       CallExprNode@77..87
@@ -39,8 +37,7 @@ RootNode@0..324
       PrimitiveTypeNode@92..96
         IntTypeKeyword@92..95 "Int"
         Whitespace@95..96 " "
-      NameNode@96..97
-        Ident@96..97 "b"
+      Ident@96..97 "b"
       Whitespace@97..98 " "
       Assignment@98..99 "="
       CallExprNode@99..120
@@ -73,8 +70,7 @@ RootNode@0..324
           StringTypeKeyword@131..137 "String"
         CloseBracket@137..138 "]"
         Whitespace@138..139 " "
-      NameNode@139..140
-        Ident@139..140 "c"
+      Ident@139..140 "c"
       Whitespace@140..141 " "
       Assignment@141..142 "="
       LiteralArrayNode@142..158
@@ -102,8 +98,7 @@ RootNode@0..324
       PrimitiveTypeNode@163..170
         StringTypeKeyword@163..169 "String"
         Whitespace@169..170 " "
-      NameNode@170..171
-        Ident@170..171 "d"
+      Ident@170..171 "d"
       Whitespace@171..172 " "
       Assignment@172..173 "="
       IndexExprNode@173..182
@@ -125,8 +120,7 @@ RootNode@0..324
       TypeRefNode@187..196
         Ident@187..195 "MyStruct"
         Whitespace@195..196 " "
-      NameNode@196..197
-        Ident@196..197 "e"
+      Ident@196..197 "e"
       Whitespace@197..198 " "
       Assignment@198..199 "="
       LiteralStructNode@199..271
@@ -162,8 +156,7 @@ RootNode@0..324
       TypeRefNode@276..282
         Ident@276..281 "MyFoo"
         Whitespace@281..282 " "
-      NameNode@282..283
-        Ident@282..283 "f"
+      Ident@282..283 "f"
       Whitespace@283..284 " "
       Assignment@284..285 "="
       LiteralStructNode@285..322

--- a/wdl-grammar/tests/parsing/precedence/source.tree
+++ b/wdl-grammar/tests/parsing/precedence/source.tree
@@ -8,9 +8,8 @@ RootNode@0..274
   Whitespace@52..54 "\n\n"
   TaskDefinitionNode@54..273
     TaskKeyword@54..58 "task"
-    NameNode@58..63
-      Whitespace@58..59 " "
-      Ident@59..63 "test"
+    Whitespace@58..59 " "
+    Ident@59..63 "test"
     Whitespace@63..64 " "
     OpenBrace@64..65 "{"
     Whitespace@65..70 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..274
       PrimitiveTypeNode@70..78
         BooleanTypeKeyword@70..77 "Boolean"
         Whitespace@77..78 " "
-      NameNode@78..79
-        Ident@78..79 "a"
+      Ident@78..79 "a"
       Whitespace@79..80 " "
       Assignment@80..81 "="
       LogicalOrExprNode@81..153
@@ -108,8 +106,7 @@ RootNode@0..274
       PrimitiveTypeNode@153..157
         IntTypeKeyword@153..156 "Int"
         Whitespace@156..157 " "
-      NameNode@157..158
-        Ident@157..158 "b"
+      Ident@157..158 "b"
       Whitespace@158..159 " "
       Assignment@159..160 "="
       SubtractionExprNode@160..193
@@ -159,8 +156,7 @@ RootNode@0..274
       PrimitiveTypeNode@193..201
         BooleanTypeKeyword@193..200 "Boolean"
         Whitespace@200..201 " "
-      NameNode@201..202
-        Ident@201..202 "c"
+      Ident@201..202 "c"
       Whitespace@202..203 " "
       Assignment@203..204 "="
       LogicalOrExprNode@204..272

--- a/wdl-grammar/tests/parsing/prefix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/prefix-exprs/source.tree
@@ -8,9 +8,8 @@ RootNode@0..179
   Whitespace@52..54 "\n\n"
   TaskDefinitionNode@54..178
     TaskKeyword@54..58 "task"
-    NameNode@58..63
-      Whitespace@58..59 " "
-      Ident@59..63 "test"
+    Whitespace@58..59 " "
+    Ident@59..63 "test"
     Whitespace@63..64 " "
     OpenBrace@64..65 "{"
     Whitespace@65..70 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..179
       PrimitiveTypeNode@70..78
         BooleanTypeKeyword@70..77 "Boolean"
         Whitespace@77..78 " "
-      NameNode@78..79
-        Ident@78..79 "a"
+      Ident@78..79 "a"
       Whitespace@79..80 " "
       Assignment@80..81 "="
       LogicalNotExprNode@81..92
@@ -32,8 +30,7 @@ RootNode@0..179
       PrimitiveTypeNode@92..100
         BooleanTypeKeyword@92..99 "Boolean"
         Whitespace@99..100 " "
-      NameNode@100..101
-        Ident@100..101 "b"
+      Ident@100..101 "b"
       Whitespace@101..102 " "
       Assignment@102..103 "="
       LogicalNotExprNode@103..123
@@ -62,8 +59,7 @@ RootNode@0..179
       PrimitiveTypeNode@123..127
         IntTypeKeyword@123..126 "Int"
         Whitespace@126..127 " "
-      NameNode@127..128
-        Ident@127..128 "c"
+      Ident@127..128 "c"
       Whitespace@128..129 " "
       Assignment@129..130 "="
       NegationExprNode@130..138
@@ -76,8 +72,7 @@ RootNode@0..179
       PrimitiveTypeNode@138..144
         FloatTypeKeyword@138..143 "Float"
         Whitespace@143..144 " "
-      NameNode@144..145
-        Ident@144..145 "d"
+      Ident@144..145 "d"
       Whitespace@145..146 " "
       Assignment@146..147 "="
       NegationExprNode@147..157
@@ -90,8 +85,7 @@ RootNode@0..179
       PrimitiveTypeNode@157..161
         IntTypeKeyword@157..160 "Int"
         Whitespace@160..161 " "
-      NameNode@161..162
-        Ident@161..162 "e"
+      Ident@161..162 "e"
       Whitespace@162..163 " "
       Assignment@163..164 "="
       NegationExprNode@164..177

--- a/wdl-grammar/tests/parsing/reserved-meta-names/source.tree
+++ b/wdl-grammar/tests/parsing/reserved-meta-names/source.tree
@@ -19,7 +19,7 @@ RootNode@0..175
       OpenBrace@92..93 "{"
       Whitespace@93..102 "\n        "
       MetadataObjectItemNode@102..118
-        VersionKeyword@102..109 "version"
+        Ident@102..109 "version"
         Colon@109..110 ":"
         LiteralStringNode@110..118
           Whitespace@110..111 " "
@@ -35,7 +35,7 @@ RootNode@0..175
       OpenBrace@145..146 "{"
       Whitespace@146..155 "\n        "
       MetadataObjectItemNode@155..166
-        TaskKeyword@155..159 "task"
+        Ident@155..159 "task"
         Colon@159..160 ":"
         LiteralStringNode@160..166
           Whitespace@160..161 " "

--- a/wdl-grammar/tests/parsing/reserved-meta-names/source.tree
+++ b/wdl-grammar/tests/parsing/reserved-meta-names/source.tree
@@ -1,0 +1,49 @@
+RootNode@0..175
+  Comment@0..56 "# This is a test of r ..."
+  Whitespace@56..58 "\n\n"
+  VersionStatementNode@58..69
+    VersionKeyword@58..65 "version"
+    Whitespace@65..66 " "
+    Version@66..69 "1.1"
+  Whitespace@69..71 "\n\n"
+  TaskDefinitionNode@71..174
+    TaskKeyword@71..75 "task"
+    Whitespace@75..76 " "
+    Ident@76..80 "test"
+    Whitespace@80..81 " "
+    OpenBrace@81..82 "{"
+    Whitespace@82..87 "\n    "
+    MetadataSectionNode@87..124
+      MetaKeyword@87..91 "meta"
+      Whitespace@91..92 " "
+      OpenBrace@92..93 "{"
+      Whitespace@93..102 "\n        "
+      MetadataObjectItemNode@102..118
+        VersionKeyword@102..109 "version"
+        Colon@109..110 ":"
+        LiteralStringNode@110..118
+          Whitespace@110..111 " "
+          DoubleQuote@111..112 "\""
+          LiteralStringText@112..117 "1.1.1"
+          DoubleQuote@117..118 "\""
+      Whitespace@118..123 "\n    "
+      CloseBrace@123..124 "}"
+    Whitespace@124..130 "\n\n    "
+    ParameterMetadataSectionNode@130..172
+      ParameterMetaKeyword@130..144 "parameter_meta"
+      Whitespace@144..145 " "
+      OpenBrace@145..146 "{"
+      Whitespace@146..155 "\n        "
+      MetadataObjectItemNode@155..166
+        TaskKeyword@155..159 "task"
+        Colon@159..160 ":"
+        LiteralStringNode@160..166
+          Whitespace@160..161 " "
+          DoubleQuote@161..162 "\""
+          LiteralStringText@162..165 "foo"
+          DoubleQuote@165..166 "\""
+      Whitespace@166..171 "\n    "
+      CloseBrace@171..172 "}"
+    Whitespace@172..173 "\n"
+    CloseBrace@173..174 "}"
+  Whitespace@174..175 "\n"

--- a/wdl-grammar/tests/parsing/reserved-meta-names/source.wdl
+++ b/wdl-grammar/tests/parsing/reserved-meta-names/source.wdl
@@ -1,0 +1,13 @@
+# This is a test of reserved names in metadata sections.
+
+version 1.1
+
+task test {
+    meta {
+        version: "1.1.1"
+    }
+
+    parameter_meta {
+        task: "foo"
+    }
+}

--- a/wdl-grammar/tests/parsing/runtime-sections/source.tree
+++ b/wdl-grammar/tests/parsing/runtime-sections/source.tree
@@ -8,9 +8,8 @@ RootNode@0..355
   Whitespace@59..61 "\n\n"
   TaskDefinitionNode@61..354
     TaskKeyword@61..65 "task"
-    NameNode@65..70
-      Whitespace@65..66 " "
-      Ident@66..70 "test"
+    Whitespace@65..66 " "
+    Ident@66..70 "test"
     Whitespace@70..71 " "
     OpenBrace@71..72 "{"
     Whitespace@72..77 "\n    "

--- a/wdl-grammar/tests/parsing/scatter-statements/source.tree
+++ b/wdl-grammar/tests/parsing/scatter-statements/source.tree
@@ -8,9 +8,8 @@ RootNode@0..193
   Whitespace@52..54 "\n\n"
   WorkflowDefinitionNode@54..192
     WorkflowKeyword@54..62 "workflow"
-    NameNode@62..67
-      Whitespace@62..63 " "
-      Ident@63..67 "test"
+    Whitespace@62..63 " "
+    Ident@63..67 "test"
     Whitespace@67..68 " "
     OpenBrace@68..69 "{"
     Whitespace@69..74 "\n    "
@@ -18,8 +17,7 @@ RootNode@0..193
       ScatterKeyword@74..81 "scatter"
       Whitespace@81..82 " "
       OpenParen@82..83 "("
-      NameNode@83..84
-        Ident@83..84 "a"
+      Ident@83..84 "a"
       Whitespace@84..85 " "
       InKeyword@85..87 "in"
       LiteralArrayNode@87..97
@@ -44,8 +42,7 @@ RootNode@0..193
         PrimitiveTypeNode@109..116
           StringTypeKeyword@109..115 "String"
           Whitespace@115..116 " "
-        NameNode@116..119
-          Ident@116..119 "msg"
+        Ident@116..119 "msg"
         Whitespace@119..120 " "
         Assignment@120..121 "="
         LiteralStringNode@121..126
@@ -56,10 +53,9 @@ RootNode@0..193
         Whitespace@126..135 "\n        "
       CallStatementNode@135..154
         CallKeyword@135..139 "call"
-        QualifiedNameNode@139..142
-          Whitespace@139..140 " "
-          Ident@140..141 "x"
-          Whitespace@141..142 " "
+        Whitespace@139..140 " "
+        Ident@140..141 "x"
+        Whitespace@141..142 " "
         OpenBrace@142..143 "{"
         Whitespace@143..144 " "
         InputKeyword@144..149 "input"
@@ -72,10 +68,9 @@ RootNode@0..193
       Whitespace@154..163 "\n        "
       CallStatementNode@163..184
         CallKeyword@163..167 "call"
-        QualifiedNameNode@167..170
-          Whitespace@167..168 " "
-          Ident@168..169 "y"
-          Whitespace@169..170 " "
+        Whitespace@167..168 " "
+        Ident@168..169 "y"
+        Whitespace@169..170 " "
         OpenBrace@170..171 "{"
         Whitespace@171..172 " "
         InputKeyword@172..177 "input"

--- a/wdl-grammar/tests/parsing/struct-definitions/source.tree
+++ b/wdl-grammar/tests/parsing/struct-definitions/source.tree
@@ -10,9 +10,8 @@ RootNode@0..1134
   Whitespace@81..82 "\n"
   StructDefinitionNode@82..97
     StructKeyword@82..88 "struct"
-    NameNode@88..94
-      Whitespace@88..89 " "
-      Ident@89..94 "Empty"
+    Whitespace@88..89 " "
+    Ident@89..94 "Empty"
     Whitespace@94..95 " "
     OpenBrace@95..96 "{"
     CloseBrace@96..97 "}"
@@ -21,9 +20,8 @@ RootNode@0..1134
   Whitespace@140..141 "\n"
   StructDefinitionNode@141..373
     StructKeyword@141..147 "struct"
-    NameNode@147..162
-      Whitespace@147..148 " "
-      Ident@148..162 "PrimitiveTypes"
+    Whitespace@147..148 " "
+    Ident@148..162 "PrimitiveTypes"
     Whitespace@162..163 " "
     OpenBrace@163..164 "{"
     Whitespace@164..169 "\n    "
@@ -108,9 +106,8 @@ RootNode@0..1134
   Whitespace@414..415 "\n"
   StructDefinitionNode@415..1133
     StructKeyword@415..421 "struct"
-    NameNode@421..434
-      Whitespace@421..422 " "
-      Ident@422..434 "ComplexTypes"
+    Whitespace@421..422 " "
+    Ident@422..434 "ComplexTypes"
     Whitespace@434..435 " "
     OpenBrace@435..436 "{"
     Whitespace@436..441 "\n    "

--- a/wdl-grammar/tests/parsing/struct-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/struct-recovery/source.tree
@@ -8,9 +8,8 @@ RootNode@0..223
   Whitespace@84..86 "\n\n"
   StructDefinitionNode@86..222
     StructKeyword@86..92 "struct"
-    NameNode@92..101
-      Whitespace@92..93 " "
-      Ident@93..101 "MyStruct"
+    Whitespace@92..93 " "
+    Ident@93..101 "MyStruct"
     Whitespace@101..102 " "
     OpenBrace@102..103 "{"
     Whitespace@103..108 "\n    "

--- a/wdl-grammar/tests/parsing/top-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/top-recovery/source.tree
@@ -8,9 +8,8 @@ RootNode@0..120
   Whitespace@57..59 "\n\n"
   StructDefinitionNode@59..84
     StructKeyword@59..65 "struct"
-    NameNode@65..67
-      Whitespace@65..66 " "
-      Ident@66..67 "A"
+    Whitespace@65..66 " "
+    Ident@66..67 "A"
     Whitespace@67..68 " "
     OpenBrace@68..69 "{"
     Whitespace@69..74 "\n    "
@@ -32,9 +31,8 @@ RootNode@0..120
   Whitespace@95..97 "\n\n"
   StructDefinitionNode@97..119
     StructKeyword@97..103 "struct"
-    NameNode@103..105
-      Whitespace@103..104 " "
-      Ident@104..105 "B"
+    Whitespace@103..104 " "
+    Ident@104..105 "B"
     Whitespace@105..106 " "
     OpenBrace@106..107 "{"
     Whitespace@107..112 "\n    "

--- a/wdl-grammar/tests/parsing/unbound-decl-in-output/source.tree
+++ b/wdl-grammar/tests/parsing/unbound-decl-in-output/source.tree
@@ -8,9 +8,8 @@ RootNode@0..167
   Whitespace@83..85 "\n\n"
   TaskDefinitionNode@85..166
     TaskKeyword@85..89 "task"
-    NameNode@89..94
-      Whitespace@89..90 " "
-      Ident@90..94 "test"
+    Whitespace@89..90 " "
+    Ident@90..94 "test"
     Whitespace@94..95 " "
     OpenBrace@95..96 "{"
     Whitespace@96..101 "\n    "
@@ -24,8 +23,7 @@ RootNode@0..167
       PrimitiveTypeNode@150..157
         StringTypeKeyword@150..156 "String"
         Whitespace@156..157 " "
-      NameNode@157..158
-        Ident@157..158 "x"
+      Ident@157..158 "x"
       Whitespace@158..163 "\n    "
       CloseBrace@163..164 "}"
     Whitespace@164..165 "\n"

--- a/wdl-grammar/tests/parsing/unterminated-metadata-string/source.tree
+++ b/wdl-grammar/tests/parsing/unterminated-metadata-string/source.tree
@@ -7,9 +7,8 @@ RootNode@0..123
     Version@62..65 "1.1"
   Whitespace@65..67 "\n\n"
   TaskKeyword@67..71 "task"
-  NameNode@71..76
-    Whitespace@71..72 " "
-    Ident@72..76 "test"
+  Whitespace@71..72 " "
+  Ident@72..76 "test"
   Whitespace@76..77 " "
   OpenBrace@77..78 "{"
   Whitespace@78..83 "\n    "


### PR DESCRIPTION
The experimental parser is too strict regarding reserved names in the parse, specifically in metadata and parameter metadata sections, where keys are allowed to be reserved names.

This commit fixes the parser to accept reserved names in addition to identifiers; the places where reserved names are not allowed will be checked during (forthcoming) validation of the tree instead.

This also fixes the incorrect recovery in metadata sections which might cause an infinite loop: the recovery was incorrectly set to recover at a value instead of any identifier, which meant that recovery would move to a token that would immediately fail, recovery would then not move, and the cycle would repeat.

Added tests for both problems.

Additionally the `NameNode` and `QualifiedNameNode` nodes have been removed from the tree in favor of simply looking for "any identifier token child" in the forthcoming AST.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
