### PR TITLE
fix: skip remaining source for unsupported versions.

### DIFF
--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the experimental parser to skip parsing if it cannot find a supported
+  version statement ([#59](https://github.com/stjude-rust-labs/wdl/pull/59))
 * Fixed handling of `None` literal values in expressions in the experimental
   parser ([#58](https://github.com/stjude-rust-labs/wdl/pull/58)).
 * Fixed the experimental parser to accept multiple placeholder options

--- a/wdl-grammar/src/experimental/lexer.rs
+++ b/wdl-grammar/src/experimental/lexer.rs
@@ -325,6 +325,30 @@ where
             peeked: None,
         }
     }
+
+    /// Consumes the remainder of the source, returning the span
+    /// of the consumed text.
+    pub fn consume_remainder(&mut self) -> Option<SourceSpan> {
+        // Reset the lexer if we've peeked
+        if let Some(peeked) = self.peeked.take() {
+            self.lexer = T::lexer(self.lexer.source());
+            if peeked.offset > 0 {
+                self.lexer.bump(peeked.offset);
+                self.lexer.next();
+            }
+        }
+
+        // Bump the remaining source
+        self.lexer.next();
+        self.lexer.bump(self.lexer.remainder().len());
+        let span = self.lexer.span();
+        assert!(self.next().is_none(), "lexer should be completed");
+        if span.is_empty() {
+            None
+        } else {
+            Some(to_source_span(span))
+        }
+    }
 }
 
 impl<'a, T> Iterator for Lexer<'a, T>

--- a/wdl-grammar/src/experimental/parser.rs
+++ b/wdl-grammar/src/experimental/parser.rs
@@ -761,6 +761,25 @@ where
         }
     }
 
+    /// Consumes the remainder of the unparsed source into a special
+    /// "unparsed" token.
+    ///
+    /// This occurs when a source file is missing a version statement or
+    /// if the version specified is unsupported.
+    pub fn consume_remainder(&mut self) {
+        if let Some(span) = self
+            .lexer
+            .as_mut()
+            .expect("there should be a lexer")
+            .consume_remainder()
+        {
+            self.events.push(Event::Token {
+                kind: SyntaxKind::Unparsed,
+                span,
+            });
+        }
+    }
+
     /// Consumes any trivia tokens by adding them to the event list.
     fn consume_trivia(
         &mut self,

--- a/wdl-grammar/src/experimental/tree.rs
+++ b/wdl-grammar/src/experimental/tree.rs
@@ -23,6 +23,10 @@ use crate::experimental::parser::Parser;
 pub enum SyntaxKind {
     /// The token is unknown to WDL.
     Unknown,
+    /// The token represents unparsed source.
+    ///
+    /// Unparsed source occurs in WDL source files with unsupported versions.
+    Unparsed,
     /// A whitespace token.
     Whitespace,
     /// A comment token.

--- a/wdl-grammar/tests/parsing/missing-version/source.tree
+++ b/wdl-grammar/tests/parsing/missing-version/source.tree
@@ -1,12 +1,4 @@
 RootNode@0..64
   Comment@0..48 "# This is a test of a ..."
   Whitespace@48..50 "\n\n"
-  TaskDefinitionNode@50..63
-    TaskKeyword@50..54 "task"
-    Whitespace@54..55 " "
-    Ident@55..58 "foo"
-    Whitespace@58..59 " "
-    OpenBrace@59..60 "{"
-    Whitespace@60..62 "\n\n"
-    CloseBrace@62..63 "}"
-  Whitespace@63..64 "\n"
+  Unparsed@50..64 "task foo {\n\n}\n"

--- a/wdl-grammar/tests/parsing/unsupported-version/source.errors
+++ b/wdl-grammar/tests/parsing/unsupported-version/source.errors
@@ -4,4 +4,5 @@
  3 │ version 100000.0
    ·         ────┬───
    ·             ╰── this version of WDL is not supported
+ 4 │ 
    ╰────

--- a/wdl-grammar/tests/parsing/unsupported-version/source.tree
+++ b/wdl-grammar/tests/parsing/unsupported-version/source.tree
@@ -1,8 +1,8 @@
-RootNode@0..63
+RootNode@0..78
   Comment@0..44 "# This is a test for  ..."
   Whitespace@44..46 "\n\n"
   VersionStatementNode@46..62
     VersionKeyword@46..53 "version"
     Whitespace@53..54 " "
     Version@54..62 "100000.0"
-  Whitespace@62..63 "\n"
+  Unparsed@62..78 "\n\ntask test {\n}\n"

--- a/wdl-grammar/tests/parsing/unsupported-version/source.wdl
+++ b/wdl-grammar/tests/parsing/unsupported-version/source.wdl
@@ -1,3 +1,6 @@
 # This is a test for an unsupported version.
 
 version 100000.0
+
+task test {
+}


### PR DESCRIPTION
This commit fixes the experimental parser such that it will skip the remaining source if it encounters a missing or unsupported WDL version.

Now it emits a single error and adds a special "unparsed" token representing the remainder of the file.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
