### PR TITLE
revert: bump crate versions to 0.4.0 (db70663).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.4.0"
+version = "0.3.0"
 authors = ["The Rust WDL project developers"]
 homepage = "https://github.com/stjude-rust-labs/wdl"
 repository = "https://github.com/stjude-rust-labs/wdl"

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.4.0 - 06-13-2024
-
 ### Fixed
 
 * Fixed the experimental parser validation to check negative numbers in
@@ -30,11 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-exported key items from `wdl-grammar`'s experimental parser implementation,
   and changed errors to use `Diagnostic` ([#68](https://github.com/stjude-rust-labs/wdl/pull/68)).
 
-## 0.3.0 (unreleased)
-
-Note: this version was skipped to make the version numbers consistent across the crates.
-
-## 0.2.0 - 05-31-2024
+## 0.2.0 - 5-31-2024
 
 * Fix ignoring comments in expressions ([#23](https://github.com/stjude-rust-labs/wdl/pull/23)).
 

--- a/wdl-ast/Cargo.toml
+++ b/wdl-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-ast"
-version.workspace = true
+version = "0.2.0"
 authors = ["Clay McLeod <clay.l.mcleod@gmail.com>"]
 edition.workspace = true
 license.workspace = true
@@ -10,7 +10,7 @@ repository = "https://github.com/stjude-rust-labs/wdl"
 documentation = "https://docs.rs/wdl-ast"
 
 [dependencies]
-wdl-grammar = { path = "../wdl-grammar", version = "0.4.0" }
+wdl-grammar = { path = "../wdl-grammar", version = "0.3.0" }
 rowan = { workspace = true }
 
 [dev-dependencies]

--- a/wdl-gauntlet/CHANGELOG.md
+++ b/wdl-gauntlet/CHANGELOG.md
@@ -7,17 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.4.0 - 06-13-2024
-
 ### Changed
 
 * Migrated `wdl-gauntlet` to use the new parser implementation ([#76](https://github.com/stjude-rust-labs/wdl/pull/76))
 
-## 0.3.0 (unreleased)
-
-Note: this version was skipped to make the version numbers consistent across the crates.
-
-## 0.2.0 - 05-31-2024
+## 0.2.0 - 5-31-2024
 
 ### Changed
 

--- a/wdl-gauntlet/Cargo.toml
+++ b/wdl-gauntlet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-gauntlet"
-version.workspace = true
+version = "0.2.0"
 description = "Testing of parse trees and ASTs within the `wdl` family of crates"
 license.workspace = true
 edition.workspace = true
@@ -8,7 +8,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wdl-lint = { path = "../wdl-lint", version = "0.4.0", features = ["codespan"] }
+wdl-lint = { path = "../wdl-lint", version = "0.3.0", features = ["codespan"] }
 clap.workspace = true
 colored.workspace = true
 dirs.workspace = true

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 - 06-13-2024
+## Unreleased
 
 ### Changed
 
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   introduced the `Diagnostic` type as a replacement, and switched the existing
   parser errors over to use `Diagnostic` ([#68](https://github.com/stjude-rust-labs/wdl/pull/68)).
 
-## 0.3.0 - 05-31-2024
+## 0.3.0 - 5-31-2024
 
 ### Fixed
 

--- a/wdl-grammar/Cargo.toml
+++ b/wdl-grammar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-grammar"
-version.workspace = true
+version = "0.3.0"
 authors = ["Clay McLeod <clay.l.mcleod@gmail.com>"]
 edition.workspace = true
 license.workspace = true

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.4.0 - 06-13-2024
-
 ### Added
 
 * Ported the `CommandSectionMixedIndentation` rule to `wdl-lint` ([#75](https://github.com/stjude-rust-labs/wdl/pull/75))
@@ -20,15 +18,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ported the `NoCurlyCommands` rule to `wdl-lint` ([#69](https://github.com/stjude-rust-labs/wdl/pull/69)).
 * Added the `wdl-lint` as the crate implementing linting rules for the future
   ([#68](https://github.com/stjude-rust-labs/wdl/pull/68)).
-
-## 0.3.0 (unreleased)
-
-Note: this version was skipped to make the version numbers consistent across the crates.
-
-## 0.2.0 (unreleased)
-
-Note: this version was skipped to make the version numbers consistent across the crates.
-
-## 0.1.0 (unreleased)
-
-Note: this version was skipped to make the version numbers consistent across the crates.

--- a/wdl-lint/Cargo.toml
+++ b/wdl-lint/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wdl-lint"
 readme = "../README.md"
 
 [dependencies]
-wdl-ast = { path = "../wdl-ast", version = "0.4.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.2.0" }
 convert_case = { workspace = true }
 
 [dev-dependencies]

--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -5,19 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-## 0.4.0 - 06-13-2024
+## [Unreleased]
 
 ### Changed
 
 * Updated to the new parser implementation and added a `wdl` binary ([#79](https://github.com/stjude-rust-labs/wdl/pull/79)).
-
-## 0.3.0 - 05-31-2024
-
-### Changed
-
-* Updated `wdl-ast`, `wdl-grammar`, and `wdl-core` crates.
 
 ## 0.2.0 — 12-17-2023
 

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.rs/wdl"
 readme = "../README.md"
 
 [dependencies]
-wdl-grammar = { path = "../wdl-grammar", version = "0.4.0", optional = true }
-wdl-ast = { path = "../wdl-ast", version = "0.4.0", optional = true }
-wdl-lint = { path = "../wdl-lint", version = "0.4.0", optional = true }
+wdl-grammar = { path = "../wdl-grammar", version = "0.3.0", optional = true }
+wdl-ast = { path = "../wdl-ast", version = "0.2.0", optional = true }
+wdl-lint = { path = "../wdl-lint", version = "0.3.0", optional = true }
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 colored = { workspace = true, optional = true }


### PR DESCRIPTION
This reverts commit db706639b24633b1903e9a3ed4934d4434af3400.

I'm working on an automation to determine if a crate needs to be released and to have it automatically bump the versions and do so in accordance with the existing documented release process.

In the meantime, revert the previous PR (we're not releasing today anyway as we're blocked on publishing `wdl-lint`).

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
