### PR TITLE
fix: make trivia locations in the CST consistent.

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed the validation diagnostics to be ordered by the start of the primary
+  label ([#85](https://github.com/stjude-rust-labs/wdl/pull/85)).
+
 ## 0.3.0 - 06-13-2024
 
 ### Fixed

--- a/wdl-ast/src/validation.rs
+++ b/wdl-ast/src/validation.rs
@@ -1,5 +1,6 @@
 //! Validator for WDL documents.
 
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use super::v1;
@@ -87,6 +88,15 @@ impl Validator {
         if diagnostics.0.is_empty() {
             Ok(())
         } else {
+            // Sort the diagnostics by start of the primary label
+            diagnostics
+                .0
+                .sort_by(|a, b| match (a.labels().next(), b.labels().next()) {
+                    (None, None) => Ordering::Equal,
+                    (None, Some(_)) => Ordering::Less,
+                    (Some(_), None) => Ordering::Greater,
+                    (Some(a), Some(b)) => a.span().start().cmp(&b.span().start()),
+                });
             Err(diagnostics.0.into())
         }
     }

--- a/wdl-ast/tests/validation.rs
+++ b/wdl-ast/tests/validation.rs
@@ -70,11 +70,7 @@ fn normalize(s: &str, is_error: bool) -> String {
     s.replace("\r\n", "\n")
 }
 
-fn format_diagnostics<'a>(
-    diagnostics: impl Iterator<Item = &'a Diagnostic>,
-    path: &Path,
-    source: &str,
-) -> String {
+fn format_diagnostics(diagnostics: &[Diagnostic], path: &Path, source: &str) -> String {
     let file = SimpleFile::new(path.as_os_str().to_str().unwrap(), source);
     let mut buffer = Buffer::no_color();
     for diagnostic in diagnostics {
@@ -136,14 +132,14 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<(), String> {
             let validator = Validator::default();
             let errors = match validator.validate(&document) {
                 Ok(()) => String::new(),
-                Err(diagnostics) => format_diagnostics(diagnostics.iter(), &path, &source),
+                Err(diagnostics) => format_diagnostics(&diagnostics, &path, &source),
             };
             compare_result(&path.with_extension("errors"), &errors, true)?;
         }
         Err(diagnostics) => {
             compare_result(
                 &path.with_extension("errors"),
-                &format_diagnostics(diagnostics.iter(), &path, &source),
+                &format_diagnostics(&diagnostics, &path, &source),
                 true,
             )?;
         }

--- a/wdl-ast/tests/validation/metadata-object-duplicate-keys/source.errors
+++ b/wdl-ast/tests/validation/metadata-object-duplicate-keys/source.errors
@@ -1,12 +1,3 @@
-error: duplicate key `foo` in metadata object
-   ┌─ tests/validation/metadata-object-duplicate-keys/source.wdl:16:13
-   │
- 8 │             foo: {
-   │             --- first key with this name is here
-   ·
-16 │             foo: "dup",
-   │             ^^^ this key is a duplicate
-
 error: duplicate key `bar` in metadata object
    ┌─ tests/validation/metadata-object-duplicate-keys/source.wdl:13:17
    │
@@ -15,4 +6,13 @@ error: duplicate key `bar` in metadata object
    ·
 13 │                 bar: "dup",
    │                 ^^^ this key is a duplicate
+
+error: duplicate key `foo` in metadata object
+   ┌─ tests/validation/metadata-object-duplicate-keys/source.wdl:16:13
+   │
+ 8 │             foo: {
+   │             --- first key with this name is here
+   ·
+16 │             foo: "dup",
+   │             ^^^ this key is a duplicate
 

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed trivia in the CST so that it appears at consistent locations; also
+  fixed the parser diagnostics to be ordered by the start of the primary label
+  ([#85](https://github.com/stjude-rust-labs/wdl/pull/85)).
 * Fixed a missing delimiter diagnostic to include a label for where the parser 
   thinks the missing delimiter might go ([#84](https://github.com/stjude-rust-labs/wdl/pull/84)).
 

--- a/wdl-grammar/src/tree.rs
+++ b/wdl-grammar/src/tree.rs
@@ -1,5 +1,6 @@
 //! Module for the concrete syntax tree (CST) representation.
 
+use std::cmp::Ordering;
 use std::fmt;
 
 use rowan::GreenNodeBuilder;
@@ -392,8 +393,17 @@ impl SyntaxTree {
     /// ```
     pub fn parse(source: &str) -> (Self, Vec<Diagnostic>) {
         let parser = Parser::new(Lexer::new(source));
-        let (events, errors) = grammar::document(source, parser);
-        Self::build(source, events, errors)
+        let (events, mut diagnostics) = grammar::document(source, parser);
+
+        // Sort the diagnostics by start of the primary label
+        diagnostics.sort_by(|a, b| match (a.labels().next(), b.labels().next()) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (Some(a), Some(b)) => a.span().start().cmp(&b.span().start()),
+        });
+
+        Self::build(source, events, diagnostics)
     }
 
     /// Builds the concrete syntax tree from a list of parser events.

--- a/wdl-grammar/tests/parsing.rs
+++ b/wdl-grammar/tests/parsing.rs
@@ -71,11 +71,7 @@ fn normalize(s: &str, is_error: bool) -> String {
     s.replace("\r\n", "\n")
 }
 
-fn format_diagnostics(
-    diagnostics: impl Iterator<Item = Diagnostic>,
-    path: &Path,
-    source: &str,
-) -> String {
+fn format_diagnostics(diagnostics: &[Diagnostic], path: &Path, source: &str) -> String {
     let file = SimpleFile::new(path.as_os_str().to_str().unwrap(), source);
     let mut buffer = Buffer::no_color();
     for diagnostic in diagnostics {
@@ -136,7 +132,7 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<(), String> {
     compare_result(&path.with_extension("tree"), &format!("{:#?}", tree), false)?;
     compare_result(
         &path.with_extension("errors"),
-        &format_diagnostics(diagnostics.into_iter(), &path, &source),
+        &format_diagnostics(&diagnostics, &path, &source),
         true,
     )?;
     ntests.fetch_add(1, Ordering::SeqCst);

--- a/wdl-grammar/tests/parsing/atoms/source.tree
+++ b/wdl-grammar/tests/parsing/atoms/source.tree
@@ -13,54 +13,54 @@ RootNode@0..661
     Whitespace@62..63 " "
     OpenBrace@63..64 "{"
     Whitespace@64..69 "\n    "
-    BoundDeclNode@69..83
-      PrimitiveTypeNode@69..73
+    BoundDeclNode@69..78
+      PrimitiveTypeNode@69..72
         IntTypeKeyword@69..72 "Int"
-        Whitespace@72..73 " "
+      Whitespace@72..73 " "
       Ident@73..74 "a"
       Whitespace@74..75 " "
       Assignment@75..76 "="
       LiteralIntegerNode@76..78
         Whitespace@76..77 " "
         Integer@77..78 "1"
-      Whitespace@78..83 "\n    "
-    BoundDeclNode@83..102
-      PrimitiveTypeNode@83..89
+    Whitespace@78..83 "\n    "
+    BoundDeclNode@83..97
+      PrimitiveTypeNode@83..88
         FloatTypeKeyword@83..88 "Float"
-        Whitespace@88..89 " "
+      Whitespace@88..89 " "
       Ident@89..90 "b"
       Whitespace@90..91 " "
       Assignment@91..92 "="
       LiteralFloatNode@92..97
         Whitespace@92..93 " "
         Float@93..97 "3.14"
-      Whitespace@97..102 "\n    "
-    BoundDeclNode@102..123
-      PrimitiveTypeNode@102..110
+    Whitespace@97..102 "\n    "
+    BoundDeclNode@102..118
+      PrimitiveTypeNode@102..109
         BooleanTypeKeyword@102..109 "Boolean"
-        Whitespace@109..110 " "
+      Whitespace@109..110 " "
       Ident@110..111 "c"
       Whitespace@111..112 " "
       Assignment@112..113 "="
       LiteralBooleanNode@113..118
         Whitespace@113..114 " "
         TrueKeyword@114..118 "true"
-      Whitespace@118..123 "\n    "
-    BoundDeclNode@123..145
-      PrimitiveTypeNode@123..131
+    Whitespace@118..123 "\n    "
+    BoundDeclNode@123..140
+      PrimitiveTypeNode@123..130
         BooleanTypeKeyword@123..130 "Boolean"
-        Whitespace@130..131 " "
+      Whitespace@130..131 " "
       Ident@131..132 "d"
       Whitespace@132..133 " "
       Assignment@133..134 "="
       LiteralBooleanNode@134..140
         Whitespace@134..135 " "
         FalseKeyword@135..140 "false"
-      Whitespace@140..145 "\n    "
-    BoundDeclNode@145..168
-      PrimitiveTypeNode@145..152
+    Whitespace@140..145 "\n    "
+    BoundDeclNode@145..163
+      PrimitiveTypeNode@145..151
         StringTypeKeyword@145..151 "String"
-        Whitespace@151..152 " "
+      Whitespace@151..152 " "
       Ident@152..153 "e"
       Whitespace@153..154 " "
       Assignment@154..155 "="
@@ -69,11 +69,11 @@ RootNode@0..661
         SingleQuote@156..157 "'"
         LiteralStringText@157..162 "hello"
         SingleQuote@162..163 "'"
-      Whitespace@163..168 "\n    "
-    BoundDeclNode@168..191
-      PrimitiveTypeNode@168..175
+    Whitespace@163..168 "\n    "
+    BoundDeclNode@168..186
+      PrimitiveTypeNode@168..174
         StringTypeKeyword@168..174 "String"
-        Whitespace@174..175 " "
+      Whitespace@174..175 " "
       Ident@175..176 "f"
       Whitespace@176..177 " "
       Assignment@177..178 "="
@@ -82,15 +82,15 @@ RootNode@0..661
         DoubleQuote@179..180 "\""
         LiteralStringText@180..185 "world"
         DoubleQuote@185..186 "\""
-      Whitespace@186..191 "\n    "
-    BoundDeclNode@191..220
-      ArrayTypeNode@191..202
+    Whitespace@186..191 "\n    "
+    BoundDeclNode@191..215
+      ArrayTypeNode@191..201
         ArrayTypeKeyword@191..196 "Array"
         OpenBracket@196..197 "["
         PrimitiveTypeNode@197..200
           IntTypeKeyword@197..200 "Int"
         CloseBracket@200..201 "]"
-        Whitespace@201..202 " "
+      Whitespace@201..202 " "
       Ident@202..203 "g"
       Whitespace@203..204 " "
       Assignment@204..205 "="
@@ -108,9 +108,9 @@ RootNode@0..661
         LiteralIntegerNode@213..214
           Integer@213..214 "3"
         CloseBracket@214..215 "]"
-      Whitespace@215..220 "\n    "
-    BoundDeclNode@220..263
-      PairTypeNode@220..242
+    Whitespace@215..220 "\n    "
+    BoundDeclNode@220..258
+      PairTypeNode@220..241
         PairTypeKeyword@220..224 "Pair"
         OpenBracket@224..225 "["
         PrimitiveTypeNode@225..232
@@ -120,7 +120,7 @@ RootNode@0..661
           Whitespace@233..234 " "
           StringTypeKeyword@234..240 "String"
         CloseBracket@240..241 "]"
-        Whitespace@241..242 " "
+      Whitespace@241..242 " "
       Ident@242..243 "h"
       Whitespace@243..244 " "
       Assignment@244..245 "="
@@ -136,9 +136,9 @@ RootNode@0..661
           LiteralStringText@254..256 "hi"
           DoubleQuote@256..257 "\""
         CloseParen@257..258 ")"
-      Whitespace@258..263 "\n    "
-    BoundDeclNode@263..321
-      MapTypeNode@263..290
+    Whitespace@258..263 "\n    "
+    BoundDeclNode@263..316
+      MapTypeNode@263..289
         MapTypeKeyword@263..266 "Map"
         OpenBracket@266..267 "["
         PrimitiveTypeNode@267..273
@@ -152,7 +152,7 @@ RootNode@0..661
             StringTypeKeyword@281..287 "String"
           CloseBracket@287..288 "]"
         CloseBracket@288..289 "]"
-        Whitespace@289..290 " "
+      Whitespace@289..290 " "
       Ident@290..291 "i"
       Whitespace@291..292 " "
       Assignment@292..293 "="
@@ -160,7 +160,7 @@ RootNode@0..661
         Whitespace@293..294 " "
         OpenBrace@294..295 "{"
         Whitespace@295..296 " "
-        LiteralMapItemNode@296..315
+        LiteralMapItemNode@296..314
           LiteralStringNode@296..303
             SingleQuote@296..297 "'"
             LiteralStringText@297..302 "hello"
@@ -174,13 +174,13 @@ RootNode@0..661
               LiteralStringText@307..312 "world"
               SingleQuote@312..313 "'"
             CloseBracket@313..314 "]"
-          Whitespace@314..315 " "
+        Whitespace@314..315 " "
         CloseBrace@315..316 "}"
-      Whitespace@316..321 "\n    "
-    BoundDeclNode@321..374
-      ObjectTypeNode@321..328
+    Whitespace@316..321 "\n    "
+    BoundDeclNode@321..369
+      ObjectTypeNode@321..327
         ObjectTypeKeyword@321..327 "Object"
-        Whitespace@327..328 " "
+      Whitespace@327..328 " "
       Ident@328..329 "j"
       Whitespace@329..330 " "
       Assignment@330..331 "="
@@ -208,19 +208,19 @@ RootNode@0..661
             DoubleQuote@356..357 "\""
         Comma@357..358 ","
         Whitespace@358..359 " "
-        LiteralObjectItemNode@359..368
+        LiteralObjectItemNode@359..367
           Ident@359..362 "baz"
           Colon@362..363 ":"
           LiteralFloatNode@363..367
             Whitespace@363..364 " "
             Float@364..367 "3.0"
-          Whitespace@367..368 " "
+        Whitespace@367..368 " "
         CloseBrace@368..369 "}"
-      Whitespace@369..374 "\n    "
-    BoundDeclNode@374..451
-      TypeRefNode@374..383
+    Whitespace@369..374 "\n    "
+    BoundDeclNode@374..446
+      TypeRefNode@374..382
         Ident@374..382 "MyStruct"
-        Whitespace@382..383 " "
+      Whitespace@382..383 " "
       Ident@383..384 "k"
       Whitespace@384..385 " "
       Assignment@385..386 "="
@@ -266,26 +266,26 @@ RootNode@0..661
           Ident@431..432 "c"
           Colon@432..433 ":"
           LogicalOrExprNode@433..445
-            NameRefNode@433..436
+            NameRefNode@433..435
               Whitespace@433..434 " "
               Ident@434..435 "c"
-              Whitespace@435..436 " "
+            Whitespace@435..436 " "
             LogicalOr@436..438 "||"
             LogicalAndExprNode@438..445
-              NameRefNode@438..441
+              NameRefNode@438..440
                 Whitespace@438..439 " "
                 Ident@439..440 "d"
-                Whitespace@440..441 " "
+              Whitespace@440..441 " "
               LogicalAnd@441..443 "&&"
               NameRefNode@443..445
                 Whitespace@443..444 " "
                 Ident@444..445 "c"
         CloseBrace@445..446 "}"
-      Whitespace@446..451 "\n    "
-    BoundDeclNode@451..468
-      PrimitiveTypeNode@451..455
+    Whitespace@446..451 "\n    "
+    BoundDeclNode@451..463
+      PrimitiveTypeNode@451..454
         IntTypeKeyword@451..454 "Int"
-        Whitespace@454..455 " "
+      Whitespace@454..455 " "
       Ident@455..456 "l"
       Whitespace@456..457 " "
       Assignment@457..458 "="
@@ -297,51 +297,51 @@ RootNode@0..661
         LiteralIntegerNode@461..462
           Integer@461..462 "0"
         CloseBracket@462..463 "]"
-      Whitespace@463..468 "\n    "
-    BoundDeclNode@468..507
-      PrimitiveTypeNode@468..472
+    Whitespace@463..468 "\n    "
+    BoundDeclNode@468..502
+      PrimitiveTypeNode@468..471
         IntTypeKeyword@468..471 "Int"
-        Whitespace@471..472 " "
+      Whitespace@471..472 " "
       Ident@472..473 "m"
       Whitespace@473..474 " "
       Assignment@474..475 "="
-      IfExprNode@475..507
+      IfExprNode@475..502
         Whitespace@475..476 " "
         IfKeyword@476..478 "if"
-        NameRefNode@478..481
+        NameRefNode@478..480
           Whitespace@478..479 " "
           Ident@479..480 "c"
-          Whitespace@480..481 " "
+        Whitespace@480..481 " "
         ThenKeyword@481..485 "then"
-        AdditionExprNode@485..492
-          NameRefNode@485..488
+        AdditionExprNode@485..491
+          NameRefNode@485..487
             Whitespace@485..486 " "
             Ident@486..487 "k"
-            Whitespace@487..488 " "
+          Whitespace@487..488 " "
           Plus@488..489 "+"
           LiteralIntegerNode@489..491
             Whitespace@489..490 " "
             Integer@490..491 "1"
-          Whitespace@491..492 " "
+        Whitespace@491..492 " "
         ElseKeyword@492..496 "else"
-        MultiplicationExprNode@496..507
-          NameRefNode@496..499
+        MultiplicationExprNode@496..502
+          NameRefNode@496..498
             Whitespace@496..497 " "
             Ident@497..498 "a"
-            Whitespace@498..499 " "
+          Whitespace@498..499 " "
           Asterisk@499..500 "*"
           LiteralIntegerNode@500..502
             Whitespace@500..501 " "
             Integer@501..502 "2"
-          Whitespace@502..507 "\n    "
-    BoundDeclNode@507..529
-      ArrayTypeNode@507..518
+    Whitespace@502..507 "\n    "
+    BoundDeclNode@507..524
+      ArrayTypeNode@507..517
         ArrayTypeKeyword@507..512 "Array"
         OpenBracket@512..513 "["
         PrimitiveTypeNode@513..516
           IntTypeKeyword@513..516 "Int"
         CloseBracket@516..517 "]"
-        Whitespace@517..518 " "
+      Whitespace@517..518 " "
       Ident@518..519 "n"
       Whitespace@519..520 " "
       Assignment@520..521 "="
@@ -349,9 +349,9 @@ RootNode@0..661
         Whitespace@521..522 " "
         OpenBracket@522..523 "["
         CloseBracket@523..524 "]"
-      Whitespace@524..529 "\n    "
-    BoundDeclNode@529..560
-      MapTypeNode@529..549
+    Whitespace@524..529 "\n    "
+    BoundDeclNode@529..555
+      MapTypeNode@529..548
         MapTypeKeyword@529..532 "Map"
         OpenBracket@532..533 "["
         PrimitiveTypeNode@533..539
@@ -361,7 +361,7 @@ RootNode@0..661
           Whitespace@540..541 " "
           StringTypeKeyword@541..547 "String"
         CloseBracket@547..548 "]"
-        Whitespace@548..549 " "
+      Whitespace@548..549 " "
       Ident@549..550 "o"
       Whitespace@550..551 " "
       Assignment@551..552 "="
@@ -369,11 +369,11 @@ RootNode@0..661
         Whitespace@552..553 " "
         OpenBrace@553..554 "{"
         CloseBrace@554..555 "}"
-      Whitespace@555..560 "\n    "
-    BoundDeclNode@560..591
-      TypeRefNode@560..564
+    Whitespace@555..560 "\n    "
+    BoundDeclNode@560..586
+      TypeRefNode@560..563
         Ident@560..563 "Foo"
-        Whitespace@563..564 " "
+      Whitespace@563..564 " "
       Ident@564..565 "p"
       Whitespace@565..566 " "
       Assignment@566..567 "="
@@ -383,7 +383,7 @@ RootNode@0..661
         Whitespace@571..572 " "
         OpenBrace@572..573 "{"
         Whitespace@573..574 " "
-        LiteralStructItemNode@574..585
+        LiteralStructItemNode@574..584
           Ident@574..577 "foo"
           Colon@577..578 ":"
           LiteralStringNode@578..584
@@ -391,13 +391,13 @@ RootNode@0..661
             DoubleQuote@579..580 "\""
             LiteralStringText@580..583 "bar"
             DoubleQuote@583..584 "\""
-          Whitespace@584..585 " "
+        Whitespace@584..585 " "
         CloseBrace@585..586 "}"
-      Whitespace@586..591 "\n    "
-    BoundDeclNode@591..616
-      ObjectTypeNode@591..598
+    Whitespace@586..591 "\n    "
+    BoundDeclNode@591..611
+      ObjectTypeNode@591..597
         ObjectTypeKeyword@591..597 "Object"
-        Whitespace@597..598 " "
+      Whitespace@597..598 " "
       Ident@598..599 "q"
       Whitespace@599..600 " "
       Assignment@600..601 "="
@@ -407,8 +407,8 @@ RootNode@0..661
         Whitespace@608..609 " "
         OpenBrace@609..610 "{"
         CloseBrace@610..611 "}"
-      Whitespace@611..616 "\n    "
-    BoundDeclNode@616..637
+    Whitespace@611..616 "\n    "
+    BoundDeclNode@616..632
       PrimitiveTypeNode@616..623
         StringTypeKeyword@616..622 "String"
         QuestionMark@622..623 "?"
@@ -419,23 +419,23 @@ RootNode@0..661
       LiteralNoneNode@627..632
         Whitespace@627..628 " "
         NoneKeyword@628..632 "None"
-      Whitespace@632..637 "\n    "
-    BoundDeclNode@637..659
-      PrimitiveTypeNode@637..645
+    Whitespace@632..637 "\n    "
+    BoundDeclNode@637..658
+      PrimitiveTypeNode@637..644
         BooleanTypeKeyword@637..644 "Boolean"
-        Whitespace@644..645 " "
+      Whitespace@644..645 " "
       Ident@645..646 "s"
       Whitespace@646..647 " "
       Assignment@647..648 "="
-      EqualityExprNode@648..659
-        NameRefNode@648..651
+      EqualityExprNode@648..658
+        NameRefNode@648..650
           Whitespace@648..649 " "
           Ident@649..650 "r"
-          Whitespace@650..651 " "
+        Whitespace@650..651 " "
         Equal@651..653 "=="
         LiteralNoneNode@653..658
           Whitespace@653..654 " "
           NoneKeyword@654..658 "None"
-        Whitespace@658..659 "\n"
+    Whitespace@658..659 "\n"
     CloseBrace@659..660 "}"
   Whitespace@660..661 "\n"

--- a/wdl-grammar/tests/parsing/brace-command-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/brace-command-recovery/source.tree
@@ -29,7 +29,7 @@ RootNode@0..165
       Whitespace@135..136 " "
       OpenBrace@136..137 "{"
       Whitespace@137..146 "\n        "
-      RuntimeItemNode@146..161
+      RuntimeItemNode@146..156
         Ident@146..149 "foo"
         Colon@149..150 ":"
         LiteralStringNode@150..156
@@ -37,7 +37,7 @@ RootNode@0..165
           DoubleQuote@151..152 "\""
           LiteralStringText@152..155 "bar"
           DoubleQuote@155..156 "\""
-        Whitespace@156..161 "\n    "
+      Whitespace@156..161 "\n    "
       CloseBrace@161..162 "}"
     Whitespace@162..163 "\n"
     CloseBrace@163..164 "}"

--- a/wdl-grammar/tests/parsing/call-statements/source.tree
+++ b/wdl-grammar/tests/parsing/call-statements/source.tree
@@ -13,18 +13,18 @@ RootNode@0..425
     Whitespace@64..65 " "
     OpenBrace@65..66 "{"
     Whitespace@66..71 "\n    "
-    CallStatementNode@71..90
+    CallStatementNode@71..85
       CallKeyword@71..75 "call"
-      CallTargetNode@75..90
+      CallTargetNode@75..85
         Whitespace@75..76 " "
         Ident@76..85 "no_params"
-        Whitespace@85..90 "\n    "
+    Whitespace@85..90 "\n    "
     CallStatementNode@90..132
       CallKeyword@90..94 "call"
-      CallTargetNode@94..107
+      CallTargetNode@94..106
         Whitespace@94..95 " "
         Ident@95..106 "with_params"
-        Whitespace@106..107 " "
+      Whitespace@106..107 " "
       OpenBrace@107..108 "{"
       Whitespace@108..109 " "
       InputKeyword@109..114 "input"
@@ -42,24 +42,24 @@ RootNode@0..425
         Ident@122..123 "c"
       Comma@123..124 ","
       Whitespace@124..125 " "
-      CallInputItemNode@125..131
+      CallInputItemNode@125..130
         Ident@125..126 "d"
         Whitespace@126..127 " "
         Assignment@127..128 "="
         LiteralIntegerNode@128..130
           Whitespace@128..129 " "
           Integer@129..130 "1"
-        Whitespace@130..131 " "
+      Whitespace@130..131 " "
       CloseBrace@131..132 "}"
     Whitespace@132..137 "\n    "
-    CallStatementNode@137..161
+    CallStatementNode@137..156
       CallKeyword@137..141 "call"
       CallTargetNode@141..156
         Whitespace@141..142 " "
         Ident@142..151 "qualified"
         Dot@151..152 "."
         Ident@152..156 "name"
-      Whitespace@156..161 "\n    "
+    Whitespace@156..161 "\n    "
     CallStatementNode@161..213
       CallKeyword@161..165 "call"
       CallTargetNode@165..180
@@ -91,7 +91,7 @@ RootNode@0..425
           Integer@201..202 "2"
       Comma@202..203 ","
       Whitespace@203..204 " "
-      CallInputItemNode@204..212
+      CallInputItemNode@204..211
         Ident@204..205 "c"
         Whitespace@205..206 " "
         Assignment@206..207 "="
@@ -100,26 +100,26 @@ RootNode@0..425
           DoubleQuote@208..209 "\""
           LiteralStringText@209..210 "3"
           DoubleQuote@210..211 "\""
-        Whitespace@211..212 " "
+      Whitespace@211..212 " "
       CloseBrace@212..213 "}"
     Whitespace@213..218 "\n    "
-    CallStatementNode@218..240
+    CallStatementNode@218..235
       CallKeyword@218..222 "call"
-      CallTargetNode@222..231
+      CallTargetNode@222..230
         Whitespace@222..223 " "
         Ident@223..230 "aliased"
-        Whitespace@230..231 " "
+      Whitespace@230..231 " "
       CallAliasNode@231..235
         AsKeyword@231..233 "as"
         Whitespace@233..234 " "
         Ident@234..235 "x"
-      Whitespace@235..240 "\n    "
+    Whitespace@235..240 "\n    "
     CallStatementNode@240..268
       CallKeyword@240..244 "call"
-      CallTargetNode@244..253
+      CallTargetNode@244..252
         Whitespace@244..245 " "
         Ident@245..252 "aliased"
-        Whitespace@252..253 " "
+      Whitespace@252..253 " "
       CallAliasNode@253..257
         AsKeyword@253..255 "as"
         Whitespace@255..256 " "
@@ -132,12 +132,12 @@ RootNode@0..425
       Whitespace@266..267 " "
       CloseBrace@267..268 "}"
     Whitespace@268..273 "\n    "
-    CallStatementNode@273..300
+    CallStatementNode@273..295
       CallKeyword@273..277 "call"
-      CallTargetNode@277..280
+      CallTargetNode@277..279
         Whitespace@277..278 " "
         Ident@278..279 "f"
-        Whitespace@279..280 " "
+      Whitespace@279..280 " "
       CallAfterNode@280..287
         AfterKeyword@280..285 "after"
         Whitespace@285..286 " "
@@ -147,13 +147,13 @@ RootNode@0..425
         AfterKeyword@288..293 "after"
         Whitespace@293..294 " "
         Ident@294..295 "y"
-      Whitespace@295..300 "\n    "
+    Whitespace@295..300 "\n    "
     CallStatementNode@300..340
       CallKeyword@300..304 "call"
-      CallTargetNode@304..307
+      CallTargetNode@304..306
         Whitespace@304..305 " "
         Ident@305..306 "f"
-        Whitespace@306..307 " "
+      Whitespace@306..307 " "
       CallAfterNode@307..314
         AfterKeyword@307..312 "after"
         Whitespace@312..313 " "
@@ -169,7 +169,7 @@ RootNode@0..425
       InputKeyword@325..330 "input"
       Colon@330..331 ":"
       Whitespace@331..332 " "
-      CallInputItemNode@332..339
+      CallInputItemNode@332..338
         Ident@332..333 "a"
         Whitespace@333..334 " "
         Assignment@334..335 "="
@@ -177,15 +177,15 @@ RootNode@0..425
           Whitespace@335..336 " "
           OpenBracket@336..337 "["
           CloseBracket@337..338 "]"
-        Whitespace@338..339 " "
+      Whitespace@338..339 " "
       CloseBrace@339..340 "}"
     Whitespace@340..345 "\n    "
-    CallStatementNode@345..369
+    CallStatementNode@345..364
       CallKeyword@345..349 "call"
-      CallTargetNode@349..352
+      CallTargetNode@349..351
         Whitespace@349..350 " "
         Ident@350..351 "f"
-        Whitespace@351..352 " "
+      Whitespace@351..352 " "
       CallAliasNode@352..356
         AsKeyword@352..354 "as"
         Whitespace@354..355 " "
@@ -195,13 +195,13 @@ RootNode@0..425
         AfterKeyword@357..362 "after"
         Whitespace@362..363 " "
         Ident@363..364 "x"
-      Whitespace@364..369 "\n    "
+    Whitespace@364..369 "\n    "
     CallStatementNode@369..422
       CallKeyword@369..373 "call"
-      CallTargetNode@373..376
+      CallTargetNode@373..375
         Whitespace@373..374 " "
         Ident@374..375 "f"
-        Whitespace@375..376 " "
+      Whitespace@375..376 " "
       CallAliasNode@376..380
         AsKeyword@376..378 "as"
         Whitespace@378..379 " "
@@ -222,7 +222,7 @@ RootNode@0..425
       InputKeyword@399..404 "input"
       Colon@404..405 ":"
       Whitespace@405..406 " "
-      CallInputItemNode@406..421
+      CallInputItemNode@406..420
         Ident@406..410 "name"
         Whitespace@410..411 " "
         Assignment@411..412 "="
@@ -231,7 +231,7 @@ RootNode@0..425
           DoubleQuote@413..414 "\""
           LiteralStringText@414..419 "hello"
           DoubleQuote@419..420 "\""
-        Whitespace@420..421 " "
+      Whitespace@420..421 " "
       CloseBrace@421..422 "}"
     Whitespace@422..423 "\n"
     CloseBrace@423..424 "}"

--- a/wdl-grammar/tests/parsing/command-sections/source.tree
+++ b/wdl-grammar/tests/parsing/command-sections/source.tree
@@ -18,10 +18,10 @@ RootNode@0..467
       Whitespace@76..77 " "
       OpenBrace@77..78 "{"
       Whitespace@78..87 "\n        "
-      BoundDeclNode@87..113
-        PrimitiveTypeNode@87..94
+      BoundDeclNode@87..108
+        PrimitiveTypeNode@87..93
           StringTypeKeyword@87..93 "String"
-          Whitespace@93..94 " "
+        Whitespace@93..94 " "
         Ident@94..98 "name"
         Whitespace@98..99 " "
         Assignment@99..100 "="
@@ -30,7 +30,7 @@ RootNode@0..467
           DoubleQuote@101..102 "\""
           LiteralStringText@102..107 "world"
           DoubleQuote@107..108 "\""
-        Whitespace@108..113 "\n    "
+      Whitespace@108..113 "\n    "
       CloseBrace@113..114 "}"
     Whitespace@114..120 "\n\n    "
     CommandSectionNode@120..261
@@ -60,10 +60,10 @@ RootNode@0..467
       Whitespace@287..288 " "
       OpenBrace@288..289 "{"
       Whitespace@289..298 "\n        "
-      BoundDeclNode@298..324
-        PrimitiveTypeNode@298..305
+      BoundDeclNode@298..319
+        PrimitiveTypeNode@298..304
           StringTypeKeyword@298..304 "String"
-          Whitespace@304..305 " "
+        Whitespace@304..305 " "
         Ident@305..309 "name"
         Whitespace@309..310 " "
         Assignment@310..311 "="
@@ -72,7 +72,7 @@ RootNode@0..467
           DoubleQuote@312..313 "\""
           LiteralStringText@313..318 "world"
           DoubleQuote@318..319 "\""
-        Whitespace@319..324 "\n    "
+      Whitespace@319..324 "\n    "
       CloseBrace@324..325 "}"
     Whitespace@325..331 "\n\n    "
     CommandSectionNode@331..464

--- a/wdl-grammar/tests/parsing/conditional-statements/source.tree
+++ b/wdl-grammar/tests/parsing/conditional-statements/source.tree
@@ -51,12 +51,12 @@ RootNode@0..442
             Whitespace@170..171 " "
             OpenBrace@171..172 "{"
             Whitespace@172..193 "\n                    "
-            CallStatementNode@193..216
+            CallStatementNode@193..199
               CallKeyword@193..197 "call"
-              CallTargetNode@197..216
+              CallTargetNode@197..199
                 Whitespace@197..198 " "
                 Ident@198..199 "z"
-                Whitespace@199..216 "\n                "
+            Whitespace@199..216 "\n                "
             CloseBrace@216..217 "}"
           Whitespace@217..230 "\n            "
           CloseBrace@230..231 "}"
@@ -67,32 +67,32 @@ RootNode@0..442
       Whitespace@308..317 "\n        "
       ConditionalStatementNode@317..352
         IfKeyword@317..319 "if"
-        NameRefNode@319..322
+        NameRefNode@319..321
           Whitespace@319..320 " "
           Ident@320..321 "x"
-          Whitespace@321..322 " "
+        Whitespace@321..322 " "
         OpenBrace@322..323 "{"
         Whitespace@323..336 "\n            "
-        CallStatementNode@336..351
+        CallStatementNode@336..342
           CallKeyword@336..340 "call"
-          CallTargetNode@340..351
+          CallTargetNode@340..342
             Whitespace@340..341 " "
             Ident@341..342 "y"
-            Whitespace@342..351 "\n        "
+        Whitespace@342..351 "\n        "
         CloseBrace@351..352 "}"
       Whitespace@352..362 "\n\n        "
       CallStatementNode@362..394
         CallKeyword@362..366 "call"
-        CallTargetNode@366..369
+        CallTargetNode@366..368
           Whitespace@366..367 " "
           Ident@367..368 "z"
-          Whitespace@368..369 " "
+        Whitespace@368..369 " "
         OpenBrace@369..370 "{"
         Whitespace@370..371 " "
         InputKeyword@371..376 "input"
         Colon@376..377 ":"
         Whitespace@377..378 " "
-        CallInputItemNode@378..393
+        CallInputItemNode@378..392
           Ident@378..382 "name"
           Whitespace@382..383 " "
           Assignment@383..384 "="
@@ -101,21 +101,21 @@ RootNode@0..442
             DoubleQuote@385..386 "\""
             LiteralStringText@386..391 "world"
             DoubleQuote@391..392 "\""
-          Whitespace@392..393 " "
+        Whitespace@392..393 " "
         CloseBrace@393..394 "}"
       Whitespace@394..403 "\n        "
       CallStatementNode@403..433
         CallKeyword@403..407 "call"
-        CallTargetNode@407..410
+        CallTargetNode@407..409
           Whitespace@407..408 " "
           Ident@408..409 "z"
-          Whitespace@409..410 " "
+        Whitespace@409..410 " "
         OpenBrace@410..411 "{"
         Whitespace@411..412 " "
         InputKeyword@412..417 "input"
         Colon@417..418 ":"
         Whitespace@418..419 " "
-        CallInputItemNode@419..432
+        CallInputItemNode@419..431
           Ident@419..423 "name"
           Whitespace@423..424 " "
           Assignment@424..425 "="
@@ -124,7 +124,7 @@ RootNode@0..442
             DoubleQuote@426..427 "\""
             LiteralStringText@427..430 "you"
             DoubleQuote@430..431 "\""
-          Whitespace@431..432 " "
+        Whitespace@431..432 " "
         CloseBrace@432..433 "}"
       Whitespace@433..438 "\n    "
       CloseBrace@438..439 "}"

--- a/wdl-grammar/tests/parsing/consistent-comments/source.tree
+++ b/wdl-grammar/tests/parsing/consistent-comments/source.tree
@@ -1,0 +1,45 @@
+RootNode@0..237
+  Comment@0..81 "## This is a test for ..."
+  Whitespace@81..82 "\n"
+  Comment@82..151 "## The comments shoul ..."
+  Whitespace@151..153 "\n\n"
+  VersionStatementNode@153..164
+    VersionKeyword@153..160 "version"
+    Whitespace@160..161 " "
+    Version@161..164 "1.1"
+  Whitespace@164..166 "\n\n"
+  WorkflowDefinitionNode@166..236
+    WorkflowKeyword@166..174 "workflow"
+    Whitespace@174..175 " "
+    Ident@175..179 "test"
+    Whitespace@179..180 " "
+    OpenBrace@180..181 "{"
+    Whitespace@181..186 "\n    "
+    Comment@186..193 "# First"
+    Whitespace@193..198 "\n    "
+    BoundDeclNode@198..207
+      PrimitiveTypeNode@198..201
+        IntTypeKeyword@198..201 "Int"
+      Whitespace@201..202 " "
+      Ident@202..203 "x"
+      Whitespace@203..204 " "
+      Assignment@204..205 "="
+      LiteralIntegerNode@205..207
+        Whitespace@205..206 " "
+        Integer@206..207 "1"
+    Whitespace@207..212 "\n    "
+    Comment@212..220 "# Second"
+    Whitespace@220..225 "\n    "
+    BoundDeclNode@225..234
+      PrimitiveTypeNode@225..228
+        IntTypeKeyword@225..228 "Int"
+      Whitespace@228..229 " "
+      Ident@229..230 "y"
+      Whitespace@230..231 " "
+      Assignment@231..232 "="
+      LiteralIntegerNode@232..234
+        Whitespace@232..233 " "
+        Integer@233..234 "2"
+    Whitespace@234..235 "\n"
+    CloseBrace@235..236 "}"
+  Whitespace@236..237 "\n"

--- a/wdl-grammar/tests/parsing/consistent-comments/source.wdl
+++ b/wdl-grammar/tests/parsing/consistent-comments/source.wdl
@@ -1,0 +1,11 @@
+## This is a test for ensuring comments show up in the CST at expected locations.
+## The comments should appear as previous siblings to each decl node.
+
+version 1.1
+
+workflow test {
+    # First
+    Int x = 1
+    # Second
+    Int y = 2
+}

--- a/wdl-grammar/tests/parsing/empty-call/source.tree
+++ b/wdl-grammar/tests/parsing/empty-call/source.tree
@@ -15,10 +15,10 @@ RootNode@0..81
     Whitespace@64..69 "\n    "
     CallStatementNode@69..79
       CallKeyword@69..73 "call"
-      CallTargetNode@73..76
+      CallTargetNode@73..75
         Whitespace@73..74 " "
         Ident@74..75 "x"
-        Whitespace@75..76 " "
+      Whitespace@75..76 " "
       OpenBrace@76..77 "{"
       Whitespace@77..78 " "
       CloseBrace@78..79 "}"

--- a/wdl-grammar/tests/parsing/escaped-newlines/source.tree
+++ b/wdl-grammar/tests/parsing/escaped-newlines/source.tree
@@ -13,10 +13,10 @@ RootNode@0..333
     Whitespace@94..95 " "
     OpenBrace@95..96 "{"
     Whitespace@96..101 "\n    "
-    BoundDeclNode@101..134
-      PrimitiveTypeNode@101..108
+    BoundDeclNode@101..128
+      PrimitiveTypeNode@101..107
         StringTypeKeyword@101..107 "String"
-        Whitespace@107..108 " "
+      Whitespace@107..108 " "
       Ident@108..109 "x"
       Whitespace@109..110 " "
       Assignment@110..111 "="
@@ -25,7 +25,7 @@ RootNode@0..333
         DoubleQuote@112..113 "\""
         LiteralStringText@113..127 "first \\\nsecond"
         DoubleQuote@127..128 "\""
-      Whitespace@128..134 "\n\n    "
+    Whitespace@128..134 "\n\n    "
     CommandSectionNode@134..204
       CommandKeyword@134..141 "command"
       Whitespace@141..142 " "
@@ -42,10 +42,10 @@ RootNode@0..333
     Whitespace@219..220 " "
     OpenBrace@220..221 "{"
     Whitespace@221..226 "\n    "
-    BoundDeclNode@226..259
-      PrimitiveTypeNode@226..233
+    BoundDeclNode@226..253
+      PrimitiveTypeNode@226..232
         StringTypeKeyword@226..232 "String"
-        Whitespace@232..233 " "
+      Whitespace@232..233 " "
       Ident@233..234 "x"
       Whitespace@234..235 " "
       Assignment@235..236 "="
@@ -54,7 +54,7 @@ RootNode@0..333
         SingleQuote@237..238 "'"
         LiteralStringText@238..252 "first \\\nsecond"
         SingleQuote@252..253 "'"
-      Whitespace@253..259 "\n\n    "
+    Whitespace@253..259 "\n\n    "
     CommandSectionNode@259..330
       CommandKeyword@259..266 "command"
       Whitespace@266..267 " "

--- a/wdl-grammar/tests/parsing/imports/source.tree
+++ b/wdl-grammar/tests/parsing/imports/source.tree
@@ -6,15 +6,15 @@ RootNode@0..245
     Whitespace@47..48 " "
     Version@48..51 "1.1"
   Whitespace@51..53 "\n\n"
-  ImportStatementNode@53..68
+  ImportStatementNode@53..67
     ImportKeyword@53..59 "import"
     LiteralStringNode@59..67
       Whitespace@59..60 " "
       DoubleQuote@60..61 "\""
       LiteralStringText@61..66 "a.wdl"
       DoubleQuote@66..67 "\""
-    Whitespace@67..68 "\n"
-  ImportStatementNode@68..121
+  Whitespace@67..68 "\n"
+  ImportStatementNode@68..120
     ImportKeyword@68..74 "import"
     LiteralStringNode@74..110
       Whitespace@74..75 " "
@@ -25,8 +25,8 @@ RootNode@0..245
     AsKeyword@111..113 "as"
     Whitespace@113..114 " "
     Ident@114..120 "stdlib"
-    Whitespace@120..121 "\n"
-  ImportStatementNode@121..171
+  Whitespace@120..121 "\n"
+  ImportStatementNode@121..169
     ImportKeyword@121..127 "import"
     LiteralStringNode@127..135
       Whitespace@127..128 " "
@@ -51,7 +51,7 @@ RootNode@0..245
       AsKeyword@163..165 "as"
       Whitespace@165..166 " "
       Ident@166..169 "Qux"
-    Whitespace@169..171 " \n"
+  Whitespace@169..171 " \n"
   ImportStatementNode@171..245
     ImportKeyword@171..177 "import"
     LiteralStringNode@177..185

--- a/wdl-grammar/tests/parsing/infix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/infix-exprs/source.tree
@@ -13,14 +13,14 @@ RootNode@0..354
     Whitespace@52..53 " "
     OpenBrace@53..54 "{"
     Whitespace@54..59 "\n    "
-    BoundDeclNode@59..89
-      PrimitiveTypeNode@59..67
+    BoundDeclNode@59..84
+      PrimitiveTypeNode@59..66
         BooleanTypeKeyword@59..66 "Boolean"
-        Whitespace@66..67 " "
+      Whitespace@66..67 " "
       Ident@67..68 "a"
       Whitespace@68..69 " "
       Assignment@69..70 "="
-      LogicalOrExprNode@70..89
+      LogicalOrExprNode@70..84
         LiteralBooleanNode@70..75
           Whitespace@70..71 " "
           TrueKeyword@71..75 "true"
@@ -29,66 +29,66 @@ RootNode@0..354
         LiteralBooleanNode@78..84
           Whitespace@78..79 " "
           FalseKeyword@79..84 "false"
-        Whitespace@84..89 "\n    "
-    BoundDeclNode@89..115
-      PrimitiveTypeNode@89..97
+    Whitespace@84..89 "\n    "
+    BoundDeclNode@89..110
+      PrimitiveTypeNode@89..96
         BooleanTypeKeyword@89..96 "Boolean"
-        Whitespace@96..97 " "
+      Whitespace@96..97 " "
       Ident@97..98 "b"
       Whitespace@98..99 " "
       Assignment@99..100 "="
-      LogicalAndExprNode@100..115
-        NameRefNode@100..103
+      LogicalAndExprNode@100..110
+        NameRefNode@100..102
           Whitespace@100..101 " "
           Ident@101..102 "a"
-          Whitespace@102..103 " "
+        Whitespace@102..103 " "
         LogicalAnd@103..105 "&&"
         LiteralBooleanNode@105..110
           Whitespace@105..106 " "
           TrueKeyword@106..110 "true"
-        Whitespace@110..115 "\n    "
-    BoundDeclNode@115..138
-      PrimitiveTypeNode@115..123
+    Whitespace@110..115 "\n    "
+    BoundDeclNode@115..133
+      PrimitiveTypeNode@115..122
         BooleanTypeKeyword@115..122 "Boolean"
-        Whitespace@122..123 " "
+      Whitespace@122..123 " "
       Ident@123..124 "c"
       Whitespace@124..125 " "
       Assignment@125..126 "="
-      EqualityExprNode@126..138
-        NameRefNode@126..129
+      EqualityExprNode@126..133
+        NameRefNode@126..128
           Whitespace@126..127 " "
           Ident@127..128 "a"
-          Whitespace@128..129 " "
+        Whitespace@128..129 " "
         Equal@129..131 "=="
-        NameRefNode@131..138
+        NameRefNode@131..133
           Whitespace@131..132 " "
           Ident@132..133 "b"
-          Whitespace@133..138 "\n    "
-    BoundDeclNode@138..165
-      PrimitiveTypeNode@138..146
+    Whitespace@133..138 "\n    "
+    BoundDeclNode@138..160
+      PrimitiveTypeNode@138..145
         BooleanTypeKeyword@138..145 "Boolean"
-        Whitespace@145..146 " "
+      Whitespace@145..146 " "
       Ident@146..147 "d"
       Whitespace@147..148 " "
       Assignment@148..149 "="
-      InequalityExprNode@149..165
-        NameRefNode@149..152
+      InequalityExprNode@149..160
+        NameRefNode@149..151
           Whitespace@149..150 " "
           Ident@150..151 "c"
-          Whitespace@151..152 " "
+        Whitespace@151..152 " "
         NotEqual@152..154 "!="
         LiteralBooleanNode@154..160
           Whitespace@154..155 " "
           FalseKeyword@155..160 "false"
-        Whitespace@160..165 "\n    "
-    BoundDeclNode@165..187
-      PrimitiveTypeNode@165..173
+    Whitespace@160..165 "\n    "
+    BoundDeclNode@165..182
+      PrimitiveTypeNode@165..172
         BooleanTypeKeyword@165..172 "Boolean"
-        Whitespace@172..173 " "
+      Whitespace@172..173 " "
       Ident@173..174 "e"
       Whitespace@174..175 " "
       Assignment@175..176 "="
-      LessExprNode@176..187
+      LessExprNode@176..182
         LiteralIntegerNode@176..178
           Whitespace@176..177 " "
           Integer@177..178 "1"
@@ -97,15 +97,15 @@ RootNode@0..354
         LiteralIntegerNode@180..182
           Whitespace@180..181 " "
           Integer@181..182 "2"
-        Whitespace@182..187 "\n    "
-    BoundDeclNode@187..210
-      PrimitiveTypeNode@187..195
+    Whitespace@182..187 "\n    "
+    BoundDeclNode@187..205
+      PrimitiveTypeNode@187..194
         BooleanTypeKeyword@187..194 "Boolean"
-        Whitespace@194..195 " "
+      Whitespace@194..195 " "
       Ident@195..196 "f"
       Whitespace@196..197 " "
       Assignment@197..198 "="
-      LessEqualExprNode@198..210
+      LessEqualExprNode@198..205
         LiteralIntegerNode@198..200
           Whitespace@198..199 " "
           Integer@199..200 "2"
@@ -114,15 +114,15 @@ RootNode@0..354
         LiteralIntegerNode@203..205
           Whitespace@203..204 " "
           Integer@204..205 "2"
-        Whitespace@205..210 "\n    "
-    BoundDeclNode@210..232
-      PrimitiveTypeNode@210..218
+    Whitespace@205..210 "\n    "
+    BoundDeclNode@210..227
+      PrimitiveTypeNode@210..217
         BooleanTypeKeyword@210..217 "Boolean"
-        Whitespace@217..218 " "
+      Whitespace@217..218 " "
       Ident@218..219 "g"
       Whitespace@219..220 " "
       Assignment@220..221 "="
-      GreaterExprNode@221..232
+      GreaterExprNode@221..227
         LiteralIntegerNode@221..223
           Whitespace@221..222 " "
           Integer@222..223 "1"
@@ -131,15 +131,15 @@ RootNode@0..354
         LiteralIntegerNode@225..227
           Whitespace@225..226 " "
           Integer@226..227 "2"
-        Whitespace@227..232 "\n    "
-    BoundDeclNode@232..255
-      PrimitiveTypeNode@232..240
+    Whitespace@227..232 "\n    "
+    BoundDeclNode@232..250
+      PrimitiveTypeNode@232..239
         BooleanTypeKeyword@232..239 "Boolean"
-        Whitespace@239..240 " "
+      Whitespace@239..240 " "
       Ident@240..241 "h"
       Whitespace@241..242 " "
       Assignment@242..243 "="
-      GreaterEqualExprNode@243..255
+      GreaterEqualExprNode@243..250
         LiteralIntegerNode@243..245
           Whitespace@243..244 " "
           Integer@244..245 "2"
@@ -148,15 +148,15 @@ RootNode@0..354
         LiteralIntegerNode@248..250
           Whitespace@248..249 " "
           Integer@249..250 "2"
-        Whitespace@250..255 "\n    "
-    BoundDeclNode@255..275
-      PrimitiveTypeNode@255..259
+    Whitespace@250..255 "\n    "
+    BoundDeclNode@255..270
+      PrimitiveTypeNode@255..258
         IntTypeKeyword@255..258 "Int"
-        Whitespace@258..259 " "
+      Whitespace@258..259 " "
       Ident@259..260 "i"
       Whitespace@260..261 " "
       Assignment@261..262 "="
-      AdditionExprNode@262..275
+      AdditionExprNode@262..270
         LiteralIntegerNode@262..265
           Whitespace@262..263 " "
           Integer@263..265 "30"
@@ -165,34 +165,34 @@ RootNode@0..354
         LiteralIntegerNode@267..270
           Whitespace@267..268 " "
           Integer@268..270 "12"
-        Whitespace@270..275 "\n    "
-    BoundDeclNode@275..296
-      PrimitiveTypeNode@275..279
+    Whitespace@270..275 "\n    "
+    BoundDeclNode@275..291
+      PrimitiveTypeNode@275..278
         IntTypeKeyword@275..278 "Int"
-        Whitespace@278..279 " "
+      Whitespace@278..279 " "
       Ident@279..280 "j"
       Whitespace@280..281 " "
       Assignment@281..282 "="
-      SubtractionExprNode@282..296
+      SubtractionExprNode@282..291
         LiteralIntegerNode@282..285
           Whitespace@282..283 " "
           Integer@283..285 "30"
         Whitespace@285..286 " "
         Minus@286..287 "-"
-        NegationExprNode@287..296
+        NegationExprNode@287..291
           Whitespace@287..288 " "
           Minus@288..289 "-"
           LiteralIntegerNode@289..291
             Integer@289..291 "12"
-          Whitespace@291..296 "\n    "
-    BoundDeclNode@296..316
-      PrimitiveTypeNode@296..300
+    Whitespace@291..296 "\n    "
+    BoundDeclNode@296..311
+      PrimitiveTypeNode@296..299
         IntTypeKeyword@296..299 "Int"
-        Whitespace@299..300 " "
+      Whitespace@299..300 " "
       Ident@300..301 "k"
       Whitespace@301..302 " "
       Assignment@302..303 "="
-      MultiplicationExprNode@303..316
+      MultiplicationExprNode@303..311
         LiteralIntegerNode@303..306
           Whitespace@303..304 " "
           Integer@304..306 "10"
@@ -201,15 +201,15 @@ RootNode@0..354
         LiteralIntegerNode@308..311
           Whitespace@308..309 " "
           Integer@309..311 "10"
-        Whitespace@311..316 "\n    "
-    BoundDeclNode@316..336
-      PrimitiveTypeNode@316..320
+    Whitespace@311..316 "\n    "
+    BoundDeclNode@316..331
+      PrimitiveTypeNode@316..319
         IntTypeKeyword@316..319 "Int"
-        Whitespace@319..320 " "
+      Whitespace@319..320 " "
       Ident@320..321 "l"
       Whitespace@321..322 " "
       Assignment@322..323 "="
-      DivisionExprNode@323..336
+      DivisionExprNode@323..331
         LiteralIntegerNode@323..326
           Whitespace@323..324 " "
           Integer@324..326 "10"
@@ -218,15 +218,15 @@ RootNode@0..354
         LiteralIntegerNode@328..331
           Whitespace@328..329 " "
           Integer@329..331 "10"
-        Whitespace@331..336 "\n    "
-    BoundDeclNode@336..352
-      PrimitiveTypeNode@336..340
+    Whitespace@331..336 "\n    "
+    BoundDeclNode@336..351
+      PrimitiveTypeNode@336..339
         IntTypeKeyword@336..339 "Int"
-        Whitespace@339..340 " "
+      Whitespace@339..340 " "
       Ident@340..341 "m"
       Whitespace@341..342 " "
       Assignment@342..343 "="
-      ModuloExprNode@343..352
+      ModuloExprNode@343..351
         LiteralIntegerNode@343..346
           Whitespace@343..344 " "
           Integer@344..346 "10"
@@ -235,6 +235,6 @@ RootNode@0..354
         LiteralIntegerNode@348..351
           Whitespace@348..349 " "
           Integer@349..351 "10"
-        Whitespace@351..352 "\n"
+    Whitespace@351..352 "\n"
     CloseBrace@352..353 "}"
   Whitespace@353..354 "\n"

--- a/wdl-grammar/tests/parsing/input-sections/source.tree
+++ b/wdl-grammar/tests/parsing/input-sections/source.tree
@@ -18,20 +18,20 @@ RootNode@0..374
       Whitespace@91..92 " "
       OpenBrace@92..93 "{"
       Whitespace@93..102 "\n        "
-      UnboundDeclNode@102..119
-        PrimitiveTypeNode@102..109
+      UnboundDeclNode@102..110
+        PrimitiveTypeNode@102..108
           StringTypeKeyword@102..108 "String"
-          Whitespace@108..109 " "
+        Whitespace@108..109 " "
         Ident@109..110 "a"
-        Whitespace@110..119 "\n        "
-      BoundDeclNode@119..141
-        PrimitiveTypeNode@119..123
+      Whitespace@110..119 "\n        "
+      BoundDeclNode@119..132
+        PrimitiveTypeNode@119..122
           IntTypeKeyword@119..122 "Int"
-          Whitespace@122..123 " "
+        Whitespace@122..123 " "
         Ident@123..124 "b"
         Whitespace@124..125 " "
         Assignment@125..126 "="
-        AdditionExprNode@126..141
+        AdditionExprNode@126..132
           LiteralIntegerNode@126..128
             Whitespace@126..127 " "
             Integer@127..128 "1"
@@ -40,11 +40,11 @@ RootNode@0..374
           LiteralIntegerNode@130..132
             Whitespace@130..131 " "
             Integer@131..132 "2"
-          Whitespace@132..141 "\n        "
-      BoundDeclNode@141..174
-        PrimitiveTypeNode@141..148
+      Whitespace@132..141 "\n        "
+      BoundDeclNode@141..165
+        PrimitiveTypeNode@141..147
           StringTypeKeyword@141..147 "String"
-          Whitespace@147..148 " "
+        Whitespace@147..148 " "
         Ident@148..149 "c"
         Whitespace@149..150 " "
         Assignment@150..151 "="
@@ -58,9 +58,9 @@ RootNode@0..374
               Ident@162..163 "a"
             CloseBrace@163..164 "}"
           DoubleQuote@164..165 "\""
-        Whitespace@165..174 "\n        "
-      UnboundDeclNode@174..197
-        MapTypeNode@174..191
+      Whitespace@165..174 "\n        "
+      UnboundDeclNode@174..192
+        MapTypeNode@174..190
           MapTypeKeyword@174..177 "Map"
           OpenBracket@177..178 "["
           PrimitiveTypeNode@178..184
@@ -70,9 +70,9 @@ RootNode@0..374
             Whitespace@185..186 " "
             IntTypeKeyword@186..189 "Int"
           CloseBracket@189..190 "]"
-          Whitespace@190..191 " "
+        Whitespace@190..191 " "
         Ident@191..192 "d"
-        Whitespace@192..197 "\n    "
+      Whitespace@192..197 "\n    "
       CloseBrace@197..198 "}"
     Whitespace@198..199 "\n"
     CloseBrace@199..200 "}"
@@ -89,14 +89,14 @@ RootNode@0..374
       Whitespace@224..225 " "
       OpenBrace@225..226 "{"
       Whitespace@226..235 "\n        "
-      UnboundDeclNode@235..253
+      UnboundDeclNode@235..244
         PrimitiveTypeNode@235..242
           StringTypeKeyword@235..241 "String"
           QuestionMark@241..242 "?"
         Whitespace@242..243 " "
         Ident@243..244 "a"
-        Whitespace@244..253 "\n        "
-      BoundDeclNode@253..276
+      Whitespace@244..253 "\n        "
+      BoundDeclNode@253..267
         PrimitiveTypeNode@253..257
           IntTypeKeyword@253..256 "Int"
           QuestionMark@256..257 "?"
@@ -104,7 +104,7 @@ RootNode@0..374
         Ident@258..259 "b"
         Whitespace@259..260 " "
         Assignment@260..261 "="
-        AdditionExprNode@261..276
+        AdditionExprNode@261..267
           LiteralIntegerNode@261..263
             Whitespace@261..262 " "
             Integer@262..263 "1"
@@ -113,11 +113,11 @@ RootNode@0..374
           LiteralIntegerNode@265..267
             Whitespace@265..266 " "
             Integer@266..267 "2"
-          Whitespace@267..276 "\n        "
-      BoundDeclNode@276..309
-        PrimitiveTypeNode@276..283
+      Whitespace@267..276 "\n        "
+      BoundDeclNode@276..300
+        PrimitiveTypeNode@276..282
           StringTypeKeyword@276..282 "String"
-          Whitespace@282..283 " "
+        Whitespace@282..283 " "
         Ident@283..284 "c"
         Whitespace@284..285 " "
         Assignment@285..286 "="
@@ -131,9 +131,9 @@ RootNode@0..374
               Ident@297..298 "a"
             CloseBrace@298..299 "}"
           DoubleQuote@299..300 "\""
-        Whitespace@300..309 "\n        "
-      UnboundDeclNode@309..336
-        MapTypeNode@309..326
+      Whitespace@300..309 "\n        "
+      UnboundDeclNode@309..327
+        MapTypeNode@309..325
           MapTypeKeyword@309..312 "Map"
           OpenBracket@312..313 "["
           PrimitiveTypeNode@313..319
@@ -143,19 +143,19 @@ RootNode@0..374
             Whitespace@320..321 " "
             IntTypeKeyword@321..324 "Int"
           CloseBracket@324..325 "]"
-          Whitespace@325..326 " "
+        Whitespace@325..326 " "
         Ident@326..327 "d"
-        Whitespace@327..336 "\n        "
-      UnboundDeclNode@336..351
-        PrimitiveTypeNode@336..341
+      Whitespace@327..336 "\n        "
+      UnboundDeclNode@336..342
+        PrimitiveTypeNode@336..340
           FileTypeKeyword@336..340 "File"
-          Whitespace@340..341 " "
+        Whitespace@340..341 " "
         Ident@341..342 "e"
-        Whitespace@342..351 "\n        "
-      BoundDeclNode@351..370
-        PrimitiveTypeNode@351..356
+      Whitespace@342..351 "\n        "
+      BoundDeclNode@351..365
+        PrimitiveTypeNode@351..355
           FileTypeKeyword@351..355 "File"
-          Whitespace@355..356 " "
+        Whitespace@355..356 " "
         Ident@356..357 "f"
         Whitespace@357..358 " "
         Assignment@358..359 "="
@@ -164,7 +164,7 @@ RootNode@0..374
           DoubleQuote@360..361 "\""
           LiteralStringText@361..364 "URL"
           DoubleQuote@364..365 "\""
-        Whitespace@365..370 "\n    "
+      Whitespace@365..370 "\n    "
       CloseBrace@370..371 "}"
     Whitespace@371..372 "\n"
     CloseBrace@372..373 "}"

--- a/wdl-grammar/tests/parsing/interpolation/source.tree
+++ b/wdl-grammar/tests/parsing/interpolation/source.tree
@@ -13,10 +13,10 @@ RootNode@0..472
     Whitespace@65..66 " "
     OpenBrace@66..67 "{"
     Whitespace@67..72 "\n    "
-    BoundDeclNode@72..98
-      PrimitiveTypeNode@72..79
+    BoundDeclNode@72..93
+      PrimitiveTypeNode@72..78
         StringTypeKeyword@72..78 "String"
-        Whitespace@78..79 " "
+      Whitespace@78..79 " "
       Ident@79..83 "name"
       Whitespace@83..84 " "
       Assignment@84..85 "="
@@ -25,11 +25,11 @@ RootNode@0..472
         SingleQuote@86..87 "'"
         LiteralStringText@87..92 "world"
         SingleQuote@92..93 "'"
-      Whitespace@93..98 "\n    "
-    BoundDeclNode@98..129
-      PrimitiveTypeNode@98..105
+    Whitespace@93..98 "\n    "
+    BoundDeclNode@98..124
+      PrimitiveTypeNode@98..104
         StringTypeKeyword@98..104 "String"
-        Whitespace@104..105 " "
+      Whitespace@104..105 " "
       Ident@105..106 "a"
       Whitespace@106..107 " "
       Assignment@107..108 "="
@@ -43,11 +43,11 @@ RootNode@0..472
             Ident@118..122 "name"
           CloseBrace@122..123 "}"
         SingleQuote@123..124 "'"
-      Whitespace@124..129 "\n    "
-    BoundDeclNode@129..161
-      PrimitiveTypeNode@129..136
+    Whitespace@124..129 "\n    "
+    BoundDeclNode@129..156
+      PrimitiveTypeNode@129..135
         StringTypeKeyword@129..135 "String"
-        Whitespace@135..136 " "
+      Whitespace@135..136 " "
       Ident@136..137 "b"
       Whitespace@137..138 " "
       Assignment@138..139 "="
@@ -61,11 +61,11 @@ RootNode@0..472
             Ident@149..154 "world"
           CloseBrace@154..155 "}"
         DoubleQuote@155..156 "\""
-      Whitespace@156..161 "\n    "
-    BoundDeclNode@161..195
-      PrimitiveTypeNode@161..168
+    Whitespace@156..161 "\n    "
+    BoundDeclNode@161..190
+      PrimitiveTypeNode@161..167
         StringTypeKeyword@161..167 "String"
-        Whitespace@167..168 " "
+      Whitespace@167..168 " "
       Ident@168..169 "c"
       Whitespace@169..170 " "
       Assignment@170..171 "="
@@ -81,11 +81,11 @@ RootNode@0..472
             DoubleQuote@187..188 "\""
           CloseBrace@188..189 "}"
         DoubleQuote@189..190 "\""
-      Whitespace@190..195 "\n    "
-    BoundDeclNode@195..229
-      PrimitiveTypeNode@195..202
+    Whitespace@190..195 "\n    "
+    BoundDeclNode@195..224
+      PrimitiveTypeNode@195..201
         StringTypeKeyword@195..201 "String"
-        Whitespace@201..202 " "
+      Whitespace@201..202 " "
       Ident@202..203 "d"
       Whitespace@203..204 " "
       Assignment@204..205 "="
@@ -101,11 +101,11 @@ RootNode@0..472
             SingleQuote@221..222 "'"
           CloseBrace@222..223 "}"
         SingleQuote@223..224 "'"
-      Whitespace@224..229 "\n    "
-    BoundDeclNode@229..280
-      PrimitiveTypeNode@229..236
+    Whitespace@224..229 "\n    "
+    BoundDeclNode@229..275
+      PrimitiveTypeNode@229..235
         StringTypeKeyword@229..235 "String"
-        Whitespace@235..236 " "
+      Whitespace@235..236 " "
       Ident@236..237 "e"
       Whitespace@237..238 " "
       Assignment@238..239 "="
@@ -134,11 +134,11 @@ RootNode@0..472
             SingleQuote@272..273 "'"
           CloseBrace@273..274 "}"
         SingleQuote@274..275 "'"
-      Whitespace@275..280 "\n    "
-    BoundDeclNode@280..318
-      PrimitiveTypeNode@280..287
+    Whitespace@275..280 "\n    "
+    BoundDeclNode@280..313
+      PrimitiveTypeNode@280..286
         StringTypeKeyword@280..286 "String"
-        Whitespace@286..287 " "
+      Whitespace@286..287 " "
       Ident@287..288 "f"
       Whitespace@288..289 " "
       Assignment@289..290 "="
@@ -170,11 +170,11 @@ RootNode@0..472
             CloseBracket@310..311 "]"
           CloseBrace@311..312 "}"
         DoubleQuote@312..313 "\""
-      Whitespace@313..318 "\n    "
-    BoundDeclNode@318..360
-      PrimitiveTypeNode@318..325
+    Whitespace@313..318 "\n    "
+    BoundDeclNode@318..355
+      PrimitiveTypeNode@318..324
         StringTypeKeyword@318..324 "String"
-        Whitespace@324..325 " "
+      Whitespace@324..325 " "
       Ident@325..326 "g"
       Whitespace@326..327 " "
       Assignment@327..328 "="
@@ -207,11 +207,11 @@ RootNode@0..472
               Integer@352..353 "1"
           CloseBrace@353..354 "}"
         DoubleQuote@354..355 "\""
-      Whitespace@355..360 "\n    "
-    BoundDeclNode@360..412
-      PrimitiveTypeNode@360..367
+    Whitespace@355..360 "\n    "
+    BoundDeclNode@360..407
+      PrimitiveTypeNode@360..366
         StringTypeKeyword@360..366 "String"
-        Whitespace@366..367 " "
+      Whitespace@366..367 " "
       Ident@367..368 "h"
       Whitespace@368..369 " "
       Assignment@369..370 "="
@@ -239,11 +239,11 @@ RootNode@0..472
             FalseKeyword@400..405 "false"
           CloseBrace@405..406 "}"
         DoubleQuote@406..407 "\""
-      Whitespace@407..412 "\n    "
-    BoundDeclNode@412..470
-      PrimitiveTypeNode@412..419
+    Whitespace@407..412 "\n    "
+    BoundDeclNode@412..448
+      PrimitiveTypeNode@412..418
         StringTypeKeyword@412..418 "String"
-        Whitespace@418..419 " "
+      Whitespace@418..419 " "
       Ident@419..420 "i"
       Whitespace@420..421 " "
       Assignment@421..422 "="
@@ -278,8 +278,8 @@ RootNode@0..472
             CloseParen@445..446 ")"
           CloseBrace@446..447 "}"
         DoubleQuote@447..448 "\""
-      Whitespace@448..449 " "
-      Comment@449..469 "# Not a `sep` option"
-      Whitespace@469..470 "\n"
+    Whitespace@448..449 " "
+    Comment@449..469 "# Not a `sep` option"
+    Whitespace@469..470 "\n"
     CloseBrace@470..471 "}"
   Whitespace@471..472 "\n"

--- a/wdl-grammar/tests/parsing/mismatched-bracket/source.tree
+++ b/wdl-grammar/tests/parsing/mismatched-bracket/source.tree
@@ -14,7 +14,7 @@ RootNode@0..143
     OpenBrace@68..69 "{"
     Whitespace@69..74 "\n    "
     UnboundDeclNode@74..95
-      MapTypeNode@74..94
+      MapTypeNode@74..93
         MapTypeKeyword@74..77 "Map"
         OpenBracket@77..78 "["
         PrimitiveTypeNode@78..84
@@ -24,7 +24,7 @@ RootNode@0..143
           Whitespace@85..86 " "
           StringTypeKeyword@86..92 "String"
         CloseBracket@92..93 "]"
-        Whitespace@93..94 " "
+      Whitespace@93..94 " "
       Ident@94..95 "x"
     Whitespace@95..100 "\n    "
     MapTypeKeyword@100..103 "Map"
@@ -32,20 +32,20 @@ RootNode@0..143
     PrimitiveTypeNode@104..111
       BooleanTypeKeyword@104..111 "Boolean"
     Comma@111..112 ","
-    ArrayTypeNode@112..127
+    ArrayTypeNode@112..126
       Whitespace@112..113 " "
       ArrayTypeKeyword@113..118 "Array"
       OpenBracket@118..119 "["
       PrimitiveTypeNode@119..125
         StringTypeKeyword@119..125 "String"
       CloseBracket@125..126 "]"
-      Whitespace@126..127 " "
+    Whitespace@126..127 " "
     Ident@127..128 "y"
     Whitespace@128..133 "\n    "
     UnboundDeclNode@133..141
-      PrimitiveTypeNode@133..140
+      PrimitiveTypeNode@133..139
         StringTypeKeyword@133..139 "String"
-        Whitespace@139..140 " "
+      Whitespace@139..140 " "
       Ident@140..141 "z"
     Whitespace@141..142 "\n"
     CloseBrace@142..143 "}"

--- a/wdl-grammar/tests/parsing/missing-comma/source.tree
+++ b/wdl-grammar/tests/parsing/missing-comma/source.tree
@@ -13,8 +13,8 @@ RootNode@0..195
     Whitespace@74..75 " "
     OpenBrace@75..76 "{"
     Whitespace@76..81 "\n    "
-    BoundDeclNode@81..193
-      MapTypeNode@81..101
+    BoundDeclNode@81..192
+      MapTypeNode@81..100
         MapTypeKeyword@81..84 "Map"
         OpenBracket@84..85 "["
         PrimitiveTypeNode@85..91
@@ -24,7 +24,7 @@ RootNode@0..195
           Whitespace@92..93 " "
           StringTypeKeyword@93..99 "String"
         CloseBracket@99..100 "]"
-        Whitespace@100..101 " "
+      Whitespace@100..101 " "
       Ident@101..104 "map"
       Whitespace@104..105 " "
       Assignment@105..106 "="
@@ -43,7 +43,7 @@ RootNode@0..195
             DoubleQuote@126..127 "\""
         Comma@127..128 ","
         Whitespace@128..137 "\n        "
-        LiteralMapItemNode@137..156
+        LiteralMapItemNode@137..147
           NameRefNode@137..140
             Ident@137..140 "bar"
           Colon@140..141 ":"
@@ -52,7 +52,7 @@ RootNode@0..195
             DoubleQuote@142..143 "\""
             LiteralStringText@143..146 "bar"
             DoubleQuote@146..147 "\""
-          Whitespace@147..156 "\n        "
+        Whitespace@147..156 "\n        "
         Ident@156..159 "baz"
         Colon@159..160 ":"
         Whitespace@160..161 " "
@@ -61,7 +61,7 @@ RootNode@0..195
         DoubleQuote@165..166 "\""
         Comma@166..167 ","
         Whitespace@167..176 "\n        "
-        LiteralMapItemNode@176..191
+        LiteralMapItemNode@176..186
           NameRefNode@176..179
             Ident@176..179 "qux"
           Colon@179..180 ":"
@@ -70,8 +70,8 @@ RootNode@0..195
             DoubleQuote@181..182 "\""
             LiteralStringText@182..185 "qux"
             DoubleQuote@185..186 "\""
-          Whitespace@186..191 "\n    "
+        Whitespace@186..191 "\n    "
         CloseBrace@191..192 "}"
-      Whitespace@192..193 "\n"
+    Whitespace@192..193 "\n"
     CloseBrace@193..194 "}"
   Whitespace@194..195 "\n"

--- a/wdl-grammar/tests/parsing/missing-version/source.tree
+++ b/wdl-grammar/tests/parsing/missing-version/source.tree
@@ -1,4 +1,2 @@
-RootNode@0..64
-  Comment@0..48 "# This is a test of a ..."
-  Whitespace@48..50 "\n\n"
-  Unparsed@50..64 "task foo {\n\n}\n"
+RootNode@0..14
+  Unparsed@0..14 "task foo {\n\n}\n"

--- a/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.tree
+++ b/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.tree
@@ -13,10 +13,10 @@ RootNode@0..156
     Whitespace@82..83 " "
     OpenBrace@83..84 "{"
     Whitespace@84..89 "\n    "
-    BoundDeclNode@89..154
-      PrimitiveTypeNode@89..96
+    BoundDeclNode@89..153
+      PrimitiveTypeNode@89..95
         StringTypeKeyword@89..95 "String"
-        Whitespace@95..96 " "
+      Whitespace@95..96 " "
       Ident@96..97 "x"
       Whitespace@97..98 " "
       Assignment@98..99 "="
@@ -67,6 +67,6 @@ RootNode@0..156
             Ident@150..151 "v"
           CloseBrace@151..152 "}"
         DoubleQuote@152..153 "\""
-      Whitespace@153..154 "\n"
+    Whitespace@153..154 "\n"
     CloseBrace@154..155 "}"
   Whitespace@155..156 "\n"

--- a/wdl-grammar/tests/parsing/name-ref/source.tree
+++ b/wdl-grammar/tests/parsing/name-ref/source.tree
@@ -13,52 +13,52 @@ RootNode@0..118
     Whitespace@62..63 " "
     OpenBrace@63..64 "{"
     Whitespace@64..69 "\n    "
-    BoundDeclNode@69..83
-      PrimitiveTypeNode@69..73
+    BoundDeclNode@69..78
+      PrimitiveTypeNode@69..72
         IntTypeKeyword@69..72 "Int"
-        Whitespace@72..73 " "
+      Whitespace@72..73 " "
       Ident@73..74 "x"
       Whitespace@74..75 " "
       Assignment@75..76 "="
       LiteralIntegerNode@76..78
         Whitespace@76..77 " "
         Integer@77..78 "0"
-      Whitespace@78..83 "\n    "
-    BoundDeclNode@83..98
-      PrimitiveTypeNode@83..87
+    Whitespace@78..83 "\n    "
+    BoundDeclNode@83..93
+      PrimitiveTypeNode@83..86
         IntTypeKeyword@83..86 "Int"
-        Whitespace@86..87 " "
+      Whitespace@86..87 " "
       Ident@87..88 "y"
       Whitespace@88..89 " "
       Assignment@89..90 "="
-      NegationExprNode@90..98
+      NegationExprNode@90..93
         Whitespace@90..91 " "
         Minus@91..92 "-"
-        NameRefNode@92..98
+        NameRefNode@92..93
           Ident@92..93 "x"
-          Whitespace@93..98 "\n    "
-    BoundDeclNode@98..116
-      PrimitiveTypeNode@98..102
+    Whitespace@93..98 "\n    "
+    BoundDeclNode@98..115
+      PrimitiveTypeNode@98..101
         IntTypeKeyword@98..101 "Int"
-        Whitespace@101..102 " "
+      Whitespace@101..102 " "
       Ident@102..103 "z"
       Whitespace@103..104 " "
       Assignment@104..105 "="
-      AdditionExprNode@105..116
-        NameRefNode@105..108
+      AdditionExprNode@105..115
+        NameRefNode@105..107
           Whitespace@105..106 " "
           Ident@106..107 "x"
-          Whitespace@107..108 " "
+        Whitespace@107..108 " "
         Plus@108..109 "+"
-        MultiplicationExprNode@109..116
-          NameRefNode@109..112
+        MultiplicationExprNode@109..115
+          NameRefNode@109..111
             Whitespace@109..110 " "
             Ident@110..111 "y"
-            Whitespace@111..112 " "
+          Whitespace@111..112 " "
           Asterisk@112..113 "*"
-          NameRefNode@113..116
+          NameRefNode@113..115
             Whitespace@113..114 " "
             Ident@114..115 "x"
-            Whitespace@115..116 "\n"
+    Whitespace@115..116 "\n"
     CloseBrace@116..117 "}"
   Whitespace@117..118 "\n"

--- a/wdl-grammar/tests/parsing/output-sections/source.tree
+++ b/wdl-grammar/tests/parsing/output-sections/source.tree
@@ -18,10 +18,10 @@ RootNode@0..415
       Whitespace@93..94 " "
       OpenBrace@94..95 "{"
       Whitespace@95..104 "\n        "
-      BoundDeclNode@104..132
-        PrimitiveTypeNode@104..111
+      BoundDeclNode@104..123
+        PrimitiveTypeNode@104..110
           StringTypeKeyword@104..110 "String"
-          Whitespace@110..111 " "
+        Whitespace@110..111 " "
         Ident@111..112 "a"
         Whitespace@112..113 " "
         Assignment@113..114 "="
@@ -30,15 +30,15 @@ RootNode@0..415
           DoubleQuote@115..116 "\""
           LiteralStringText@116..122 "friend"
           DoubleQuote@122..123 "\""
-        Whitespace@123..132 "\n        "
-      BoundDeclNode@132..154
-        PrimitiveTypeNode@132..136
+      Whitespace@123..132 "\n        "
+      BoundDeclNode@132..145
+        PrimitiveTypeNode@132..135
           IntTypeKeyword@132..135 "Int"
-          Whitespace@135..136 " "
+        Whitespace@135..136 " "
         Ident@136..137 "b"
         Whitespace@137..138 " "
         Assignment@138..139 "="
-        AdditionExprNode@139..154
+        AdditionExprNode@139..145
           LiteralIntegerNode@139..141
             Whitespace@139..140 " "
             Integer@140..141 "1"
@@ -47,11 +47,11 @@ RootNode@0..415
           LiteralIntegerNode@143..145
             Whitespace@143..144 " "
             Integer@144..145 "2"
-          Whitespace@145..154 "\n        "
-      BoundDeclNode@154..187
-        PrimitiveTypeNode@154..161
+      Whitespace@145..154 "\n        "
+      BoundDeclNode@154..178
+        PrimitiveTypeNode@154..160
           StringTypeKeyword@154..160 "String"
-          Whitespace@160..161 " "
+        Whitespace@160..161 " "
         Ident@161..162 "c"
         Whitespace@162..163 " "
         Assignment@163..164 "="
@@ -65,9 +65,9 @@ RootNode@0..415
               Ident@175..176 "a"
             CloseBrace@176..177 "}"
           DoubleQuote@177..178 "\""
-        Whitespace@178..187 "\n        "
-      BoundDeclNode@187..238
-        MapTypeNode@187..204
+      Whitespace@178..187 "\n        "
+      BoundDeclNode@187..233
+        MapTypeNode@187..203
           MapTypeKeyword@187..190 "Map"
           OpenBracket@190..191 "["
           PrimitiveTypeNode@191..197
@@ -77,7 +77,7 @@ RootNode@0..415
             Whitespace@198..199 " "
             IntTypeKeyword@199..202 "Int"
           CloseBracket@202..203 "]"
-          Whitespace@203..204 " "
+        Whitespace@203..204 " "
         Ident@204..205 "d"
         Whitespace@205..206 " "
         Assignment@206..207 "="
@@ -117,7 +117,7 @@ RootNode@0..415
               Whitespace@230..231 " "
               Integer@231..232 "2"
           CloseBrace@232..233 "}"
-        Whitespace@233..238 "\n    "
+      Whitespace@233..238 "\n    "
       CloseBrace@238..239 "}"
     Whitespace@239..240 "\n"
     CloseBrace@240..241 "}"
@@ -134,10 +134,10 @@ RootNode@0..415
       Whitespace@266..267 " "
       OpenBrace@267..268 "{"
       Whitespace@268..277 "\n        "
-      BoundDeclNode@277..305
-        PrimitiveTypeNode@277..284
+      BoundDeclNode@277..296
+        PrimitiveTypeNode@277..283
           StringTypeKeyword@277..283 "String"
-          Whitespace@283..284 " "
+        Whitespace@283..284 " "
         Ident@284..285 "a"
         Whitespace@285..286 " "
         Assignment@286..287 "="
@@ -146,15 +146,15 @@ RootNode@0..415
           DoubleQuote@288..289 "\""
           LiteralStringText@289..295 "friend"
           DoubleQuote@295..296 "\""
-        Whitespace@296..305 "\n        "
-      BoundDeclNode@305..327
-        PrimitiveTypeNode@305..309
+      Whitespace@296..305 "\n        "
+      BoundDeclNode@305..318
+        PrimitiveTypeNode@305..308
           IntTypeKeyword@305..308 "Int"
-          Whitespace@308..309 " "
+        Whitespace@308..309 " "
         Ident@309..310 "b"
         Whitespace@310..311 " "
         Assignment@311..312 "="
-        AdditionExprNode@312..327
+        AdditionExprNode@312..318
           LiteralIntegerNode@312..314
             Whitespace@312..313 " "
             Integer@313..314 "1"
@@ -163,11 +163,11 @@ RootNode@0..415
           LiteralIntegerNode@316..318
             Whitespace@316..317 " "
             Integer@317..318 "2"
-          Whitespace@318..327 "\n        "
-      BoundDeclNode@327..360
-        PrimitiveTypeNode@327..334
+      Whitespace@318..327 "\n        "
+      BoundDeclNode@327..351
+        PrimitiveTypeNode@327..333
           StringTypeKeyword@327..333 "String"
-          Whitespace@333..334 " "
+        Whitespace@333..334 " "
         Ident@334..335 "c"
         Whitespace@335..336 " "
         Assignment@336..337 "="
@@ -181,9 +181,9 @@ RootNode@0..415
               Ident@348..349 "a"
             CloseBrace@349..350 "}"
           DoubleQuote@350..351 "\""
-        Whitespace@351..360 "\n        "
-      BoundDeclNode@360..411
-        MapTypeNode@360..377
+      Whitespace@351..360 "\n        "
+      BoundDeclNode@360..406
+        MapTypeNode@360..376
           MapTypeKeyword@360..363 "Map"
           OpenBracket@363..364 "["
           PrimitiveTypeNode@364..370
@@ -193,7 +193,7 @@ RootNode@0..415
             Whitespace@371..372 " "
             IntTypeKeyword@372..375 "Int"
           CloseBracket@375..376 "]"
-          Whitespace@376..377 " "
+        Whitespace@376..377 " "
         Ident@377..378 "d"
         Whitespace@378..379 " "
         Assignment@379..380 "="
@@ -233,7 +233,7 @@ RootNode@0..415
               Whitespace@403..404 " "
               Integer@404..405 "2"
           CloseBrace@405..406 "}"
-        Whitespace@406..411 "\n    "
+      Whitespace@406..411 "\n    "
       CloseBrace@411..412 "}"
     Whitespace@412..413 "\n"
     CloseBrace@413..414 "}"

--- a/wdl-grammar/tests/parsing/postfix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/postfix-exprs/source.tree
@@ -13,10 +13,10 @@ RootNode@0..324
     Whitespace@63..64 " "
     OpenBrace@64..65 "{"
     Whitespace@65..70 "\n    "
-    BoundDeclNode@70..92
-      PrimitiveTypeNode@70..74
+    BoundDeclNode@70..87
+      PrimitiveTypeNode@70..73
         IntTypeKeyword@70..73 "Int"
-        Whitespace@73..74 " "
+      Whitespace@73..74 " "
       Ident@74..75 "a"
       Whitespace@75..76 " "
       Assignment@76..77 "="
@@ -32,11 +32,11 @@ RootNode@0..324
         LiteralIntegerNode@85..86
           Integer@85..86 "1"
         CloseParen@86..87 ")"
-      Whitespace@87..92 "\n    "
-    BoundDeclNode@92..125
-      PrimitiveTypeNode@92..96
+    Whitespace@87..92 "\n    "
+    BoundDeclNode@92..120
+      PrimitiveTypeNode@92..95
         IntTypeKeyword@92..95 "Int"
-        Whitespace@95..96 " "
+      Whitespace@95..96 " "
       Ident@96..97 "b"
       Whitespace@97..98 " "
       Assignment@98..99 "="
@@ -61,15 +61,15 @@ RootNode@0..324
         LiteralIntegerNode@117..119
           Integer@117..119 "10"
         CloseParen@119..120 ")"
-      Whitespace@120..125 "\n    "
-    BoundDeclNode@125..163
-      ArrayTypeNode@125..139
+    Whitespace@120..125 "\n    "
+    BoundDeclNode@125..158
+      ArrayTypeNode@125..138
         ArrayTypeKeyword@125..130 "Array"
         OpenBracket@130..131 "["
         PrimitiveTypeNode@131..137
           StringTypeKeyword@131..137 "String"
         CloseBracket@137..138 "]"
-        Whitespace@138..139 " "
+      Whitespace@138..139 " "
       Ident@139..140 "c"
       Whitespace@140..141 " "
       Assignment@141..142 "="
@@ -93,11 +93,11 @@ RootNode@0..324
           LiteralStringText@155..156 "c"
           DoubleQuote@156..157 "\""
         CloseBracket@157..158 "]"
-      Whitespace@158..163 "\n    "
-    BoundDeclNode@163..187
-      PrimitiveTypeNode@163..170
+    Whitespace@158..163 "\n    "
+    BoundDeclNode@163..182
+      PrimitiveTypeNode@163..169
         StringTypeKeyword@163..169 "String"
-        Whitespace@169..170 " "
+      Whitespace@169..170 " "
       Ident@170..171 "d"
       Whitespace@171..172 " "
       Assignment@172..173 "="
@@ -107,19 +107,19 @@ RootNode@0..324
           Ident@174..175 "c"
         OpenBracket@175..176 "["
         AdditionExprNode@176..181
-          NameRefNode@176..178
+          NameRefNode@176..177
             Ident@176..177 "a"
-            Whitespace@177..178 " "
+          Whitespace@177..178 " "
           Plus@178..179 "+"
           NameRefNode@179..181
             Whitespace@179..180 " "
             Ident@180..181 "b"
         CloseBracket@181..182 "]"
-      Whitespace@182..187 "\n    "
-    BoundDeclNode@187..276
-      TypeRefNode@187..196
+    Whitespace@182..187 "\n    "
+    BoundDeclNode@187..271
+      TypeRefNode@187..195
         Ident@187..195 "MyStruct"
-        Whitespace@195..196 " "
+      Whitespace@195..196 " "
       Ident@196..197 "e"
       Whitespace@197..198 " "
       Assignment@198..199 "="
@@ -129,7 +129,7 @@ RootNode@0..324
         Whitespace@208..209 " "
         OpenBrace@209..210 "{"
         Whitespace@210..219 "\n        "
-        LiteralStructItemNode@219..270
+        LiteralStructItemNode@219..265
           Ident@219..222 "foo"
           Colon@222..223 ":"
           LiteralStructNode@223..265
@@ -149,13 +149,13 @@ RootNode@0..324
             Comma@254..255 ","
             Whitespace@255..264 "\n        "
             CloseBrace@264..265 "}"
-          Whitespace@265..270 "\n    "
+        Whitespace@265..270 "\n    "
         CloseBrace@270..271 "}"
-      Whitespace@271..276 "\n    "
-    BoundDeclNode@276..323
-      TypeRefNode@276..282
+    Whitespace@271..276 "\n    "
+    BoundDeclNode@276..322
+      TypeRefNode@276..281
         Ident@276..281 "MyFoo"
-        Whitespace@281..282 " "
+      Whitespace@281..282 " "
       Ident@282..283 "f"
       Whitespace@283..284 " "
       Assignment@284..285 "="
@@ -165,7 +165,7 @@ RootNode@0..324
         Whitespace@291..292 " "
         OpenBrace@292..293 "{"
         Whitespace@293..302 "\n        "
-        LiteralStructItemNode@302..321
+        LiteralStructItemNode@302..316
           Ident@302..305 "foo"
           Colon@305..306 ":"
           AccessExprNode@306..316
@@ -177,7 +177,7 @@ RootNode@0..324
               Ident@309..312 "foo"
             Dot@312..313 "."
             Ident@313..316 "bar"
-          Whitespace@316..321 "\n    "
+        Whitespace@316..321 "\n    "
         CloseBrace@321..322 "}"
-      Whitespace@322..323 "\n"
+    Whitespace@322..323 "\n"
     CloseBrace@323..324 "}"

--- a/wdl-grammar/tests/parsing/precedence/source.tree
+++ b/wdl-grammar/tests/parsing/precedence/source.tree
@@ -13,27 +13,27 @@ RootNode@0..274
     Whitespace@63..64 " "
     OpenBrace@64..65 "{"
     Whitespace@65..70 "\n    "
-    BoundDeclNode@70..153
-      PrimitiveTypeNode@70..78
+    BoundDeclNode@70..148
+      PrimitiveTypeNode@70..77
         BooleanTypeKeyword@70..77 "Boolean"
-        Whitespace@77..78 " "
+      Whitespace@77..78 " "
       Ident@78..79 "a"
       Whitespace@79..80 " "
       Assignment@80..81 "="
-      LogicalOrExprNode@81..153
+      LogicalOrExprNode@81..148
         LiteralBooleanNode@81..86
           Whitespace@81..82 " "
           TrueKeyword@82..86 "true"
         Whitespace@86..87 " "
         LogicalOr@87..89 "||"
-        LogicalAndExprNode@89..153
+        LogicalAndExprNode@89..148
           LiteralBooleanNode@89..95
             Whitespace@89..90 " "
             FalseKeyword@90..95 "false"
           Whitespace@95..96 " "
           LogicalAnd@96..98 "&&"
-          InequalityExprNode@98..153
-            EqualityExprNode@98..106
+          InequalityExprNode@98..148
+            EqualityExprNode@98..105
               LiteralIntegerNode@98..100
                 Whitespace@98..99 " "
                 Integer@99..100 "1"
@@ -42,12 +42,12 @@ RootNode@0..274
               LiteralIntegerNode@103..105
                 Whitespace@103..104 " "
                 Integer@104..105 "0"
-              Whitespace@105..106 " "
+            Whitespace@105..106 " "
             NotEqual@106..108 "!="
-            GreaterEqualExprNode@108..153
-              GreaterExprNode@108..124
-                LessEqualExprNode@108..120
-                  LessExprNode@108..115
+            GreaterEqualExprNode@108..148
+              GreaterExprNode@108..123
+                LessEqualExprNode@108..119
+                  LessExprNode@108..114
                     LiteralIntegerNode@108..110
                       Whitespace@108..109 " "
                       Integer@109..110 "1"
@@ -56,20 +56,20 @@ RootNode@0..274
                     LiteralIntegerNode@112..114
                       Whitespace@112..113 " "
                       Integer@113..114 "0"
-                    Whitespace@114..115 " "
+                  Whitespace@114..115 " "
                   LessEqual@115..117 "<="
                   LiteralIntegerNode@117..119
                     Whitespace@117..118 " "
                     Integer@118..119 "1"
-                  Whitespace@119..120 " "
+                Whitespace@119..120 " "
                 Greater@120..121 ">"
                 LiteralIntegerNode@121..123
                   Whitespace@121..122 " "
                   Integer@122..123 "0"
-                Whitespace@123..124 " "
+              Whitespace@123..124 " "
               GreaterEqual@124..126 ">="
-              SubtractionExprNode@126..153
-                AdditionExprNode@126..133
+              SubtractionExprNode@126..148
+                AdditionExprNode@126..132
                   LiteralIntegerNode@126..128
                     Whitespace@126..127 " "
                     Integer@127..128 "1"
@@ -78,11 +78,11 @@ RootNode@0..274
                   LiteralIntegerNode@130..132
                     Whitespace@130..131 " "
                     Integer@131..132 "2"
-                  Whitespace@132..133 " "
+                Whitespace@132..133 " "
                 Minus@133..134 "-"
-                ModuloExprNode@134..153
-                  DivisionExprNode@134..145
-                    MultiplicationExprNode@134..141
+                ModuloExprNode@134..148
+                  DivisionExprNode@134..144
+                    MultiplicationExprNode@134..140
                       LiteralIntegerNode@134..136
                         Whitespace@134..135 " "
                         Integer@135..136 "3"
@@ -91,25 +91,25 @@ RootNode@0..274
                       LiteralIntegerNode@138..140
                         Whitespace@138..139 " "
                         Integer@139..140 "4"
-                      Whitespace@140..141 " "
+                    Whitespace@140..141 " "
                     Slash@141..142 "/"
                     LiteralIntegerNode@142..144
                       Whitespace@142..143 " "
                       Integer@143..144 "5"
-                    Whitespace@144..145 " "
+                  Whitespace@144..145 " "
                   Percent@145..146 "%"
                   LiteralIntegerNode@146..148
                     Whitespace@146..147 " "
                     Integer@147..148 "6"
-                  Whitespace@148..153 "\n    "
-    BoundDeclNode@153..193
-      PrimitiveTypeNode@153..157
+    Whitespace@148..153 "\n    "
+    BoundDeclNode@153..188
+      PrimitiveTypeNode@153..156
         IntTypeKeyword@153..156 "Int"
-        Whitespace@156..157 " "
+      Whitespace@156..157 " "
       Ident@157..158 "b"
       Whitespace@158..159 " "
       Assignment@159..160 "="
-      SubtractionExprNode@160..193
+      SubtractionExprNode@160..188
         ParenthesizedExprNode@160..168
           Whitespace@160..161 " "
           OpenParen@161..162 "("
@@ -124,7 +124,7 @@ RootNode@0..274
           CloseParen@167..168 ")"
         Whitespace@168..169 " "
         Minus@169..170 "-"
-        DivisionExprNode@170..193
+        DivisionExprNode@170..188
           ParenthesizedExprNode@170..178
             Whitespace@170..171 " "
             OpenParen@171..172 "("
@@ -151,24 +151,24 @@ RootNode@0..274
                 Whitespace@185..186 " "
                 Integer@186..187 "6"
             CloseParen@187..188 ")"
-          Whitespace@188..193 "\n    "
-    BoundDeclNode@193..272
-      PrimitiveTypeNode@193..201
+    Whitespace@188..193 "\n    "
+    BoundDeclNode@193..271
+      PrimitiveTypeNode@193..200
         BooleanTypeKeyword@193..200 "Boolean"
-        Whitespace@200..201 " "
+      Whitespace@200..201 " "
       Ident@201..202 "c"
       Whitespace@202..203 " "
       Assignment@203..204 "="
-      LogicalOrExprNode@204..272
-        LogicalAndExprNode@204..264
-          EqualityExprNode@204..255
-            InequalityExprNode@204..250
-              LessExprNode@204..245
-                LessEqualExprNode@204..241
-                  GreaterExprNode@204..236
-                    GreaterEqualExprNode@204..232
-                      SubtractionExprNode@204..227
-                        AdditionExprNode@204..211
+      LogicalOrExprNode@204..271
+        LogicalAndExprNode@204..263
+          EqualityExprNode@204..254
+            InequalityExprNode@204..249
+              LessExprNode@204..244
+                LessEqualExprNode@204..240
+                  GreaterExprNode@204..235
+                    GreaterEqualExprNode@204..231
+                      SubtractionExprNode@204..226
+                        AdditionExprNode@204..210
                           LiteralIntegerNode@204..206
                             Whitespace@204..205 " "
                             Integer@205..206 "1"
@@ -177,11 +177,11 @@ RootNode@0..274
                           LiteralIntegerNode@208..210
                             Whitespace@208..209 " "
                             Integer@209..210 "2"
-                          Whitespace@210..211 " "
+                        Whitespace@210..211 " "
                         Minus@211..212 "-"
-                        ModuloExprNode@212..227
-                          DivisionExprNode@212..223
-                            MultiplicationExprNode@212..219
+                        ModuloExprNode@212..226
+                          DivisionExprNode@212..222
+                            MultiplicationExprNode@212..218
                               LiteralIntegerNode@212..214
                                 Whitespace@212..213 " "
                                 Integer@213..214 "3"
@@ -190,56 +190,56 @@ RootNode@0..274
                               LiteralIntegerNode@216..218
                                 Whitespace@216..217 " "
                                 Integer@217..218 "4"
-                              Whitespace@218..219 " "
+                            Whitespace@218..219 " "
                             Slash@219..220 "/"
                             LiteralIntegerNode@220..222
                               Whitespace@220..221 " "
                               Integer@221..222 "5"
-                            Whitespace@222..223 " "
+                          Whitespace@222..223 " "
                           Percent@223..224 "%"
                           LiteralIntegerNode@224..226
                             Whitespace@224..225 " "
                             Integer@225..226 "6"
-                          Whitespace@226..227 " "
+                      Whitespace@226..227 " "
                       GreaterEqual@227..229 ">="
                       LiteralIntegerNode@229..231
                         Whitespace@229..230 " "
                         Integer@230..231 "0"
-                      Whitespace@231..232 " "
+                    Whitespace@231..232 " "
                     Greater@232..233 ">"
                     LiteralIntegerNode@233..235
                       Whitespace@233..234 " "
                       Integer@234..235 "1"
-                    Whitespace@235..236 " "
+                  Whitespace@235..236 " "
                   LessEqual@236..238 "<="
                   LiteralIntegerNode@238..240
                     Whitespace@238..239 " "
                     Integer@239..240 "0"
-                  Whitespace@240..241 " "
+                Whitespace@240..241 " "
                 Less@241..242 "<"
                 LiteralIntegerNode@242..244
                   Whitespace@242..243 " "
                   Integer@243..244 "1"
-                Whitespace@244..245 " "
+              Whitespace@244..245 " "
               NotEqual@245..247 "!="
               LiteralIntegerNode@247..249
                 Whitespace@247..248 " "
                 Integer@248..249 "0"
-              Whitespace@249..250 " "
+            Whitespace@249..250 " "
             Equal@250..252 "=="
             LiteralIntegerNode@252..254
               Whitespace@252..253 " "
               Integer@253..254 "1"
-            Whitespace@254..255 " "
+          Whitespace@254..255 " "
           LogicalAnd@255..257 "&&"
           LiteralBooleanNode@257..263
             Whitespace@257..258 " "
             FalseKeyword@258..263 "false"
-          Whitespace@263..264 " "
+        Whitespace@263..264 " "
         LogicalOr@264..266 "||"
         LiteralBooleanNode@266..271
           Whitespace@266..267 " "
           TrueKeyword@267..271 "true"
-        Whitespace@271..272 "\n"
+    Whitespace@271..272 "\n"
     CloseBrace@272..273 "}"
   Whitespace@273..274 "\n"

--- a/wdl-grammar/tests/parsing/prefix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/prefix-exprs/source.tree
@@ -13,102 +13,102 @@ RootNode@0..179
     Whitespace@63..64 " "
     OpenBrace@64..65 "{"
     Whitespace@65..70 "\n    "
-    BoundDeclNode@70..92
-      PrimitiveTypeNode@70..78
+    BoundDeclNode@70..87
+      PrimitiveTypeNode@70..77
         BooleanTypeKeyword@70..77 "Boolean"
-        Whitespace@77..78 " "
+      Whitespace@77..78 " "
       Ident@78..79 "a"
       Whitespace@79..80 " "
       Assignment@80..81 "="
-      LogicalNotExprNode@81..92
+      LogicalNotExprNode@81..87
         Whitespace@81..82 " "
         Exclamation@82..83 "!"
         LiteralBooleanNode@83..87
           TrueKeyword@83..87 "true"
-        Whitespace@87..92 "\n    "
-    BoundDeclNode@92..123
-      PrimitiveTypeNode@92..100
+    Whitespace@87..92 "\n    "
+    BoundDeclNode@92..118
+      PrimitiveTypeNode@92..99
         BooleanTypeKeyword@92..99 "Boolean"
-        Whitespace@99..100 " "
+      Whitespace@99..100 " "
       Ident@100..101 "b"
       Whitespace@101..102 " "
       Assignment@102..103 "="
-      LogicalNotExprNode@103..123
+      LogicalNotExprNode@103..118
         Whitespace@103..104 " "
         Exclamation@104..105 "!"
-        LogicalNotExprNode@105..123
+        LogicalNotExprNode@105..118
           Exclamation@105..106 "!"
-          LogicalNotExprNode@106..123
+          LogicalNotExprNode@106..118
             Exclamation@106..107 "!"
-            LogicalNotExprNode@107..123
+            LogicalNotExprNode@107..118
               Exclamation@107..108 "!"
-              LogicalNotExprNode@108..123
+              LogicalNotExprNode@108..118
                 Exclamation@108..109 "!"
-                LogicalNotExprNode@109..123
+                LogicalNotExprNode@109..118
                   Exclamation@109..110 "!"
-                  LogicalNotExprNode@110..123
+                  LogicalNotExprNode@110..118
                     Exclamation@110..111 "!"
-                    LogicalNotExprNode@111..123
+                    LogicalNotExprNode@111..118
                       Exclamation@111..112 "!"
-                      LogicalNotExprNode@112..123
+                      LogicalNotExprNode@112..118
                         Exclamation@112..113 "!"
                         LiteralBooleanNode@113..118
                           FalseKeyword@113..118 "false"
-                        Whitespace@118..123 "\n    "
-    BoundDeclNode@123..138
-      PrimitiveTypeNode@123..127
+    Whitespace@118..123 "\n    "
+    BoundDeclNode@123..133
+      PrimitiveTypeNode@123..126
         IntTypeKeyword@123..126 "Int"
-        Whitespace@126..127 " "
+      Whitespace@126..127 " "
       Ident@127..128 "c"
       Whitespace@128..129 " "
       Assignment@129..130 "="
-      NegationExprNode@130..138
+      NegationExprNode@130..133
         Whitespace@130..131 " "
         Minus@131..132 "-"
         LiteralIntegerNode@132..133
           Integer@132..133 "2"
-        Whitespace@133..138 "\n    "
-    BoundDeclNode@138..157
-      PrimitiveTypeNode@138..144
+    Whitespace@133..138 "\n    "
+    BoundDeclNode@138..152
+      PrimitiveTypeNode@138..143
         FloatTypeKeyword@138..143 "Float"
-        Whitespace@143..144 " "
+      Whitespace@143..144 " "
       Ident@144..145 "d"
       Whitespace@145..146 " "
       Assignment@146..147 "="
-      NegationExprNode@147..157
+      NegationExprNode@147..152
         Whitespace@147..148 " "
         Minus@148..149 "-"
         LiteralFloatNode@149..152
           Float@149..152 "2.0"
-        Whitespace@152..157 "\n    "
-    BoundDeclNode@157..177
-      PrimitiveTypeNode@157..161
+    Whitespace@152..157 "\n    "
+    BoundDeclNode@157..176
+      PrimitiveTypeNode@157..160
         IntTypeKeyword@157..160 "Int"
-        Whitespace@160..161 " "
+      Whitespace@160..161 " "
       Ident@161..162 "e"
       Whitespace@162..163 " "
       Assignment@163..164 "="
-      NegationExprNode@164..177
+      NegationExprNode@164..176
         Whitespace@164..165 " "
         Minus@165..166 "-"
-        NegationExprNode@166..177
+        NegationExprNode@166..176
           Minus@166..167 "-"
-          NegationExprNode@167..177
+          NegationExprNode@167..176
             Minus@167..168 "-"
-            NegationExprNode@168..177
+            NegationExprNode@168..176
               Minus@168..169 "-"
-              NegationExprNode@169..177
+              NegationExprNode@169..176
                 Minus@169..170 "-"
-                NegationExprNode@170..177
+                NegationExprNode@170..176
                   Minus@170..171 "-"
-                  NegationExprNode@171..177
+                  NegationExprNode@171..176
                     Minus@171..172 "-"
-                    NegationExprNode@172..177
+                    NegationExprNode@172..176
                       Minus@172..173 "-"
-                      NegationExprNode@173..177
+                      NegationExprNode@173..176
                         Minus@173..174 "-"
                         LiteralIntegerNode@174..176
                           Integer@174..176 "42"
-                        Whitespace@176..177 "\n"
+    Whitespace@176..177 "\n"
     CloseBrace@177..178 "}"
   Whitespace@178..179 "\n"

--- a/wdl-grammar/tests/parsing/runtime-sections/source.tree
+++ b/wdl-grammar/tests/parsing/runtime-sections/source.tree
@@ -18,7 +18,7 @@ RootNode@0..355
       Whitespace@84..85 " "
       OpenBrace@85..86 "{"
       Whitespace@86..95 "\n        "
-      RuntimeItemNode@95..130
+      RuntimeItemNode@95..121
         Ident@95..104 "container"
         Colon@104..105 ":"
         LiteralStringNode@105..121
@@ -26,8 +26,8 @@ RootNode@0..355
           DoubleQuote@106..107 "\""
           LiteralStringText@107..120 "ubuntu:latest"
           DoubleQuote@120..121 "\""
-        Whitespace@121..130 "\n        "
-      RuntimeItemNode@130..157
+      Whitespace@121..130 "\n        "
+      RuntimeItemNode@130..148
         Ident@130..139 "maxMemory"
         Colon@139..140 ":"
         LiteralStringNode@140..148
@@ -35,29 +35,29 @@ RootNode@0..355
           DoubleQuote@141..142 "\""
           LiteralStringText@142..147 "36 GB"
           DoubleQuote@147..148 "\""
-        Whitespace@148..157 "\n        "
-      RuntimeItemNode@157..176
+      Whitespace@148..157 "\n        "
+      RuntimeItemNode@157..167
         Ident@157..163 "maxCpu"
         Colon@163..164 ":"
         LiteralIntegerNode@164..167
           Whitespace@164..165 " "
           Integer@165..167 "24"
-        Whitespace@167..176 "\n        "
-      RuntimeItemNode@176..200
+      Whitespace@167..176 "\n        "
+      RuntimeItemNode@176..191
         Ident@176..185 "shortTask"
         Colon@185..186 ":"
         LiteralBooleanNode@186..191
           Whitespace@186..187 " "
           TrueKeyword@187..191 "true"
-        Whitespace@191..200 "\n        "
-      RuntimeItemNode@200..236
+      Whitespace@191..200 "\n        "
+      RuntimeItemNode@200..227
         Ident@200..220 "localizationOptional"
         Colon@220..221 ":"
         LiteralBooleanNode@221..227
           Whitespace@221..222 " "
           FalseKeyword@222..227 "false"
-        Whitespace@227..236 "\n        "
-      RuntimeItemNode@236..351
+      Whitespace@227..236 "\n        "
+      RuntimeItemNode@236..346
         Ident@236..242 "inputs"
         Colon@242..243 ":"
         LiteralObjectNode@243..346
@@ -66,7 +66,7 @@ RootNode@0..355
           Whitespace@250..251 " "
           OpenBrace@251..252 "{"
           Whitespace@252..265 "\n            "
-          LiteralObjectItemNode@265..345
+          LiteralObjectItemNode@265..336
             Ident@265..268 "foo"
             Colon@268..269 ":"
             LiteralObjectNode@269..336
@@ -75,17 +75,17 @@ RootNode@0..355
               Whitespace@276..277 " "
               OpenBrace@277..278 "{"
               Whitespace@278..296 " \n                "
-              LiteralObjectItemNode@296..335
+              LiteralObjectItemNode@296..322
                 Ident@296..316 "localizationOptional"
                 Colon@316..317 ":"
                 LiteralBooleanNode@317..322
                   Whitespace@317..318 " "
                   TrueKeyword@318..322 "true"
-                Whitespace@322..335 "\n            "
+              Whitespace@322..335 "\n            "
               CloseBrace@335..336 "}"
-            Whitespace@336..345 "\n        "
+          Whitespace@336..345 "\n        "
           CloseBrace@345..346 "}"
-        Whitespace@346..351 "\n    "
+      Whitespace@346..351 "\n    "
       CloseBrace@351..352 "}"
     Whitespace@352..353 "\n"
     CloseBrace@353..354 "}"

--- a/wdl-grammar/tests/parsing/scatter-statements/source.tree
+++ b/wdl-grammar/tests/parsing/scatter-statements/source.tree
@@ -38,10 +38,10 @@ RootNode@0..193
       Whitespace@98..99 " "
       OpenBrace@99..100 "{"
       Whitespace@100..109 "\n        "
-      BoundDeclNode@109..135
-        PrimitiveTypeNode@109..116
+      BoundDeclNode@109..126
+        PrimitiveTypeNode@109..115
           StringTypeKeyword@109..115 "String"
-          Whitespace@115..116 " "
+        Whitespace@115..116 " "
         Ident@116..119 "msg"
         Whitespace@119..120 " "
         Assignment@120..121 "="
@@ -50,37 +50,37 @@ RootNode@0..193
           DoubleQuote@122..123 "\""
           LiteralStringText@123..125 "hi"
           DoubleQuote@125..126 "\""
-        Whitespace@126..135 "\n        "
+      Whitespace@126..135 "\n        "
       CallStatementNode@135..154
         CallKeyword@135..139 "call"
-        CallTargetNode@139..142
+        CallTargetNode@139..141
           Whitespace@139..140 " "
           Ident@140..141 "x"
-          Whitespace@141..142 " "
+        Whitespace@141..142 " "
         OpenBrace@142..143 "{"
         Whitespace@143..144 " "
         InputKeyword@144..149 "input"
         Colon@149..150 ":"
         Whitespace@150..151 " "
-        CallInputItemNode@151..153
+        CallInputItemNode@151..152
           Ident@151..152 "a"
-          Whitespace@152..153 " "
+        Whitespace@152..153 " "
         CloseBrace@153..154 "}"
       Whitespace@154..163 "\n        "
       CallStatementNode@163..184
         CallKeyword@163..167 "call"
-        CallTargetNode@167..170
+        CallTargetNode@167..169
           Whitespace@167..168 " "
           Ident@168..169 "y"
-          Whitespace@169..170 " "
+        Whitespace@169..170 " "
         OpenBrace@170..171 "{"
         Whitespace@171..172 " "
         InputKeyword@172..177 "input"
         Colon@177..178 ":"
         Whitespace@178..179 " "
-        CallInputItemNode@179..183
+        CallInputItemNode@179..182
           Ident@179..182 "msg"
-          Whitespace@182..183 " "
+        Whitespace@182..183 " "
         CloseBrace@183..184 "}"
       Whitespace@184..189 "\n    "
       CloseBrace@189..190 "}"

--- a/wdl-grammar/tests/parsing/struct-definitions/source.tree
+++ b/wdl-grammar/tests/parsing/struct-definitions/source.tree
@@ -28,9 +28,9 @@ RootNode@0..1134
     Comment@169..179 "# Booleans"
     Whitespace@179..184 "\n    "
     UnboundDeclNode@184..193
-      PrimitiveTypeNode@184..192
+      PrimitiveTypeNode@184..191
         BooleanTypeKeyword@184..191 "Boolean"
-        Whitespace@191..192 " "
+      Whitespace@191..192 " "
       Ident@192..193 "a"
     Whitespace@193..198 "\n    "
     UnboundDeclNode@198..208
@@ -43,9 +43,9 @@ RootNode@0..1134
     Comment@214..220 "# Ints"
     Whitespace@220..225 "\n    "
     UnboundDeclNode@225..230
-      PrimitiveTypeNode@225..229
+      PrimitiveTypeNode@225..228
         IntTypeKeyword@225..228 "Int"
-        Whitespace@228..229 " "
+      Whitespace@228..229 " "
       Ident@229..230 "c"
     Whitespace@230..235 "\n    "
     UnboundDeclNode@235..241
@@ -58,9 +58,9 @@ RootNode@0..1134
     Comment@251..259 "# Floats"
     Whitespace@259..264 "\n    "
     UnboundDeclNode@264..271
-      PrimitiveTypeNode@264..270
+      PrimitiveTypeNode@264..269
         FloatTypeKeyword@264..269 "Float"
-        Whitespace@269..270 " "
+      Whitespace@269..270 " "
       Ident@270..271 "e"
     Whitespace@271..276 "\n    "
     UnboundDeclNode@276..284
@@ -73,9 +73,9 @@ RootNode@0..1134
     Comment@294..303 "# Strings"
     Whitespace@303..308 "\n    "
     UnboundDeclNode@308..316
-      PrimitiveTypeNode@308..315
+      PrimitiveTypeNode@308..314
         StringTypeKeyword@308..314 "String"
-        Whitespace@314..315 " "
+      Whitespace@314..315 " "
       Ident@315..316 "g"
     Whitespace@316..321 "\n    "
     UnboundDeclNode@321..330
@@ -88,9 +88,9 @@ RootNode@0..1134
     Comment@340..347 "# Files"
     Whitespace@347..352 "\n    "
     UnboundDeclNode@352..358
-      PrimitiveTypeNode@352..357
+      PrimitiveTypeNode@352..356
         FileTypeKeyword@352..356 "File"
-        Whitespace@356..357 " "
+      Whitespace@356..357 " "
       Ident@357..358 "i"
     Whitespace@358..363 "\n    "
     UnboundDeclNode@363..370
@@ -114,7 +114,7 @@ RootNode@0..1134
     Comment@441..447 "# Maps"
     Whitespace@447..452 "\n    "
     UnboundDeclNode@452..474
-      MapTypeNode@452..473
+      MapTypeNode@452..472
         MapTypeKeyword@452..455 "Map"
         OpenBracket@455..456 "["
         PrimitiveTypeNode@456..463
@@ -124,11 +124,11 @@ RootNode@0..1134
           Whitespace@464..465 " "
           StringTypeKeyword@465..471 "String"
         CloseBracket@471..472 "]"
-        Whitespace@472..473 " "
+      Whitespace@472..473 " "
       Ident@473..474 "a"
     Whitespace@474..479 "\n    "
     UnboundDeclNode@479..505
-      MapTypeNode@479..504
+      MapTypeNode@479..503
         MapTypeKeyword@479..482 "Map"
         OpenBracket@482..483 "["
         PrimitiveTypeNode@483..487
@@ -143,11 +143,11 @@ RootNode@0..1134
             StringTypeKeyword@495..501 "String"
           CloseBracket@501..502 "]"
         CloseBracket@502..503 "]"
-        Whitespace@503..504 " "
+      Whitespace@503..504 " "
       Ident@504..505 "b"
     Whitespace@505..510 "\n    "
     UnboundDeclNode@510..555
-      MapTypeNode@510..554
+      MapTypeNode@510..553
         MapTypeKeyword@510..513 "Map"
         OpenBracket@513..514 "["
         PrimitiveTypeNode@514..519
@@ -173,11 +173,11 @@ RootNode@0..1134
             CloseBracket@550..551 "]"
           CloseBracket@551..552 "]"
         CloseBracket@552..553 "]"
-        Whitespace@553..554 " "
+      Whitespace@553..554 " "
       Ident@554..555 "c"
     Whitespace@555..560 "\n    "
     UnboundDeclNode@560..615
-      MapTypeNode@560..614
+      MapTypeNode@560..613
         MapTypeKeyword@560..563 "Map"
         OpenBracket@563..564 "["
         PrimitiveTypeNode@564..570
@@ -207,11 +207,11 @@ RootNode@0..1134
             CloseBracket@610..611 "]"
           CloseBracket@611..612 "]"
         CloseBracket@612..613 "]"
-        Whitespace@613..614 " "
+      Whitespace@613..614 " "
       Ident@614..615 "d"
     Whitespace@615..620 "\n    "
     UnboundDeclNode@620..637
-      MapTypeNode@620..636
+      MapTypeNode@620..635
         MapTypeKeyword@620..623 "Map"
         OpenBracket@623..624 "["
         PrimitiveTypeNode@624..628
@@ -221,23 +221,23 @@ RootNode@0..1134
           Whitespace@629..630 " "
           FileTypeKeyword@630..634 "File"
         CloseBracket@634..635 "]"
-        Whitespace@635..636 " "
+      Whitespace@635..636 " "
       Ident@636..637 "e"
     Whitespace@637..643 "\n\n    "
     Comment@643..651 "# Arrays"
     Whitespace@651..656 "\n    "
     UnboundDeclNode@656..672
-      ArrayTypeNode@656..671
+      ArrayTypeNode@656..670
         ArrayTypeKeyword@656..661 "Array"
         OpenBracket@661..662 "["
         PrimitiveTypeNode@662..669
           BooleanTypeKeyword@662..669 "Boolean"
         CloseBracket@669..670 "]"
-        Whitespace@670..671 " "
+      Whitespace@670..671 " "
       Ident@671..672 "f"
     Whitespace@672..677 "\n    "
     UnboundDeclNode@677..698
-      ArrayTypeNode@677..697
+      ArrayTypeNode@677..696
         ArrayTypeKeyword@677..682 "Array"
         OpenBracket@682..683 "["
         ArrayTypeNode@683..695
@@ -247,11 +247,11 @@ RootNode@0..1134
             FloatTypeKeyword@689..694 "Float"
           CloseBracket@694..695 "]"
         CloseBracket@695..696 "]"
-        Whitespace@696..697 " "
+      Whitespace@696..697 " "
       Ident@697..698 "g"
     Whitespace@698..703 "\n    "
     UnboundDeclNode@703..731
-      ArrayTypeNode@703..730
+      ArrayTypeNode@703..729
         ArrayTypeKeyword@703..708 "Array"
         OpenBracket@708..709 "["
         MapTypeNode@709..728
@@ -265,11 +265,11 @@ RootNode@0..1134
             ObjectTypeKeyword@721..727 "Object"
           CloseBracket@727..728 "]"
         CloseBracket@728..729 "]"
-        Whitespace@729..730 " "
+      Whitespace@729..730 " "
       Ident@730..731 "h"
     Whitespace@731..736 "\n    "
     UnboundDeclNode@736..778
-      ArrayTypeNode@736..777
+      ArrayTypeNode@736..776
         ArrayTypeKeyword@736..741 "Array"
         OpenBracket@741..742 "["
         ArrayTypeNode@742..775
@@ -292,28 +292,28 @@ RootNode@0..1134
             CloseBracket@773..774 "]"
           CloseBracket@774..775 "]"
         CloseBracket@775..776 "]"
-        Whitespace@776..777 " "
+      Whitespace@776..777 " "
       Ident@777..778 "i"
     Whitespace@778..783 "\n    "
     UnboundDeclNode@783..802
-      ArrayTypeNode@783..801
+      ArrayTypeNode@783..800
         ArrayTypeKeyword@783..788 "Array"
         OpenBracket@788..789 "["
         TypeRefNode@789..799
           Ident@789..799 "CustomType"
         CloseBracket@799..800 "]"
-        Whitespace@800..801 " "
+      Whitespace@800..801 " "
       Ident@801..802 "j"
     Whitespace@802..807 "\n    "
     UnboundDeclNode@807..828
-      ArrayTypeNode@807..819
+      ArrayTypeNode@807..818
         ArrayTypeKeyword@807..812 "Array"
         OpenBracket@812..813 "["
         PrimitiveTypeNode@813..816
           IntTypeKeyword@813..816 "Int"
         CloseBracket@816..817 "]"
         Plus@817..818 "+"
-        Whitespace@818..819 " "
+      Whitespace@818..819 " "
       Ident@819..828 "non_empty"
     Whitespace@828..833 "\n    "
     UnboundDeclNode@833..868
@@ -331,7 +331,7 @@ RootNode@0..1134
     Comment@874..881 "# Pairs"
     Whitespace@881..886 "\n    "
     UnboundDeclNode@886..910
-      PairTypeNode@886..909
+      PairTypeNode@886..908
         PairTypeKeyword@886..890 "Pair"
         OpenBracket@890..891 "["
         PrimitiveTypeNode@891..898
@@ -341,11 +341,11 @@ RootNode@0..1134
           Whitespace@899..900 " "
           BooleanTypeKeyword@900..907 "Boolean"
         CloseBracket@907..908 "]"
-        Whitespace@908..909 " "
+      Whitespace@908..909 " "
       Ident@909..910 "k"
     Whitespace@910..915 "\n    "
     UnboundDeclNode@915..962
-      PairTypeNode@915..961
+      PairTypeNode@915..960
         PairTypeKeyword@915..919 "Pair"
         OpenBracket@919..920 "["
         PairTypeNode@920..952
@@ -372,11 +372,11 @@ RootNode@0..1134
           Whitespace@953..954 " "
           FloatTypeKeyword@954..959 "Float"
         CloseBracket@959..960 "]"
-        Whitespace@960..961 " "
+      Whitespace@960..961 " "
       Ident@961..962 "l"
     Whitespace@962..967 "\n    "
     UnboundDeclNode@967..1015
-      PairTypeNode@967..1014
+      PairTypeNode@967..1013
         PairTypeKeyword@967..971 "Pair"
         OpenBracket@971..972 "["
         MapTypeNode@972..1006
@@ -404,11 +404,11 @@ RootNode@0..1134
           IntTypeKeyword@1008..1011 "Int"
           QuestionMark@1011..1012 "?"
         CloseBracket@1012..1013 "]"
-        Whitespace@1013..1014 " "
+      Whitespace@1013..1014 " "
       Ident@1014..1015 "m"
     Whitespace@1015..1020 "\n    "
     UnboundDeclNode@1020..1057
-      PairTypeNode@1020..1056
+      PairTypeNode@1020..1055
         PairTypeKeyword@1020..1024 "Pair"
         OpenBracket@1024..1025 "["
         ArrayTypeNode@1025..1038
@@ -427,23 +427,23 @@ RootNode@0..1134
             QuestionMark@1052..1053 "?"
           CloseBracket@1053..1054 "]"
         CloseBracket@1054..1055 "]"
-        Whitespace@1055..1056 " "
+      Whitespace@1055..1056 " "
       Ident@1056..1057 "n"
     Whitespace@1057..1063 "\n\n    "
     Comment@1063..1071 "# Object"
     Whitespace@1071..1076 "\n    "
     UnboundDeclNode@1076..1084
-      ObjectTypeNode@1076..1083
+      ObjectTypeNode@1076..1082
         ObjectTypeKeyword@1076..1082 "Object"
-        Whitespace@1082..1083 " "
+      Whitespace@1082..1083 " "
       Ident@1083..1084 "o"
     Whitespace@1084..1090 "\n\n    "
     Comment@1090..1104 "# Custom types"
     Whitespace@1104..1109 "\n    "
     UnboundDeclNode@1109..1117
-      TypeRefNode@1109..1116
+      TypeRefNode@1109..1115
         Ident@1109..1115 "MyType"
-        Whitespace@1115..1116 " "
+      Whitespace@1115..1116 " "
       Ident@1116..1117 "p"
     Whitespace@1117..1122 "\n    "
     UnboundDeclNode@1122..1131

--- a/wdl-grammar/tests/parsing/struct-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/struct-recovery/source.tree
@@ -18,9 +18,9 @@ RootNode@0..223
     Comment@110..125 "# Unknown token"
     Whitespace@125..130 "\n    "
     UnboundDeclNode@130..138
-      PrimitiveTypeNode@130..137
+      PrimitiveTypeNode@130..136
         StringTypeKeyword@130..136 "String"
-        Whitespace@136..137 " "
+      Whitespace@136..137 " "
       Ident@137..138 "a"
     Whitespace@138..143 "\n    "
     QuestionMark@143..144 "?"
@@ -28,9 +28,9 @@ RootNode@0..223
     Comment@146..164 "# Unexpected token"
     Whitespace@164..169 "\n    "
     UnboundDeclNode@169..176
-      PrimitiveTypeNode@169..175
+      PrimitiveTypeNode@169..174
         FloatTypeKeyword@169..174 "Float"
-        Whitespace@174..175 " "
+      Whitespace@174..175 " "
       Ident@175..176 "b"
     Whitespace@176..181 "\n    "
     StructKeyword@181..187 "struct"
@@ -38,9 +38,9 @@ RootNode@0..223
     Comment@190..210 "# Unexpected keyword"
     Whitespace@210..215 "\n    "
     UnboundDeclNode@215..220
-      PrimitiveTypeNode@215..219
+      PrimitiveTypeNode@215..218
         IntTypeKeyword@215..218 "Int"
-        Whitespace@218..219 " "
+      Whitespace@218..219 " "
       Ident@219..220 "c"
     Whitespace@220..221 "\n"
     CloseBrace@221..222 "}"

--- a/wdl-grammar/tests/parsing/top-recovery/source.tree
+++ b/wdl-grammar/tests/parsing/top-recovery/source.tree
@@ -14,9 +14,9 @@ RootNode@0..120
     OpenBrace@68..69 "{"
     Whitespace@69..74 "\n    "
     UnboundDeclNode@74..82
-      PrimitiveTypeNode@74..81
+      PrimitiveTypeNode@74..80
         StringTypeKeyword@74..80 "String"
-        Whitespace@80..81 " "
+      Whitespace@80..81 " "
       Ident@81..82 "x"
     Whitespace@82..83 "\n"
     CloseBrace@83..84 "}"
@@ -37,9 +37,9 @@ RootNode@0..120
     OpenBrace@106..107 "{"
     Whitespace@107..112 "\n    "
     UnboundDeclNode@112..117
-      PrimitiveTypeNode@112..116
+      PrimitiveTypeNode@112..115
         IntTypeKeyword@112..115 "Int"
-        Whitespace@115..116 " "
+      Whitespace@115..116 " "
       Ident@116..117 "y"
     Whitespace@117..118 "\n"
     CloseBrace@118..119 "}"

--- a/wdl-grammar/tests/parsing/unbound-decl-in-output/source.tree
+++ b/wdl-grammar/tests/parsing/unbound-decl-in-output/source.tree
@@ -20,9 +20,9 @@ RootNode@0..167
       Whitespace@109..118 "\n        "
       Comment@118..141 "# This should be bound!"
       Whitespace@141..150 "\n        "
-      PrimitiveTypeNode@150..157
+      PrimitiveTypeNode@150..156
         StringTypeKeyword@150..156 "String"
-        Whitespace@156..157 " "
+      Whitespace@156..157 " "
       Ident@157..158 "x"
       Whitespace@158..163 "\n    "
       CloseBrace@163..164 "}"

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed the preamble whitespace and preamble comment rules to look for the 
+  version statement trivia based on it now being children of the version 
+  statement ([#85](https://github.com/stjude-rust-labs/wdl/pull/85)).
+
 ## 0.1.0 - 06-13-2024
 
 ### Added

--- a/wdl-lint/tests/lints.rs
+++ b/wdl-lint/tests/lints.rs
@@ -70,11 +70,7 @@ fn normalize(s: &str, is_error: bool) -> String {
     s.replace("\r\n", "\n")
 }
 
-fn format_diagnostics<'a>(
-    diagnostics: impl Iterator<Item = &'a Diagnostic>,
-    path: &Path,
-    source: &str,
-) -> String {
+fn format_diagnostics(diagnostics: &[Diagnostic], path: &Path, source: &str) -> String {
     let file = SimpleFile::new(path.as_os_str().to_str().unwrap(), source);
     let mut buffer = Buffer::no_color();
     for diagnostic in diagnostics {
@@ -138,14 +134,14 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<(), String> {
             validator.add_v1_visitors(rules.iter().map(|r| r.visitor()));
             let errors = match validator.validate(&document) {
                 Ok(()) => String::new(),
-                Err(diagnostics) => format_diagnostics(diagnostics.iter(), &path, &source),
+                Err(diagnostics) => format_diagnostics(&diagnostics, &path, &source),
             };
             compare_result(&path.with_extension("errors"), &errors, true)?;
         }
         Err(diagnostics) => {
             compare_result(
                 &path.with_extension("errors"),
-                &format_diagnostics(diagnostics.iter(), &path, &source),
+                &format_diagnostics(&diagnostics, &path, &source),
                 true,
             )?;
         }

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
@@ -7,17 +7,21 @@ note[PreambleWhitespace]: unnecessary whitespace in document preamble
   = fix: remove the unnecessary whitespace
 
 note[PreambleComments]: preamble comments cannot come after the version statement
-  ┌─ tests/lints/preamble-comment-after-version/source.wdl:6:1
-  │
-6 │ ## This is a preamble comment after the version
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  │
-  = fix: change each comment to start with `#` followed by a space
+   ┌─ tests/lints/preamble-comment-after-version/source.wdl:6:1
+   │  
+ 6 │ ╭ ## This is a preamble comment after the version
+ 7 │ │ 
+ 8 │ │ ## Also a preamble comment
+ 9 │ │ 
+10 │ │ ## And this one is bad too!
+   │ ╰───────────────────────────^
+   │  
+   = fix: change each comment to start with `#` followed by a space
 
 note[PreambleComments]: preamble comments cannot come after the version statement
-   ┌─ tests/lints/preamble-comment-after-version/source.wdl:15:5
+   ┌─ tests/lints/preamble-comment-after-version/source.wdl:19:5
    │
-15 │     ## This one is bad!
+19 │     ## This one is bad!
    │     ^^^^^^^^^^^^^^^^^^^
    │
    = fix: change each comment to start with `#` followed by a space

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
@@ -5,6 +5,10 @@ version 1.1
 
 ## This is a preamble comment after the version
 
+## Also a preamble comment
+
+## And this one is bad too!
+
 # This comment is okay though
 
 ### So is this comment


### PR DESCRIPTION
This fixes where trivia is located in the CST so that it is consistent; the previous inconsistency was the result of attaching trivia to the CST whenever a `peek` operation was performed.

Now any trivia encountered during a `peek` is buffered and attached only when we consume the next token from the stream or before a node is started.

This also fixes sorting the diagnostics returned from parsing and validation such that it is sorted by primary label offset.

Fixes #81.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
