### PR TITLE
feat: implement the `ImportPlacement` rule.

### DIFF
--- a/Arena.toml
+++ b/Arena.toml
@@ -49,6 +49,10 @@ message = "ww-fastq-to-cram.wdl:23:10: warning[SnakeCase]: workflow name `Paired
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:2:1: note[PreambleWhitespace]: expected a blank line after the version statement"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:57:13: warning[Whitespace]: line contains trailing whitespace"
 
 [[diagnostics]]
@@ -150,6 +154,10 @@ message = "ww-star-deseq2.wdl:255:5: note[MatchingParameterMeta]: task `RNASeQC`
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
 message = "ww-star-deseq2.wdl:25:36: warning[Whitespace]: line contains trailing whitespace"
+
+[[diagnostics]]
+document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
+message = "ww-star-deseq2.wdl:2:1: note[PreambleWhitespace]: expected a blank line after the version statement"
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
@@ -354,6 +362,10 @@ message = "ww-vc-trio.wdl:29:10: warning[MatchingParameterMeta]: workflow `ww_vc
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:2:1: note[PreambleComments]: preamble comments cannot come after the version statement"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:2:1: note[PreambleWhitespace]: expected a blank line after the version statement"
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"

--- a/wdl-ast/src/lib.rs
+++ b/wdl-ast/src/lib.rs
@@ -49,6 +49,7 @@ use std::sync::Arc;
 pub use rowan::ast::support;
 pub use rowan::ast::AstChildren;
 pub use rowan::ast::AstNode;
+pub use rowan::Direction;
 pub use wdl_grammar::Diagnostic;
 pub use wdl_grammar::Label;
 pub use wdl_grammar::Severity;

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the CST for an unparsable file (i.e. one without a supported version)
+  to contain trivia before the version statement and correct spans for the
+  unparsed token ([#89](https://github.com/stjude-rust-labs/wdl/pull/89)).
+* Fixed last trivia in the file attaching as a child to the last node in the
+  file instead of as a child of the root ([#89](https://github.com/stjude-rust-labs/wdl/pull/89)).
 * Fixed diagnostics around encountering string member names in struct literals
   ([#87](https://github.com/stjude-rust-labs/wdl/pull/87)).
 * Fixed diagnostic label spans that point at strings to include the entire span
@@ -16,14 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed trivia in the CST so that it appears at consistent locations; also
   fixed the parser diagnostics to be ordered by the start of the primary label
   ([#85](https://github.com/stjude-rust-labs/wdl/pull/85)).
-* Fixed a missing delimiter diagnostic to include a label for where the parser 
+* Fixed a missing delimiter diagnostic to include a label for where the parser
   thinks the missing delimiter might go ([#84](https://github.com/stjude-rust-labs/wdl/pull/84)).
 
 ## 0.4.0 - 6-13-2024
 
 ### Changed
 
-* Removed the old parser implementation in favor of the new parser 
+* Removed the old parser implementation in favor of the new parser
   implementation; this also removes the `experimental` feature from the crate ([#79](https://github.com/stjude-rust-labs/wdl/pull/79)).
 * Removed dependency on `miette` and `thiserror` in the experimental parser,
   introduced the `Diagnostic` type as a replacement, and switched the existing
@@ -47,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the experimental parser ([#52](https://github.com/stjude-rust-labs/wdl/pull/52)).
 * Fixed parsing of empty inputs to a task call statement in the
   experimental parser ([#54](https://github.com/stjude-rust-labs/wdl/pull/54)).
-* Fixed parsing of postfix `+` qualifier on array types in the experimental 
+* Fixed parsing of postfix `+` qualifier on array types in the experimental
   parser ([#53](https://github.com/stjude-rust-labs/wdl/pull/53)).
 * Fixed parsing of placeholder options in the experimental parser such
   that it can disambiguate between the `sep` option and a `sep` function
@@ -70,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and workflows in the experimental parser ([#39](https://github.com/stjude-rust-labs/wdl/pull/39)).
 * Adds support for parsing struct definitions to the experimental parser;
   requires the `experimental` feature to be activated ([#38](https://github.com/stjude-rust-labs/wdl/pull/38)).
-* Adds a new experimental `SyntaxTree` representation; requires the 
+* Adds a new experimental `SyntaxTree` representation; requires the
   `experimental` feature to be activated ([#36](https://github.com/stjude-rust-labs/wdl/pull/36)).
 * Adds an `experimental` module containing the start of a new
   infallible WDL parser implementation based on `logos` and `rowan` ([#30](https://github.com/stjude-rust-labs/wdl/pull/30)).

--- a/wdl-grammar/src/grammar/v1.rs
+++ b/wdl-grammar/src/grammar/v1.rs
@@ -378,6 +378,9 @@ pub fn items(parser: &mut Parser<'_>) {
             marker.abandon(parser);
         }
     }
+
+    // This call to `next` is important as `next` adds any remaining buffered events
+    assert!(parser.next().is_none(), "parser is not finished");
 }
 
 /// Parses a single top-level item in a WDL document.

--- a/wdl-grammar/tests/parsing/imports/source.tree
+++ b/wdl-grammar/tests/parsing/imports/source.tree
@@ -52,7 +52,7 @@ RootNode@0..245
       Whitespace@165..166 " "
       Ident@166..169 "Qux"
   Whitespace@169..171 " \n"
-  ImportStatementNode@171..245
+  ImportStatementNode@171..244
     ImportKeyword@171..177 "import"
     LiteralStringNode@177..185
       Whitespace@177..178 " "
@@ -90,4 +90,4 @@ RootNode@0..245
       AsKeyword@236..238 "as"
       Whitespace@238..239 " "
       Ident@239..244 "Corge"
-    Whitespace@244..245 "\n"
+  Whitespace@244..245 "\n"

--- a/wdl-grammar/tests/parsing/missing-version/source.tree
+++ b/wdl-grammar/tests/parsing/missing-version/source.tree
@@ -1,2 +1,4 @@
-RootNode@0..14
-  Unparsed@0..14 "task foo {\n\n}\n"
+RootNode@0..64
+  Comment@0..48 "# This is a test of a ..."
+  Whitespace@48..50 "\n\n"
+  Unparsed@50..64 "task foo {\n\n}\n"

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added the `ImportPlacement` lint rule ([#89](https://github.com/stjude-rust-labs/wdl/pull/89)).
+
 ### Fixed
 
+* Fixed the preamble whitespace rule to check for a blank line following the
+  version statement ([#89](https://github.com/stjude-rust-labs/wdl/pull/89)).
 * Fixed the preamble whitespace and preamble comment rules to look for the 
   version statement trivia based on it now being children of the version 
   statement ([#85](https://github.com/stjude-rust-labs/wdl/pull/85)).

--- a/wdl-lint/RULES.md
+++ b/wdl-lint/RULES.md
@@ -6,16 +6,16 @@ be out of sync with released packages.
 
 ## Lint Rules
 
-| Name                             | Tags                          | Description                                                                  |
-|:---------------------------------|:------------------------------|:-----------------------------------------------------------------------------|
-| `CommandSectionMixedIndentation` | Clarity, Correctness, Spacing | Ensures that lines within a command do not mix spaces and tabs.              |
-| `DoubleQuotes`                   | Clarity, Style                | Ensures that strings are defined using double quotes.                        |
-| `EndingNewline`                  | Spacing, Style                | Ensures that documents end with a single newline character.                  |
-| `ImportPlacement`                | Clarity                       | Ensures that imports are placed immediately following the version statement. |
-| `MatchingParameterMeta`          | Completeness                  | Ensures that inputs have a matching entry in a `parameter_meta` section.     |
-| `MissingRuntime`                 | Completeness, Portability     | Ensures that tasks have a runtime section.                                   |
-| `NoCurlyCommands`                | Clarity                       | Ensures that tasks use heredoc syntax in command sections.                   |
-| `PreambleComments`               | Clarity, Spacing, Style       | Ensures that documents have correct comments in the preamble.                |
-| `PreambleWhitespace`             | Spacing, Style                | Ensures that documents have correct whitespace in the preamble.              |
-| `SnakeCase`                      | Clarity, Naming, Style        | Ensures that tasks, workflows, and variables use snake_case.                 |
-| `Whitespace`                     | Spacing, Style                | Ensures that a document does not contain undesired whitespace.               |
+| Name                             | Tags                          | Description                                                                           |
+|:---------------------------------|:------------------------------|:--------------------------------------------------------------------------------------|
+| `CommandSectionMixedIndentation` | Clarity, Correctness, Spacing | Ensures that lines within a command do not mix spaces and tabs.                       |
+| `DoubleQuotes`                   | Clarity, Style                | Ensures that strings are defined using double quotes.                                 |
+| `EndingNewline`                  | Spacing, Style                | Ensures that documents end with a single newline character.                           |
+| `ImportPlacement`                | Clarity                       | Ensures that imports are placed between the version statement and any document items. |
+| `MatchingParameterMeta`          | Completeness                  | Ensures that inputs have a matching entry in a `parameter_meta` section.              |
+| `MissingRuntime`                 | Completeness, Portability     | Ensures that tasks have a runtime section.                                            |
+| `NoCurlyCommands`                | Clarity                       | Ensures that tasks use heredoc syntax in command sections.                            |
+| `PreambleComments`               | Clarity, Spacing, Style       | Ensures that documents have correct comments in the preamble.                         |
+| `PreambleWhitespace`             | Spacing, Style                | Ensures that documents have correct whitespace in the preamble.                       |
+| `SnakeCase`                      | Clarity, Naming, Style        | Ensures that tasks, workflows, and variables use snake_case.                          |
+| `Whitespace`                     | Spacing, Style                | Ensures that a document does not contain undesired whitespace.                        |

--- a/wdl-lint/RULES.md
+++ b/wdl-lint/RULES.md
@@ -6,15 +6,16 @@ be out of sync with released packages.
 
 ## Lint Rules
 
-| Name                             | Tags                          | Description                                                              |
-|:---------------------------------|:------------------------------|:-------------------------------------------------------------------------|
-| `CommandSectionMixedIndentation` | Clarity, Correctness, Spacing | Ensures that lines within a command do not mix spaces and tabs.          |
-| `DoubleQuotes`                   | Clarity, Style                | Ensures that strings are defined using double quotes.                    |
-| `EndingNewline`                  | Spacing, Style                | Ensures that documents end with a single newline character.              |
-| `MatchingParameterMeta`          | Completeness                  | Ensures that inputs have a matching entry in a `parameter_meta` section. |
-| `MissingRuntime`                 | Completeness, Portability     | Ensures that tasks have a runtime section.                               |
-| `NoCurlyCommands`                | Clarity                       | Ensures that tasks use heredoc syntax in command sections.               |
-| `PreambleComments`               | Clarity, Spacing, Style       | Ensures that documents have correct comments in the preamble.            |
-| `PreambleWhitespace`             | Spacing, Style                | Ensures that documents have correct whitespace in the preamble.          |
-| `SnakeCase`                      | Clarity, Naming, Style        | Ensures that tasks, workflows, and variables use snake_case.             |
-| `Whitespace`                     | Spacing, Style                | Ensures that a document does not contain undesired whitespace.           |
+| Name                             | Tags                          | Description                                                                  |
+|:---------------------------------|:------------------------------|:-----------------------------------------------------------------------------|
+| `CommandSectionMixedIndentation` | Clarity, Correctness, Spacing | Ensures that lines within a command do not mix spaces and tabs.              |
+| `DoubleQuotes`                   | Clarity, Style                | Ensures that strings are defined using double quotes.                        |
+| `EndingNewline`                  | Spacing, Style                | Ensures that documents end with a single newline character.                  |
+| `ImportPlacement`                | Clarity                       | Ensures that imports are placed immediately following the version statement. |
+| `MatchingParameterMeta`          | Completeness                  | Ensures that inputs have a matching entry in a `parameter_meta` section.     |
+| `MissingRuntime`                 | Completeness, Portability     | Ensures that tasks have a runtime section.                                   |
+| `NoCurlyCommands`                | Clarity                       | Ensures that tasks use heredoc syntax in command sections.                   |
+| `PreambleComments`               | Clarity, Spacing, Style       | Ensures that documents have correct comments in the preamble.                |
+| `PreambleWhitespace`             | Spacing, Style                | Ensures that documents have correct whitespace in the preamble.              |
+| `SnakeCase`                      | Clarity, Naming, Style        | Ensures that tasks, workflows, and variables use snake_case.                 |
+| `Whitespace`                     | Spacing, Style                | Ensures that a document does not contain undesired whitespace.               |

--- a/wdl-lint/src/v1.rs
+++ b/wdl-lint/src/v1.rs
@@ -8,6 +8,7 @@ use crate::TagSet;
 mod command_mixed_indentation;
 mod double_quotes;
 mod ending_newline;
+mod import_placement;
 mod matching_parameter_meta;
 mod missing_runtime;
 mod no_curly_commands;
@@ -19,6 +20,7 @@ mod whitespace;
 pub use command_mixed_indentation::*;
 pub use double_quotes::*;
 pub use ending_newline::*;
+pub use import_placement::*;
 pub use matching_parameter_meta::*;
 pub use missing_runtime::*;
 pub use no_curly_commands::*;
@@ -68,6 +70,7 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
         Box::new(MatchingParameterMetaRule),
         Box::new(WhitespaceRule),
         Box::new(CommandSectionMixedIndentationRule),
+        Box::new(ImportPlacementRule),
     ];
 
     // Ensure all the rule ids are unique and pascal case

--- a/wdl-lint/src/v1/import_placement.rs
+++ b/wdl-lint/src/v1/import_placement.rs
@@ -24,7 +24,10 @@ fn misplaced_import(span: Span) -> Diagnostic {
     Diagnostic::warning("misplaced import")
         .with_rule(ID)
         .with_highlight(span)
-        .with_fix("move this import so that it comes directly after the version statement")
+        .with_fix(
+            "move this import so that it comes after the version statement but before any \
+             document items",
+        )
 }
 
 /// Detects incorrect import placements.
@@ -37,7 +40,7 @@ impl Rule for ImportPlacementRule {
     }
 
     fn description(&self) -> &'static str {
-        "Ensures that imports are placed immediately following the version statement."
+        "Ensures that imports are placed between the version statement and any document items."
     }
 
     fn explanation(&self) -> &'static str {

--- a/wdl-lint/src/v1/import_placement.rs
+++ b/wdl-lint/src/v1/import_placement.rs
@@ -1,0 +1,118 @@
+//! A lint rule for import placements.
+
+use wdl_ast::v1::ImportStatement;
+use wdl_ast::v1::StructDefinition;
+use wdl_ast::v1::TaskDefinition;
+use wdl_ast::v1::Visitor;
+use wdl_ast::v1::WorkflowDefinition;
+use wdl_ast::AstNode;
+use wdl_ast::Diagnostic;
+use wdl_ast::Diagnostics;
+use wdl_ast::Span;
+use wdl_ast::ToSpan;
+use wdl_ast::VisitReason;
+
+use super::Rule;
+use crate::Tag;
+use crate::TagSet;
+
+/// The identifier for the import placement rule.
+const ID: &str = "ImportPlacement";
+
+/// Creates a "misplaced import" diagnostic.
+fn misplaced_import(span: Span) -> Diagnostic {
+    Diagnostic::warning("misplaced import")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("move this import so that it comes directly after the version statement")
+}
+
+/// Detects incorrect import placements.
+#[derive(Debug, Clone, Copy)]
+pub struct ImportPlacementRule;
+
+impl Rule for ImportPlacementRule {
+    fn id(&self) -> &'static str {
+        ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that imports are placed immediately following the version statement."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "All import statements should follow the WDL version declaration with one empty line \
+         between the version and the first import statement."
+    }
+
+    fn tags(&self) -> TagSet {
+        TagSet::new(&[Tag::Clarity])
+    }
+
+    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
+        Box::new(ImportPlacementVisitor::default())
+    }
+}
+
+/// Implements the visitor for the import placement rule.
+#[derive(Default)]
+struct ImportPlacementVisitor {
+    /// Whether or not an import statement is considered invalid.
+    invalid: bool,
+}
+
+impl Visitor for ImportPlacementVisitor {
+    type State = Diagnostics;
+
+    fn import_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &ImportStatement,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        if self.invalid {
+            state.add(misplaced_import(stmt.syntax().text_range().to_span()));
+        }
+    }
+
+    fn struct_definition(
+        &mut self,
+        _: &mut Self::State,
+        reason: VisitReason,
+        _: &StructDefinition,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        // Saw an item other than an import, imports are no longer valid
+        self.invalid = true;
+    }
+
+    fn task_definition(&mut self, _: &mut Self::State, reason: VisitReason, _: &TaskDefinition) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        // Saw an item other than an import, imports are no longer valid
+        self.invalid = true;
+    }
+
+    fn workflow_definition(
+        &mut self,
+        _: &mut Self::State,
+        reason: VisitReason,
+        _: &WorkflowDefinition,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        // Saw an item other than an import, imports are no longer valid
+        self.invalid = true;
+    }
+}

--- a/wdl-lint/src/v1/preamble_whitespace.rs
+++ b/wdl-lint/src/v1/preamble_whitespace.rs
@@ -29,12 +29,20 @@ fn unnecessary_whitespace(span: Span) -> Diagnostic {
         .with_fix("remove the unnecessary whitespace")
 }
 
-/// Creates an "expected a blank line" diagnostic.
-fn expected_blank_line(span: Span) -> Diagnostic {
+/// Creates an "expected a blank line before" diagnostic.
+fn expected_blank_line_before(span: Span) -> Diagnostic {
     Diagnostic::note("expected a blank line before the version statement")
         .with_rule(ID)
         .with_highlight(span)
         .with_fix("add a blank line between the last preamble comment and the version statement")
+}
+
+/// Creates an "expected a blank line after" diagnostic.
+fn expected_blank_line_after(span: Span) -> Diagnostic {
+    Diagnostic::note("expected a blank line after the version statement")
+        .with_rule(ID)
+        .with_label("add a blank line before this", span)
+        .with_fix("add a blank line immediately after the version statement")
 }
 
 /// Detects incorrect whitespace in a document preamble.
@@ -71,8 +79,12 @@ impl Rule for PreambleWhitespaceRule {
 /// Implements the visitor for the preamble whitespace rule.
 #[derive(Default, Debug)]
 struct PreambleWhitespaceVisitor {
-    /// Whether or not the rule has finished.
-    finished: bool,
+    /// Whether or not we've entered the version statement.
+    entered_version: bool,
+    /// Whether or not we've exited the version statement.
+    exited_version: bool,
+    /// Whether or not we've visited whitespace *after* the version statement.
+    checked_blank_after: bool,
 }
 
 impl Visitor for PreambleWhitespaceVisitor {
@@ -85,11 +97,12 @@ impl Visitor for PreambleWhitespaceVisitor {
         stmt: &VersionStatement,
     ) {
         if reason == VisitReason::Exit {
+            self.exited_version = true;
             return;
         }
 
         // We're finished after the version statement
-        self.finished = true;
+        self.entered_version = true;
 
         // If the previous token is whitespace and its previous token is a comment,
         // then the whitespace should just be two lines
@@ -123,7 +136,7 @@ impl Visitor for PreambleWhitespaceVisitor {
                             // If the previous byte isn't a newline, then we are missing a blank
                             // line
                             if text.as_bytes()[next_start - 1] != b'\n' {
-                                state.add(expected_blank_line(Span::new(
+                                state.add(expected_blank_line_before(Span::new(
                                     usize::from(range.start()) + start,
                                     1,
                                 )));
@@ -143,7 +156,7 @@ impl Visitor for PreambleWhitespaceVisitor {
 
                     // We expected two lines
                     if count < 2 {
-                        state.add(expected_blank_line(range.to_span()));
+                        state.add(expected_blank_line_before(range.to_span()));
                     }
                 } else {
                     // Whitespace without a comment before it
@@ -157,7 +170,47 @@ impl Visitor for PreambleWhitespaceVisitor {
     }
 
     fn whitespace(&mut self, state: &mut Self::State, whitespace: &Whitespace) {
-        if self.finished {
+        if self.exited_version {
+            // Check to see if we've already checked for a blank line after the version
+            // statement
+            if self.checked_blank_after {
+                return;
+            }
+
+            self.checked_blank_after = true;
+
+            let mut count = 0;
+            let text = whitespace.as_str();
+            let span = whitespace.span();
+            for (_, _, next_start) in lines_with_offset(text) {
+                count += 1;
+                if count == 2 {
+                    // If the previous byte isn't a newline, then we are missing a blank
+                    // line after the version statement
+                    if text.as_bytes()[next_start - 1] != b'\n' {
+                        state.add(expected_blank_line_after(Span::new(
+                            span.start() + next_start,
+                            1,
+                        )));
+                    }
+
+                    break;
+                }
+            }
+
+            // We expected two lines
+            if count < 2 {
+                state.add(expected_blank_line_after(Span::new(
+                    span.start() + span.len(),
+                    1,
+                )));
+            }
+
+            return;
+        }
+
+        // Ignore whitespace inside the version statement itself
+        if self.entered_version {
             return;
         }
 

--- a/wdl-lint/src/v1/preamble_whitespace.rs
+++ b/wdl-lint/src/v1/preamble_whitespace.rs
@@ -64,7 +64,7 @@ impl Rule for PreambleWhitespaceRule {
          before the version declaration. If there are no comments, the version declaration must be \
          the first line of the document. If there are comments, there must be exactly one blank \
          line between the last comment and the version declaration. No extraneous whitespace is \
-         allowed."
+         allowed. A blank line must come after the preamble."
     }
 
     fn tags(&self) -> TagSet {

--- a/wdl-lint/tests/lints/import-placements/source.errors
+++ b/wdl-lint/tests/lints/import-placements/source.errors
@@ -1,0 +1,16 @@
+warning[ImportPlacement]: misplaced import
+   ┌─ tests/lints/import-placements/source.wdl:15:1
+   │
+15 │ import "bad"
+   │ ^^^^^^^^^^^^
+   │
+   = fix: move this import so that it comes directly after the version statement
+
+warning[ImportPlacement]: misplaced import
+   ┌─ tests/lints/import-placements/source.wdl:17:1
+   │
+17 │ import "also bad"
+   │ ^^^^^^^^^^^^^^^^^
+   │
+   = fix: move this import so that it comes directly after the version statement
+

--- a/wdl-lint/tests/lints/import-placements/source.errors
+++ b/wdl-lint/tests/lints/import-placements/source.errors
@@ -1,16 +1,16 @@
 warning[ImportPlacement]: misplaced import
-   ┌─ tests/lints/import-placements/source.wdl:15:1
+   ┌─ tests/lints/import-placements/source.wdl:13:1
    │
-15 │ import "bad"
+13 │ import "bad"
    │ ^^^^^^^^^^^^
    │
-   = fix: move this import so that it comes directly after the version statement
+   = fix: move this import so that it comes after the version statement but before any document items
 
 warning[ImportPlacement]: misplaced import
-   ┌─ tests/lints/import-placements/source.wdl:17:1
+   ┌─ tests/lints/import-placements/source.wdl:14:1
    │
-17 │ import "also bad"
+14 │ import "also bad"
    │ ^^^^^^^^^^^^^^^^^
    │
-   = fix: move this import so that it comes directly after the version statement
+   = fix: move this import so that it comes after the version statement but before any document items
 

--- a/wdl-lint/tests/lints/import-placements/source.wdl
+++ b/wdl-lint/tests/lints/import-placements/source.wdl
@@ -3,9 +3,7 @@
 version 1.1
 
 import "good"
-
 import "good"
-
 import "good"
 
 workflow test {
@@ -13,5 +11,4 @@ workflow test {
 }
 
 import "bad"
-
 import "also bad"

--- a/wdl-lint/tests/lints/import-placements/source.wdl
+++ b/wdl-lint/tests/lints/import-placements/source.wdl
@@ -1,0 +1,17 @@
+## This is a test of import placements.
+
+version 1.1
+
+import "good"
+
+import "good"
+
+import "good"
+
+workflow test {
+
+}
+
+import "bad"
+
+import "also bad"

--- a/wdl-lint/tests/lints/missing-blank-line-after-version/source.errors
+++ b/wdl-lint/tests/lints/missing-blank-line-after-version/source.errors
@@ -1,0 +1,8 @@
+note[PreambleWhitespace]: expected a blank line after the version statement
+  ┌─ tests/lints/missing-blank-line-after-version/source.wdl:4:1
+  │
+4 │ workflow test {
+  │ ^ add a blank line before this
+  │
+  = fix: add a blank line immediately after the version statement
+

--- a/wdl-lint/tests/lints/missing-blank-line-after-version/source.wdl
+++ b/wdl-lint/tests/lints/missing-blank-line-after-version/source.wdl
@@ -1,0 +1,6 @@
+## This is a test of a missing blank line following the version statement.
+
+version 1.1
+workflow test {
+
+}


### PR DESCRIPTION
**Rule Name**: `ImportPlacement`

This commit implements the `ImportPlacement` rule which warns if an import comes after a non-import top-level item in the document.

Additionally, this fixes the `PreambleWhitespace` rule to check for a blank line following the version statement.

Also fixed:

* Last whitespace in the file was attaching as a child to the last node in the document instead of as top-level whitespace.
* The CST for an "unparsed" file (i.e. missing version statement or unsupported version) was missing trivia before the version statement and the unparsed token span was incorrect.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Rule specific checks:

- [x] You have added the rule as an entry within `RULES.md`.
- [x] You have added the rule to the `rules()` function in `wdl-lint/src/v1.rs`.
- [x] You have added a test cases in `wdl-lint/tests/lints` that covers every 
      possible diagnostic emitted for the rule within the file where the rule  
      is implemented.
- [x] You have run `wdl-gauntlet --refresh` to ensure that there are no 
      unintended changes to the baseline configuration file (`Gauntlet.toml`).
- [x] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the 
      rules added/removed are now reflected in the baseline configuration file 
      (`Arena.toml`).

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
