### PR TITLE
fix: accept multiple placeholder options in experimental parser.

### DIFF
--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the experimental parser to accept multiple placeholder options
+  ([#57](https://github.com/stjude-rust-labs/wdl/pull/57)).
 * Fixed recovery in the experimental parser to move past interpolations in
   strings and commands ([#56](https://github.com/stjude-rust-labs/wdl/pull/56)).
 * Fixed parsing of reserved identifiers and recovery in metadata sections

--- a/wdl-grammar/tests/parsing/interpolation/source.tree
+++ b/wdl-grammar/tests/parsing/interpolation/source.tree
@@ -154,8 +154,8 @@ RootNode@0..472
               DoubleQuote@298..299 "\""
               LiteralStringText@299..300 " "
               DoubleQuote@300..301 "\""
-          LiteralArrayNode@301..311
-            Whitespace@301..302 " "
+          Whitespace@301..302 " "
+          LiteralArrayNode@302..311
             OpenBracket@302..303 "["
             LiteralIntegerNode@303..304
               Integer@303..304 "1"
@@ -190,11 +190,11 @@ RootNode@0..472
               DoubleQuote@340..341 "\""
               LiteralStringText@341..344 "n/a"
               DoubleQuote@344..345 "\""
-          AdditionExprNode@345..353
-            DivisionExprNode@345..351
-              MultiplicationExprNode@345..349
-                LiteralIntegerNode@345..347
-                  Whitespace@345..346 " "
+          Whitespace@345..346 " "
+          AdditionExprNode@346..353
+            DivisionExprNode@346..351
+              MultiplicationExprNode@346..349
+                LiteralIntegerNode@346..347
                   Integer@346..347 "1"
                 Asterisk@347..348 "*"
                 LiteralIntegerNode@348..349
@@ -234,8 +234,8 @@ RootNode@0..472
               DoubleQuote@393..394 "\""
               LiteralStringText@394..398 "true"
               DoubleQuote@398..399 "\""
-          LiteralBooleanNode@399..405
-            Whitespace@399..400 " "
+          Whitespace@399..400 " "
+          LiteralBooleanNode@400..405
             FalseKeyword@400..405 "false"
           CloseBrace@405..406 "}"
         DoubleQuote@406..407 "\""

--- a/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.tree
+++ b/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.tree
@@ -1,0 +1,72 @@
+RootNode@0..156
+  Comment@0..58 "# This is a test of a ..."
+  Whitespace@58..60 "\n\n"
+  VersionStatementNode@60..71
+    VersionKeyword@60..67 "version"
+    Whitespace@67..68 " "
+    Version@68..71 "1.1"
+  Whitespace@71..73 "\n\n"
+  TaskDefinitionNode@73..155
+    TaskKeyword@73..77 "task"
+    Whitespace@77..78 " "
+    Ident@78..82 "test"
+    Whitespace@82..83 " "
+    OpenBrace@83..84 "{"
+    Whitespace@84..89 "\n    "
+    BoundDeclNode@89..154
+      PrimitiveTypeNode@89..96
+        StringTypeKeyword@89..95 "String"
+        Whitespace@95..96 " "
+      Ident@96..97 "x"
+      Whitespace@97..98 " "
+      Assignment@98..99 "="
+      LiteralStringNode@99..153
+        Whitespace@99..100 " "
+        DoubleQuote@100..101 "\""
+        PlaceholderNode@101..152
+          PlaceholderOpen@101..103 "~{"
+          PlaceholderSepOptionNode@103..113
+            Ident@103..106 "sep"
+            Whitespace@106..107 " "
+            Assignment@107..108 "="
+            LiteralStringNode@108..113
+              Whitespace@108..109 " "
+              DoubleQuote@109..110 "\""
+              LiteralStringText@110..112 ", "
+              DoubleQuote@112..113 "\""
+          PlaceholderDefaultOptionNode@113..126
+            Whitespace@113..114 " "
+            Ident@114..121 "default"
+            Whitespace@121..122 " "
+            Assignment@122..123 "="
+            LiteralStringNode@123..126
+              Whitespace@123..124 " "
+              DoubleQuote@124..125 "\""
+              DoubleQuote@125..126 "\""
+          PlaceholderTrueFalseOptionNode@126..149
+            Whitespace@126..127 " "
+            TrueKeyword@127..131 "true"
+            Whitespace@131..132 " "
+            Assignment@132..133 "="
+            LiteralStringNode@133..137
+              Whitespace@133..134 " "
+              DoubleQuote@134..135 "\""
+              LiteralStringText@135..136 "Y"
+              DoubleQuote@136..137 "\""
+            Whitespace@137..138 " "
+            FalseKeyword@138..143 "false"
+            Whitespace@143..144 " "
+            Assignment@144..145 "="
+            LiteralStringNode@145..149
+              Whitespace@145..146 " "
+              DoubleQuote@146..147 "\""
+              LiteralStringText@147..148 "N"
+              DoubleQuote@148..149 "\""
+          Whitespace@149..150 " "
+          NameReferenceNode@150..151
+            Ident@150..151 "v"
+          CloseBrace@151..152 "}"
+        DoubleQuote@152..153 "\""
+      Whitespace@153..154 "\n"
+    CloseBrace@154..155 "}"
+  Whitespace@155..156 "\n"

--- a/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.wdl
+++ b/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.wdl
@@ -1,0 +1,7 @@
+# This is a test of accepting multiple placeholder options
+
+version 1.1
+
+task test {
+    String x = "~{sep = ", " default = "" true = "Y" false = "N" v}"
+}


### PR DESCRIPTION
This commit changes the experimental parser to accept multiple placeholder options instead of just one.

We will later validate during a validation pass that there is at most one placeholder option specified, but we should accept multiple options in the grammar.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
