### PR TITLE
feat: port preamble comment and whitespace lint rules.

### DIFF
--- a/wdl-ast/src/experimental.rs
+++ b/wdl-ast/src/experimental.rs
@@ -267,6 +267,33 @@ impl AstNode for Document {
     }
 }
 
+/// Represents a whitespace token in the AST.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Whitespace(SyntaxToken);
+
+impl AstToken for Whitespace {
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == SyntaxKind::Whitespace
+    }
+
+    fn cast(syntax: SyntaxToken) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match syntax.kind() {
+            SyntaxKind::Whitespace => Some(Self(syntax)),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+}
+
 /// Represents a comment token in the AST.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Comment(SyntaxToken);

--- a/wdl-ast/src/experimental/v1/validation/strings.rs
+++ b/wdl-ast/src/experimental/v1/validation/strings.rs
@@ -9,7 +9,6 @@ use crate::experimental::AstToken;
 use crate::experimental::Diagnostic;
 use crate::experimental::Diagnostics;
 use crate::experimental::Span;
-use crate::experimental::VisitReason;
 
 /// Creates an "unknown escape sequence" diagnostic
 fn unknown_escape_sequence(sequence: &str, span: Span) -> Diagnostic {
@@ -122,11 +121,7 @@ pub struct LiteralTextVisitor;
 impl Visitor for LiteralTextVisitor {
     type State = Diagnostics;
 
-    fn string_text(&mut self, state: &mut Self::State, reason: VisitReason, text: &StringText) {
-        if reason == VisitReason::Exit {
-            return;
-        }
-
+    fn string_text(&mut self, state: &mut Self::State, text: &StringText) {
         check_text(
             state,
             text.syntax().text_range().start().into(),

--- a/wdl-ast/src/experimental/validation.rs
+++ b/wdl-ast/src/experimental/validation.rs
@@ -4,8 +4,10 @@ use std::sync::Arc;
 
 use super::v1;
 use super::Ast;
+use super::Comment;
 use super::Diagnostic;
 use super::VisitReason;
+use super::Whitespace;
 use crate::experimental::Document;
 use crate::experimental::VersionStatement;
 
@@ -112,6 +114,18 @@ impl v1::Visitor for Validator {
         }
     }
 
+    fn whitespace(&mut self, state: &mut Self::State, whitespace: &Whitespace) {
+        for visitor in self.v1.iter_mut() {
+            visitor.whitespace(state, whitespace);
+        }
+    }
+
+    fn comment(&mut self, state: &mut Self::State, comment: &Comment) {
+        for visitor in self.v1.iter_mut() {
+            visitor.comment(state, comment);
+        }
+    }
+
     fn version_statement(
         &mut self,
         state: &mut Self::State,
@@ -200,14 +214,9 @@ impl v1::Visitor for Validator {
         }
     }
 
-    fn command_text(
-        &mut self,
-        state: &mut Self::State,
-        reason: VisitReason,
-        text: &v1::CommandText,
-    ) {
+    fn command_text(&mut self, state: &mut Self::State, text: &v1::CommandText) {
         for visitor in self.v1.iter_mut() {
-            visitor.command_text(state, reason, text);
+            visitor.command_text(state, text);
         }
     }
 
@@ -278,9 +287,9 @@ impl v1::Visitor for Validator {
         }
     }
 
-    fn string_text(&mut self, state: &mut Self::State, reason: VisitReason, text: &v1::StringText) {
+    fn string_text(&mut self, state: &mut Self::State, text: &v1::StringText) {
         for visitor in self.v1.iter_mut() {
-            visitor.string_text(state, reason, text);
+            visitor.string_text(state, text);
         }
     }
 

--- a/wdl-grammar/src/experimental/lexer.rs
+++ b/wdl-grammar/src/experimental/lexer.rs
@@ -87,7 +87,7 @@ pub enum PreambleToken {
     Whitespace,
 
     /// A comment.
-    #[regex(r"#[^\n]*")]
+    #[regex(r"#[^\r\n]*")]
     Comment,
 
     /// The `version` keyword.
@@ -155,7 +155,7 @@ pub enum VersionStatementToken {
     Whitespace,
 
     /// A comment.
-    #[regex(r"#[^\n]*")]
+    #[regex(r"#[^\r\n]*")]
     Comment,
 
     /// A WDL version.

--- a/wdl-grammar/src/experimental/lexer/v1.rs
+++ b/wdl-grammar/src/experimental/lexer/v1.rs
@@ -264,7 +264,7 @@ pub enum Token {
     Whitespace,
 
     /// A comment.
-    #[regex(r"#[^\n]*")]
+    #[regex(r"#[^\r\n]*")]
     Comment,
 
     /// A literal float.

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Ported the `PreambleWhitespace` and `PreambleComments` rules to `wdl-lint`
+  ([#72](https://github.com/stjude-rust-labs/wdl/pull/72))
 * Ported the `SnakeCase` rule to `wdl-lint` ([#71](https://github.com/stjude-rust-labs/wdl/pull/71)).
 * Ported the `NoCurlyCommands` rule to `wdl-lint` ([#69](https://github.com/stjude-rust-labs/wdl/pull/69)).
 * Added the `wdl-lint` as the crate implementing linting rules for the future

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(rustdoc::broken_intra_doc_links)]
 
 mod tags;
+pub(crate) mod util;
 pub mod v1;
 
 pub use tags::*;

--- a/wdl-lint/src/util.rs
+++ b/wdl-lint/src/util.rs
@@ -1,0 +1,88 @@
+//! A module for utility functions for the lint rules.
+
+/// Iterates over the lines of a string and returns the line, starting offset,
+/// and next possible starting offset.
+pub fn lines_with_offset(s: &str) -> impl Iterator<Item = (&str, usize, usize)> {
+    let mut offset = 0;
+    std::iter::from_fn(move || {
+        if offset >= s.len() {
+            return None;
+        }
+
+        let start = offset;
+        loop {
+            match s[offset..].find(|c| c == '\r' || c == '\n') {
+                Some(i) => {
+                    let end = offset + i;
+                    offset = end + 1;
+
+                    if s.as_bytes().get(end) == Some(&b'\r') {
+                        if s.as_bytes().get(end + 1) != Some(&b'\n') {
+                            continue;
+                        }
+
+                        // There are two characters in the newline
+                        offset += 1;
+                    }
+
+                    return Some((&s[start..end], start, offset));
+                }
+                None => {
+                    offset = s.len();
+                    return Some((&s[start..], start, offset));
+                }
+            }
+        }
+    })
+}
+
+/// Strips a single newline from the end of a string.
+pub fn strip_newline(s: &str) -> Option<&str> {
+    s.strip_suffix("\r\n").or_else(|| s.strip_suffix('\n'))
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_strip_newline() {
+        let s = "this has no newline";
+        assert!(strip_newline(s).is_none());
+
+        let s = "this has a single newline\n";
+        assert_eq!(strip_newline(s), Some("this has a single newline"));
+
+        let s = "this has a single Windows newline\r\n";
+        assert_eq!(strip_newline(s), Some("this has a single Windows newline"));
+
+        let s = "this has more than one newline\n\n";
+        assert_eq!(strip_newline(s), Some("this has more than one newline\n"));
+
+        let s = "this has more than one Windows newline\r\n\r\n";
+        assert_eq!(
+            strip_newline(s),
+            Some("this has more than one Windows newline\r\n")
+        );
+    }
+
+    #[test]
+    fn test_lines_with_offset() {
+        let s = "This string\nhas many\n\nnewlines, including Windows\r\n\r\nand even a \r that \
+                 should not be a newline\n";
+        let lines = lines_with_offset(s).collect::<Vec<_>>();
+        assert_eq!(
+            lines,
+            &[
+                ("This string", 0, 12),
+                ("has many", 12, 21),
+                ("", 21, 22),
+                ("newlines, including Windows", 22, 51),
+                ("", 51, 53),
+                ("and even a \r that should not be a newline", 53, 95),
+            ]
+        );
+    }
+}

--- a/wdl-lint/src/v1.rs
+++ b/wdl-lint/src/v1.rs
@@ -11,12 +11,16 @@ mod double_quotes;
 mod ending_newline;
 mod missing_runtime;
 mod no_curly_commands;
+mod preamble_comments;
+mod preamble_whitespace;
 mod snake_case;
 
 pub use double_quotes::*;
 pub use ending_newline::*;
 pub use missing_runtime::*;
 pub use no_curly_commands::*;
+pub use preamble_comments::*;
+pub use preamble_whitespace::*;
 pub use snake_case::*;
 
 /// A trait implemented by lint rules.
@@ -55,6 +59,8 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
         Box::new(SnakeCaseRule),
         Box::new(MissingRuntimeRule),
         Box::new(EndingNewlineRule),
+        Box::new(PreambleWhitespaceRule),
+        Box::new(PreambleCommentsRule),
     ];
 
     // Ensure all the rule ids are unique and pascal case

--- a/wdl-lint/src/v1/ending_newline.rs
+++ b/wdl-lint/src/v1/ending_newline.rs
@@ -10,6 +10,7 @@ use wdl_ast::experimental::SyntaxKind;
 use wdl_ast::experimental::VisitReason;
 
 use super::Rule;
+use crate::util::strip_newline;
 use crate::Tag;
 use crate::TagSet;
 
@@ -63,11 +64,6 @@ impl Rule for EndingNewlineRule {
     fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
         Box::new(EndingNewlineVisitor)
     }
-}
-
-/// Strips a newline sequence from the end of the given string.
-fn strip_newline(s: &str) -> Option<&str> {
-    s.strip_prefix("\r\n").or_else(|| s.strip_prefix('\n'))
 }
 
 /// Implements the visitor for the ending newline rule.

--- a/wdl-lint/src/v1/preamble_comments.rs
+++ b/wdl-lint/src/v1/preamble_comments.rs
@@ -76,7 +76,7 @@ impl Rule for PreambleCommentsRule {
     }
 
     fn tags(&self) -> TagSet {
-        TagSet::new(&[Tag::Spacing, Tag::Style])
+        TagSet::new(&[Tag::Spacing, Tag::Style, Tag::Clarity])
     }
 
     fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
@@ -128,7 +128,7 @@ impl Visitor for PreambleCommentsVisitor {
             }
 
             // Check for missing space
-            if !text.starts_with(' ') {
+            if !text.is_empty() && !text.starts_with(' ') {
                 state.add(missing_space(comment.span()));
                 return;
             }

--- a/wdl-lint/src/v1/preamble_comments.rs
+++ b/wdl-lint/src/v1/preamble_comments.rs
@@ -1,0 +1,142 @@
+//! A lint rule that checks for an incorrect preamble comments.
+
+use wdl_ast::experimental::v1::Visitor;
+use wdl_ast::experimental::AstToken;
+use wdl_ast::experimental::Comment;
+use wdl_ast::experimental::Diagnostic;
+use wdl_ast::experimental::Diagnostics;
+use wdl_ast::experimental::Span;
+use wdl_ast::experimental::VersionStatement;
+use wdl_ast::experimental::VisitReason;
+
+use super::Rule;
+use crate::Tag;
+use crate::TagSet;
+
+/// The identifier for the preamble comments rule.
+const ID: &str = "PreambleComments";
+
+/// Creates an "invalid preamble comment" diagnostic.
+fn invalid_preamble_comment(span: Span) -> Diagnostic {
+    Diagnostic::note("preamble comments must start with `##`")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("change the comment to start with `##` followed by a space")
+}
+
+/// Creates a "too many pound signs" diagnostic.
+fn too_many_pound_signs(span: Span) -> Diagnostic {
+    Diagnostic::note("preamble comments cannot start with more than two `#`")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("change the comment to start with `##` followed by a space")
+}
+
+/// Creates a "missing space" diagnostic.
+fn missing_space(span: Span) -> Diagnostic {
+    Diagnostic::note("preamble comments must have a space after `##`")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("add a space between `##` and the start of the comment")
+}
+
+/// Creates a "preamble comment after version" diagnostic.
+fn preamble_comment_after_version(span: Span) -> Diagnostic {
+    Diagnostic::note("preamble comments cannot come after the version statement")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("change the comment to start with `#` followed by a space")
+}
+
+/// Detects incorrect comments in a document preamble.
+#[derive(Debug, Clone, Copy)]
+pub struct PreambleCommentsRule;
+
+impl Rule for PreambleCommentsRule {
+    fn id(&self) -> &'static str {
+        ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that documents have correct comments in the preamble."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "Preamble comments are full line comments before the version declaration and they start \
+         with a double pound sign. These comments are reserved for documentation that doesn't fit \
+         within any of the WDL-defined documentation elements (such as `meta` and `parameter_meta` \
+         sections). They may provide context for a collection of tasks or structs, or they may \
+         provide a high-level overview of the workflow. Double-pound-sign comments are not allowed \
+         after the version declaration. All comments before the version declaration should start \
+         with a double pound sign (or if they are not suitable as preamble comments they should be \
+         moved to _after_ the version declaration). Comments beginning with 3 or more pound signs \
+         are permitted after the version declaration, as they are not considered preamble \
+         comments. Comments beginning with 3 or more pound signs before the version declaration \
+         are not permitted."
+    }
+
+    fn tags(&self) -> TagSet {
+        TagSet::new(&[Tag::Spacing, Tag::Style])
+    }
+
+    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
+        Box::new(PreambleCommentsVisitor::default())
+    }
+}
+
+/// Implements the visitor for the preamble comments rule.
+#[derive(Default, Debug)]
+struct PreambleCommentsVisitor {
+    /// Whether or not the preamble has finished.
+    finished: bool,
+}
+
+impl Visitor for PreambleCommentsVisitor {
+    type State = Diagnostics;
+
+    fn version_statement(
+        &mut self,
+        _: &mut Self::State,
+        reason: VisitReason,
+        _: &VersionStatement,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        // We're finished after the version statement
+        self.finished = true;
+    }
+
+    fn comment(&mut self, state: &mut Self::State, comment: &Comment) {
+        let text = comment.as_str();
+        if self.finished {
+            if let Some(text) = text.strip_prefix("##") {
+                if !text.starts_with('#') {
+                    state.add(preamble_comment_after_version(comment.span()));
+                }
+            }
+
+            return;
+        }
+
+        if let Some(text) = text.strip_prefix("##") {
+            // Check for too many pound signs
+            if text.starts_with('#') {
+                state.add(too_many_pound_signs(comment.span()));
+                return;
+            }
+
+            // Check for missing space
+            if !text.starts_with(' ') {
+                state.add(missing_space(comment.span()));
+                return;
+            }
+
+            // Valid preamble comment
+            return;
+        }
+
+        state.add(invalid_preamble_comment(comment.span()));
+    }
+}

--- a/wdl-lint/src/v1/preamble_whitespace.rs
+++ b/wdl-lint/src/v1/preamble_whitespace.rs
@@ -185,9 +185,25 @@ impl Visitor for PreambleWhitespaceVisitor {
                 // Whitespace token is valid
                 return;
             }
+
+            // Don't include the newline separating the previous comment from the whitespace
+            let offset = if s.starts_with("\r\n") {
+                2
+            } else if s.starts_with('\n') {
+                1
+            } else {
+                0
+            };
+
+            let span = whitespace.span();
+            state.add(unnecessary_whitespace(Span::new(
+                span.start() + offset,
+                span.len() - offset,
+            )));
+            return;
         }
 
-        // At this point, the whitespace is unnecessary
+        // At this point, the whitespace is entirely unnecessary
         state.add(unnecessary_whitespace(whitespace.span()));
     }
 }

--- a/wdl-lint/src/v1/preamble_whitespace.rs
+++ b/wdl-lint/src/v1/preamble_whitespace.rs
@@ -1,0 +1,192 @@
+//! A lint rule that checks for an incorrect preamble whitespace.
+
+use wdl_ast::experimental::v1::Visitor;
+use wdl_ast::experimental::AstNode;
+use wdl_ast::experimental::AstToken;
+use wdl_ast::experimental::Diagnostic;
+use wdl_ast::experimental::Diagnostics;
+use wdl_ast::experimental::Span;
+use wdl_ast::experimental::SyntaxElement;
+use wdl_ast::experimental::SyntaxKind;
+use wdl_ast::experimental::ToSpan;
+use wdl_ast::experimental::VersionStatement;
+use wdl_ast::experimental::VisitReason;
+use wdl_ast::experimental::Whitespace;
+
+use super::Rule;
+use crate::util::lines_with_offset;
+use crate::Tag;
+use crate::TagSet;
+
+/// The identifier for the preamble whitespace rule.
+const ID: &str = "PreambleWhitespace";
+
+/// Creates an "unnecessary whitespace" diagnostic.
+fn unnecessary_whitespace(span: Span) -> Diagnostic {
+    Diagnostic::note("unnecessary whitespace in document preamble")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("remove the unnecessary whitespace")
+}
+
+/// Creates an "expected a blank line" diagnostic.
+fn expected_blank_line(span: Span) -> Diagnostic {
+    Diagnostic::note("expected a blank line before version statement")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("add a blank line between the last preamble comment and the version statement")
+}
+
+/// Detects incorrect whitespace in a document preamble.
+#[derive(Debug, Clone, Copy)]
+pub struct PreambleWhitespaceRule;
+
+impl Rule for PreambleWhitespaceRule {
+    fn id(&self) -> &'static str {
+        ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that documents have correct whitespace in the preamble."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "The document preamble is defined as anything before the version declaration statement and \
+         the version declaration statement itself. Only comments and whitespace are permitted \
+         before the version declaration. If there are no comments, the version declaration must be \
+         the first line of the document. If there are comments, there must be exactly one blank \
+         line between the last comment and the version declaration."
+    }
+
+    fn tags(&self) -> TagSet {
+        TagSet::new(&[Tag::Spacing, Tag::Style])
+    }
+
+    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
+        Box::new(PreambleWhitespaceVisitor::default())
+    }
+}
+
+/// Implements the visitor for the preamble whitespace rule.
+#[derive(Default, Debug)]
+struct PreambleWhitespaceVisitor {
+    /// Whether or not the rule has finished.
+    finished: bool,
+}
+
+impl Visitor for PreambleWhitespaceVisitor {
+    type State = Diagnostics;
+
+    fn version_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &VersionStatement,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        // We're finished after the version statement
+        self.finished = true;
+
+        // If the previous token is whitespace and its previous token is a comment,
+        // then the whitespace should just be two lines
+        match stmt
+            .syntax()
+            .prev_sibling_or_token()
+            .and_then(SyntaxElement::into_token)
+        {
+            Some(whitespace) if whitespace.kind() == SyntaxKind::Whitespace => {
+                let range = whitespace.text_range();
+                if whitespace
+                    .prev_sibling_or_token()
+                    .map(|s| s.kind() == SyntaxKind::Comment)
+                    .unwrap_or(false)
+                {
+                    // There's a preceding comment, so it is expected that the whitespace is only
+                    // two newlines in a row
+                    let text = whitespace.text();
+                    let mut count = 0;
+                    for (line, start, next_start) in lines_with_offset(text) {
+                        // If this is not a blank line, it's unnecessary whitespace
+                        if !line.is_empty() {
+                            state.add(unnecessary_whitespace(Span::new(
+                                usize::from(range.start()) + start,
+                                line.len(),
+                            )));
+                        }
+
+                        count += 1;
+                        if count == 2 {
+                            // If the previous byte isn't a newline, then we are missing a blank
+                            // line
+                            if text.as_bytes()[next_start - 1] != b'\n' {
+                                state.add(expected_blank_line(Span::new(
+                                    usize::from(range.start()) + start,
+                                    1,
+                                )));
+                            }
+
+                            // We're at the second line, the remainder is unnecessary whitespace
+                            if next_start < text.len() {
+                                state.add(unnecessary_whitespace(Span::new(
+                                    usize::from(range.start()) + next_start,
+                                    text.len() - next_start,
+                                )));
+                            }
+
+                            break;
+                        }
+                    }
+
+                    // We expected two lines
+                    if count < 2 {
+                        state.add(expected_blank_line(range.to_span()));
+                    }
+                } else {
+                    // Whitespace without a comment before it
+                    state.add(unnecessary_whitespace(range.to_span()));
+                }
+            }
+            _ => {
+                // Previous token is not whitespace
+            }
+        }
+    }
+
+    fn whitespace(&mut self, state: &mut Self::State, whitespace: &Whitespace) {
+        if self.finished {
+            return;
+        }
+
+        // If the next sibling is the version statement, let the `version_statement`
+        // callback handle this particular whitespace
+        if whitespace
+            .syntax()
+            .next_sibling_or_token()
+            .map(|s| s.kind() == SyntaxKind::VersionStatementNode)
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        // Otherwise, the whitespace should have a comment token before it
+        if whitespace
+            .syntax()
+            .prev_sibling_or_token()
+            .map(|s| s.kind() == SyntaxKind::Comment)
+            .unwrap_or(false)
+        {
+            // Previous sibling is a comment, check that this is a single newline
+            let s = whitespace.as_str();
+            if s == "\r\n" || s == "\n" {
+                // Whitespace token is valid
+                return;
+            }
+        }
+
+        // At this point, the whitespace is unnecessary
+        state.add(unnecessary_whitespace(whitespace.span()));
+    }
+}

--- a/wdl-lint/src/v1/preamble_whitespace.rs
+++ b/wdl-lint/src/v1/preamble_whitespace.rs
@@ -31,7 +31,7 @@ fn unnecessary_whitespace(span: Span) -> Diagnostic {
 
 /// Creates an "expected a blank line" diagnostic.
 fn expected_blank_line(span: Span) -> Diagnostic {
-    Diagnostic::note("expected a blank line before version statement")
+    Diagnostic::note("expected a blank line before the version statement")
         .with_rule(ID)
         .with_highlight(span)
         .with_fix("add a blank line between the last preamble comment and the version statement")
@@ -55,7 +55,8 @@ impl Rule for PreambleWhitespaceRule {
          the version declaration statement itself. Only comments and whitespace are permitted \
          before the version declaration. If there are no comments, the version declaration must be \
          the first line of the document. If there are comments, there must be exactly one blank \
-         line between the last comment and the version declaration."
+         line between the last comment and the version declaration. No extraneous whitespace is \
+         allowed."
     }
 
     fn tags(&self) -> TagSet {

--- a/wdl-lint/tests/lints/curly-command/source.wdl
+++ b/wdl-lint/tests/lints/curly-command/source.wdl
@@ -1,4 +1,4 @@
-# This is a test of the `NoCurlyCommands` lint
+## This is a test of the `NoCurlyCommands` lint
 
 version 1.1
 

--- a/wdl-lint/tests/lints/double-quotes/source.wdl
+++ b/wdl-lint/tests/lints/double-quotes/source.wdl
@@ -1,4 +1,4 @@
-# This is a test of the `double_quotes` lint
+## This is a test of the `double_quotes` lint
 
 version 1.1
 

--- a/wdl-lint/tests/lints/invalid-preamble-comment/source.errors
+++ b/wdl-lint/tests/lints/invalid-preamble-comment/source.errors
@@ -1,0 +1,16 @@
+note: preamble comments must start with `##` [rule: PreambleComments]
+  ┌─ tests/lints/invalid-preamble-comment/source.wdl:1:1
+  │
+1 │ # This is an invalid preamble comment.
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: change the comment to start with `##` followed by a space
+
+note: preamble comments must start with `##` [rule: PreambleComments]
+  ┌─ tests/lints/invalid-preamble-comment/source.wdl:3:1
+  │
+3 │ # This one is invalid too!
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: change the comment to start with `##` followed by a space
+

--- a/wdl-lint/tests/lints/invalid-preamble-comment/source.wdl
+++ b/wdl-lint/tests/lints/invalid-preamble-comment/source.wdl
@@ -1,0 +1,9 @@
+# This is an invalid preamble comment.
+## This one is fine
+# This one is invalid too!
+
+version 1.1
+
+workflow test {
+
+}

--- a/wdl-lint/tests/lints/missing-comment-space/source.errors
+++ b/wdl-lint/tests/lints/missing-comment-space/source.errors
@@ -1,0 +1,8 @@
+note: preamble comments must have a space after `##` [rule: PreambleComments]
+  ┌─ tests/lints/missing-comment-space/source.wdl:1:1
+  │
+1 │ ##This preamble comment is missing a space.
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: add a space between `##` and the start of the comment
+

--- a/wdl-lint/tests/lints/missing-comment-space/source.wdl
+++ b/wdl-lint/tests/lints/missing-comment-space/source.wdl
@@ -1,0 +1,8 @@
+##This preamble comment is missing a space.
+## But this one isn't!
+
+version 1.1
+
+workflow test {
+
+}

--- a/wdl-lint/tests/lints/missing-comment-space/source.wdl
+++ b/wdl-lint/tests/lints/missing-comment-space/source.wdl
@@ -1,5 +1,7 @@
 ##This preamble comment is missing a space.
-## But this one isn't!
+##
+## But this one isn't and neither are the empty ones
+##
 
 version 1.1
 

--- a/wdl-lint/tests/lints/missing-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/missing-eof-newline/source.wdl
@@ -1,4 +1,4 @@
-# This is a test of a missing EOF newline lint
+## This is a test of a missing EOF newline lint
 
 version 1.1
 

--- a/wdl-lint/tests/lints/missing-preamble-ws/source.errors
+++ b/wdl-lint/tests/lints/missing-preamble-ws/source.errors
@@ -1,0 +1,10 @@
+note: expected a blank line before version statement [rule: PreambleWhitespace]
+  ┌─ tests/lints/missing-preamble-ws/source.wdl:1:50
+  │  
+1 │   ## This is a test of missing preamble whitespace.
+  │ ╭─────────────────────────────────────────────────^
+2 │ │ version 1.1
+  │ ╰^
+  │  
+  = fix: add a blank line between the last preamble comment and the version statement
+

--- a/wdl-lint/tests/lints/missing-preamble-ws/source.errors
+++ b/wdl-lint/tests/lints/missing-preamble-ws/source.errors
@@ -1,4 +1,4 @@
-note: expected a blank line before version statement [rule: PreambleWhitespace]
+note: expected a blank line before the version statement [rule: PreambleWhitespace]
   ┌─ tests/lints/missing-preamble-ws/source.wdl:1:50
   │  
 1 │   ## This is a test of missing preamble whitespace.

--- a/wdl-lint/tests/lints/missing-preamble-ws/source.wdl
+++ b/wdl-lint/tests/lints/missing-preamble-ws/source.wdl
@@ -1,0 +1,6 @@
+## This is a test of missing preamble whitespace.
+version 1.1
+
+workflow text {
+
+}

--- a/wdl-lint/tests/lints/missing-runtime-block/source.wdl
+++ b/wdl-lint/tests/lints/missing-runtime-block/source.wdl
@@ -1,4 +1,4 @@
-# This is a test of the `missing_runtime_block` lint
+## This is a test of the `missing_runtime_block` lint
 
 version 1.1
 

--- a/wdl-lint/tests/lints/multiple-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/multiple-eof-newline/source.wdl
@@ -1,4 +1,4 @@
-# This is a test of multiple EOF newlines lint
+## This is a test of multiple EOF newlines lint
 
 version 1.1
 

--- a/wdl-lint/tests/lints/no-preamble-comments/source.wdl
+++ b/wdl-lint/tests/lints/no-preamble-comments/source.wdl
@@ -1,0 +1,7 @@
+version 1.1
+
+# This is a test of having no preamble comments and correct whitespace
+ 
+workflow test {
+
+}

--- a/wdl-lint/tests/lints/one-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/one-eof-newline/source.wdl
@@ -1,5 +1,5 @@
-# This is a test of the missing EOF newline lint
-# `source.errors` should be empty
+## This is a test of the missing EOF newline lint
+## `source.errors` should be empty
 
 version 1.1
 

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
@@ -1,11 +1,9 @@
 note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
-  ┌─ tests/lints/preamble-comment-after-version/source.wdl:1:38
-  │  
-1 │   ## This is a normal preamble comment.
-  │ ╭─────────────────────────────────────^
-2 │ │        ## Bad leading whitespace!
-  │ ╰───────^
-  │  
+  ┌─ tests/lints/preamble-comment-after-version/source.wdl:2:1
+  │
+2 │        ## Bad leading whitespace!
+  │ ^^^^^^^
+  │
   = fix: remove the unnecessary whitespace
 
 note: preamble comments cannot come after the version statement [rule: PreambleComments]

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
@@ -1,15 +1,25 @@
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/preamble-comment-after-version/source.wdl:1:38
+  │  
+1 │   ## This is a normal preamble comment.
+  │ ╭─────────────────────────────────────^
+2 │ │        ## Bad leading whitespace!
+  │ ╰───────^
+  │  
+  = fix: remove the unnecessary whitespace
+
 note: preamble comments cannot come after the version statement [rule: PreambleComments]
-  ┌─ tests/lints/preamble-comment-after-version/source.wdl:5:1
+  ┌─ tests/lints/preamble-comment-after-version/source.wdl:6:1
   │
-5 │ ## This is a preamble comment after the version
+6 │ ## This is a preamble comment after the version
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = fix: change the comment to start with `#` followed by a space
 
 note: preamble comments cannot come after the version statement [rule: PreambleComments]
-   ┌─ tests/lints/preamble-comment-after-version/source.wdl:14:5
+   ┌─ tests/lints/preamble-comment-after-version/source.wdl:15:5
    │
-14 │     ## This one is bad!
+15 │     ## This one is bad!
    │     ^^^^^^^^^^^^^^^^^^^
    │
    = fix: change the comment to start with `#` followed by a space

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
@@ -1,0 +1,16 @@
+note: preamble comments cannot come after the version statement [rule: PreambleComments]
+  ┌─ tests/lints/preamble-comment-after-version/source.wdl:5:1
+  │
+5 │ ## This is a preamble comment after the version
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: change the comment to start with `#` followed by a space
+
+note: preamble comments cannot come after the version statement [rule: PreambleComments]
+   ┌─ tests/lints/preamble-comment-after-version/source.wdl:14:5
+   │
+14 │     ## This one is bad!
+   │     ^^^^^^^^^^^^^^^^^^^
+   │
+   = fix: change the comment to start with `#` followed by a space
+

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
@@ -1,4 +1,5 @@
 ## This is a normal preamble comment.
+       ## Bad leading whitespace!
 
 version 1.1
 

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
@@ -1,0 +1,15 @@
+## This is a normal preamble comment.
+
+version 1.1
+
+## This is a preamble comment after the version
+
+# This comment is okay though
+
+### So is this comment
+
+##### And this comment too!
+
+workflow test {
+    ## This one is bad!
+}

--- a/wdl-lint/tests/lints/preamble-ws/source.errors
+++ b/wdl-lint/tests/lints/preamble-ws/source.errors
@@ -6,7 +6,7 @@ note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
   │
   = fix: remove the unnecessary whitespace
 
-note: expected a blank line before version statement [rule: PreambleWhitespace]
+note: expected a blank line before the version statement [rule: PreambleWhitespace]
   ┌─ tests/lints/preamble-ws/source.wdl:2:1
   │
 2 │         version 1.1

--- a/wdl-lint/tests/lints/preamble-ws/source.errors
+++ b/wdl-lint/tests/lints/preamble-ws/source.errors
@@ -1,0 +1,16 @@
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/preamble-ws/source.wdl:2:1
+  │
+2 │         version 1.1
+  │ ^^^^^^^^
+  │
+  = fix: remove the unnecessary whitespace
+
+note: expected a blank line before version statement [rule: PreambleWhitespace]
+  ┌─ tests/lints/preamble-ws/source.wdl:2:1
+  │
+2 │         version 1.1
+  │ ^
+  │
+  = fix: add a blank line between the last preamble comment and the version statement
+

--- a/wdl-lint/tests/lints/preamble-ws/source.wdl
+++ b/wdl-lint/tests/lints/preamble-ws/source.wdl
@@ -1,0 +1,6 @@
+## This is a test of both missing and extraneous preamble whitespace.
+        version 1.1
+
+workflow text {
+
+}

--- a/wdl-lint/tests/lints/snake-case/source.wdl
+++ b/wdl-lint/tests/lints/snake-case/source.wdl
@@ -1,4 +1,4 @@
-# Test SnakeCase rule
+## Test SnakeCase rule
 
 version 1.0
 

--- a/wdl-lint/tests/lints/too-many-pounds-preamble/source.errors
+++ b/wdl-lint/tests/lints/too-many-pounds-preamble/source.errors
@@ -1,0 +1,16 @@
+note: preamble comments cannot start with more than two `#` [rule: PreambleComments]
+  ┌─ tests/lints/too-many-pounds-preamble/source.wdl:1:1
+  │
+1 │ ### This comment has too many pound signs!
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: change the comment to start with `##` followed by a space
+
+note: preamble comments cannot start with more than two `#` [rule: PreambleComments]
+  ┌─ tests/lints/too-many-pounds-preamble/source.wdl:3:1
+  │
+3 │ ###### This comment also has too many pound signs!
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: change the comment to start with `##` followed by a space
+

--- a/wdl-lint/tests/lints/too-many-pounds-preamble/source.wdl
+++ b/wdl-lint/tests/lints/too-many-pounds-preamble/source.wdl
@@ -1,0 +1,9 @@
+### This comment has too many pound signs!
+## This one is fine though.
+###### This comment also has too many pound signs!
+
+version 1.1
+
+workflow test {
+
+}

--- a/wdl-lint/tests/lints/two-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/two-eof-newline/source.wdl
@@ -1,4 +1,4 @@
-# This is a test of two EOF newlines lint
+## This is a test of two EOF newlines lint
 
 version 1.1
 

--- a/wdl-lint/tests/lints/unnecessary-preamble-ws/source.errors
+++ b/wdl-lint/tests/lints/unnecessary-preamble-ws/source.errors
@@ -1,0 +1,18 @@
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/unnecessary-preamble-ws/source.wdl:4:1
+  │
+4 │            
+  │ ^^^^^^^^^^^
+  │
+  = fix: remove the unnecessary whitespace
+
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/unnecessary-preamble-ws/source.wdl:5:1
+  │  
+5 │ ╭ 
+6 │ │ 
+7 │ │   version 1.1
+  │ ╰──^
+  │  
+  = fix: remove the unnecessary whitespace
+

--- a/wdl-lint/tests/lints/unnecessary-preamble-ws/source.wdl
+++ b/wdl-lint/tests/lints/unnecessary-preamble-ws/source.wdl
@@ -1,0 +1,11 @@
+## This is a test of ensuring that we print two diagnostics:
+## The first is for the whitespace following the last comment
+## The second is for the whitespace between the end of that line to the version keyword
+           
+
+
+  version 1.1
+
+workflow test {
+
+}

--- a/wdl-lint/tests/lints/ws-after-blank-line/source.errors
+++ b/wdl-lint/tests/lints/ws-after-blank-line/source.errors
@@ -1,0 +1,9 @@
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/ws-after-blank-line/source.wdl:3:1
+  │  
+3 │ ╭      
+4 │ │ version 1.1
+  │ ╰^
+  │  
+  = fix: remove the unnecessary whitespace
+

--- a/wdl-lint/tests/lints/ws-after-blank-line/source.wdl
+++ b/wdl-lint/tests/lints/ws-after-blank-line/source.wdl
@@ -1,0 +1,8 @@
+## This is a test of whitespace after a blank line.
+
+     
+version 1.1
+
+workflow test {
+
+}

--- a/wdl-lint/tests/lints/ws-before-version/source.errors
+++ b/wdl-lint/tests/lints/ws-before-version/source.errors
@@ -1,0 +1,11 @@
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/ws-before-version/source.wdl:1:1
+  │  
+1 │ ╭     
+2 │ │ 
+3 │ │   
+4 │ │     version 1.1
+  │ ╰────^
+  │  
+  = fix: remove the unnecessary whitespace
+

--- a/wdl-lint/tests/lints/ws-before-version/source.wdl
+++ b/wdl-lint/tests/lints/ws-before-version/source.wdl
@@ -1,0 +1,10 @@
+    
+
+  
+    version 1.1
+
+# This is a test of unnecessary whitespace before the version statement
+
+workflow test {
+
+}

--- a/wdl-lint/tests/lints/ws-preamble-comments/source.errors
+++ b/wdl-lint/tests/lints/ws-preamble-comments/source.errors
@@ -1,0 +1,23 @@
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/ws-preamble-comments/source.wdl:1:58
+  │  
+1 │   ## This is a test of whitespace between preamble comments
+  │ ╭─────────────────────────────────────────────────────────^
+2 │ │ 
+3 │ │   
+4 │ │ ## The above lines should be a warning, as well as below
+  │ ╰^
+  │  
+  = fix: remove the unnecessary whitespace
+
+note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
+  ┌─ tests/lints/ws-preamble-comments/source.wdl:4:57
+  │  
+4 │   ## The above lines should be a warning, as well as below
+  │ ╭────────────────────────────────────────────────────────^
+5 │ │ 
+6 │ │ ## Last comment
+  │ ╰^
+  │  
+  = fix: remove the unnecessary whitespace
+

--- a/wdl-lint/tests/lints/ws-preamble-comments/source.errors
+++ b/wdl-lint/tests/lints/ws-preamble-comments/source.errors
@@ -1,9 +1,7 @@
 note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
-  ┌─ tests/lints/ws-preamble-comments/source.wdl:1:58
+  ┌─ tests/lints/ws-preamble-comments/source.wdl:2:1
   │  
-1 │   ## This is a test of whitespace between preamble comments
-  │ ╭─────────────────────────────────────────────────────────^
-2 │ │ 
+2 │ ╭ 
 3 │ │   
 4 │ │ ## The above lines should be a warning, as well as below
   │ ╰^
@@ -11,11 +9,9 @@ note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
   = fix: remove the unnecessary whitespace
 
 note: unnecessary whitespace in document preamble [rule: PreambleWhitespace]
-  ┌─ tests/lints/ws-preamble-comments/source.wdl:4:57
+  ┌─ tests/lints/ws-preamble-comments/source.wdl:5:1
   │  
-4 │   ## The above lines should be a warning, as well as below
-  │ ╭────────────────────────────────────────────────────────^
-5 │ │ 
+5 │ ╭ 
 6 │ │ ## Last comment
   │ ╰^
   │  

--- a/wdl-lint/tests/lints/ws-preamble-comments/source.wdl
+++ b/wdl-lint/tests/lints/ws-preamble-comments/source.wdl
@@ -1,0 +1,12 @@
+## This is a test of whitespace between preamble comments
+
+  
+## The above lines should be a warning, as well as below
+
+## Last comment
+
+version 1.1
+
+workflow test {
+
+}


### PR DESCRIPTION
This commit ports the preamble comment and whitespace lint rules to the new parser.

It adds supports for visiting whitespace and comment tokens as well.

Token visitations no longer get called twice as they never have children, so the `VisitReason` was removed as a parameter.

Also contains a fix to the comment tokenization so that comments don't capture a carriage return on `\r\n` line endings.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
