### PR TITLE
feat: implement support for `#@ except` comments in `wdl-lint`.

### DIFF
--- a/wdl-gauntlet/src/lib.rs
+++ b/wdl-gauntlet/src/lib.rs
@@ -41,6 +41,7 @@ pub use repository::Repository;
 use wdl_lint::ast::Document;
 use wdl_lint::ast::Validator;
 use wdl_lint::rules;
+use wdl_lint::ExceptVisitor;
 
 use crate::repository::WorkDir;
 
@@ -184,7 +185,8 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                 Ok(document) => {
                     let mut validator = Validator::default();
                     if args.arena {
-                        validator.add_visitors(rules().into_iter().map(|r| r.visitor()));
+                        validator
+                            .add_visitor(ExceptVisitor::new(rules().iter().map(AsRef::as_ref)));
                     }
 
                     match validator.validate(&document) {

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for `#@ except` comments to disable lint rules ([#101](https://github.com/stjude-rust-labs/wdl/pull/101)).
 * Added the `LineWidth` lint rule (#99).
 * Added the `ImportWhitespace` and `ImportSort` lint rules (#98).
 * Added the `MissingMetas` and `MissingOutput` lint rules (#96).

--- a/wdl-lint/Cargo.toml
+++ b/wdl-lint/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../README.md"
 [dependencies]
 wdl-ast = { path = "../wdl-ast", version = "0.3.0" }
 convert_case = { workspace = true }
+indexmap = { workspace = true }
 
 [dev-dependencies]
 codespan-reporting = { workspace = true }

--- a/wdl-lint/src/except.rs
+++ b/wdl-lint/src/except.rs
@@ -1,0 +1,402 @@
+//! Implementation of the `except` visitor.
+
+use std::collections::HashSet;
+
+use indexmap::IndexMap;
+use wdl_ast::v1;
+use wdl_ast::AstNode;
+use wdl_ast::Comment;
+use wdl_ast::Diagnostic;
+use wdl_ast::Diagnostics;
+use wdl_ast::Direction;
+use wdl_ast::Document;
+use wdl_ast::Span;
+use wdl_ast::SyntaxElement;
+use wdl_ast::SyntaxKind;
+use wdl_ast::SyntaxNode;
+use wdl_ast::VersionStatement;
+use wdl_ast::VisitReason;
+use wdl_ast::Visitor;
+use wdl_ast::Whitespace;
+
+use crate::Rule;
+
+/// The prefix of `except` comments.
+pub const EXCEPT_COMMENT_PREFIX: &str = "#@ except:";
+
+/// Creates an "unknown rule" diagnostic.
+fn unknown_rule(id: &str, span: Span) -> Diagnostic {
+    Diagnostic::note(format!("unknown lint rule `{id}`"))
+        .with_label("cannot make an exception for this rule", span)
+        .with_fix("remove the rule from the exception list")
+}
+
+/// A visitor that respects `#@ except` comments.
+///
+/// The format for the comment is `#@ except: <ids>`, where `ids` is a
+/// comma-separated list of lint rule identifiers.
+///
+/// Any `#@ except` comments that come before the version statement will disable
+/// the rule for the entire document.
+///
+/// Otherwise, `#@ except` comments disable the rule for the immediately
+/// following AST node.
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct ExceptVisitor {
+    /// The map of rule name to visitor.
+    visitors: IndexMap<&'static str, Box<dyn Visitor<State = Diagnostics>>>,
+    /// The set of globally disabled rules; these rules no longer appear in the
+    /// `visitors` map.
+    global: HashSet<String>,
+    /// A stack of exceptions; the first is the offset of the syntax element
+    /// with the comment and the second is the set of exceptions.
+    exceptions: Vec<(usize, HashSet<String>)>,
+}
+
+impl ExceptVisitor {
+    /// Creates a new except visitor with the given rules.
+    pub fn new<'a>(rules: impl Iterator<Item = &'a dyn Rule>) -> Self {
+        Self {
+            visitors: rules.map(|r| (r.id(), r.visitor())).collect(),
+            global: Default::default(),
+            exceptions: Default::default(),
+        }
+    }
+
+    /// Invokes a callback on each rule's visitor provided the rule is not
+    /// currently excepted.
+    fn each_enabled_rule<F>(
+        &mut self,
+        state: &mut Diagnostics,
+        reason: VisitReason,
+        node: &SyntaxNode,
+        mut cb: F,
+    ) where
+        F: FnMut(&mut Diagnostics, &mut dyn Visitor<State = Diagnostics>),
+    {
+        let start = node.text_range().start().into();
+
+        if reason == VisitReason::Enter {
+            let exceptions = self.exceptions_for(state, node);
+            if !exceptions.is_empty() {
+                self.exceptions.push((start, exceptions));
+            }
+        }
+
+        for (id, visitor) in &mut self.visitors {
+            if self.exceptions.iter().any(|(_, set)| set.contains(*id)) {
+                continue;
+            }
+
+            cb(state, visitor.as_mut());
+        }
+
+        if reason == VisitReason::Exit {
+            if let Some((prev, _)) = self.exceptions.last() {
+                if *prev == start {
+                    self.exceptions.pop();
+                }
+            }
+        }
+    }
+
+    /// Gets the set of excepted rule ids for the given syntax node.
+    fn exceptions_for(&self, state: &mut Diagnostics, node: &SyntaxNode) -> HashSet<String> {
+        let siblings = node
+            .siblings_with_tokens(Direction::Prev)
+            .skip(1)
+            .take_while(|s| s.kind() == SyntaxKind::Whitespace || s.kind() == SyntaxKind::Comment)
+            .filter_map(SyntaxElement::into_token);
+
+        let mut set = HashSet::default();
+        for sibling in siblings {
+            if sibling.kind() == SyntaxKind::Whitespace {
+                continue;
+            }
+
+            if let Some(ids) = sibling.text().strip_prefix(EXCEPT_COMMENT_PREFIX) {
+                let start: usize = sibling.text_range().start().into();
+                let mut offset = EXCEPT_COMMENT_PREFIX.len();
+                for id in ids.split(',') {
+                    // First trim the start so we can determine how much whitespace was removed
+                    let trimmed_start = id.trim_start();
+                    // Next trim the end
+                    let trimmed: &str = trimmed_start.trim_end();
+
+                    // Calculate the span based off the current offset and how much whitespace was
+                    // trimmed
+                    let span = Span::new(
+                        start + offset + (id.len() - trimmed_start.len()),
+                        trimmed.len(),
+                    );
+
+                    if !self.visitors.contains_key(trimmed) && !self.global.contains(trimmed) {
+                        state.add(unknown_rule(trimmed, span));
+                    } else {
+                        set.insert(trimmed.to_string());
+                    }
+
+                    offset += id.len() + 1 /* comma */;
+                }
+            }
+        }
+
+        set
+    }
+}
+
+impl Visitor for ExceptVisitor {
+    type State = Diagnostics;
+
+    fn document(&mut self, state: &mut Self::State, reason: VisitReason, doc: &Document) {
+        if reason == VisitReason::Enter {
+            // Set the global exceptions
+            if let Some(stmt) = doc.version_statement() {
+                self.global = self.exceptions_for(state, stmt.syntax());
+                for id in &self.global {
+                    // This is a shift remove to maintain the original order provided at
+                    // construction time; this is O(N), but both the set of visitors and exceptions
+                    // is consistently small.
+                    self.visitors.shift_remove(id.as_str());
+                }
+            }
+        }
+
+        // We don't need to check the exceptions here as the globally-disabled rules
+        // were already removed.
+        for (_, visitor) in &mut self.visitors {
+            visitor.document(state, reason, doc);
+        }
+    }
+
+    fn whitespace(&mut self, state: &mut Self::State, whitespace: &Whitespace) {
+        for (id, visitor) in &mut self.visitors {
+            if self.exceptions.iter().any(|(_, set)| set.contains(*id)) {
+                continue;
+            }
+
+            visitor.whitespace(state, whitespace);
+        }
+    }
+
+    fn comment(&mut self, state: &mut Self::State, comment: &Comment) {
+        for (id, visitor) in &mut self.visitors {
+            if self.exceptions.iter().any(|(_, set)| set.contains(*id)) {
+                continue;
+            }
+
+            visitor.comment(state, comment);
+        }
+    }
+
+    fn version_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &VersionStatement,
+    ) {
+        // We call every visitor here as we've already disabled the global rules based
+        // on the version statement
+        for (_, visitor) in &mut self.visitors {
+            visitor.version_statement(state, reason, stmt);
+        }
+    }
+
+    fn import_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &v1::ImportStatement,
+    ) {
+        self.each_enabled_rule(state, reason, stmt.syntax(), |state, visitor| {
+            visitor.import_statement(state, reason, stmt)
+        });
+    }
+
+    fn struct_definition(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        def: &v1::StructDefinition,
+    ) {
+        self.each_enabled_rule(state, reason, def.syntax(), |state, visitor| {
+            visitor.struct_definition(state, reason, def)
+        });
+    }
+
+    fn task_definition(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        task: &v1::TaskDefinition,
+    ) {
+        self.each_enabled_rule(state, reason, task.syntax(), |state, visitor| {
+            visitor.task_definition(state, reason, task)
+        });
+    }
+
+    fn workflow_definition(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        workflow: &v1::WorkflowDefinition,
+    ) {
+        self.each_enabled_rule(state, reason, workflow.syntax(), |state, visitor| {
+            visitor.workflow_definition(state, reason, workflow)
+        });
+    }
+
+    fn input_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::InputSection,
+    ) {
+        self.each_enabled_rule(state, reason, section.syntax(), |state, visitor| {
+            visitor.input_section(state, reason, section)
+        });
+    }
+
+    fn output_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::OutputSection,
+    ) {
+        self.each_enabled_rule(state, reason, section.syntax(), |state, visitor| {
+            visitor.output_section(state, reason, section)
+        });
+    }
+
+    fn command_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::CommandSection,
+    ) {
+        self.each_enabled_rule(state, reason, section.syntax(), |state, visitor| {
+            visitor.command_section(state, reason, section)
+        });
+    }
+
+    fn command_text(&mut self, state: &mut Self::State, text: &v1::CommandText) {
+        for (id, visitor) in &mut self.visitors {
+            if self.exceptions.iter().any(|(_, set)| set.contains(*id)) {
+                continue;
+            }
+
+            visitor.command_text(state, text);
+        }
+    }
+
+    fn runtime_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::RuntimeSection,
+    ) {
+        self.each_enabled_rule(state, reason, section.syntax(), |state, visitor| {
+            visitor.runtime_section(state, reason, section)
+        });
+    }
+
+    fn metadata_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::MetadataSection,
+    ) {
+        self.each_enabled_rule(state, reason, section.syntax(), |state, visitor| {
+            visitor.metadata_section(state, reason, section)
+        });
+    }
+
+    fn parameter_metadata_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::ParameterMetadataSection,
+    ) {
+        self.each_enabled_rule(state, reason, section.syntax(), |state, visitor| {
+            visitor.parameter_metadata_section(state, reason, section)
+        });
+    }
+
+    fn metadata_object(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        object: &v1::MetadataObject,
+    ) {
+        self.each_enabled_rule(state, reason, object.syntax(), |state, visitor| {
+            visitor.metadata_object(state, reason, object)
+        });
+    }
+
+    fn unbound_decl(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        decl: &v1::UnboundDecl,
+    ) {
+        self.each_enabled_rule(state, reason, decl.syntax(), |state, visitor| {
+            visitor.unbound_decl(state, reason, decl)
+        });
+    }
+
+    fn bound_decl(&mut self, state: &mut Self::State, reason: VisitReason, decl: &v1::BoundDecl) {
+        self.each_enabled_rule(state, reason, decl.syntax(), |state, visitor| {
+            visitor.bound_decl(state, reason, decl)
+        });
+    }
+
+    fn expr(&mut self, state: &mut Self::State, reason: VisitReason, expr: &v1::Expr) {
+        self.each_enabled_rule(state, reason, expr.syntax(), |state, visitor| {
+            visitor.expr(state, reason, expr)
+        });
+    }
+
+    fn string_text(&mut self, state: &mut Self::State, text: &v1::StringText) {
+        for (id, visitor) in &mut self.visitors {
+            if self.exceptions.iter().any(|(_, set)| set.contains(*id)) {
+                continue;
+            }
+
+            visitor.string_text(state, text);
+        }
+    }
+
+    fn conditional_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &v1::ConditionalStatement,
+    ) {
+        self.each_enabled_rule(state, reason, stmt.syntax(), |state, visitor| {
+            visitor.conditional_statement(state, reason, stmt)
+        });
+    }
+
+    fn scatter_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &v1::ScatterStatement,
+    ) {
+        self.each_enabled_rule(state, reason, stmt.syntax(), |state, visitor| {
+            visitor.scatter_statement(state, reason, stmt)
+        });
+    }
+
+    fn call_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &v1::CallStatement,
+    ) {
+        self.each_enabled_rule(state, reason, stmt.syntax(), |state, visitor| {
+            visitor.call_statement(state, reason, stmt)
+        });
+    }
+}

--- a/wdl-lint/src/except.rs
+++ b/wdl-lint/src/except.rs
@@ -124,14 +124,14 @@ impl ExceptVisitor {
                     // Next trim the end
                     let trimmed: &str = trimmed_start.trim_end();
 
-                    // Calculate the span based off the current offset and how much whitespace was
-                    // trimmed
-                    let span = Span::new(
-                        start + offset + (id.len() - trimmed_start.len()),
-                        trimmed.len(),
-                    );
-
                     if !self.visitors.contains_key(trimmed) && !self.global.contains(trimmed) {
+                        // Calculate the span based off the current offset and how much whitespace
+                        // was trimmed
+                        let span = Span::new(
+                            start + offset + (id.len() - trimmed_start.len()),
+                            trimmed.len(),
+                        );
+
                         state.add(unknown_rule(trimmed, span));
                     } else {
                         set.insert(trimmed.to_string());

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -9,11 +9,12 @@
 //! use wdl_lint::ast::Document;
 //! use wdl_lint::ast::Validator;
 //! use wdl_lint::rules;
+//! use wdl_lint::ExceptVisitor;
 //!
 //! match Document::parse(source).into_result() {
 //!     Ok(document) => {
 //!         let mut validator = Validator::default();
-//!         validator.add_visitors(rules().into_iter().map(|r| r.visitor()));
+//!         validator.add_visitor(ExceptVisitor::new(rules().iter().map(AsRef::as_ref)));
 //!         match validator.validate(&document) {
 //!             Ok(_) => {
 //!                 // The document was valid WDL and passed all lints
@@ -36,14 +37,17 @@
 #![warn(clippy::missing_docs_in_private_items)]
 #![warn(rustdoc::broken_intra_doc_links)]
 
+use wdl_ast::Diagnostics;
+use wdl_ast::Visitor;
+
+mod except;
 pub mod rules;
 mod tags;
 pub(crate) mod util;
 
+pub use except::*;
 pub use tags::*;
 pub use wdl_ast as ast;
-use wdl_ast::Diagnostics;
-use wdl_ast::Visitor;
 
 /// A trait implemented by lint rules.
 pub trait Rule {

--- a/wdl-lint/src/rules/preamble_comments.rs
+++ b/wdl-lint/src/rules/preamble_comments.rs
@@ -13,6 +13,7 @@ use wdl_ast::Visitor;
 use crate::Rule;
 use crate::Tag;
 use crate::TagSet;
+use crate::EXCEPT_COMMENT_PREFIX;
 
 /// The identifier for the preamble comments rule.
 const ID: &str = "PreambleComments";
@@ -105,7 +106,8 @@ impl Visitor for PreambleCommentsVisitor {
 
         let check = |text: &str| {
             let double_pound = text == "##" || text.starts_with("## ");
-            (self.finished && !double_pound) || (!self.finished && double_pound)
+            let except = text.starts_with(EXCEPT_COMMENT_PREFIX);
+            (self.finished && !double_pound) || (!self.finished && (double_pound | except))
         };
 
         if check(comment.as_str()) {

--- a/wdl-lint/tests/lints.rs
+++ b/wdl-lint/tests/lints.rs
@@ -32,6 +32,7 @@ use wdl_ast::Diagnostic;
 use wdl_ast::Document;
 use wdl_ast::Validator;
 use wdl_lint::rules;
+use wdl_lint::ExceptVisitor;
 
 fn find_tests() -> Vec<PathBuf> {
     // Check for filter arguments consisting of test names
@@ -129,9 +130,8 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<(), String> {
         .replace("\r\n", "\n");
     match Document::parse(&source).into_result() {
         Ok(document) => {
-            let rules = rules();
             let mut validator = Validator::default();
-            validator.add_visitors(rules.iter().map(|r| r.visitor()));
+            validator.add_visitor(ExceptVisitor::new(rules().iter().map(AsRef::as_ref)));
             let errors = match validator.validate(&document) {
                 Ok(()) => String::new(),
                 Err(diagnostics) => format_diagnostics(&diagnostics, &path, &source),

--- a/wdl-lint/tests/lints/command-mixed-line-cont/source.errors
+++ b/wdl-lint/tests/lints/command-mixed-line-cont/source.errors
@@ -1,29 +1,21 @@
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed-line-cont/source.wdl:11:2
+   ┌─ tests/lints/command-mixed-line-cont/source.wdl:12:2
    │
- 9 │     command <<<
+10 │     command <<<
    │     ------- this command section uses both tabs and spaces in leading whitespace
-10 │         this line has a continuation /
-11 │            and should be a warning
+11 │         this line has a continuation /
+12 │            and should be a warning
    │  ^^^ indented with spaces until this tab
    │
    = fix: use the same whitespace character for indentation
 
-warning[NoCurlyCommands]: task `test2` uses curly braces in command section
-   ┌─ tests/lints/command-mixed-line-cont/source.wdl:22:5
-   │
-22 │     command {
-   │     ^^^^^^^ this command section uses curly braces
-   │
-   = fix: instead of curly braces, use heredoc syntax (<<<>>>>) for command sections
-
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed-line-cont/source.wdl:24:2
+   ┌─ tests/lints/command-mixed-line-cont/source.wdl:25:2
    │
-22 │     command {
+23 │     command {
    │     ------- this command section uses both tabs and spaces in leading whitespace
-23 │         this line has a continuation /
-24 │            and should be a warning
+24 │         this line has a continuation /
+25 │            and should be a warning
    │  ^^^ indented with spaces until this tab
    │
    = fix: use the same whitespace character for indentation

--- a/wdl-lint/tests/lints/command-mixed-line-cont/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-line-cont/source.wdl
@@ -1,3 +1,4 @@
+#@ except: NoCurlyCommands
 ## This is a test of having mixed indentation in a line continuation.
 
 version 1.1

--- a/wdl-lint/tests/lints/command-mixed-spaces-first/source.errors
+++ b/wdl-lint/tests/lints/command-mixed-spaces-first/source.errors
@@ -1,29 +1,21 @@
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed-spaces-first/source.wdl:11:1
+   ┌─ tests/lints/command-mixed-spaces-first/source.wdl:12:1
    │
- 9 │     command <<<
+10 │     command <<<
    │     ------- this command section uses both tabs and spaces in leading whitespace
-10 │         this line is prefixed with spaces
-11 │         this line is prefixed with ~{"tabs"}
+11 │         this line is prefixed with spaces
+12 │         this line is prefixed with ~{"tabs"}
    │ ^^^^ indented with spaces until this tab
    │
    = fix: use the same whitespace character for indentation
 
-warning[NoCurlyCommands]: task `test2` uses curly braces in command section
-   ┌─ tests/lints/command-mixed-spaces-first/source.wdl:22:5
-   │
-22 │     command {
-   │     ^^^^^^^ this command section uses curly braces
-   │
-   = fix: instead of curly braces, use heredoc syntax (<<<>>>>) for command sections
-
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed-spaces-first/source.wdl:24:1
+   ┌─ tests/lints/command-mixed-spaces-first/source.wdl:25:1
    │
-22 │     command {
+23 │     command {
    │     ------- this command section uses both tabs and spaces in leading whitespace
-23 │         this line is prefixed with spaces
-24 │         this line is prefixed with ~{"tabs"}
+24 │         this line is prefixed with spaces
+25 │         this line is prefixed with ~{"tabs"}
    │ ^^^^ indented with spaces until this tab
    │
    = fix: use the same whitespace character for indentation

--- a/wdl-lint/tests/lints/command-mixed-spaces-first/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-spaces-first/source.wdl
@@ -1,3 +1,4 @@
+#@ except: NoCurlyCommands
 ## This is a test of having spaces before tabs in command sections.
 
 version 1.1

--- a/wdl-lint/tests/lints/command-mixed-tabs-first/source.errors
+++ b/wdl-lint/tests/lints/command-mixed-tabs-first/source.errors
@@ -1,29 +1,21 @@
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed-tabs-first/source.wdl:11:1
+   ┌─ tests/lints/command-mixed-tabs-first/source.wdl:12:1
    │
- 9 │     command <<<
+10 │     command <<<
    │     ------- this command section uses both tabs and spaces in leading whitespace
-10 │         this line is prefixed with ~{"tabs"}
-11 │         this line is prefixed with spaces
+11 │         this line is prefixed with ~{"tabs"}
+12 │         this line is prefixed with spaces
    │ ^ indented with tabs until this space
    │
    = fix: use the same whitespace character for indentation
 
-warning[NoCurlyCommands]: task `test2` uses curly braces in command section
-   ┌─ tests/lints/command-mixed-tabs-first/source.wdl:22:5
-   │
-22 │     command {
-   │     ^^^^^^^ this command section uses curly braces
-   │
-   = fix: instead of curly braces, use heredoc syntax (<<<>>>>) for command sections
-
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed-tabs-first/source.wdl:24:1
+   ┌─ tests/lints/command-mixed-tabs-first/source.wdl:25:1
    │
-22 │     command {
+23 │     command {
    │     ------- this command section uses both tabs and spaces in leading whitespace
-23 │         this line is prefixed with ~{"tabs"}
-24 │         this line is prefixed with spaces
+24 │         this line is prefixed with ~{"tabs"}
+25 │         this line is prefixed with spaces
    │ ^ indented with tabs until this space
    │
    = fix: use the same whitespace character for indentation

--- a/wdl-lint/tests/lints/command-mixed-tabs-first/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-tabs-first/source.wdl
@@ -1,3 +1,4 @@
+#@ except: NoCurlyCommands
 ## This is a test of having tabs before spaces in command sections.
 
 version 1.1

--- a/wdl-lint/tests/lints/command-mixed-trailing/source.errors
+++ b/wdl-lint/tests/lints/command-mixed-trailing/source.errors
@@ -1,8 +1,0 @@
-warning[NoCurlyCommands]: task `test2` uses curly braces in command section
-   ┌─ tests/lints/command-mixed-trailing/source.wdl:22:5
-   │
-22 │     command {
-   │     ^^^^^^^ this command section uses curly braces
-   │
-   = fix: instead of curly braces, use heredoc syntax (<<<>>>>) for command sections
-

--- a/wdl-lint/tests/lints/command-mixed-trailing/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-trailing/source.wdl
@@ -1,3 +1,4 @@
+#@ except: NoCurlyCommands
 ## This is a test of having mixed _trailing_ indentation in command sections.
 ## There should be no warnings from the `CommandSectionMixedIndentation` rule.
 

--- a/wdl-lint/tests/lints/command-mixed-ws-ok/source.errors
+++ b/wdl-lint/tests/lints/command-mixed-ws-ok/source.errors
@@ -1,8 +1,0 @@
-warning[NoCurlyCommands]: task `test2` uses curly braces in command section
-   ┌─ tests/lints/command-mixed-ws-ok/source.wdl:27:5
-   │
-27 │     command {
-   │     ^^^^^^^ this command section uses curly braces
-   │
-   = fix: instead of curly braces, use heredoc syntax (<<<>>>>) for command sections
-

--- a/wdl-lint/tests/lints/command-mixed-ws-ok/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-ws-ok/source.wdl
@@ -1,3 +1,4 @@
+#@ except: NoCurlyCommands
 ## This is a test of having mixed indentation inside of a placeholder.
 ## This should not cause a warning for the `CommandSectionMixedIndentation` rule.
 

--- a/wdl-lint/tests/lints/command-mixed/source.errors
+++ b/wdl-lint/tests/lints/command-mixed/source.errors
@@ -1,27 +1,19 @@
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed/source.wdl:10:3
+   ┌─ tests/lints/command-mixed/source.wdl:11:3
    │
- 9 │     command <<<
+10 │     command <<<
    │     ------- this command section uses both tabs and spaces in leading whitespace
-10 │             this line has both tabs and spaces
+11 │             this line has both tabs and spaces
    │         ^ indented with tabs until this space
    │
    = fix: use the same whitespace character for indentation
 
-warning[NoCurlyCommands]: task `test2` uses curly braces in command section
-   ┌─ tests/lints/command-mixed/source.wdl:21:5
-   │
-21 │     command {
-   │     ^^^^^^^ this command section uses curly braces
-   │
-   = fix: instead of curly braces, use heredoc syntax (<<<>>>>) for command sections
-
 warning[CommandSectionMixedIndentation]: mixed indentation within a command
-   ┌─ tests/lints/command-mixed/source.wdl:22:3
+   ┌─ tests/lints/command-mixed/source.wdl:23:3
    │
-21 │     command {
+22 │     command {
    │     ------- this command section uses both tabs and spaces in leading whitespace
-22 │             this line has both tabs and spaces
+23 │             this line has both tabs and spaces
    │         ^ indented with tabs until this space
    │
    = fix: use the same whitespace character for indentation

--- a/wdl-lint/tests/lints/command-mixed/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed/source.wdl
@@ -1,3 +1,4 @@
+#@ except: NoCurlyCommands
 ## This is a test of having mixed indentation on the same line in command sections.
 
 version 1.1

--- a/wdl-lint/tests/lints/double-quotes/source.wdl
+++ b/wdl-lint/tests/lints/double-quotes/source.wdl
@@ -1,4 +1,4 @@
-## This is a test of the `double_quotes` lint
+## This is a test of the `DoubleQuotes` lint
 
 version 1.1
 
@@ -15,5 +15,8 @@ workflow test {
                 }"
             }'
         }!"
+    String excepted =
+        #@ except: DoubleQuotes
+        'this string is excepted'
     output {}
 }

--- a/wdl-lint/tests/lints/except/source.errors
+++ b/wdl-lint/tests/lints/except/source.errors
@@ -1,0 +1,32 @@
+note: unknown lint rule `Unknown`
+  ┌─ tests/lints/except/source.wdl:1:39
+  │
+1 │ #@ except: Whitespace, EndingNewline, Unknown
+  │                                       ^^^^^^^ cannot make an exception for this rule
+  │
+  = fix: remove the rule from the exception list
+
+note: unknown lint rule `AlsoUnknown`
+   ┌─ tests/lints/except/source.wdl:21:26
+   │
+21 │     #@ except: SnakeCase,AlsoUnknown
+   │                          ^^^^^^^^^^^ cannot make an exception for this rule
+   │
+   = fix: remove the rule from the exception list
+
+warning[SnakeCase]: struct member name `NotOk` is not snake_case
+   ┌─ tests/lints/except/source.wdl:23:9
+   │
+23 │     Int NotOk       # NOT OK
+   │         ^^^^^ this name must be snake_case
+   │
+   = fix: replace `NotOk` with `not_ok`
+
+warning[DoubleQuotes]: string defined with single quotes
+   ┌─ tests/lints/except/source.wdl:28:18
+   │
+28 │     String bad = 'bad string'   # NOT OK
+   │                  ^^^^^^^^^^^^
+   │
+   = fix: change the single quotes to double quotes
+

--- a/wdl-lint/tests/lints/except/source.wdl
+++ b/wdl-lint/tests/lints/except/source.wdl
@@ -1,0 +1,38 @@
+#@ except: Whitespace, EndingNewline, Unknown
+## This is a test of the `#@ except` comments.
+## The above exceptions apply to the whole file.
+
+version 1.1
+
+# This applies only to the struct and everything in it
+#@ except: PascalCase,SnakeCase
+struct OK {         # OK
+    Int AlsoOk      # OK
+    Int OKTOO       # OK
+}
+
+
+# Intentional extraneous whitespace lines that should not be a warning
+# because we've excepted the rule for the entire document
+
+
+# This applies to the specified members only
+struct Ok {         # OK
+    #@ except: SnakeCase,AlsoUnknown
+    Int AlsoOk      # OK
+    Int NotOk       # NOT OK
+}
+
+#@ except: MissingMetas,MissingOutput,Whitespace
+workflow test {
+    String bad = 'bad string'   # NOT OK
+    String good = #@ except: DoubleQuotes
+        'good string'           # OK
+}
+
+
+# Lots of trailing whitespace too!
+
+
+
+

--- a/wdl-lint/tests/lints/one-invalid-preamble-comment/source.errors
+++ b/wdl-lint/tests/lints/one-invalid-preamble-comment/source.errors
@@ -1,32 +1,14 @@
 note[PreambleComments]: preamble comments must start with `##` followed by a space
-   ┌─ tests/lints/one-invalid-preamble-comment/source.wdl:1:1
+   ┌─ tests/lints/one-invalid-preamble-comment/source.wdl:2:1
    │  
- 1 │ ╭ # This is a test of having one big invalid preamble comment.
- 2 │ │ #
- 3 │ │ 
- 4 │ │ # All of the lines
+ 2 │ ╭ # This is a test of having one big invalid preamble comment.
+ 3 │ │ #
+ 4 │ │ 
+ 5 │ │ # All of the lines
    · │
-10 │ │ # as a single diagnostic
-11 │ │ # warning
+11 │ │ # as a single diagnostic
+12 │ │ # warning
    │ ╰─────────^
    │  
    = fix: change each preamble comment to start with `##` followed by a space
-
-note[PreambleWhitespace]: unnecessary whitespace in document preamble
-  ┌─ tests/lints/one-invalid-preamble-comment/source.wdl:3:1
-  │  
-3 │ ╭ 
-4 │ │ # All of the lines
-  │ ╰^
-  │  
-  = fix: remove the unnecessary whitespace
-
-note[PreambleWhitespace]: unnecessary whitespace in document preamble
-   ┌─ tests/lints/one-invalid-preamble-comment/source.wdl:9:1
-   │  
- 9 │ ╭ 
-10 │ │ # as a single diagnostic
-   │ ╰^
-   │  
-   = fix: remove the unnecessary whitespace
 

--- a/wdl-lint/tests/lints/one-invalid-preamble-comment/source.wdl
+++ b/wdl-lint/tests/lints/one-invalid-preamble-comment/source.wdl
@@ -1,3 +1,4 @@
+#@ except: PreambleWhitespace
 # This is a test of having one big invalid preamble comment.
 #
 

--- a/wdl-lint/tests/lints/pascal-case/source.wdl
+++ b/wdl-lint/tests/lints/pascal-case/source.wdl
@@ -17,3 +17,8 @@ struct This_Is_Bad_Too {
 struct ThisNameIsAGoodOne {
     Int x
 }
+
+#@ except: PascalCase
+struct excepted_name {
+    Int x
+}

--- a/wdl-lint/tests/lints/snake-case/source.wdl
+++ b/wdl-lint/tests/lints/snake-case/source.wdl
@@ -57,4 +57,6 @@ task good_task {
 struct GoodStruct {
     String good_field
     String bAdFiElD  # unfortunately, `convert-case` doesn't understand sarcasm case
+    #@ except: SnakeCase
+    String OK
 }

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -19,6 +19,7 @@ use wdl::ast::Diagnostic;
 use wdl::ast::Document;
 use wdl::ast::Validator;
 use wdl::lint::rules;
+use wdl::lint::ExceptVisitor;
 
 /// Emits the given diagnostics to the output stream.
 ///
@@ -135,7 +136,7 @@ impl LintCommand {
         match Document::parse(&source).into_result() {
             Ok(document) => {
                 let mut validator = Validator::default();
-                validator.add_visitors(rules().into_iter().map(|r| r.visitor()));
+                validator.add_visitor(ExceptVisitor::new(rules().iter().map(AsRef::as_ref)));
                 if let Err(diagnostics) = validator.validate(&document) {
                     emit_diagnostics(&self.path, &source, &diagnostics)?;
 


### PR DESCRIPTION
This commit implements support for `#@ except` comments for linting.

If the comment appears in the preamble, the rule will be disabled for the entire document.

Otherwise, if the comment precedes a node in the AST, the rule will be disabled for that node and all of its children.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
