### PR TITLE
feat: add initial support for 1.2 with the exponentiation operator.

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* Add support for the exponentiation operator in WDL 1.2 ([#111](https://github.com/stjude-rust-labs/wdl/pull/111)).
+
 ## 0.4.0 - 06-28-2024
 
 ### Added

--- a/wdl-ast/src/lib.rs
+++ b/wdl-ast/src/lib.rs
@@ -272,7 +272,7 @@ impl Document {
             .map(|s| {
                 let v = s.version();
                 match v.as_str() {
-                    "1.0" | "1.1" => {
+                    "1.0" | "1.1" | "1.2" => {
                         Ast::V1(v1::Ast::cast(self.0.clone()).expect("root should cast"))
                     }
                     _ => Ast::Unsupported,

--- a/wdl-ast/src/validation.rs
+++ b/wdl-ast/src/validation.rs
@@ -17,6 +17,7 @@ mod keys;
 mod names;
 mod numbers;
 mod strings;
+mod version;
 
 /// Represents a collection of validation diagnostics.
 ///
@@ -110,6 +111,7 @@ impl Default for Validator {
                 Box::<keys::UniqueKeysVisitor>::default(),
                 Box::<numbers::NumberVisitor>::default(),
                 Box::<names::UniqueNamesVisitor>::default(),
+                Box::<version::VersionVisitor>::default(),
             ],
         }
     }

--- a/wdl-ast/src/validation/version.rs
+++ b/wdl-ast/src/validation/version.rs
@@ -1,0 +1,98 @@
+//! Validation of supported syntax for WDL versions.
+
+use std::str::FromStr;
+
+use rowan::ast::support::token;
+use wdl_grammar::ToSpan;
+
+use crate::v1::Expr;
+use crate::AstNode;
+use crate::AstToken;
+use crate::Diagnostic;
+use crate::Diagnostics;
+use crate::Document;
+use crate::Span;
+use crate::SyntaxKind;
+use crate::VisitReason;
+use crate::Visitor;
+
+/// Creates an "exponentiation requirement" diagnostic.
+fn exponentiation_requirement(span: Span) -> Diagnostic {
+    Diagnostic::error("usage of the exponentiation operator requires WDL version 1.2")
+        .with_highlight(span)
+}
+
+/// Represents a supported V1 WDL version.
+// NOTE: it is expected that this enumeration is in increasing order of 1.x versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum V1 {
+    /// The document version is 1.0.
+    Zero,
+    /// The document version is 1.1.
+    One,
+    /// The document version is 1.2.
+    Two,
+}
+
+/// Represents a supported WDL version.
+// NOTE: it is expected that this enumeration is in increasing order of WDL versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Version {
+    /// The document version is 1.x.
+    V1(V1),
+}
+
+impl FromStr for Version {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "1.0" => Ok(Self::V1(V1::Zero)),
+            "1.1" => Ok(Self::V1(V1::One)),
+            "1.2" => Ok(Self::V1(V1::Two)),
+            _ => Err(()),
+        }
+    }
+}
+
+/// An AST visitor that ensures the syntax present in the document matches the
+/// document's declared version.
+#[derive(Debug, Default)]
+pub struct VersionVisitor {
+    /// Stores the version of the WDL document we're visiting.
+    version: Option<Version>,
+}
+
+impl Visitor for VersionVisitor {
+    type State = Diagnostics;
+
+    fn document(&mut self, _: &mut Self::State, reason: VisitReason, document: &Document) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        self.version = document
+            .version_statement()
+            .and_then(|s| s.version().as_str().parse().ok());
+    }
+
+    fn expr(&mut self, state: &mut Self::State, reason: VisitReason, expr: &Expr) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        if let Some(version) = self.version {
+            match expr {
+                Expr::Exponentiation(e) if version < Version::V1(V1::Two) => {
+                    state.add(exponentiation_requirement(
+                        token(e.syntax(), SyntaxKind::Exponentiation)
+                            .expect("should have operator")
+                            .text_range()
+                            .to_span(),
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/wdl-ast/tests/validation/exponentiation-unsupported/source.errors
+++ b/wdl-ast/tests/validation/exponentiation-unsupported/source.errors
@@ -1,0 +1,6 @@
+error: usage of the exponentiation operator requires WDL version 1.2
+  ┌─ tests/validation/exponentiation-unsupported/source.wdl:5:16
+  │
+5 │     Int x = 10 ** 10
+  │                ^^
+

--- a/wdl-ast/tests/validation/exponentiation-unsupported/source.wdl
+++ b/wdl-ast/tests/validation/exponentiation-unsupported/source.wdl
@@ -1,0 +1,7 @@
+## This is a test of the exponentiation operator not being supported
+version 1.1
+
+task test {
+    Int x = 10 ** 10
+    command <<<>>>
+}

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* Add support for the exponentiation operator in WDL 1.2 ([#111](https://github.com/stjude-rust-labs/wdl/pull/111)).
+
 ## 0.5.0 - 06-28-2024
 
 ### Fixed

--- a/wdl-grammar/src/grammar.rs
+++ b/wdl-grammar/src/grammar.rs
@@ -81,7 +81,7 @@ pub fn document(source: &str, mut parser: PreambleParser<'_>) -> (Vec<Event>, Ve
                     // version is supported by this implementation
                     let version: &str = &source[span.start()..span.end()];
                     match version {
-                        "1.0" | "1.1" => {
+                        "1.0" | "1.1" | "1.2" => {
                             let mut parser = parser.morph();
                             v1::items(&mut parser);
                             root.complete(&mut parser, SyntaxKind::RootNode);

--- a/wdl-grammar/src/grammar/v1.rs
+++ b/wdl-grammar/src/grammar/v1.rs
@@ -216,6 +216,7 @@ const INFIX_OPERATOR_EXPECTED_SET: TokenSet = TokenSet::new(&[
     Token::Plus as u8,
     Token::Minus as u8,
     Token::Asterisk as u8,
+    Token::Exponentiation as u8,
     Token::Slash as u8,
     Token::Percent as u8,
     Token::Equal as u8,
@@ -1880,8 +1881,8 @@ fn prefix_precedence(token: Token) -> (u8, SyntaxKind, Associativity) {
     use Associativity::*;
     use SyntaxKind::*;
     match token {
-        Token::Exclamation => (7, LogicalNotExprNode, Right),
-        Token::Minus => (7, NegationExprNode, Right),
+        Token::Exclamation => (8, LogicalNotExprNode, Right),
+        Token::Minus => (8, NegationExprNode, Right),
         // As paren expression is ambiguous with a pair literal expression,
         // this is handled in `atom_expr`
         // Token::OpenParen => 11,
@@ -1909,6 +1910,7 @@ fn infix_precedence(token: Token) -> (u8, SyntaxKind, Associativity) {
         Token::Asterisk => (6, MultiplicationExprNode, Left),
         Token::Slash => (6, DivisionExprNode, Left),
         Token::Percent => (6, ModuloExprNode, Left),
+        Token::Exponentiation => (7, ExponentiationExprNode, Left),
         _ => panic!("unknown infix operator token"),
     }
 }
@@ -1919,9 +1921,9 @@ fn infix_precedence(token: Token) -> (u8, SyntaxKind, Associativity) {
 fn postfix_precedence(token: Token) -> u8 {
     // All postfix operators are left-associative
     match token {
-        Token::OpenParen => 8,
-        Token::OpenBracket => 9,
-        Token::Dot => 10,
+        Token::OpenParen => 9,
+        Token::OpenBracket => 10,
+        Token::Dot => 11,
         _ => panic!("unknown postfix operator token"),
     }
 }

--- a/wdl-grammar/src/lexer/v1.rs
+++ b/wdl-grammar/src/lexer/v1.rs
@@ -469,6 +469,9 @@ pub enum Token {
     /// The `*` symbol.
     #[token("*")]
     Asterisk,
+    /// The `**` symbol.
+    #[token("**")]
+    Exponentiation,
     /// The `/` symbol.
     #[token("/")]
     Slash,
@@ -570,6 +573,7 @@ impl<'a> ParserToken<'a> for Token {
             Self::LogicalOr => SyntaxKind::LogicalOr,
             Self::LogicalAnd => SyntaxKind::LogicalAnd,
             Self::Asterisk => SyntaxKind::Asterisk,
+            Self::Exponentiation => SyntaxKind::Exponentiation,
             Self::Slash => SyntaxKind::Slash,
             Self::Percent => SyntaxKind::Percent,
             Self::Equal => SyntaxKind::Equal,
@@ -655,6 +659,7 @@ impl<'a> ParserToken<'a> for Token {
             Self::LogicalOr => "`||`",
             Self::LogicalAnd => "`&&`",
             Self::Asterisk => "`*`",
+            Self::Exponentiation => "`**`",
             Self::Slash => "`/`",
             Self::Percent => "`%`",
             Self::Equal => "`==`",

--- a/wdl-grammar/src/tree.rs
+++ b/wdl-grammar/src/tree.rs
@@ -154,6 +154,8 @@ pub enum SyntaxKind {
     LogicalAnd,
     /// The `*` symbol token.
     Asterisk,
+    /// The `**` symbol token.
+    Exponentiation,
     /// The `/` symbol token.
     Slash,
     /// The `%` symbol token.
@@ -302,6 +304,8 @@ pub enum SyntaxKind {
     DivisionExprNode,
     /// Represents a modulo expression node.
     ModuloExprNode,
+    /// Represents a exponentiation expr node.
+    ExponentiationExprNode,
     /// Represents a call expression node.'
     CallExprNode,
     /// Represents an index expression node.

--- a/wdl-grammar/tests/parsing/exponentiation/source.tree
+++ b/wdl-grammar/tests/parsing/exponentiation/source.tree
@@ -1,0 +1,34 @@
+RootNode@0..101
+  Comment@0..52 "## This is a test of  ..."
+  Whitespace@52..53 "\n"
+  VersionStatementNode@53..64
+    VersionKeyword@53..60 "version"
+    Whitespace@60..61 " "
+    Version@61..64 "1.2"
+  Whitespace@64..66 "\n\n"
+  TaskDefinitionNode@66..100
+    TaskKeyword@66..70 "task"
+    Whitespace@70..71 " "
+    Ident@71..75 "test"
+    Whitespace@75..76 " "
+    OpenBrace@76..77 "{"
+    Whitespace@77..82 "\n    "
+    BoundDeclNode@82..98
+      PrimitiveTypeNode@82..85
+        IntTypeKeyword@82..85 "Int"
+      Whitespace@85..86 " "
+      Ident@86..87 "x"
+      Whitespace@87..88 " "
+      Assignment@88..89 "="
+      Whitespace@89..90 " "
+      ExponentiationExprNode@90..98
+        LiteralIntegerNode@90..92
+          Integer@90..92 "10"
+        Whitespace@92..93 " "
+        Exponentiation@93..95 "**"
+        Whitespace@95..96 " "
+        LiteralIntegerNode@96..98
+          Integer@96..98 "10"
+    Whitespace@98..99 "\n"
+    CloseBrace@99..100 "}"
+  Whitespace@100..101 "\n"

--- a/wdl-grammar/tests/parsing/exponentiation/source.wdl
+++ b/wdl-grammar/tests/parsing/exponentiation/source.wdl
@@ -1,0 +1,6 @@
+## This is a test of the 1.2 exponentiation operator
+version 1.2
+
+task test {
+    Int x = 10 ** 10
+}

--- a/wdl-grammar/tests/parsing/precedence/source.tree
+++ b/wdl-grammar/tests/parsing/precedence/source.tree
@@ -1,4 +1,4 @@
-RootNode@0..274
+RootNode@0..295
   Comment@0..39 "# This is a test of o ..."
   Whitespace@39..41 "\n\n"
   VersionStatementNode@41..52
@@ -6,14 +6,14 @@ RootNode@0..274
     Whitespace@48..49 " "
     Version@49..52 "1.1"
   Whitespace@52..54 "\n\n"
-  TaskDefinitionNode@54..273
+  TaskDefinitionNode@54..294
     TaskKeyword@54..58 "task"
     Whitespace@58..59 " "
     Ident@59..63 "test"
     Whitespace@63..64 " "
     OpenBrace@64..65 "{"
     Whitespace@65..70 "\n    "
-    BoundDeclNode@70..148
+    BoundDeclNode@70..153
       PrimitiveTypeNode@70..77
         BooleanTypeKeyword@70..77 "Boolean"
       Whitespace@77..78 " "
@@ -21,19 +21,19 @@ RootNode@0..274
       Whitespace@79..80 " "
       Assignment@80..81 "="
       Whitespace@81..82 " "
-      LogicalOrExprNode@82..148
+      LogicalOrExprNode@82..153
         LiteralBooleanNode@82..86
           TrueKeyword@82..86 "true"
         Whitespace@86..87 " "
         LogicalOr@87..89 "||"
         Whitespace@89..90 " "
-        LogicalAndExprNode@90..148
+        LogicalAndExprNode@90..153
           LiteralBooleanNode@90..95
             FalseKeyword@90..95 "false"
           Whitespace@95..96 " "
           LogicalAnd@96..98 "&&"
           Whitespace@98..99 " "
-          InequalityExprNode@99..148
+          InequalityExprNode@99..153
             EqualityExprNode@99..105
               LiteralIntegerNode@99..100
                 Integer@99..100 "1"
@@ -45,7 +45,7 @@ RootNode@0..274
             Whitespace@105..106 " "
             NotEqual@106..108 "!="
             Whitespace@108..109 " "
-            GreaterEqualExprNode@109..148
+            GreaterEqualExprNode@109..153
               GreaterExprNode@109..123
                 LessEqualExprNode@109..119
                   LessExprNode@109..114
@@ -69,7 +69,7 @@ RootNode@0..274
               Whitespace@123..124 " "
               GreaterEqual@124..126 ">="
               Whitespace@126..127 " "
-              SubtractionExprNode@127..148
+              SubtractionExprNode@127..153
                 AdditionExprNode@127..132
                   LiteralIntegerNode@127..128
                     Integer@127..128 "1"
@@ -81,7 +81,7 @@ RootNode@0..274
                 Whitespace@132..133 " "
                 Minus@133..134 "-"
                 Whitespace@134..135 " "
-                ModuloExprNode@135..148
+                ModuloExprNode@135..153
                   DivisionExprNode@135..144
                     MultiplicationExprNode@135..140
                       LiteralIntegerNode@135..136
@@ -99,147 +99,174 @@ RootNode@0..274
                   Whitespace@144..145 " "
                   Percent@145..146 "%"
                   Whitespace@146..147 " "
-                  LiteralIntegerNode@147..148
-                    Integer@147..148 "6"
-    Whitespace@148..153 "\n    "
-    BoundDeclNode@153..188
-      PrimitiveTypeNode@153..156
-        IntTypeKeyword@153..156 "Int"
-      Whitespace@156..157 " "
-      Ident@157..158 "b"
-      Whitespace@158..159 " "
-      Assignment@159..160 "="
-      Whitespace@160..161 " "
-      SubtractionExprNode@161..188
-        ParenthesizedExprNode@161..168
-          OpenParen@161..162 "("
-          AdditionExprNode@162..167
-            LiteralIntegerNode@162..163
-              Integer@162..163 "1"
-            Whitespace@163..164 " "
-            Plus@164..165 "+"
-            Whitespace@165..166 " "
-            LiteralIntegerNode@166..167
-              Integer@166..167 "2"
-          CloseParen@167..168 ")"
-        Whitespace@168..169 " "
-        Minus@169..170 "-"
-        Whitespace@170..171 " "
-        DivisionExprNode@171..188
-          ParenthesizedExprNode@171..178
-            OpenParen@171..172 "("
-            MultiplicationExprNode@172..177
-              LiteralIntegerNode@172..173
-                Integer@172..173 "3"
-              Whitespace@173..174 " "
-              Asterisk@174..175 "*"
-              Whitespace@175..176 " "
-              LiteralIntegerNode@176..177
-                Integer@176..177 "4"
-            CloseParen@177..178 ")"
-          Whitespace@178..179 " "
-          Slash@179..180 "/"
-          Whitespace@180..181 " "
-          ParenthesizedExprNode@181..188
-            OpenParen@181..182 "("
-            ModuloExprNode@182..187
-              LiteralIntegerNode@182..183
-                Integer@182..183 "5"
-              Whitespace@183..184 " "
-              Percent@184..185 "%"
-              Whitespace@185..186 " "
-              LiteralIntegerNode@186..187
-                Integer@186..187 "6"
-            CloseParen@187..188 ")"
-    Whitespace@188..193 "\n    "
-    BoundDeclNode@193..271
-      PrimitiveTypeNode@193..200
-        BooleanTypeKeyword@193..200 "Boolean"
-      Whitespace@200..201 " "
-      Ident@201..202 "c"
-      Whitespace@202..203 " "
-      Assignment@203..204 "="
-      Whitespace@204..205 " "
-      LogicalOrExprNode@205..271
-        LogicalAndExprNode@205..263
-          EqualityExprNode@205..254
-            InequalityExprNode@205..249
-              LessExprNode@205..244
-                LessEqualExprNode@205..240
-                  GreaterExprNode@205..235
-                    GreaterEqualExprNode@205..231
-                      SubtractionExprNode@205..226
-                        AdditionExprNode@205..210
-                          LiteralIntegerNode@205..206
-                            Integer@205..206 "1"
-                          Whitespace@206..207 " "
-                          Plus@207..208 "+"
-                          Whitespace@208..209 " "
-                          LiteralIntegerNode@209..210
-                            Integer@209..210 "2"
-                        Whitespace@210..211 " "
-                        Minus@211..212 "-"
-                        Whitespace@212..213 " "
-                        ModuloExprNode@213..226
-                          DivisionExprNode@213..222
-                            MultiplicationExprNode@213..218
-                              LiteralIntegerNode@213..214
-                                Integer@213..214 "3"
-                              Whitespace@214..215 " "
-                              Asterisk@215..216 "*"
-                              Whitespace@216..217 " "
-                              LiteralIntegerNode@217..218
-                                Integer@217..218 "4"
-                            Whitespace@218..219 " "
-                            Slash@219..220 "/"
-                            Whitespace@220..221 " "
-                            LiteralIntegerNode@221..222
-                              Integer@221..222 "5"
+                  ExponentiationExprNode@147..153
+                    LiteralIntegerNode@147..148
+                      Integer@147..148 "6"
+                    Whitespace@148..149 " "
+                    Exponentiation@149..151 "**"
+                    Whitespace@151..152 " "
+                    LiteralIntegerNode@152..153
+                      Integer@152..153 "7"
+    Whitespace@153..158 "\n    "
+    BoundDeclNode@158..204
+      PrimitiveTypeNode@158..161
+        IntTypeKeyword@158..161 "Int"
+      Whitespace@161..162 " "
+      Ident@162..163 "b"
+      Whitespace@163..164 " "
+      Assignment@164..165 "="
+      Whitespace@165..166 " "
+      SubtractionExprNode@166..204
+        ParenthesizedExprNode@166..173
+          OpenParen@166..167 "("
+          AdditionExprNode@167..172
+            LiteralIntegerNode@167..168
+              Integer@167..168 "1"
+            Whitespace@168..169 " "
+            Plus@169..170 "+"
+            Whitespace@170..171 " "
+            LiteralIntegerNode@171..172
+              Integer@171..172 "2"
+          CloseParen@172..173 ")"
+        Whitespace@173..174 " "
+        Minus@174..175 "-"
+        Whitespace@175..176 " "
+        DivisionExprNode@176..204
+          ParenthesizedExprNode@176..183
+            OpenParen@176..177 "("
+            MultiplicationExprNode@177..182
+              LiteralIntegerNode@177..178
+                Integer@177..178 "3"
+              Whitespace@178..179 " "
+              Asterisk@179..180 "*"
+              Whitespace@180..181 " "
+              LiteralIntegerNode@181..182
+                Integer@181..182 "4"
+            CloseParen@182..183 ")"
+          Whitespace@183..184 " "
+          Slash@184..185 "/"
+          Whitespace@185..186 " "
+          ExponentiationExprNode@186..204
+            ParenthesizedExprNode@186..193
+              OpenParen@186..187 "("
+              ModuloExprNode@187..192
+                LiteralIntegerNode@187..188
+                  Integer@187..188 "5"
+                Whitespace@188..189 " "
+                Percent@189..190 "%"
+                Whitespace@190..191 " "
+                LiteralIntegerNode@191..192
+                  Integer@191..192 "6"
+              CloseParen@192..193 ")"
+            Whitespace@193..194 " "
+            Exponentiation@194..196 "**"
+            Whitespace@196..197 " "
+            ParenthesizedExprNode@197..204
+              OpenParen@197..198 "("
+              MultiplicationExprNode@198..203
+                LiteralIntegerNode@198..199
+                  Integer@198..199 "7"
+                Whitespace@199..200 " "
+                Asterisk@200..201 "*"
+                Whitespace@201..202 " "
+                LiteralIntegerNode@202..203
+                  Integer@202..203 "8"
+              CloseParen@203..204 ")"
+    Whitespace@204..209 "\n    "
+    BoundDeclNode@209..292
+      PrimitiveTypeNode@209..216
+        BooleanTypeKeyword@209..216 "Boolean"
+      Whitespace@216..217 " "
+      Ident@217..218 "c"
+      Whitespace@218..219 " "
+      Assignment@219..220 "="
+      Whitespace@220..221 " "
+      LogicalOrExprNode@221..292
+        LogicalAndExprNode@221..284
+          EqualityExprNode@221..275
+            InequalityExprNode@221..270
+              LessExprNode@221..265
+                LessEqualExprNode@221..261
+                  GreaterExprNode@221..256
+                    GreaterEqualExprNode@221..252
+                      SubtractionExprNode@221..247
+                        AdditionExprNode@221..226
+                          LiteralIntegerNode@221..222
+                            Integer@221..222 "1"
                           Whitespace@222..223 " "
-                          Percent@223..224 "%"
+                          Plus@223..224 "+"
                           Whitespace@224..225 " "
                           LiteralIntegerNode@225..226
-                            Integer@225..226 "6"
-                      Whitespace@226..227 " "
-                      GreaterEqual@227..229 ">="
-                      Whitespace@229..230 " "
-                      LiteralIntegerNode@230..231
-                        Integer@230..231 "0"
-                    Whitespace@231..232 " "
-                    Greater@232..233 ">"
-                    Whitespace@233..234 " "
-                    LiteralIntegerNode@234..235
-                      Integer@234..235 "1"
-                  Whitespace@235..236 " "
-                  LessEqual@236..238 "<="
-                  Whitespace@238..239 " "
-                  LiteralIntegerNode@239..240
-                    Integer@239..240 "0"
-                Whitespace@240..241 " "
-                Less@241..242 "<"
-                Whitespace@242..243 " "
-                LiteralIntegerNode@243..244
-                  Integer@243..244 "1"
-              Whitespace@244..245 " "
-              NotEqual@245..247 "!="
-              Whitespace@247..248 " "
-              LiteralIntegerNode@248..249
-                Integer@248..249 "0"
-            Whitespace@249..250 " "
-            Equal@250..252 "=="
-            Whitespace@252..253 " "
-            LiteralIntegerNode@253..254
-              Integer@253..254 "1"
-          Whitespace@254..255 " "
-          LogicalAnd@255..257 "&&"
-          Whitespace@257..258 " "
-          LiteralBooleanNode@258..263
-            FalseKeyword@258..263 "false"
-        Whitespace@263..264 " "
-        LogicalOr@264..266 "||"
-        Whitespace@266..267 " "
-        LiteralBooleanNode@267..271
-          TrueKeyword@267..271 "true"
-    Whitespace@271..272 "\n"
-    CloseBrace@272..273 "}"
-  Whitespace@273..274 "\n"
+                            Integer@225..226 "2"
+                        Whitespace@226..227 " "
+                        Minus@227..228 "-"
+                        Whitespace@228..229 " "
+                        ModuloExprNode@229..247
+                          DivisionExprNode@229..238
+                            MultiplicationExprNode@229..234
+                              LiteralIntegerNode@229..230
+                                Integer@229..230 "3"
+                              Whitespace@230..231 " "
+                              Asterisk@231..232 "*"
+                              Whitespace@232..233 " "
+                              LiteralIntegerNode@233..234
+                                Integer@233..234 "4"
+                            Whitespace@234..235 " "
+                            Slash@235..236 "/"
+                            Whitespace@236..237 " "
+                            LiteralIntegerNode@237..238
+                              Integer@237..238 "5"
+                          Whitespace@238..239 " "
+                          Percent@239..240 "%"
+                          Whitespace@240..241 " "
+                          ExponentiationExprNode@241..247
+                            LiteralIntegerNode@241..242
+                              Integer@241..242 "6"
+                            Whitespace@242..243 " "
+                            Exponentiation@243..245 "**"
+                            Whitespace@245..246 " "
+                            LiteralIntegerNode@246..247
+                              Integer@246..247 "7"
+                      Whitespace@247..248 " "
+                      GreaterEqual@248..250 ">="
+                      Whitespace@250..251 " "
+                      LiteralIntegerNode@251..252
+                        Integer@251..252 "0"
+                    Whitespace@252..253 " "
+                    Greater@253..254 ">"
+                    Whitespace@254..255 " "
+                    LiteralIntegerNode@255..256
+                      Integer@255..256 "1"
+                  Whitespace@256..257 " "
+                  LessEqual@257..259 "<="
+                  Whitespace@259..260 " "
+                  LiteralIntegerNode@260..261
+                    Integer@260..261 "0"
+                Whitespace@261..262 " "
+                Less@262..263 "<"
+                Whitespace@263..264 " "
+                LiteralIntegerNode@264..265
+                  Integer@264..265 "1"
+              Whitespace@265..266 " "
+              NotEqual@266..268 "!="
+              Whitespace@268..269 " "
+              LiteralIntegerNode@269..270
+                Integer@269..270 "0"
+            Whitespace@270..271 " "
+            Equal@271..273 "=="
+            Whitespace@273..274 " "
+            LiteralIntegerNode@274..275
+              Integer@274..275 "1"
+          Whitespace@275..276 " "
+          LogicalAnd@276..278 "&&"
+          Whitespace@278..279 " "
+          LiteralBooleanNode@279..284
+            FalseKeyword@279..284 "false"
+        Whitespace@284..285 " "
+        LogicalOr@285..287 "||"
+        Whitespace@287..288 " "
+        LiteralBooleanNode@288..292
+          TrueKeyword@288..292 "true"
+    Whitespace@292..293 "\n"
+    CloseBrace@293..294 "}"
+  Whitespace@294..295 "\n"

--- a/wdl-grammar/tests/parsing/precedence/source.wdl
+++ b/wdl-grammar/tests/parsing/precedence/source.wdl
@@ -3,7 +3,7 @@
 version 1.1
 
 task test {
-    Boolean a = true || false && 1 == 0 != 1 < 0 <= 1 > 0 >= 1 + 2 - 3 * 4 / 5 % 6
-    Int b = (1 + 2) - (3 * 4) / (5 % 6)
-    Boolean c = 1 + 2 - 3 * 4 / 5 % 6 >= 0 > 1 <= 0 < 1 != 0 == 1 && false || true
+    Boolean a = true || false && 1 == 0 != 1 < 0 <= 1 > 0 >= 1 + 2 - 3 * 4 / 5 % 6 ** 7
+    Int b = (1 + 2) - (3 * 4) / (5 % 6) ** (7 * 8)
+    Boolean c = 1 + 2 - 3 * 4 / 5 % 6 ** 7 >= 0 > 1 <= 0 < 1 != 0 == 1 && false || true
 }


### PR DESCRIPTION
This commit implements initial support for WDL 1.2 with the introduction of the exponentiation operator.

This is only initial support for 1.2; there are a number of changes required for the parser to be 1.2 spec-compliant and for the lint rules to be updated.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
