### PR TITLE
feat: add `parent` method to AST sections.

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `parent` method to section representations in the experimental AST
+  ([#70](https://github.com/stjude-rust-labs/wdl/pull/70)).
 * Added validation rules for the experimental AST ([#65](https://github.com/stjude-rust-labs/wdl/pull/65)).
 * Added a new experimental AST for the experimental parser; this implementation
   is currently feature-gated behind the `experimental` feature ([#64](https://github.com/stjude-rust-labs/wdl/pull/64)).

--- a/wdl-ast/src/experimental.rs
+++ b/wdl-ast/src/experimental.rs
@@ -15,8 +15,9 @@
 
 use std::sync::Arc;
 
-use rowan::ast::support::child;
-use rowan::ast::AstNode;
+pub use rowan::ast::support;
+pub use rowan::ast::AstChildren;
+pub use rowan::ast::AstNode;
 pub use wdl_grammar::experimental::Diagnostic;
 pub use wdl_grammar::experimental::Label;
 pub use wdl_grammar::experimental::Severity;
@@ -226,7 +227,7 @@ impl Document {
     ///
     /// A return value of `None` signifies a missing version statement.
     pub fn version_statement(&self) -> Option<VersionStatement> {
-        child(&self.0)
+        support::child(&self.0)
     }
 
     /// Gets the AST representation of the document.

--- a/wdl-ast/src/experimental/v1.rs
+++ b/wdl-ast/src/experimental/v1.rs
@@ -1,9 +1,8 @@
 //! AST representation for a 1.x WDL document.
 
-use rowan::ast::support::children;
-use rowan::ast::AstChildren;
-use rowan::ast::AstNode;
-
+use crate::experimental::support::children;
+use crate::experimental::AstChildren;
+use crate::experimental::AstNode;
 use crate::experimental::SyntaxKind;
 use crate::experimental::SyntaxNode;
 use crate::experimental::WorkflowDescriptionLanguage;

--- a/wdl-ast/src/experimental/v1/decls.rs
+++ b/wdl-ast/src/experimental/v1/decls.rs
@@ -2,12 +2,11 @@
 
 use std::fmt;
 
-use rowan::ast::support;
-use rowan::ast::support::child;
-use rowan::ast::AstNode;
-
 use super::Expr;
+use crate::experimental::support;
+use crate::experimental::support::child;
 use crate::experimental::token;
+use crate::experimental::AstNode;
 use crate::experimental::AstToken;
 use crate::experimental::Ident;
 use crate::experimental::SyntaxKind;

--- a/wdl-ast/src/experimental/v1/expr.rs
+++ b/wdl-ast/src/experimental/v1/expr.rs
@@ -1,12 +1,11 @@
 //! V1 AST representation for expressions.
 
-use rowan::ast::support;
-use rowan::ast::support::child;
-use rowan::ast::support::children;
-use rowan::ast::AstChildren;
-use rowan::ast::AstNode;
-
+use crate::experimental::support;
+use crate::experimental::support::child;
+use crate::experimental::support::children;
 use crate::experimental::token;
+use crate::experimental::AstChildren;
+use crate::experimental::AstNode;
 use crate::experimental::AstToken;
 use crate::experimental::Ident;
 use crate::experimental::SyntaxElement;

--- a/wdl-ast/src/experimental/v1/import.rs
+++ b/wdl-ast/src/experimental/v1/import.rs
@@ -1,12 +1,11 @@
 //! V1 AST representation for import statements.
 
-use rowan::ast::support::child;
-use rowan::ast::support::children;
-use rowan::ast::AstChildren;
-use rowan::ast::AstNode;
-
 use super::LiteralString;
+use crate::experimental::support::child;
+use crate::experimental::support::children;
 use crate::experimental::token;
+use crate::experimental::AstChildren;
+use crate::experimental::AstNode;
 use crate::experimental::AstToken;
 use crate::experimental::Ident;
 use crate::experimental::SyntaxElement;

--- a/wdl-ast/src/experimental/v1/struct.rs
+++ b/wdl-ast/src/experimental/v1/struct.rs
@@ -1,11 +1,10 @@
 //! V1 AST representation for struct definitions.
 
-use rowan::ast::support::children;
-use rowan::ast::AstChildren;
-use rowan::ast::AstNode;
-
 use super::UnboundDecl;
+use crate::experimental::support::children;
 use crate::experimental::token;
+use crate::experimental::AstChildren;
+use crate::experimental::AstNode;
 use crate::experimental::Ident;
 use crate::experimental::SyntaxKind;
 use crate::experimental::SyntaxNode;

--- a/wdl-ast/src/experimental/v1/task.rs
+++ b/wdl-ast/src/experimental/v1/task.rs
@@ -14,6 +14,7 @@ use super::LiteralFloat;
 use super::LiteralInteger;
 use super::LiteralString;
 use super::Placeholder;
+use super::WorkflowDefinition;
 use crate::experimental::token;
 use crate::experimental::AstToken;
 use crate::experimental::Ident;
@@ -168,6 +169,73 @@ impl AstNode for TaskItem {
     }
 }
 
+/// Represents either a task or a workflow.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TaskOrWorkflow {
+    /// The item is a task.
+    Task(TaskDefinition),
+    /// The item is a workflow.
+    Workflow(WorkflowDefinition),
+}
+
+impl TaskOrWorkflow {
+    /// Unwraps to a task definition.
+    ///
+    /// # Panics
+    ///
+    /// Panics if it is not a task definition.
+    pub fn unwrap_task(self) -> TaskDefinition {
+        match self {
+            Self::Task(task) => task,
+            _ => panic!("not a task definition"),
+        }
+    }
+
+    /// Unwraps to a workflow definition.
+    ///
+    /// # Panics
+    ///
+    /// Panics if it is not a workflow definition.
+    pub fn unwrap_workflow(self) -> WorkflowDefinition {
+        match self {
+            Self::Workflow(workflow) => workflow,
+            _ => panic!("not a workflow definition"),
+        }
+    }
+}
+
+impl AstNode for TaskOrWorkflow {
+    type Language = WorkflowDescriptionLanguage;
+
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        matches!(
+            kind,
+            SyntaxKind::TaskDefinitionNode | SyntaxKind::WorkflowDefinitionNode
+        )
+    }
+
+    fn cast(node: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match node.kind() {
+            SyntaxKind::TaskDefinitionNode => Some(Self::Task(TaskDefinition(node))),
+            SyntaxKind::WorkflowDefinitionNode => Some(Self::Workflow(WorkflowDefinition(node))),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            Self::Task(t) => &t.0,
+            Self::Workflow(w) => &w.0,
+        }
+    }
+}
+
 /// Represents an input section in a task or workflow definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InputSection(pub(super) SyntaxNode);
@@ -176,6 +244,12 @@ impl InputSection {
     /// Gets the declarations of the input section.
     pub fn declarations(&self) -> AstChildren<Decl> {
         children(&self.0)
+    }
+
+    /// Gets the parent of the input section.
+    pub fn parent(&self) -> TaskOrWorkflow {
+        TaskOrWorkflow::cast(self.0.parent().expect("should have a parent"))
+            .expect("parent should cast")
     }
 }
 
@@ -212,6 +286,12 @@ impl OutputSection {
     /// Gets the declarations of the output section.
     pub fn declarations(&self) -> AstChildren<BoundDecl> {
         children(&self.0)
+    }
+
+    /// Gets the parent of the output section.
+    pub fn parent(&self) -> TaskOrWorkflow {
+        TaskOrWorkflow::cast(self.0.parent().expect("should have a parent"))
+            .expect("parent should cast")
     }
 }
 
@@ -270,6 +350,12 @@ impl CommandSection {
         }
 
         None
+    }
+
+    /// Gets the parent of the command section.
+    pub fn parent(&self) -> TaskDefinition {
+        TaskDefinition::cast(self.0.parent().expect("should have a parent"))
+            .expect("parent should cast")
     }
 }
 
@@ -377,6 +463,12 @@ impl RuntimeSection {
     pub fn items(&self) -> AstChildren<RuntimeItem> {
         children(&self.0)
     }
+
+    /// Gets the parent of the runtime section.
+    pub fn parent(&self) -> TaskDefinition {
+        TaskDefinition::cast(self.0.parent().expect("should have a parent"))
+            .expect("parent should cast")
+    }
 }
 
 impl AstNode for RuntimeSection {
@@ -453,6 +545,12 @@ impl MetadataSection {
     /// Gets the items of the metadata section.
     pub fn items(&self) -> AstChildren<MetadataObjectItem> {
         children(&self.0)
+    }
+
+    /// Gets the parent of the metadata section.
+    pub fn parent(&self) -> TaskOrWorkflow {
+        TaskOrWorkflow::cast(self.0.parent().expect("should have a parent"))
+            .expect("parent should cast")
     }
 }
 
@@ -785,6 +883,12 @@ impl ParameterMetadataSection {
     pub fn items(&self) -> AstChildren<MetadataObjectItem> {
         children(&self.0)
     }
+
+    /// Gets the parent of the parameter metadata section.
+    pub fn parent(&self) -> TaskOrWorkflow {
+        TaskOrWorkflow::cast(self.0.parent().expect("should have a parent"))
+            .expect("parent should cast")
+    }
 }
 
 impl AstNode for ParameterMetadataSection {
@@ -871,6 +975,7 @@ task test {
         assert_eq!(inputs.len(), 1);
 
         // First task input
+        assert_eq!(inputs[0].parent().unwrap_task().name().as_str(), "test");
         let decls: Vec<_> = inputs[0].declarations().collect();
         assert_eq!(decls.len(), 1);
         assert_eq!(
@@ -887,6 +992,7 @@ task test {
         assert_eq!(outputs.len(), 1);
 
         // First task output
+        assert_eq!(outputs[0].parent().unwrap_task().name().as_str(), "test");
         let decls: Vec<_> = outputs[0].declarations().collect();
         assert_eq!(decls.len(), 1);
         assert_eq!(decls[0].ty().to_string(), "String");
@@ -907,6 +1013,7 @@ task test {
         assert_eq!(commands.len(), 1);
 
         // First task command
+        assert_eq!(commands[0].parent().name().as_str(), "test");
         assert!(commands[0].is_heredoc());
         let parts: Vec<_> = commands[0].parts().collect();
         assert_eq!(parts.len(), 3);
@@ -931,6 +1038,7 @@ task test {
         assert_eq!(runtimes.len(), 1);
 
         // First task runtime
+        assert_eq!(runtimes[0].parent().name().as_str(), "test");
         let items: Vec<_> = runtimes[0].items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "container");
@@ -950,6 +1058,7 @@ task test {
         assert_eq!(metadata.len(), 1);
 
         // First metadata
+        assert_eq!(metadata[0].parent().unwrap_task().name().as_str(), "test");
         let items: Vec<_> = metadata[0].items().collect();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].name().as_str(), "description");
@@ -967,6 +1076,7 @@ task test {
         assert_eq!(param_meta.len(), 1);
 
         // First task parameter metadata
+        assert_eq!(param_meta[0].parent().unwrap_task().name().as_str(), "test");
         let items: Vec<_> = param_meta[0].items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "name");

--- a/wdl-ast/src/experimental/v1/task.rs
+++ b/wdl-ast/src/experimental/v1/task.rs
@@ -1,11 +1,5 @@
 //! V1 AST representation for task definitions.
 
-use rowan::ast::support;
-use rowan::ast::support::child;
-use rowan::ast::support::children;
-use rowan::ast::AstChildren;
-use rowan::ast::AstNode;
-
 use super::BoundDecl;
 use super::Decl;
 use super::Expr;
@@ -15,7 +9,12 @@ use super::LiteralInteger;
 use super::LiteralString;
 use super::Placeholder;
 use super::WorkflowDefinition;
+use crate::experimental::support;
+use crate::experimental::support::child;
+use crate::experimental::support::children;
 use crate::experimental::token;
+use crate::experimental::AstChildren;
+use crate::experimental::AstNode;
 use crate::experimental::AstToken;
 use crate::experimental::Ident;
 use crate::experimental::SyntaxElement;

--- a/wdl-ast/src/experimental/v1/validation/counts.rs
+++ b/wdl-ast/src/experimental/v1/validation/counts.rs
@@ -13,6 +13,7 @@ use crate::experimental::v1::ParameterMetadataSection;
 use crate::experimental::v1::RuntimeSection;
 use crate::experimental::v1::StructDefinition;
 use crate::experimental::v1::TaskDefinition;
+use crate::experimental::v1::TaskOrWorkflow;
 use crate::experimental::v1::Visitor;
 use crate::experimental::v1::WorkflowDefinition;
 use crate::experimental::AstToken;
@@ -25,24 +26,6 @@ use crate::experimental::SyntaxKind;
 use crate::experimental::SyntaxNode;
 use crate::experimental::ToSpan;
 use crate::experimental::VisitReason;
-
-/// Represents context of an error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Context {
-    /// The error occurred in a task.
-    Task,
-    /// The error occurred in a workflow.
-    Workflow,
-}
-
-impl fmt::Display for Context {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Task => write!(f, "task"),
-            Self::Workflow => write!(f, "workflow"),
-        }
-    }
-}
 
 /// Represents section context of an error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -100,8 +83,7 @@ fn missing_command_section(task: Ident) -> Diagnostic {
 
 /// Creates a "duplicate section" diagnostic
 fn duplicate_section(
-    context: Context,
-    name: &str,
+    parent: TaskOrWorkflow,
     section: Section,
     first: Span,
     duplicate: &SyntaxNode,
@@ -117,8 +99,14 @@ fn duplicate_section(
 
     let token = support::token(duplicate, kind).expect("should have keyword token");
 
+    let (context, name) = match parent {
+        TaskOrWorkflow::Task(t) => ("task", t.name()),
+        TaskOrWorkflow::Workflow(w) => ("workflow", w.name()),
+    };
+
     Diagnostic::error(format!(
-        "{context} `{name}` contains a duplicate {section} section"
+        "{context} `{name}` contains a duplicate {section} section",
+        name = name.as_str()
     ))
     .with_label(
         format!("this {section} section is a duplicate"),
@@ -157,8 +145,6 @@ pub struct CountingVisitor {
     has_task: bool,
     /// Whether or not the document has at least one struct.
     has_struct: bool,
-    /// The context of the current task or workflow.
-    context: Option<(Context, String)>,
     /// The span of the first command section in the task.
     command: Option<Span>,
     /// The span of the first input section in the task or workflow.
@@ -177,7 +163,6 @@ pub struct CountingVisitor {
 impl CountingVisitor {
     /// Resets the task/workflow count state.
     fn reset(&mut self) {
-        self.context = None;
         self.command = None;
         self.input = None;
         self.output = None;
@@ -217,7 +202,6 @@ impl Visitor for CountingVisitor {
         }
 
         let name = workflow.name();
-        self.context = Some((Context::Workflow, name.as_str().to_string()));
         self.workflow = Some(name.span());
     }
 
@@ -236,7 +220,6 @@ impl Visitor for CountingVisitor {
             return;
         }
 
-        self.context = Some((Context::Task, task.name().as_str().to_string()));
         self.has_task = true;
     }
 
@@ -268,10 +251,8 @@ impl Visitor for CountingVisitor {
         }
 
         if let Some(command) = self.command {
-            let (context, name) = self.context.as_ref().expect("should have context");
             state.add(duplicate_section(
-                *context,
-                name,
+                TaskOrWorkflow::Task(section.parent()),
                 Section::Command,
                 command,
                 section.syntax(),
@@ -295,10 +276,8 @@ impl Visitor for CountingVisitor {
         }
 
         if let Some(input) = self.input {
-            let (context, name) = self.context.as_ref().expect("should have context");
             state.add(duplicate_section(
-                *context,
-                name,
+                section.parent(),
                 Section::Input,
                 input,
                 section.syntax(),
@@ -322,10 +301,8 @@ impl Visitor for CountingVisitor {
         }
 
         if let Some(output) = self.output {
-            let (context, name) = self.context.as_ref().expect("should have context");
             state.add(duplicate_section(
-                *context,
-                name,
+                section.parent(),
                 Section::Output,
                 output,
                 section.syntax(),
@@ -349,10 +326,8 @@ impl Visitor for CountingVisitor {
         }
 
         if let Some(runtime) = self.runtime {
-            let (context, name) = self.context.as_ref().expect("should have context");
             state.add(duplicate_section(
-                *context,
-                name,
+                TaskOrWorkflow::Task(section.parent()),
                 Section::Runtime,
                 runtime,
                 section.syntax(),
@@ -376,10 +351,8 @@ impl Visitor for CountingVisitor {
         }
 
         if let Some(metadata) = self.metadata {
-            let (context, name) = self.context.as_ref().expect("should have context");
             state.add(duplicate_section(
-                *context,
-                name,
+                section.parent(),
                 Section::Metadata,
                 metadata,
                 section.syntax(),
@@ -403,10 +376,8 @@ impl Visitor for CountingVisitor {
         }
 
         if let Some(metadata) = self.param_metadata {
-            let (context, name) = self.context.as_ref().expect("should have context");
             state.add(duplicate_section(
-                *context,
-                name,
+                section.parent(),
                 Section::ParameterMetadata,
                 metadata,
                 section.syntax(),

--- a/wdl-ast/src/experimental/v1/validation/counts.rs
+++ b/wdl-ast/src/experimental/v1/validation/counts.rs
@@ -2,9 +2,7 @@
 
 use std::fmt;
 
-use rowan::ast::support;
-use rowan::ast::AstNode;
-
+use crate::experimental::support;
 use crate::experimental::v1::CommandSection;
 use crate::experimental::v1::InputSection;
 use crate::experimental::v1::MetadataSection;
@@ -16,6 +14,7 @@ use crate::experimental::v1::TaskDefinition;
 use crate::experimental::v1::TaskOrWorkflow;
 use crate::experimental::v1::Visitor;
 use crate::experimental::v1::WorkflowDefinition;
+use crate::experimental::AstNode;
 use crate::experimental::AstToken;
 use crate::experimental::Diagnostic;
 use crate::experimental::Diagnostics;

--- a/wdl-ast/src/experimental/v1/validation/numbers.rs
+++ b/wdl-ast/src/experimental/v1/validation/numbers.rs
@@ -1,11 +1,10 @@
 //! Validation of number literals in a V1 AST.
 
-use rowan::ast::support;
-use rowan::ast::AstNode;
-
+use crate::experimental::support;
 use crate::experimental::v1::Expr;
 use crate::experimental::v1::LiteralExpr;
 use crate::experimental::v1::Visitor;
+use crate::experimental::AstNode;
 use crate::experimental::AstToken;
 use crate::experimental::Diagnostic;
 use crate::experimental::Diagnostics;

--- a/wdl-ast/src/experimental/v1/visitor.rs
+++ b/wdl-ast/src/experimental/v1/visitor.rs
@@ -1,6 +1,5 @@
 //! Implementation of the V1 AST visitor.
 
-use rowan::ast::AstNode;
 use rowan::WalkEvent;
 
 use super::BoundDecl;
@@ -22,6 +21,7 @@ use super::StructDefinition;
 use super::TaskDefinition;
 use super::UnboundDecl;
 use super::WorkflowDefinition;
+use crate::experimental::AstNode;
 use crate::experimental::Document;
 use crate::experimental::SyntaxKind;
 use crate::experimental::SyntaxNode;

--- a/wdl-ast/src/experimental/v1/workflow.rs
+++ b/wdl-ast/src/experimental/v1/workflow.rs
@@ -635,6 +635,7 @@ workflow test {
         assert_eq!(inputs.len(), 1);
 
         // First input declarations
+        assert_eq!(inputs[0].parent().unwrap_workflow().name().as_str(), "test");
         let decls: Vec<_> = inputs[0].declarations().collect();
         assert_eq!(decls.len(), 2);
 
@@ -663,6 +664,10 @@ workflow test {
         assert_eq!(outputs.len(), 1);
 
         // First output declarations
+        assert_eq!(
+            outputs[0].parent().unwrap_workflow().name().as_str(),
+            "test"
+        );
         let decls: Vec<_> = outputs[0].declarations().collect();
         assert_eq!(decls.len(), 1);
 
@@ -841,6 +846,10 @@ workflow test {
         assert_eq!(metadata.len(), 1);
 
         // First metadata
+        assert_eq!(
+            metadata[0].parent().unwrap_workflow().name().as_str(),
+            "test"
+        );
         let items: Vec<_> = metadata[0].items().collect();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].name().as_str(), "description");
@@ -856,6 +865,10 @@ workflow test {
         assert_eq!(param_meta.len(), 1);
 
         // First parameter metadata
+        assert_eq!(
+            param_meta[0].parent().unwrap_workflow().name().as_str(),
+            "test"
+        );
         let items: Vec<_> = param_meta[0].items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "name");

--- a/wdl-ast/src/experimental/v1/workflow.rs
+++ b/wdl-ast/src/experimental/v1/workflow.rs
@@ -1,17 +1,16 @@
 //! V1 AST representation for workflows.
 
-use rowan::ast::support::child;
-use rowan::ast::support::children;
-use rowan::ast::AstChildren;
-use rowan::ast::AstNode;
-
 use super::BoundDecl;
 use super::Expr;
 use super::InputSection;
 use super::MetadataSection;
 use super::OutputSection;
 use super::ParameterMetadataSection;
+use crate::experimental::support::child;
+use crate::experimental::support::children;
 use crate::experimental::token;
+use crate::experimental::AstChildren;
+use crate::experimental::AstNode;
 use crate::experimental::AstToken;
 use crate::experimental::Ident;
 use crate::experimental::SyntaxElement;

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Ported the `NoCurlyCommands` rule to `wdl-lint` ([#69](https://github.com/stjude-rust-labs/wdl/pull/69)).
 * Added the `wdl-lint` as the crate implementing linting rules for the future
   ([#68](https://github.com/stjude-rust-labs/wdl/pull/68)).

--- a/wdl-lint/Cargo.toml
+++ b/wdl-lint/Cargo.toml
@@ -13,7 +13,6 @@ readme = "../README.md"
 [dependencies]
 wdl-ast = { path = "../wdl-ast", version = "0.2.0", features = ["experimental"] }
 convert_case = { workspace = true }
-rowan = { workspace = true }
 
 [dev-dependencies]
 codespan-reporting = { workspace = true }

--- a/wdl-lint/src/v1/ending_newline.rs
+++ b/wdl-lint/src/v1/ending_newline.rs
@@ -1,7 +1,7 @@
 //! A lint rule for newlines at the end of the document.
 
-use rowan::ast::AstNode;
 use wdl_ast::experimental::v1::Visitor;
+use wdl_ast::experimental::AstNode;
 use wdl_ast::experimental::Diagnostic;
 use wdl_ast::experimental::Diagnostics;
 use wdl_ast::experimental::Document;

--- a/wdl-lint/src/v1/no_curly_commands.rs
+++ b/wdl-lint/src/v1/no_curly_commands.rs
@@ -4,6 +4,7 @@ use rowan::ast::support;
 use rowan::ast::AstNode;
 use wdl_ast::experimental::v1::CommandSection;
 use wdl_ast::experimental::v1::Visitor;
+use wdl_ast::experimental::AstToken;
 use wdl_ast::experimental::Diagnostic;
 use wdl_ast::experimental::Diagnostics;
 use wdl_ast::experimental::Span;
@@ -73,16 +74,14 @@ impl Visitor for NoCurlyCommandsVisitor {
         }
 
         if !section.is_heredoc() {
+            let name = section.parent().name();
             let command_keyword = support::token(section.syntax(), SyntaxKind::CommandKeyword)
                 .expect("should have a command keyword token");
-            let span = command_keyword.text_range();
 
-            let task = section
-                .syntax()
-                .parent()
-                .expect("should have a parent node");
-            let name = support::token(&task, SyntaxKind::Ident).expect("should have a task name");
-            state.add(curly_commands(name.text(), span.to_span()));
+            state.add(curly_commands(
+                name.as_str(),
+                command_keyword.text_range().to_span(),
+            ));
         }
     }
 }

--- a/wdl-lint/src/v1/no_curly_commands.rs
+++ b/wdl-lint/src/v1/no_curly_commands.rs
@@ -1,9 +1,9 @@
 //! A lint rule for ensuring no curly commands are used.
 
-use rowan::ast::support;
-use rowan::ast::AstNode;
+use wdl_ast::experimental::support;
 use wdl_ast::experimental::v1::CommandSection;
 use wdl_ast::experimental::v1::Visitor;
+use wdl_ast::experimental::AstNode;
 use wdl_ast::experimental::AstToken;
 use wdl_ast::experimental::Diagnostic;
 use wdl_ast::experimental::Diagnostics;


### PR DESCRIPTION
This commit adds a `parent` method to the AST representation of sections.

For task-specific sections, the method returns `TaskDefinition`.

For sections that appear in both tasks and workflows, the method returns a `TaskOrWorkflow` enumeration.

Also included is removing `rowan` as a dependency of `wdl-lint` by re-exporting what's needed from `wdl-ast`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
