### PR TITLE
fix: add a label for suggesting where to put a missing delimiter.

### DIFF
--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed a missing delimiter diagnostic to include a label for where the parser 
+  thinks the missing delimiter might go ([#84](https://github.com/stjude-rust-labs/wdl/pull/84)).
+
 ## 0.4.0 - 6-13-2024
 
 ### Changed

--- a/wdl-grammar/tests/parsing/missing-comma/source.errors
+++ b/wdl-grammar/tests/parsing/missing-comma/source.errors
@@ -1,0 +1,8 @@
+error: expected `,`, but found identifier
+  ┌─ tests/parsing/missing-comma/source.wdl:9:9
+  │
+8 │         bar: "bar"
+  │                  - consider adding a `,` after this
+9 │         baz: "baz",
+  │         ^^^ unexpected identifier
+

--- a/wdl-grammar/tests/parsing/missing-comma/source.tree
+++ b/wdl-grammar/tests/parsing/missing-comma/source.tree
@@ -1,0 +1,77 @@
+RootNode@0..195
+  Comment@0..46 "# This is a test of a ..."
+  Whitespace@46..48 "\n\n"
+  VersionStatementNode@48..59
+    VersionKeyword@48..55 "version"
+    Whitespace@55..56 " "
+    Version@56..59 "1.1"
+  Whitespace@59..61 "\n\n"
+  WorkflowDefinitionNode@61..194
+    WorkflowKeyword@61..69 "workflow"
+    Whitespace@69..70 " "
+    Ident@70..74 "test"
+    Whitespace@74..75 " "
+    OpenBrace@75..76 "{"
+    Whitespace@76..81 "\n    "
+    BoundDeclNode@81..193
+      MapTypeNode@81..101
+        MapTypeKeyword@81..84 "Map"
+        OpenBracket@84..85 "["
+        PrimitiveTypeNode@85..91
+          StringTypeKeyword@85..91 "String"
+        Comma@91..92 ","
+        PrimitiveTypeNode@92..99
+          Whitespace@92..93 " "
+          StringTypeKeyword@93..99 "String"
+        CloseBracket@99..100 "]"
+        Whitespace@100..101 " "
+      Ident@101..104 "map"
+      Whitespace@104..105 " "
+      Assignment@105..106 "="
+      LiteralMapNode@106..192
+        Whitespace@106..107 " "
+        OpenBrace@107..108 "{"
+        Whitespace@108..117 "\n        "
+        LiteralMapItemNode@117..127
+          NameRefNode@117..120
+            Ident@117..120 "foo"
+          Colon@120..121 ":"
+          LiteralStringNode@121..127
+            Whitespace@121..122 " "
+            DoubleQuote@122..123 "\""
+            LiteralStringText@123..126 "foo"
+            DoubleQuote@126..127 "\""
+        Comma@127..128 ","
+        Whitespace@128..137 "\n        "
+        LiteralMapItemNode@137..156
+          NameRefNode@137..140
+            Ident@137..140 "bar"
+          Colon@140..141 ":"
+          LiteralStringNode@141..147
+            Whitespace@141..142 " "
+            DoubleQuote@142..143 "\""
+            LiteralStringText@143..146 "bar"
+            DoubleQuote@146..147 "\""
+          Whitespace@147..156 "\n        "
+        Ident@156..159 "baz"
+        Colon@159..160 ":"
+        Whitespace@160..161 " "
+        DoubleQuote@161..162 "\""
+        LiteralStringText@162..165 "baz"
+        DoubleQuote@165..166 "\""
+        Comma@166..167 ","
+        Whitespace@167..176 "\n        "
+        LiteralMapItemNode@176..191
+          NameRefNode@176..179
+            Ident@176..179 "qux"
+          Colon@179..180 ":"
+          LiteralStringNode@180..186
+            Whitespace@180..181 " "
+            DoubleQuote@181..182 "\""
+            LiteralStringText@182..185 "qux"
+            DoubleQuote@185..186 "\""
+          Whitespace@186..191 "\n    "
+        CloseBrace@191..192 "}"
+      Whitespace@192..193 "\n"
+    CloseBrace@193..194 "}"
+  Whitespace@194..195 "\n"

--- a/wdl-grammar/tests/parsing/missing-comma/source.wdl
+++ b/wdl-grammar/tests/parsing/missing-comma/source.wdl
@@ -1,0 +1,12 @@
+# This is a test of a missing comma delimiter.
+
+version 1.1
+
+workflow test {
+    Map[String, String] map = {
+        foo: "foo",
+        bar: "bar"
+        baz: "baz",
+        qux: "qux"
+    }
+}


### PR DESCRIPTION
This commit changes the `delimited` method of `Parser` to add a label to the expected diagnostic for a missing delimiter.

It does this by finding the last non-trivia token event and using its span to point at where the missing delimiter might go.

Also fixes a failure to consume a delimiter if recovery stops at a delimiter.

Fixes #67.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
