### PR TITLE
refactor: make `Rule` a supertrait of `Visitor`.

### DIFF
--- a/wdl-gauntlet/src/lib.rs
+++ b/wdl-gauntlet/src/lib.rs
@@ -40,8 +40,7 @@ use report::UnmatchedStatus;
 pub use repository::Repository;
 use wdl_lint::ast::Document;
 use wdl_lint::ast::Validator;
-use wdl_lint::rules;
-use wdl_lint::ExceptVisitor;
+use wdl_lint::LintVisitor;
 
 use crate::repository::WorkDir;
 
@@ -185,8 +184,7 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                 Ok(document) => {
                     let mut validator = Validator::default();
                     if args.arena {
-                        validator
-                            .add_visitor(ExceptVisitor::new(rules().iter().map(AsRef::as_ref)));
+                        validator.add_visitor(LintVisitor::default());
                     }
 
                     match validator.validate(&document) {

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-### Changed
-
+* Refactored the lint rules so that they directly implement `Visitor`; renamed
+  `ExceptVisitor` to `LintVisitor` ([#103](https://github.com/stjude-rust-labs/wdl/pull/103)).
 * Refactored the lint rules so that they are not in a `v1` module
   ([#95](https://github.com/stjude-rust-labs/wdl/pull/95)).
 

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -94,16 +94,9 @@ impl Rule for CommandSectionMixedIndentationRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Correctness, Tag::Spacing, Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(CommandSectionMixedIndentationVisitor)
-    }
 }
 
-/// Implements the visitor for the command section mixed indentation rule.
-struct CommandSectionMixedIndentationVisitor;
-
-impl Visitor for CommandSectionMixedIndentationVisitor {
+impl Visitor for CommandSectionMixedIndentationRule {
     type State = Diagnostics;
 
     fn command_section(

--- a/wdl-lint/src/rules/double_quotes.rs
+++ b/wdl-lint/src/rules/double_quotes.rs
@@ -46,16 +46,9 @@ impl Rule for DoubleQuotesRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Clarity, Tag::Style])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(DoubleQuotesVisitor)
-    }
 }
 
-/// Implements the visitor for the double quotes rule.
-struct DoubleQuotesVisitor;
-
-impl Visitor for DoubleQuotesVisitor {
+impl Visitor for DoubleQuotesRule {
     type State = Diagnostics;
 
     fn expr(&mut self, state: &mut Self::State, reason: VisitReason, expr: &Expr) {

--- a/wdl-lint/src/rules/ending_newline.rs
+++ b/wdl-lint/src/rules/ending_newline.rs
@@ -60,16 +60,9 @@ impl Rule for EndingNewlineRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Spacing, Tag::Style])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(EndingNewlineVisitor)
-    }
 }
 
-/// Implements the visitor for the ending newline rule.
-struct EndingNewlineVisitor;
-
-impl Visitor for EndingNewlineVisitor {
+impl Visitor for EndingNewlineRule {
     type State = Diagnostics;
 
     fn document(&mut self, state: &mut Self::State, reason: VisitReason, doc: &Document) {

--- a/wdl-lint/src/rules/import_placement.rs
+++ b/wdl-lint/src/rules/import_placement.rs
@@ -31,8 +31,11 @@ fn misplaced_import(span: Span) -> Diagnostic {
 }
 
 /// Detects incorrect import placements.
-#[derive(Debug, Clone, Copy)]
-pub struct ImportPlacementRule;
+#[derive(Default, Debug, Clone, Copy)]
+pub struct ImportPlacementRule {
+    /// Whether or not an import statement is considered invalid.
+    invalid: bool,
+}
 
 impl Rule for ImportPlacementRule {
     fn id(&self) -> &'static str {
@@ -51,20 +54,9 @@ impl Rule for ImportPlacementRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(ImportPlacementVisitor::default())
-    }
 }
 
-/// Implements the visitor for the import placement rule.
-#[derive(Default)]
-struct ImportPlacementVisitor {
-    /// Whether or not an import statement is considered invalid.
-    invalid: bool,
-}
-
-impl Visitor for ImportPlacementVisitor {
+impl Visitor for ImportPlacementRule {
     type State = Diagnostics;
 
     fn import_statement(

--- a/wdl-lint/src/rules/import_sort.rs
+++ b/wdl-lint/src/rules/import_sort.rs
@@ -57,16 +57,9 @@ impl Rule for ImportSortRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Style, Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(ImportSortVisitor)
-    }
 }
 
-/// Implements the visitor for the import sort rule.
-struct ImportSortVisitor;
-
-impl Visitor for ImportSortVisitor {
+impl Visitor for ImportSortRule {
     type State = Diagnostics;
 
     fn import_statement(

--- a/wdl-lint/src/rules/import_whitespace.rs
+++ b/wdl-lint/src/rules/import_whitespace.rs
@@ -47,7 +47,7 @@ fn improper_whitespace_before_import(span: Span) -> Diagnostic {
 }
 
 /// Detects whitespace between imports.
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct ImportWhitespaceRule;
 
 impl Rule for ImportWhitespaceRule {
@@ -73,17 +73,9 @@ impl Rule for ImportWhitespaceRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Style, Tag::Clarity, Tag::Spacing])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(ImportWhitespaceVisitor)
-    }
 }
 
-/// Implements the visitor for the import whitespace rule.
-#[derive(Debug, Default)]
-struct ImportWhitespaceVisitor;
-
-impl Visitor for ImportWhitespaceVisitor {
+impl Visitor for ImportWhitespaceRule {
     type State = Diagnostics;
 
     fn import_statement(

--- a/wdl-lint/src/rules/inconsistent_newlines.rs
+++ b/wdl-lint/src/rules/inconsistent_newlines.rs
@@ -24,8 +24,15 @@ fn inconsistent_newlines(span: Span) -> Diagnostic {
 }
 
 /// Detects imports that are not sorted lexicographically.
-#[derive(Debug, Clone, Copy)]
-pub struct InconsistentNewlinesRule;
+#[derive(Default, Debug, Clone, Copy)]
+pub struct InconsistentNewlinesRule {
+    /// The number of carriage returns in the file.
+    carriage_return: u32,
+    /// The number of newlines in the file.
+    newline: u32,
+    /// Location of first inconsistent newline.
+    first_inconsistent: Option<Span>,
+}
 
 impl Rule for InconsistentNewlinesRule {
     fn id(&self) -> &'static str {
@@ -44,34 +51,9 @@ impl Rule for InconsistentNewlinesRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Style, Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(InconsistentNewlinesVisitor::default())
-    }
 }
 
-/// Implements the visitor for the import sort rule.
-struct InconsistentNewlinesVisitor {
-    /// The number of carriage returns in the file.
-    carriage_return: u32,
-    /// The number of newlines in the file.
-    newline: u32,
-    /// Location of first inconsistent newline.
-    first_inconsistent: Option<Span>,
-}
-
-/// Implements the default inconsistent newlines visitor.
-impl Default for InconsistentNewlinesVisitor {
-    fn default() -> Self {
-        Self {
-            carriage_return: 0,
-            newline: 0,
-            first_inconsistent: None,
-        }
-    }
-}
-
-impl Visitor for InconsistentNewlinesVisitor {
+impl Visitor for InconsistentNewlinesRule {
     type State = Diagnostics;
 
     fn document(&mut self, state: &mut Self::State, reason: VisitReason, _doc: &wdl_ast::Document) {

--- a/wdl-lint/src/rules/input_not_sorted.rs
+++ b/wdl-lint/src/rules/input_not_sorted.rs
@@ -52,16 +52,9 @@ impl Rule for InputNotSortedRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Style, Tag::Clarity, Tag::Sorting])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(InputNotSortedVisitor)
-    }
 }
 
-/// Implements the visitor for the input not sorted rule.
-struct InputNotSortedVisitor;
-
-impl Visitor for InputNotSortedVisitor {
+impl Visitor for InputNotSortedRule {
     type State = Diagnostics;
 
     fn input_section(

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -23,43 +23,7 @@ fn line_too_long(span: Span, max_width: usize) -> Diagnostic {
 
 /// Detects lines that exceed a certain width.
 #[derive(Debug, Clone, Copy)]
-pub struct LineWidthRule(usize);
-
-/// Implements the default line width rule.
-impl Default for LineWidthRule {
-    fn default() -> Self {
-        Self(90)
-    }
-}
-
-impl Rule for LineWidthRule {
-    fn id(&self) -> &'static str {
-        ID
-    }
-
-    fn description(&self) -> &'static str {
-        "Ensures that lines do not exceed a certain width. That width is currently set to 90 \
-         characters."
-    }
-
-    fn explanation(&self) -> &'static str {
-        "Lines should not exceed a certain width to make it easier to read and understand the \
-         code. Code within the either the meta or parameter meta sections is not checked. Comments \
-         are included in the line width check. The current maximum width is 90 characters."
-    }
-
-    fn tags(&self) -> TagSet {
-        TagSet::new(&[Tag::Style, Tag::Clarity, Tag::Spacing])
-    }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(LineWidthVisitor::new(self.0))
-    }
-}
-
-/// A visitor that detects lines that exceed a certain width.
-#[derive(Debug, Clone, Copy)]
-struct LineWidthVisitor {
+pub struct LineWidthRule {
     /// The maximum width of a line.
     max_width: usize,
     /// The offset of the previous newline.
@@ -68,16 +32,7 @@ struct LineWidthVisitor {
     should_ignore: bool,
 }
 
-impl LineWidthVisitor {
-    /// Creates a new line width visitor.
-    fn new(max_width: usize) -> Self {
-        Self {
-            max_width,
-            prev_newline_offset: 0,
-            should_ignore: false,
-        }
-    }
-
+impl LineWidthRule {
     /// Detects lines that exceed a certain width.
     fn detect_line_too_long(&mut self, state: &mut Diagnostics, text: &str, start: usize) {
         let mut cur_newline_offset = start;
@@ -104,7 +59,39 @@ impl LineWidthVisitor {
     }
 }
 
-impl Visitor for LineWidthVisitor {
+/// Implements the default line width rule.
+impl Default for LineWidthRule {
+    fn default() -> Self {
+        Self {
+            max_width: 90,
+            prev_newline_offset: 0,
+            should_ignore: false,
+        }
+    }
+}
+
+impl Rule for LineWidthRule {
+    fn id(&self) -> &'static str {
+        ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that lines do not exceed a certain width. That width is currently set to 90 \
+         characters."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "Lines should not exceed a certain width to make it easier to read and understand the \
+         code. Code within the either the meta or parameter meta sections is not checked. Comments \
+         are included in the line width check. The current maximum width is 90 characters."
+    }
+
+    fn tags(&self) -> TagSet {
+        TagSet::new(&[Tag::Style, Tag::Clarity, Tag::Spacing])
+    }
+}
+
+impl Visitor for LineWidthRule {
     type State = Diagnostics;
 
     fn whitespace(&mut self, state: &mut Self::State, whitespace: &wdl_ast::Whitespace) {

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -84,10 +84,6 @@ impl Rule for MatchingParameterMetaRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Completeness])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(MatchingParameterMetaVisitor)
-    }
 }
 
 /// Checks for both missing and extra items in a `parameter_meta` section.
@@ -128,10 +124,7 @@ fn check_parameter_meta(
     }
 }
 
-/// Implements the visitor for the matching parameter meta rule.
-struct MatchingParameterMetaVisitor;
-
-impl Visitor for MatchingParameterMetaVisitor {
+impl Visitor for MatchingParameterMetaRule {
     type State = Diagnostics;
 
     fn task_definition(

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -102,17 +102,9 @@ impl Rule for MissingMetasRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Completeness, Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(MissingMetasVisitor)
-    }
 }
 
-/// Implements the visitor for the missing meta and parameter_meta sections
-/// rule.
-struct MissingMetasVisitor;
-
-impl Visitor for MissingMetasVisitor {
+impl Visitor for MissingMetasRule {
     type State = Diagnostics;
 
     fn task_definition(

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -65,16 +65,9 @@ impl Rule for MissingOutputRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Completeness, Tag::Portability])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(MissingOutputVisitor)
-    }
 }
 
-/// Implements the visitor for the missing output section rule.
-struct MissingOutputVisitor;
-
-impl Visitor for MissingOutputVisitor {
+impl Visitor for MissingOutputRule {
     type State = Diagnostics;
 
     fn task_definition(

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -43,16 +43,9 @@ impl Rule for MissingRuntimeRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Completeness, Tag::Portability])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(MissingRuntimeVisitor)
-    }
 }
 
-/// Implements the visitor for the missing runtime section rule.
-struct MissingRuntimeVisitor;
-
-impl Visitor for MissingRuntimeVisitor {
+impl Visitor for MissingRuntimeRule {
     type State = Diagnostics;
 
     fn task_definition(

--- a/wdl-lint/src/rules/no_curly_commands.rs
+++ b/wdl-lint/src/rules/no_curly_commands.rs
@@ -51,16 +51,9 @@ impl Rule for NoCurlyCommandsRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(NoCurlyCommandsVisitor)
-    }
 }
 
-/// Implements the visitor for the no curly commands rule.
-struct NoCurlyCommandsVisitor;
-
-impl Visitor for NoCurlyCommandsVisitor {
+impl Visitor for NoCurlyCommandsRule {
     type State = Diagnostics;
 
     fn command_section(

--- a/wdl-lint/src/rules/pascal_case.rs
+++ b/wdl-lint/src/rules/pascal_case.rs
@@ -47,10 +47,6 @@ impl Rule for PascalCaseRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Naming, Tag::Style, Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::new(PascalCaseVisitor)
-    }
 }
 
 /// Checks if the given name is pascal case, and if not adds a warning to the
@@ -65,10 +61,7 @@ fn check_name(name: &str, span: Span, diagnostics: &mut Diagnostics) {
     }
 }
 
-/// Implements the visitor for the pascal case rule.
-struct PascalCaseVisitor;
-
-impl Visitor for PascalCaseVisitor {
+impl Visitor for PascalCaseRule {
     type State = Diagnostics;
 
     fn struct_definition(

--- a/wdl-lint/src/rules/preamble_comments.rs
+++ b/wdl-lint/src/rules/preamble_comments.rs
@@ -35,8 +35,13 @@ fn preamble_comment_after_version(span: Span) -> Diagnostic {
 }
 
 /// Detects incorrect comments in a document preamble.
-#[derive(Debug, Clone, Copy)]
-pub struct PreambleCommentsRule;
+#[derive(Default, Debug, Clone, Copy)]
+pub struct PreambleCommentsRule {
+    /// Whether or not the preamble has finished.
+    finished: bool,
+    /// The number of comment tokens to skip.
+    skip_count: usize,
+}
 
 impl Rule for PreambleCommentsRule {
     fn id(&self) -> &'static str {
@@ -64,22 +69,9 @@ impl Rule for PreambleCommentsRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Spacing, Tag::Style, Tag::Clarity])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::<PreambleCommentsVisitor>::default()
-    }
 }
 
-/// Implements the visitor for the preamble comments rule.
-#[derive(Default, Debug)]
-struct PreambleCommentsVisitor {
-    /// Whether or not the preamble has finished.
-    finished: bool,
-    /// The number of comment tokens to skip.
-    skip_count: usize,
-}
-
-impl Visitor for PreambleCommentsVisitor {
+impl Visitor for PreambleCommentsRule {
     type State = Diagnostics;
 
     fn version_statement(

--- a/wdl-lint/src/rules/preamble_whitespace.rs
+++ b/wdl-lint/src/rules/preamble_whitespace.rs
@@ -46,8 +46,15 @@ fn expected_blank_line_after(span: Span) -> Diagnostic {
 }
 
 /// Detects incorrect whitespace in a document preamble.
-#[derive(Debug, Clone, Copy)]
-pub struct PreambleWhitespaceRule;
+#[derive(Default, Debug, Clone, Copy)]
+pub struct PreambleWhitespaceRule {
+    /// Whether or not we've entered the version statement.
+    entered_version: bool,
+    /// Whether or not we've exited the version statement.
+    exited_version: bool,
+    /// Whether or not we've visited whitespace *after* the version statement.
+    checked_blank_after: bool,
+}
 
 impl Rule for PreambleWhitespaceRule {
     fn id(&self) -> &'static str {
@@ -70,24 +77,9 @@ impl Rule for PreambleWhitespaceRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Spacing, Tag::Style])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::<PreambleWhitespaceVisitor>::default()
-    }
 }
 
-/// Implements the visitor for the preamble whitespace rule.
-#[derive(Default, Debug)]
-struct PreambleWhitespaceVisitor {
-    /// Whether or not we've entered the version statement.
-    entered_version: bool,
-    /// Whether or not we've exited the version statement.
-    exited_version: bool,
-    /// Whether or not we've visited whitespace *after* the version statement.
-    checked_blank_after: bool,
-}
-
-impl Visitor for PreambleWhitespaceVisitor {
+impl Visitor for PreambleWhitespaceRule {
     type State = Diagnostics;
 
     fn version_statement(

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -43,8 +43,12 @@ fn more_than_one_blank_line(span: Span) -> Diagnostic {
 }
 
 /// Detects undesired whitespace.
-#[derive(Debug, Clone, Copy)]
-pub struct WhitespaceRule;
+#[derive(Default, Debug, Clone, Copy)]
+pub struct WhitespaceRule {
+    /// Whether or not the version statement has been encountered in the
+    /// document.
+    has_version: bool,
+}
 
 impl Rule for WhitespaceRule {
     fn id(&self) -> &'static str {
@@ -65,21 +69,9 @@ impl Rule for WhitespaceRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Style, Tag::Spacing])
     }
-
-    fn visitor(&self) -> Box<dyn Visitor<State = Diagnostics>> {
-        Box::<WhitespaceVisitor>::default()
-    }
 }
 
-/// Implements the visitor for whitespace rule.
-#[derive(Default)]
-struct WhitespaceVisitor {
-    /// Whether or not the version statement has been encountered in the
-    /// document.
-    has_version: bool,
-}
-
-impl Visitor for WhitespaceVisitor {
+impl Visitor for WhitespaceRule {
     type State = Diagnostics;
 
     fn version_statement(

--- a/wdl-lint/tests/lints.rs
+++ b/wdl-lint/tests/lints.rs
@@ -31,8 +31,7 @@ use rayon::prelude::*;
 use wdl_ast::Diagnostic;
 use wdl_ast::Document;
 use wdl_ast::Validator;
-use wdl_lint::rules;
-use wdl_lint::ExceptVisitor;
+use wdl_lint::LintVisitor;
 
 fn find_tests() -> Vec<PathBuf> {
     // Check for filter arguments consisting of test names
@@ -130,7 +129,7 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<(), String> {
     match Document::parse(&source).into_result() {
         Ok(document) => {
             let mut validator = Validator::default();
-            validator.add_visitor(ExceptVisitor::new(rules().iter().map(AsRef::as_ref)));
+            validator.add_visitor(LintVisitor::default());
             let errors = match validator.validate(&document) {
                 Ok(()) => String::new(),
                 Err(diagnostics) => format_diagnostics(&diagnostics, &path, &source),

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -18,8 +18,7 @@ use colored::Colorize;
 use wdl::ast::Diagnostic;
 use wdl::ast::Document;
 use wdl::ast::Validator;
-use wdl::lint::rules;
-use wdl::lint::ExceptVisitor;
+use wdl::lint::LintVisitor;
 
 /// Emits the given diagnostics to the output stream.
 ///
@@ -136,7 +135,7 @@ impl LintCommand {
         match Document::parse(&source).into_result() {
             Ok(document) => {
                 let mut validator = Validator::default();
-                validator.add_visitor(ExceptVisitor::new(rules().iter().map(AsRef::as_ref)));
+                validator.add_visitor(LintVisitor::default());
                 if let Err(diagnostics) = validator.validate(&document) {
                     emit_diagnostics(&self.path, &source, &diagnostics)?;
 

--- a/wdl/src/lib.rs
+++ b/wdl/src/lib.rs
@@ -63,12 +63,12 @@
 //! # let source = "version 1.1\nworkflow test {}";
 //! use wdl::ast::Document;
 //! use wdl::ast::Validator;
-//! use wdl::lint::rules;
+//! use wdl::lint::LintVisitor;
 //!
 //! match Document::parse(source).into_result() {
 //!     Ok(document) => {
 //!         let mut validator = Validator::default();
-//!         validator.add_visitors(rules().into_iter().map(|r| r.visitor()));
+//!         validator.add_visitor(LintVisitor::default());
 //!         match validator.validate(&document) {
 //!             Ok(_) => {
 //!                 // The document was valid WDL and passed all lints


### PR DESCRIPTION
Originally, `Visitor` was version specific, so the idea was that you would ask a rule for its "V1" visitor, "V2" visitor, etc. to add to the validator.

However, that is no longer the case as `Visitor` is now version agnostic.

Therefore, this commit removes the unnecessary "visitor" types implementing the rules by having `Rule` be a supertrait of `Visitor`; now the rules themselves implement the `Visitor` trait.

I also renamed `ExceptVisitor` to simply `LintVisitor` to make the API a little cleaner; the visitor now means "run all lint rules and respect `except` comments". The name `ExceptVisitor` was too specific.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
