### PR TITLE
fix: treat `None` as a literal expression in the experimental parser.

### DIFF
--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed handling of `None` literal values in expressions in the experimental
+  parser ([#58](https://github.com/stjude-rust-labs/wdl/pull/58)).
 * Fixed the experimental parser to accept multiple placeholder options
   ([#57](https://github.com/stjude-rust-labs/wdl/pull/57)).
 * Fixed recovery in the experimental parser to move past interpolations in

--- a/wdl-grammar/src/experimental/grammar/v1.rs
+++ b/wdl-grammar/src/experimental/grammar/v1.rs
@@ -264,7 +264,6 @@ const ANY_IDENT: TokenSet = TokenSet::new(&[
     Token::FloatTypeKeyword as u8,
     Token::IntTypeKeyword as u8,
     Token::MapTypeKeyword as u8,
-    Token::NoneTypeKeyword as u8,
     Token::ObjectTypeKeyword as u8,
     Token::PairTypeKeyword as u8,
     Token::StringTypeKeyword as u8,
@@ -280,6 +279,7 @@ const ANY_IDENT: TokenSet = TokenSet::new(&[
     Token::ImportKeyword as u8,
     Token::InputKeyword as u8,
     Token::MetaKeyword as u8,
+    Token::NoneKeyword as u8,
     Token::NullKeyword as u8,
     Token::ObjectKeyword as u8,
     Token::OutputKeyword as u8,
@@ -1012,6 +1012,12 @@ fn metadata_value(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker
     }
 }
 
+/// Parses a literal `None` value.
+fn none(parser: &mut Parser<'_>, marker: Marker) -> Result<CompletedMarker, (Marker, Error)> {
+    parser.require(Token::NoneKeyword);
+    Ok(marker.complete(parser, SyntaxKind::LiteralNoneNode))
+}
+
 /// Parses a number.
 fn number(
     parser: &mut Parser<'_>,
@@ -1665,6 +1671,7 @@ fn atom_expr(
     peeked: Token,
 ) -> Result<CompletedMarker, (Marker, Error)> {
     match peeked {
+        Token::NoneKeyword => none(parser, marker),
         Token::Float | Token::Integer => number(parser, marker, false),
         Token::TrueKeyword | Token::FalseKeyword => boolean(parser, marker),
         Token::SQStringStart => single_quote_string(parser, marker, true),

--- a/wdl-grammar/src/experimental/lexer/v1.rs
+++ b/wdl-grammar/src/experimental/lexer/v1.rs
@@ -268,9 +268,6 @@ pub enum Token {
     /// The `Map` type keyword.
     #[token("Map")]
     MapTypeKeyword,
-    /// The `None` type keyword.
-    #[token("None")]
-    NoneTypeKeyword,
     /// The `Object` type keyword.
     #[token("Object")]
     ObjectTypeKeyword,
@@ -316,6 +313,9 @@ pub enum Token {
     /// The `meta` keyword.
     #[token("meta")]
     MetaKeyword,
+    /// The `None` keyword.
+    #[token("None")]
+    NoneKeyword,
     /// The `null` keyword.
     #[token("null")]
     NullKeyword,
@@ -465,7 +465,6 @@ impl<'a> ParserToken<'a> for Token {
             Self::FloatTypeKeyword => SyntaxKind::FloatTypeKeyword,
             Self::IntTypeKeyword => SyntaxKind::IntTypeKeyword,
             Self::MapTypeKeyword => SyntaxKind::MapTypeKeyword,
-            Self::NoneTypeKeyword => SyntaxKind::NoneTypeKeyword,
             Self::ObjectTypeKeyword => SyntaxKind::ObjectTypeKeyword,
             Self::PairTypeKeyword => SyntaxKind::PairTypeKeyword,
             Self::StringTypeKeyword => SyntaxKind::StringTypeKeyword,
@@ -481,6 +480,7 @@ impl<'a> ParserToken<'a> for Token {
             Self::ImportKeyword => SyntaxKind::ImportKeyword,
             Self::InputKeyword => SyntaxKind::InputKeyword,
             Self::MetaKeyword => SyntaxKind::MetaKeyword,
+            Self::NoneKeyword => SyntaxKind::NoneKeyword,
             Self::NullKeyword => SyntaxKind::NullKeyword,
             Self::ObjectKeyword => SyntaxKind::ObjectKeyword,
             Self::OutputKeyword => SyntaxKind::OutputKeyword,
@@ -551,7 +551,6 @@ impl<'a> ParserToken<'a> for Token {
             Self::FloatTypeKeyword => "`Float` keyword",
             Self::IntTypeKeyword => "`Int` keyword",
             Self::MapTypeKeyword => "`Map` keyword",
-            Self::NoneTypeKeyword => "`None` keyword",
             Self::ObjectTypeKeyword => "`Object` keyword",
             Self::PairTypeKeyword => "`Pair` keyword",
             Self::StringTypeKeyword => "`String` keyword",
@@ -567,6 +566,7 @@ impl<'a> ParserToken<'a> for Token {
             Self::ImportKeyword => "`import` keyword",
             Self::InputKeyword => "`input` keyword",
             Self::MetaKeyword => "`meta` keyword",
+            Self::NoneKeyword => "`None` keyword",
             Self::NullKeyword => "`null` keyword",
             Self::ObjectKeyword => "`object` keyword",
             Self::OutputKeyword => "`output` keyword",
@@ -1339,7 +1339,7 @@ workflow"#,
                 (Ok(Whitespace), 29..30),
                 (Ok(MapTypeKeyword), 30..33),
                 (Ok(Whitespace), 33..34),
-                (Ok(NoneTypeKeyword), 34..38),
+                (Ok(NoneKeyword), 34..38),
                 (Ok(Whitespace), 38..39),
                 (Ok(ObjectTypeKeyword), 39..45),
                 (Ok(Whitespace), 45..46),

--- a/wdl-grammar/src/experimental/tree.rs
+++ b/wdl-grammar/src/experimental/tree.rs
@@ -55,8 +55,6 @@ pub enum SyntaxKind {
     IntTypeKeyword,
     /// The `Map` type keyword token.
     MapTypeKeyword,
-    /// The `None` type keyword token.
-    NoneTypeKeyword,
     /// The `Object` type keyword token.
     ObjectTypeKeyword,
     /// The `Pair` type keyword token.
@@ -87,6 +85,8 @@ pub enum SyntaxKind {
     InputKeyword,
     /// The `meta` keyword token.
     MetaKeyword,
+    /// The `None` keyword.
+    NoneKeyword,
     /// The `null` keyword token.
     NullKeyword,
     /// The `object` keyword token.
@@ -239,6 +239,8 @@ pub enum SyntaxKind {
     LiteralFloatNode,
     /// Represents a literal boolean node.
     LiteralBooleanNode,
+    /// Represents a literal `None` node.
+    LiteralNoneNode,
     /// Represents a literal null node.
     LiteralNullNode,
     /// Represents a literal string node.

--- a/wdl-grammar/tests/parsing/atoms/source.tree
+++ b/wdl-grammar/tests/parsing/atoms/source.tree
@@ -1,4 +1,4 @@
-RootNode@0..602
+RootNode@0..649
   Comment@0..38 "# This is a test for  ..."
   Whitespace@38..40 "\n\n"
   VersionStatementNode@40..51
@@ -6,7 +6,7 @@ RootNode@0..602
     Whitespace@47..48 " "
     Version@48..51 "1.1"
   Whitespace@51..53 "\n\n"
-  TaskDefinitionNode@53..601
+  TaskDefinitionNode@53..648
     TaskKeyword@53..57 "task"
     Whitespace@57..58 " "
     Ident@58..62 "test"
@@ -384,7 +384,7 @@ RootNode@0..602
         OpenBrace@572..573 "{"
         CloseBrace@573..574 "}"
       Whitespace@574..579 "\n    "
-    BoundDeclNode@579..600
+    BoundDeclNode@579..604
       ObjectTypeNode@579..586
         ObjectTypeKeyword@579..585 "Object"
         Whitespace@585..586 " "
@@ -397,6 +397,35 @@ RootNode@0..602
         Whitespace@596..597 " "
         OpenBrace@597..598 "{"
         CloseBrace@598..599 "}"
-      Whitespace@599..600 "\n"
-    CloseBrace@600..601 "}"
-  Whitespace@601..602 "\n"
+      Whitespace@599..604 "\n    "
+    BoundDeclNode@604..625
+      PrimitiveTypeNode@604..611
+        StringTypeKeyword@604..610 "String"
+        QuestionMark@610..611 "?"
+      Whitespace@611..612 " "
+      Ident@612..613 "r"
+      Whitespace@613..614 " "
+      Assignment@614..615 "="
+      LiteralNoneNode@615..620
+        Whitespace@615..616 " "
+        NoneKeyword@616..620 "None"
+      Whitespace@620..625 "\n    "
+    BoundDeclNode@625..647
+      PrimitiveTypeNode@625..633
+        BooleanTypeKeyword@625..632 "Boolean"
+        Whitespace@632..633 " "
+      Ident@633..634 "s"
+      Whitespace@634..635 " "
+      Assignment@635..636 "="
+      EqualityExprNode@636..647
+        NameReferenceNode@636..639
+          Whitespace@636..637 " "
+          Ident@637..638 "r"
+          Whitespace@638..639 " "
+        Equal@639..641 "=="
+        LiteralNoneNode@641..646
+          Whitespace@641..642 " "
+          NoneKeyword@642..646 "None"
+        Whitespace@646..647 "\n"
+    CloseBrace@647..648 "}"
+  Whitespace@648..649 "\n"

--- a/wdl-grammar/tests/parsing/atoms/source.wdl
+++ b/wdl-grammar/tests/parsing/atoms/source.wdl
@@ -20,4 +20,6 @@ task test {
     Map[String, String] o = {}
     Foo p = Foo {}
     Object q = object {}
+    String? r = None
+    Boolean s = r == None
 }


### PR DESCRIPTION
This commit treats `None` as a literal `None` value in expressions, rather than a name reference; this distinguishes `None` as a special value.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
