### PR TITLE
fix: improve diagnostics that have a label pointing at a string.

### DIFF
--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -4,11 +4,11 @@ commit_hash = "26eeda81a0540dc793fc69b0c390d232ca7ca50a"
 
 [repositories."PacificBiosciences/HiFi-human-WGS-WDL"]
 identifier = "PacificBiosciences/HiFi-human-WGS-WDL"
-commit_hash = "b8057d3e3fa575f45f55f7ac7df47fa9bc5f73e0"
+commit_hash = "9a1a2846443e4b621f1dca0259fd3fa21885156a"
 
 [repositories."aws-samples/amazon-omics-tutorials"]
 identifier = "aws-samples/amazon-omics-tutorials"
-commit_hash = "6c1ae7111deb8f4af68a3c43bff28c7008873b15"
+commit_hash = "0a49b4326f67ac72150159a183084a252cf45ee0"
 
 [repositories."biowdl/tasks"]
 identifier = "biowdl/tasks"
@@ -49,11 +49,11 @@ filters = ["/template/task-templates.wdl"]
 
 [repositories."theiagen/public_health_bioinformatics"]
 identifier = "theiagen/public_health_bioinformatics"
-commit_hash = "092f19a0f610eb0a01757456932519bbbfe2bbd9"
+commit_hash = "74c12d3bbced7177638fdfdc50c56f8bc40a0f5a"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
-message = "mutec2.wdl:112:40: error: expected input section, output section, runtime section, metadata section, parameter metadata section, conditional statement, scatter statement, task call statement, or private declaration, but found `{`"
+message = "mutec2.wdl:112:40: error: expected input section, output section, runtime section, metadata section, parameter metadata section, conditional statement, scatter statement, call statement, or private declaration, but found `{`"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed diagnostic label spans that point at strings to include the entire span
+  of the string ([#86](https://github.com/stjude-rust-labs/wdl/pull/86)).
 * Fixed trivia in the CST so that it appears at consistent locations; also
   fixed the parser diagnostics to be ordered by the start of the primary label
   ([#85](https://github.com/stjude-rust-labs/wdl/pull/85)).

--- a/wdl-grammar/src/diagnostic.rs
+++ b/wdl-grammar/src/diagnostic.rs
@@ -172,6 +172,11 @@ impl Diagnostic {
         self.labels.iter()
     }
 
+    /// Gets the mutable labels of the diagnostic.
+    pub fn labels_mut(&mut self) -> impl Iterator<Item = &mut Label> {
+        self.labels.iter_mut()
+    }
+
     /// Converts this diagnostic to a `codespan` [Diagnostic].
     ///
     /// [Diagnostic]: codespan_reporting::diagnostic::Diagnostic
@@ -240,6 +245,11 @@ impl Label {
     /// Gets the span of the label.
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    /// Sets the span of the label.
+    pub fn set_span(&mut self, span: Span) {
+        self.span = span;
     }
 }
 

--- a/wdl-grammar/src/grammar/v1.rs
+++ b/wdl-grammar/src/grammar/v1.rs
@@ -125,7 +125,7 @@ const WORKFLOW_ITEM_EXPECTED_NAMES: &[&str] = &[
     "parameter metadata section",
     "conditional statement",
     "scatter statement",
-    "task call statement",
+    "call statement",
     "private declaration",
 ];
 

--- a/wdl-grammar/src/grammar/v1.rs
+++ b/wdl-grammar/src/grammar/v1.rs
@@ -374,8 +374,7 @@ pub fn items(parser: &mut Parser<'_>) {
     while parser.peek().is_some() {
         let marker = parser.start();
         if let Err((marker, e)) = item(parser, marker) {
-            parser.diagnostic(e);
-            parser.recover(TOP_RECOVERY_SET);
+            parser.recover(e, TOP_RECOVERY_SET);
             marker.abandon(parser);
         }
     }
@@ -736,9 +735,8 @@ fn interpolate_brace_command(
                 // Parse the placeholder expression
                 let mut parser = interpolator.into_parser();
                 if let Err((marker, e)) = placeholder_expr(&mut parser, marker, span) {
-                    parser.diagnostic(e);
                     marker.abandon(&mut parser);
-                    parser.recover(TokenSet::new(&[Token::CloseBrace as u8]));
+                    parser.recover(e, TokenSet::new(&[Token::CloseBrace as u8]));
                     parser.next_if(Token::CloseBrace);
                 }
 
@@ -819,12 +817,11 @@ pub(crate) fn interpolate_heredoc_command(
                 // Parse the placeholder expression
                 let mut parser = interpolator.into_parser();
                 if let Err((marker, e)) = placeholder_expr(&mut parser, marker, span) {
-                    parser.diagnostic(e);
                     marker.abandon(&mut parser);
-                    parser.recover(TokenSet::new(&[
-                        Token::CloseBrace as u8,
-                        Token::HeredocCommandEnd as u8,
-                    ]));
+                    parser.recover(
+                        e,
+                        TokenSet::new(&[Token::CloseBrace as u8, Token::HeredocCommandEnd as u8]),
+                    );
                     parser.next_if(Token::CloseBrace);
                 }
 
@@ -1134,12 +1131,11 @@ pub(crate) fn single_quote_interpolate(
                 // Parse the placeholder expression
                 let mut parser = interpolator.into_parser();
                 if let Err((marker, e)) = placeholder_expr(&mut parser, marker, span) {
-                    parser.diagnostic(e);
                     marker.abandon(&mut parser);
-                    parser.recover(TokenSet::new(&[
-                        Token::CloseBrace as u8,
-                        Token::SQStringStart as u8,
-                    ]));
+                    parser.recover(
+                        e,
+                        TokenSet::new(&[Token::CloseBrace as u8, Token::SQStringStart as u8]),
+                    );
                     parser.next_if(Token::CloseBrace);
                 }
 
@@ -1249,12 +1245,11 @@ pub(crate) fn double_quote_interpolate(
                 // Parse the placeholder expression
                 let mut parser = interpolator.into_parser();
                 if let Err((marker, e)) = placeholder_expr(&mut parser, marker, span) {
-                    parser.diagnostic(e);
                     marker.abandon(&mut parser);
-                    parser.recover(TokenSet::new(&[
-                        Token::CloseBrace as u8,
-                        Token::DQStringStart as u8,
-                    ]));
+                    parser.recover(
+                        e,
+                        TokenSet::new(&[Token::CloseBrace as u8, Token::DQStringStart as u8]),
+                    );
                     parser.next_if(Token::CloseBrace);
                 }
 

--- a/wdl-grammar/src/lexer/v1.rs
+++ b/wdl-grammar/src/lexer/v1.rs
@@ -599,8 +599,7 @@ impl<'a> ParserToken<'a> for Token {
             Self::Float => "float",
             Self::Integer => "integer",
             Self::Ident => "identifier",
-            Self::SQStringStart => "`'`",
-            Self::DQStringStart => "`\"`",
+            Self::SQStringStart | Self::DQStringStart => "string",
             Self::HeredocCommandStart => "`<<<`",
             Self::HeredocCommandEnd => "`>>>`",
             Self::ArrayTypeKeyword => "`Array` keyword",
@@ -673,25 +672,29 @@ impl<'a> ParserToken<'a> for Token {
         matches!(self, Self::Whitespace | Self::Comment)
     }
 
-    fn recover_interpolation(token: Self, start: Span, parser: &mut Parser<'a, Self>) {
+    fn recover_interpolation(token: Self, start: Span, parser: &mut Parser<'a, Self>) -> bool {
         match token {
             Self::SQStringStart => {
                 if let Err(e) = parser.interpolate(|i| single_quote_interpolate(start, true, i)) {
                     parser.diagnostic(e);
                 }
+                true
             }
             Self::DQStringStart => {
                 if let Err(e) = parser.interpolate(|i| double_quote_interpolate(start, true, i)) {
                     parser.diagnostic(e);
                 }
+                true
             }
             Self::HeredocCommandStart => {
                 if let Err(e) = parser.interpolate(|i| interpolate_heredoc_command(start, i)) {
                     parser.diagnostic(e);
                 }
+                true
             }
             _ => {
                 // Not an interpolation
+                false
             }
         }
     }

--- a/wdl-grammar/tests/parsing/recovery-past-string/source.errors
+++ b/wdl-grammar/tests/parsing/recovery-past-string/source.errors
@@ -1,6 +1,6 @@
-error: expected metadata key, but found `"`
+error: expected metadata key, but found string
   ┌─ tests/parsing/recovery-past-string/source.wdl:7:9
   │
 7 │         "invalid": "~{value}"
-  │         ^ unexpected `"`
+  │         ^^^^^^^^^ unexpected string
 

--- a/wdl-grammar/tests/parsing/unexpected-string/source.errors
+++ b/wdl-grammar/tests/parsing/unexpected-string/source.errors
@@ -1,4 +1,4 @@
-error: expected input section, output section, runtime section, metadata section, parameter metadata section, conditional statement, scatter statement, task call statement, or private declaration, but found string
+error: expected input section, output section, runtime section, metadata section, parameter metadata section, conditional statement, scatter statement, call statement, or private declaration, but found string
   ┌─ tests/parsing/unexpected-string/source.wdl:6:5
   │
 6 │     "this ${'~{"string"}'} is unexpected!"

--- a/wdl-grammar/tests/parsing/unexpected-string/source.errors
+++ b/wdl-grammar/tests/parsing/unexpected-string/source.errors
@@ -1,0 +1,6 @@
+error: expected input section, output section, runtime section, metadata section, parameter metadata section, conditional statement, scatter statement, task call statement, or private declaration, but found string
+  ┌─ tests/parsing/unexpected-string/source.wdl:6:5
+  │
+6 │     "this ${'~{"string"}'} is unexpected!"
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected string
+

--- a/wdl-grammar/tests/parsing/unexpected-string/source.tree
+++ b/wdl-grammar/tests/parsing/unexpected-string/source.tree
@@ -1,0 +1,35 @@
+RootNode@0..138
+  Comment@0..62 "## This is a test of  ..."
+  Whitespace@62..64 "\n\n"
+  VersionStatementNode@64..75
+    VersionKeyword@64..71 "version"
+    Whitespace@71..72 " "
+    Version@72..75 "1.1"
+  Whitespace@75..77 "\n\n"
+  WorkflowDefinitionNode@77..137
+    WorkflowKeyword@77..85 "workflow"
+    Whitespace@85..86 " "
+    Ident@86..90 "test"
+    Whitespace@90..91 " "
+    OpenBrace@91..92 "{"
+    Whitespace@92..97 "\n    "
+    DoubleQuote@97..98 "\""
+    LiteralStringText@98..103 "this "
+    PlaceholderNode@103..119
+      PlaceholderOpen@103..105 "${"
+      LiteralStringNode@105..118
+        SingleQuote@105..106 "'"
+        PlaceholderNode@106..117
+          PlaceholderOpen@106..108 "~{"
+          LiteralStringNode@108..116
+            DoubleQuote@108..109 "\""
+            LiteralStringText@109..115 "string"
+            DoubleQuote@115..116 "\""
+          CloseBrace@116..117 "}"
+        SingleQuote@117..118 "'"
+      CloseBrace@118..119 "}"
+    LiteralStringText@119..134 " is unexpected!"
+    DoubleQuote@134..135 "\""
+    Whitespace@135..136 "\n"
+    CloseBrace@136..137 "}"
+  Whitespace@137..138 "\n"

--- a/wdl-grammar/tests/parsing/unexpected-string/source.wdl
+++ b/wdl-grammar/tests/parsing/unexpected-string/source.wdl
@@ -1,0 +1,7 @@
+## This is a test of properly showing a string in a diagnostic
+
+version 1.1
+
+workflow test {
+    "this ${'~{"string"}'} is unexpected!"
+}


### PR DESCRIPTION
This fix improves any diagnostic that has a label pointing at a string.

Previously the label would point just at the opening quote of the string because we don't know the span of the string until after we recover; recovery asks the lexer to move past any interpolations it encounters.

The fix is to pass the diagnostic we're recovering for to the `recover` method and adjust any labels that start an interpolation context to include the source that was moved past.

Fixes #80.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
