### PR TITLE
fix: fix empty call inputs.

### DIFF
--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed parsing of empty inputs to a task call statement in the
+  experimental parser ([#54](https://github.com/stjude-rust-labs/wdl/pull/54)).
 * Fixed parsing of postfix `+` qualifier on array types in the experimental 
   parser ([#53](https://github.com/stjude-rust-labs/wdl/pull/53)).
 * Fixed parsing of placeholder options in the experimental parser such

--- a/wdl-grammar/tests/parsing/empty-call/source.tree
+++ b/wdl-grammar/tests/parsing/empty-call/source.tree
@@ -1,0 +1,27 @@
+RootNode@0..81
+  Comment@0..34 "# This is a test of a ..."
+  Whitespace@34..36 "\n\n"
+  VersionStatementNode@36..47
+    VersionKeyword@36..43 "version"
+    Whitespace@43..44 " "
+    Version@44..47 "1.1"
+  Whitespace@47..49 "\n\n"
+  WorkflowDefinitionNode@49..81
+    WorkflowKeyword@49..57 "workflow"
+    NameNode@57..62
+      Whitespace@57..58 " "
+      Ident@58..62 "test"
+    Whitespace@62..63 " "
+    OpenBrace@63..64 "{"
+    Whitespace@64..69 "\n    "
+    CallStatementNode@69..79
+      CallKeyword@69..73 "call"
+      QualifiedNameNode@73..76
+        Whitespace@73..74 " "
+        Ident@74..75 "x"
+        Whitespace@75..76 " "
+      OpenBrace@76..77 "{"
+      Whitespace@77..78 " "
+      CloseBrace@78..79 "}"
+    Whitespace@79..80 "\n"
+    CloseBrace@80..81 "}"

--- a/wdl-grammar/tests/parsing/empty-call/source.wdl
+++ b/wdl-grammar/tests/parsing/empty-call/source.wdl
@@ -1,0 +1,7 @@
+# This is a test of an empty call.
+
+version 1.1
+
+workflow test {
+    call x { }
+}

--- a/wdl-grammar/tests/parsing/mismatched-brace/source.errors
+++ b/wdl-grammar/tests/parsing/mismatched-brace/source.errors
@@ -3,7 +3,7 @@
  4 │ 
  5 │ task test {
    ·           ┬
-   ·           ╰── this brace is not matched
+   ·           ╰── this `{` is not matched
  6 │     meta {
  7 │     }
    ╰────

--- a/wdl-grammar/tests/parsing/mismatched-bracket/source.errors
+++ b/wdl-grammar/tests/parsing/mismatched-bracket/source.errors
@@ -1,9 +1,9 @@
   × expected `]`, but found identifier
-   ╭─[tests/parsing/mismatched-bracket/source.wdl:7:8]
+   ╭─[tests/parsing/mismatched-bracket/source.wdl:7:32]
  6 │     Map[String, String] x
  7 │     Map[Boolean, Array[String] y
    ·        ┬                       ┬
    ·        │                       ╰── unexpected identifier
-   ·        ╰── this bracket is not matched
+   ·        ╰── this `[` is not matched
  8 │     String z
    ╰────

--- a/wdl-grammar/tests/parsing/unterminated-metadata-string/source.errors
+++ b/wdl-grammar/tests/parsing/unterminated-metadata-string/source.errors
@@ -11,7 +11,7 @@
  5 │ task test {
  6 │     meta {
    ·          ┬
-   ·          ╰── this brace is not matched
+   ·          ╰── this `{` is not matched
  7 │         a: 'unterminated
  8 │     }
  9 │ }
@@ -21,7 +21,7 @@
  4 │ 
  5 │ task test {
    ·           ┬
-   ·           ╰── this brace is not matched
+   ·           ╰── this `{` is not matched
  6 │     meta {
  7 │         a: 'unterminated
  8 │     }


### PR DESCRIPTION
This commit fixes the experimental parser to allow for empty braces following a task call expression.

Additionally, it refactors the "matched" token utility functions and the expected error variants.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
