### PR TITLE
feat: implement `hints` sections from WDL 1.2.

### DIFF
--- a/wdl-analysis/src/scope.rs
+++ b/wdl-analysis/src/scope.rs
@@ -921,6 +921,7 @@ impl DocumentScope {
                 | v1::TaskItem::Output(_)
                 | v1::TaskItem::Command(_)
                 | v1::TaskItem::Requirements(_)
+                | v1::TaskItem::Hints(_)
                 | v1::TaskItem::Runtime(_)
                 | v1::TaskItem::Metadata(_)
                 | v1::TaskItem::ParameterMetadata(_) => continue,
@@ -1017,7 +1018,8 @@ impl DocumentScope {
                 v1::WorkflowItem::Input(_)
                 | v1::WorkflowItem::Output(_)
                 | v1::WorkflowItem::Metadata(_)
-                | v1::WorkflowItem::ParameterMetadata(_) => continue,
+                | v1::WorkflowItem::ParameterMetadata(_)
+                | v1::WorkflowItem::Hints(_) => continue,
             }
         }
 

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for `hints` sections in WDL 1.2 ([#121](https://github.com/stjude-rust-labs/wdl/pull/121)).
 * Add support for `requirements` sections in WDL 1.2 ([#117](https://github.com/stjude-rust-labs/wdl/pull/117)).
 * Add support for the exponentiation operator in WDL 1.2 ([#111](https://github.com/stjude-rust-labs/wdl/pull/111)).
 
@@ -39,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Refactored the `Visitor` trait and validation visitors so that they are not 
+* Refactored the `Visitor` trait and validation visitors so that they are not
   in a `v1` module ([#95](https://github.com/stjude-rust-labs/wdl/pull/95)).
 
 ## 0.3.0 - 06-13-2024
@@ -59,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Removed the old AST implementation in favor of new new parser; this also 
+* Removed the old AST implementation in favor of new new parser; this also
   removes the `experimental` feature from the crate ([#79](https://github.com/stjude-rust-labs/wdl/pull/79)).
 * Removed dependency on `miette` and `thiserror` in the experimental parser,
   re-exported key items from `wdl-grammar`'s experimental parser implementation,

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -474,6 +474,12 @@ pub enum LiteralExpr {
     Struct(LiteralStruct),
     /// The literal is a `None`.
     None(LiteralNone),
+    /// The literal is a `hints`.
+    Hints(LiteralHints),
+    /// The literal is an `input`.
+    Input(LiteralInput),
+    /// The literal is an `output`.
+    Output(LiteralOutput),
 }
 
 impl LiteralExpr {
@@ -596,6 +602,42 @@ impl LiteralExpr {
             _ => panic!("not a literal `None`"),
         }
     }
+
+    /// Unwraps the expression into a literal `hints`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the expression is not a literal `hints`.
+    pub fn unwrap_hints(self) -> LiteralHints {
+        match self {
+            Self::Hints(literal) => literal,
+            _ => panic!("not a literal `hints`"),
+        }
+    }
+
+    /// Unwraps the expression into a literal `input`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the expression is not a literal `input`.
+    pub fn unwrap_input(self) -> LiteralInput {
+        match self {
+            Self::Input(literal) => literal,
+            _ => panic!("not a literal `input`"),
+        }
+    }
+
+    /// Unwraps the expression into a literal `output`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the expression is not a literal `output`.
+    pub fn unwrap_output(self) -> LiteralOutput {
+        match self {
+            Self::Output(literal) => literal,
+            _ => panic!("not a literal `output`"),
+        }
+    }
 }
 
 impl AstNode for LiteralExpr {
@@ -617,6 +659,9 @@ impl AstNode for LiteralExpr {
                 | SyntaxKind::LiteralObjectNode
                 | SyntaxKind::LiteralStructNode
                 | SyntaxKind::LiteralNoneNode
+                | SyntaxKind::LiteralHintsNode
+                | SyntaxKind::LiteralInputNode
+                | SyntaxKind::LiteralOutputNode
         )
     }
 
@@ -635,6 +680,9 @@ impl AstNode for LiteralExpr {
             SyntaxKind::LiteralObjectNode => Some(Self::Object(LiteralObject(syntax))),
             SyntaxKind::LiteralStructNode => Some(Self::Struct(LiteralStruct(syntax))),
             SyntaxKind::LiteralNoneNode => Some(Self::None(LiteralNone(syntax))),
+            SyntaxKind::LiteralHintsNode => Some(Self::Hints(LiteralHints(syntax))),
+            SyntaxKind::LiteralInputNode => Some(Self::Input(LiteralInput(syntax))),
+            SyntaxKind::LiteralOutputNode => Some(Self::Output(LiteralOutput(syntax))),
             _ => None,
         }
     }
@@ -651,6 +699,9 @@ impl AstNode for LiteralExpr {
             Self::Object(o) => &o.0,
             Self::Struct(s) => &s.0,
             Self::None(n) => &n.0,
+            Self::Hints(h) => &h.0,
+            Self::Input(i) => &i.0,
+            Self::Output(o) => &o.0,
         }
     }
 }
@@ -1709,6 +1760,247 @@ impl AstNode for LiteralNone {
     {
         match syntax.kind() {
             SyntaxKind::LiteralNoneNode => Some(Self(syntax)),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.0
+    }
+}
+
+/// Represents a literal `hints`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiteralHints(SyntaxNode);
+
+impl LiteralHints {
+    /// Gets the items of the literal hints.
+    pub fn items(&self) -> AstChildren<LiteralHintsItem> {
+        children(&self.0)
+    }
+}
+
+impl AstNode for LiteralHints {
+    type Language = WorkflowDescriptionLanguage;
+
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == SyntaxKind::LiteralHintsNode
+    }
+
+    fn cast(syntax: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match syntax.kind() {
+            SyntaxKind::LiteralHintsNode => Some(Self(syntax)),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.0
+    }
+}
+
+/// Represents a literal hints item.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiteralHintsItem(SyntaxNode);
+
+impl LiteralHintsItem {
+    /// Gets the name of the hints item.
+    pub fn name(&self) -> Ident {
+        token(&self.0).expect("expected an item name")
+    }
+
+    /// Gets the expression of the hints item.
+    pub fn expr(&self) -> Expr {
+        child(&self.0).expect("expected an item expression")
+    }
+}
+
+impl AstNode for LiteralHintsItem {
+    type Language = WorkflowDescriptionLanguage;
+
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == SyntaxKind::LiteralHintsItemNode
+    }
+
+    fn cast(syntax: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match syntax.kind() {
+            SyntaxKind::LiteralHintsItemNode => Some(Self(syntax)),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.0
+    }
+}
+
+/// Represents a literal `input`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiteralInput(SyntaxNode);
+
+impl LiteralInput {
+    /// Gets the items of the literal input.
+    pub fn items(&self) -> AstChildren<LiteralInputItem> {
+        children(&self.0)
+    }
+}
+
+impl AstNode for LiteralInput {
+    type Language = WorkflowDescriptionLanguage;
+
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == SyntaxKind::LiteralInputNode
+    }
+
+    fn cast(syntax: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match syntax.kind() {
+            SyntaxKind::LiteralInputNode => Some(Self(syntax)),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.0
+    }
+}
+
+/// Represents a literal input item.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiteralInputItem(SyntaxNode);
+
+impl LiteralInputItem {
+    /// Gets the names of the input item.
+    ///
+    /// More than one name indicates a struct member path.
+    pub fn names(&self) -> impl Iterator<Item = Ident> {
+        self.0
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .filter_map(Ident::cast)
+    }
+
+    /// Gets the expression of the input item.
+    pub fn expr(&self) -> Expr {
+        child(&self.0).expect("expected an item expression")
+    }
+}
+
+impl AstNode for LiteralInputItem {
+    type Language = WorkflowDescriptionLanguage;
+
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == SyntaxKind::LiteralInputItemNode
+    }
+
+    fn cast(syntax: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match syntax.kind() {
+            SyntaxKind::LiteralInputItemNode => Some(Self(syntax)),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.0
+    }
+}
+
+/// Represents a literal `output`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiteralOutput(SyntaxNode);
+
+impl LiteralOutput {
+    /// Gets the items of the literal output.
+    pub fn items(&self) -> AstChildren<LiteralOutputItem> {
+        children(&self.0)
+    }
+}
+
+impl AstNode for LiteralOutput {
+    type Language = WorkflowDescriptionLanguage;
+
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == SyntaxKind::LiteralOutputNode
+    }
+
+    fn cast(syntax: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match syntax.kind() {
+            SyntaxKind::LiteralOutputNode => Some(Self(syntax)),
+            _ => None,
+        }
+    }
+
+    fn syntax(&self) -> &SyntaxNode {
+        &self.0
+    }
+}
+
+/// Represents a literal output item.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiteralOutputItem(SyntaxNode);
+
+impl LiteralOutputItem {
+    /// Gets the names of the output item.
+    ///
+    /// More than one name indicates a struct member path.
+    pub fn names(&self) -> impl Iterator<Item = Ident> {
+        self.0
+            .children_with_tokens()
+            .filter_map(SyntaxElement::into_token)
+            .filter_map(Ident::cast)
+    }
+
+    /// Gets the expression of the output item.
+    pub fn expr(&self) -> Expr {
+        child(&self.0).expect("expected an item expression")
+    }
+}
+
+impl AstNode for LiteralOutputItem {
+    type Language = WorkflowDescriptionLanguage;
+
+    fn can_cast(kind: SyntaxKind) -> bool
+    where
+        Self: Sized,
+    {
+        kind == SyntaxKind::LiteralOutputItemNode
+    }
+
+    fn cast(syntax: SyntaxNode) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match syntax.kind() {
+            SyntaxKind::LiteralOutputItemNode => Some(Self(syntax)),
             _ => None,
         }
     }
@@ -3576,6 +3868,411 @@ task test {
         let mut visitor = MyVisitor(0);
         document.visit(&mut (), &mut visitor);
         assert_eq!(visitor.0, 2);
+    }
+
+    #[test]
+    fn literal_hints() {
+        let (document, diagnostics) = Document::parse(
+            r#"
+version 1.2
+
+task test {
+    hints {
+        foo: hints {
+            bar: "bar"
+            baz: "baz"
+        }
+        bar: "bar"
+        baz: hints {
+            a: 1
+            b: 10.0
+            c: {
+                "foo": "bar"
+            }
+        }
+    }
+}
+"#,
+        );
+
+        assert!(diagnostics.is_empty());
+        let ast = document.ast();
+        let ast = ast.as_v1().expect("should be a V1 AST");
+        let tasks: Vec<_> = ast.tasks().collect();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name().as_str(), "test");
+
+        // Task hints
+        let hints: Vec<_> = tasks[0].hints().collect();
+        assert_eq!(hints.len(), 1);
+        let items: Vec<_> = hints[0].items().collect();
+        assert_eq!(items.len(), 3);
+
+        // First hints item
+        assert_eq!(items[0].name().as_str(), "foo");
+        let inner: Vec<_> = items[0]
+            .expr()
+            .unwrap_literal()
+            .unwrap_hints()
+            .items()
+            .collect();
+        assert_eq!(inner.len(), 2);
+        assert_eq!(inner[0].name().as_str(), "bar");
+        assert_eq!(
+            inner[0]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "bar"
+        );
+        assert_eq!(inner[1].name().as_str(), "baz");
+        assert_eq!(
+            inner[1]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "baz"
+        );
+
+        // Second hints item
+        assert_eq!(items[1].name().as_str(), "bar");
+        assert_eq!(
+            items[1]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "bar"
+        );
+
+        // Third hints item
+        assert_eq!(items[2].name().as_str(), "baz");
+        let inner: Vec<_> = items[2]
+            .expr()
+            .unwrap_literal()
+            .unwrap_hints()
+            .items()
+            .collect();
+        assert_eq!(inner.len(), 3);
+        assert_eq!(inner[0].name().as_str(), "a");
+        assert_eq!(
+            inner[0]
+                .expr()
+                .unwrap_literal()
+                .unwrap_integer()
+                .value()
+                .unwrap(),
+            1
+        );
+        assert_eq!(inner[1].name().as_str(), "b");
+        assert_relative_eq!(
+            inner[1]
+                .expr()
+                .unwrap_literal()
+                .unwrap_float()
+                .value()
+                .unwrap(),
+            10.0
+        );
+        assert_eq!(inner[2].name().as_str(), "c");
+        let map: Vec<_> = inner[2]
+            .expr()
+            .unwrap_literal()
+            .unwrap_map()
+            .items()
+            .collect();
+        assert_eq!(map.len(), 1);
+        let (k, v) = map[0].key_value();
+        assert_eq!(
+            k.unwrap_literal().unwrap_string().text().unwrap().as_str(),
+            "foo"
+        );
+        assert_eq!(
+            v.unwrap_literal().unwrap_string().text().unwrap().as_str(),
+            "bar"
+        );
+
+        // Use a visitor to count the number of literal `hints` in the tree
+        struct MyVisitor(usize);
+
+        impl Visitor for MyVisitor {
+            type State = ();
+
+            fn document(
+                &mut self,
+                _: &mut Self::State,
+                _: VisitReason,
+                _: &Document,
+                _: SupportedVersion,
+            ) {
+            }
+
+            fn expr(&mut self, _: &mut Self::State, reason: VisitReason, expr: &Expr) {
+                if reason == VisitReason::Enter {
+                    if let Expr::Literal(LiteralExpr::Hints(_)) = expr {
+                        self.0 += 1;
+                    }
+                }
+            }
+        }
+
+        let mut visitor = MyVisitor(0);
+        document.visit(&mut (), &mut visitor);
+        assert_eq!(visitor.0, 2);
+    }
+
+    #[test]
+    fn literal_input() {
+        let (document, diagnostics) = Document::parse(
+            r#"
+version 1.2
+
+task test {
+    hints {
+        inputs: input {
+            a: hints {
+                foo: "bar"
+            }
+            b.c.d: hints {
+                bar: "baz"
+            }
+        }
+    }
+}
+"#,
+        );
+
+        assert!(diagnostics.is_empty());
+        let ast = document.ast();
+        let ast = ast.as_v1().expect("should be a V1 AST");
+        let tasks: Vec<_> = ast.tasks().collect();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name().as_str(), "test");
+
+        // Task hints
+        let hints: Vec<_> = tasks[0].hints().collect();
+        assert_eq!(hints.len(), 1);
+        let items: Vec<_> = hints[0].items().collect();
+        assert_eq!(items.len(), 1);
+
+        // First hints item
+        assert_eq!(items[0].name().as_str(), "inputs");
+        let input: Vec<_> = items[0]
+            .expr()
+            .unwrap_literal()
+            .unwrap_input()
+            .items()
+            .collect();
+        assert_eq!(input.len(), 2);
+        assert_eq!(
+            input[0]
+                .names()
+                .map(|i| i.as_str().to_string())
+                .collect::<Vec<_>>(),
+            ["a"]
+        );
+        let inner: Vec<_> = input[0]
+            .expr()
+            .unwrap_literal()
+            .unwrap_hints()
+            .items()
+            .collect();
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0].name().as_str(), "foo");
+        assert_eq!(
+            inner[0]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "bar"
+        );
+        assert_eq!(
+            input[1]
+                .names()
+                .map(|i| i.as_str().to_string())
+                .collect::<Vec<_>>(),
+            ["b", "c", "d"]
+        );
+        let inner: Vec<_> = input[1]
+            .expr()
+            .unwrap_literal()
+            .unwrap_hints()
+            .items()
+            .collect();
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0].name().as_str(), "bar");
+        assert_eq!(
+            inner[0]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "baz"
+        );
+
+        // Use a visitor to count the number of literal `hints` in the tree
+        struct MyVisitor(usize);
+
+        impl Visitor for MyVisitor {
+            type State = ();
+
+            fn document(
+                &mut self,
+                _: &mut Self::State,
+                _: VisitReason,
+                _: &Document,
+                _: SupportedVersion,
+            ) {
+            }
+
+            fn expr(&mut self, _: &mut Self::State, reason: VisitReason, expr: &Expr) {
+                if reason == VisitReason::Enter {
+                    if let Expr::Literal(LiteralExpr::Input(_)) = expr {
+                        self.0 += 1;
+                    }
+                }
+            }
+        }
+
+        let mut visitor = MyVisitor(0);
+        document.visit(&mut (), &mut visitor);
+        assert_eq!(visitor.0, 1);
+    }
+
+    #[test]
+    fn literal_output() {
+        let (document, diagnostics) = Document::parse(
+            r#"
+version 1.2
+
+task test {
+    hints {
+        outputs: output {
+            a: hints {
+                foo: "bar"
+            }
+            b.c.d: hints {
+                bar: "baz"
+            }
+        }
+    }
+}
+"#,
+        );
+
+        assert!(diagnostics.is_empty());
+        let ast = document.ast();
+        let ast = ast.as_v1().expect("should be a V1 AST");
+        let tasks: Vec<_> = ast.tasks().collect();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name().as_str(), "test");
+
+        // Task hints
+        let hints: Vec<_> = tasks[0].hints().collect();
+        assert_eq!(hints.len(), 1);
+        let items: Vec<_> = hints[0].items().collect();
+        assert_eq!(items.len(), 1);
+
+        // First hints item
+        assert_eq!(items[0].name().as_str(), "outputs");
+        let output: Vec<_> = items[0]
+            .expr()
+            .unwrap_literal()
+            .unwrap_output()
+            .items()
+            .collect();
+        assert_eq!(output.len(), 2);
+        assert_eq!(
+            output[0]
+                .names()
+                .map(|i| i.as_str().to_string())
+                .collect::<Vec<_>>(),
+            ["a"]
+        );
+        let inner: Vec<_> = output[0]
+            .expr()
+            .unwrap_literal()
+            .unwrap_hints()
+            .items()
+            .collect();
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0].name().as_str(), "foo");
+        assert_eq!(
+            inner[0]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "bar"
+        );
+        assert_eq!(
+            output[1]
+                .names()
+                .map(|i| i.as_str().to_string())
+                .collect::<Vec<_>>(),
+            ["b", "c", "d"]
+        );
+        let inner: Vec<_> = output[1]
+            .expr()
+            .unwrap_literal()
+            .unwrap_hints()
+            .items()
+            .collect();
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0].name().as_str(), "bar");
+        assert_eq!(
+            inner[0]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "baz"
+        );
+
+        // Use a visitor to count the number of literal `hints` in the tree
+        struct MyVisitor(usize);
+
+        impl Visitor for MyVisitor {
+            type State = ();
+
+            fn document(
+                &mut self,
+                _: &mut Self::State,
+                _: VisitReason,
+                _: &Document,
+                _: SupportedVersion,
+            ) {
+            }
+
+            fn expr(&mut self, _: &mut Self::State, reason: VisitReason, expr: &Expr) {
+                if reason == VisitReason::Enter {
+                    if let Expr::Literal(LiteralExpr::Output(_)) = expr {
+                        self.0 += 1;
+                    }
+                }
+            }
+        }
+
+        let mut visitor = MyVisitor(0);
+        document.visit(&mut (), &mut visitor);
+        assert_eq!(visitor.0, 1);
     }
 
     #[test]

--- a/wdl-ast/src/v1/workflow.rs
+++ b/wdl-ast/src/v1/workflow.rs
@@ -2,6 +2,7 @@
 
 use super::BoundDecl;
 use super::Expr;
+use super::HintsSection;
 use super::InputSection;
 use super::MetadataSection;
 use super::OutputSection;
@@ -58,6 +59,11 @@ impl WorkflowDefinition {
         children(&self.0)
     }
 
+    /// Gets the hints sections of the workflow.
+    pub fn hints(&self) -> AstChildren<HintsSection> {
+        children(&self.0)
+    }
+
     /// Gets the private declarations of the workflow.
     pub fn declarations(&self) -> AstChildren<BoundDecl> {
         children(&self.0)
@@ -106,6 +112,8 @@ pub enum WorkflowItem {
     Metadata(MetadataSection),
     /// The item is a parameter meta section.
     ParameterMetadata(ParameterMetadataSection),
+    /// The item is a hints section.
+    Hints(HintsSection),
     /// The item is a private bound declaration.
     Declaration(BoundDecl),
 }
@@ -126,6 +134,7 @@ impl AstNode for WorkflowItem {
                 | SyntaxKind::CallStatementNode
                 | SyntaxKind::MetadataSectionNode
                 | SyntaxKind::ParameterMetadataSectionNode
+                | SyntaxKind::HintsSectionNode
                 | SyntaxKind::BoundDeclNode
         )
     }
@@ -146,6 +155,7 @@ impl AstNode for WorkflowItem {
             SyntaxKind::ParameterMetadataSectionNode => {
                 Some(Self::ParameterMetadata(ParameterMetadataSection(syntax)))
             }
+            SyntaxKind::HintsSectionNode => Some(Self::Hints(HintsSection(syntax))),
             SyntaxKind::BoundDeclNode => Some(Self::Declaration(BoundDecl(syntax))),
             _ => None,
         }
@@ -160,6 +170,7 @@ impl AstNode for WorkflowItem {
             Self::Call(s) => &s.0,
             Self::Metadata(m) => &m.0,
             Self::ParameterMetadata(m) => &m.0,
+            Self::Hints(h) => &h.0,
             Self::Declaration(d) => &d.0,
         }
     }
@@ -612,6 +623,10 @@ workflow test {
         }
     }
 
+    hints {
+        foo: "bar"
+    }
+
     String x = "private"
 }
 "#,
@@ -872,6 +887,26 @@ workflow test {
         assert_eq!(
             items[0].value().unwrap_string().text().unwrap().as_str(),
             "a name to greet"
+        );
+
+        // Workflow hints
+        let hints: Vec<_> = workflows[0].hints().collect();
+        assert_eq!(hints.len(), 1);
+
+        // First workflow hints
+        assert_eq!(hints[0].parent().unwrap_workflow().name().as_str(), "test");
+        let items: Vec<_> = hints[0].items().collect();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name().as_str(), "foo");
+        assert_eq!(
+            items[0]
+                .expr()
+                .unwrap_literal()
+                .unwrap_string()
+                .text()
+                .unwrap()
+                .as_str(),
+            "bar"
         );
 
         // Workflow declarations

--- a/wdl-ast/src/validation.rs
+++ b/wdl-ast/src/validation.rs
@@ -11,6 +11,7 @@ use crate::VersionStatement;
 use crate::Visitor;
 
 mod counts;
+mod exprs;
 mod keys;
 mod numbers;
 mod requirements;
@@ -101,6 +102,7 @@ impl Default for Validator {
                 Box::<numbers::NumberVisitor>::default(),
                 Box::<version::VersionVisitor>::default(),
                 Box::<requirements::RequirementsVisitor>::default(),
+                Box::<exprs::ScopedExprVisitor>::default(),
             ],
         }
     }
@@ -235,6 +237,17 @@ impl Visitor for Validator {
     ) {
         for visitor in self.visitors.iter_mut() {
             visitor.requirements_section(state, reason, section);
+        }
+    }
+
+    fn hints_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::HintsSection,
+    ) {
+        for visitor in self.visitors.iter_mut() {
+            visitor.hints_section(state, reason, section);
         }
     }
 

--- a/wdl-ast/src/validation/exprs.rs
+++ b/wdl-ast/src/validation/exprs.rs
@@ -1,0 +1,166 @@
+//! Validation of scoped expressions.
+
+use std::fmt;
+
+use rowan::ast::support::token;
+
+use crate::v1;
+use crate::version::V1;
+use crate::AstNode;
+use crate::Diagnostic;
+use crate::Diagnostics;
+use crate::Document;
+use crate::Span;
+use crate::SupportedVersion;
+use crate::SyntaxKind;
+use crate::ToSpan;
+use crate::VisitReason;
+use crate::Visitor;
+
+/// Creates a "hints scope required" diagnostic.
+fn hints_scope_required(literal: &Literal) -> Diagnostic {
+    Diagnostic::error(format!(
+        "`{literal}` literals can only be used within a hints section"
+    ))
+    .with_highlight(literal.span())
+}
+
+/// Creates a "literal cannot nest" diagnostic.
+fn literal_cannot_nest(nested: &Literal, outer: &Literal) -> Diagnostic {
+    Diagnostic::error(format!(
+        "`{nested}` literals cannot be nested within `{outer}` literals"
+    ))
+    .with_label(
+        format!("this `{nested}` literal cannot be nested"),
+        nested.span(),
+    )
+    .with_label(format!("the outer `{outer}` literal is here"), outer.span())
+}
+
+/// Keeps track of the spans of a `hints`, `input`, or `output` literal.
+#[derive(Debug, Clone, Copy)]
+enum Literal {
+    /// The literal is a `hints`.
+    Hints(Span),
+    /// The literal is an `input`.
+    Input(Span),
+    /// The literal is an `output`.
+    Output(Span),
+}
+
+impl Literal {
+    /// Gets the span of literal.
+    fn span(&self) -> Span {
+        match self {
+            Self::Hints(s) | Self::Input(s) | Self::Output(s) => *s,
+        }
+    }
+}
+
+impl fmt::Display for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hints(_) => write!(f, "hints"),
+            Self::Input(_) => write!(f, "input"),
+            Self::Output(_) => write!(f, "output"),
+        }
+    }
+}
+
+/// An AST visitor that ensures that certain expressions only appear in
+/// acceptable scopes.
+#[derive(Debug, Default)]
+pub struct ScopedExprVisitor {
+    /// The version of the document we're currently visiting.
+    version: Option<SupportedVersion>,
+    /// Whether or not we're currently in a `hints` section.
+    in_hints_section: bool,
+    /// The stack of literals encountered.
+    literals: Vec<Literal>,
+}
+
+impl Visitor for ScopedExprVisitor {
+    type State = Diagnostics;
+
+    fn document(
+        &mut self,
+        _: &mut Self::State,
+        reason: VisitReason,
+        _: &Document,
+        version: SupportedVersion,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        *self = Default::default();
+        self.version = Some(version);
+    }
+
+    fn hints_section(&mut self, _: &mut Self::State, reason: VisitReason, _: &v1::HintsSection) {
+        self.in_hints_section = reason == VisitReason::Enter;
+    }
+
+    fn expr(&mut self, state: &mut Self::State, reason: VisitReason, expr: &v1::Expr) {
+        // Only visit expressions for WDL >=1.2
+        if self.version.expect("should have a version") < SupportedVersion::V1(V1::Two) {
+            return;
+        }
+
+        if reason == VisitReason::Exit {
+            match expr {
+                v1::Expr::Literal(v1::LiteralExpr::Hints(_))
+                | v1::Expr::Literal(v1::LiteralExpr::Input(_))
+                | v1::Expr::Literal(v1::LiteralExpr::Output(_)) => {
+                    self.literals.pop();
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        let literal = match expr {
+            v1::Expr::Literal(v1::LiteralExpr::Hints(l)) => Literal::Hints(
+                token(l.syntax(), SyntaxKind::HintsKeyword)
+                    .expect("should have keyword")
+                    .text_range()
+                    .to_span(),
+            ),
+            v1::Expr::Literal(v1::LiteralExpr::Input(l)) => Literal::Input(
+                token(l.syntax(), SyntaxKind::InputKeyword)
+                    .expect("should have keyword")
+                    .text_range()
+                    .to_span(),
+            ),
+            v1::Expr::Literal(v1::LiteralExpr::Output(l)) => Literal::Output(
+                token(l.syntax(), SyntaxKind::OutputKeyword)
+                    .expect("should have keyword")
+                    .text_range()
+                    .to_span(),
+            ),
+            _ => return,
+        };
+
+        if self.in_hints_section {
+            // Check for prohibited nesting
+            let prohibited = match literal {
+                Literal::Hints(_) => {
+                    self.literals.len() > 1
+                        || (self.literals.len() == 1
+                            && matches!(self.literals[0], Literal::Hints(_)))
+                }
+                Literal::Input(_) | Literal::Output(_) => !self.literals.is_empty(),
+            };
+
+            if prohibited {
+                let outer = self.literals.last().expect("should have an outer literal");
+                state.add(literal_cannot_nest(&literal, outer));
+            }
+        } else {
+            // Any use of these literals outside of a `hints` section is prohibited
+            state.add(hints_scope_required(&literal));
+        }
+
+        self.literals.push(literal);
+    }
+}

--- a/wdl-ast/src/validation/keys.rs
+++ b/wdl-ast/src/validation/keys.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::v1::Expr;
+use crate::v1::HintsSection;
 use crate::v1::LiteralExpr;
 use crate::v1::MetadataObject;
 use crate::v1::MetadataSection;
@@ -25,6 +26,8 @@ use crate::Visitor;
 enum Context {
     /// The error is in the requirements section.
     RequirementsSection,
+    /// The error is in the hints section.
+    HintsSection,
     /// The error is in a runtime section.
     RuntimeSection,
     /// The error is in a metadata section.
@@ -43,6 +46,7 @@ impl fmt::Display for Context {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::RequirementsSection => write!(f, "requirements section"),
+            Self::HintsSection => write!(f, "hints section"),
             Self::RuntimeSection => write!(f, "runtime section"),
             Self::MetadataSection => write!(f, "metadata section"),
             Self::ParameterMetadataSection => write!(f, "parameter metadata section"),
@@ -157,6 +161,25 @@ impl Visitor for UniqueKeysVisitor {
             ],
             section.items().map(|i| i.name()),
             Context::RequirementsSection,
+            state,
+        );
+    }
+
+    fn hints_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &HintsSection,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_duplicate_keys(
+            &mut self.0,
+            &[],
+            section.items().map(|i| i.name()),
+            Context::HintsSection,
             state,
         );
     }

--- a/wdl-ast/src/visitor.rs
+++ b/wdl-ast/src/visitor.rs
@@ -29,6 +29,7 @@ use crate::v1::CommandSection;
 use crate::v1::CommandText;
 use crate::v1::ConditionalStatement;
 use crate::v1::Expr;
+use crate::v1::HintsSection;
 use crate::v1::ImportStatement;
 use crate::v1::InputSection;
 use crate::v1::MetadataObject;
@@ -166,6 +167,15 @@ pub trait Visitor: Send + Sync {
         state: &mut Self::State,
         reason: VisitReason,
         section: &RequirementsSection,
+    ) {
+    }
+
+    /// Visits a hints section node.
+    fn hints_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &HintsSection,
     ) {
     }
 
@@ -335,6 +345,9 @@ pub(crate) fn visit<V: Visitor>(root: &SyntaxNode, state: &mut V::State, visitor
                 reason,
                 &RequirementsSection(element.into_node().unwrap()),
             ),
+            SyntaxKind::HintsSectionNode => {
+                visitor.hints_section(state, reason, &HintsSection(element.into_node().unwrap()))
+            }
             SyntaxKind::RequirementsItemNode => {
                 // Skip this node as it's part of a requirements section
             }
@@ -373,7 +386,10 @@ pub(crate) fn visit<V: Visitor>(root: &SyntaxNode, state: &mut V::State, visitor
             ),
             SyntaxKind::LiteralMapItemNode
             | SyntaxKind::LiteralObjectItemNode
-            | SyntaxKind::LiteralStructItemNode => {
+            | SyntaxKind::LiteralStructItemNode
+            | SyntaxKind::LiteralHintsItemNode
+            | SyntaxKind::LiteralInputItemNode
+            | SyntaxKind::LiteralOutputItemNode => {
                 // Skip these nodes as they're part of literal expressions
             }
             k @ (SyntaxKind::LiteralIntegerNode
@@ -386,6 +402,9 @@ pub(crate) fn visit<V: Visitor>(root: &SyntaxNode, state: &mut V::State, visitor
             | SyntaxKind::LiteralMapNode
             | SyntaxKind::LiteralObjectNode
             | SyntaxKind::LiteralStructNode
+            | SyntaxKind::LiteralHintsNode
+            | SyntaxKind::LiteralInputNode
+            | SyntaxKind::LiteralOutputNode
             | SyntaxKind::ParenthesizedExprNode
             | SyntaxKind::NameRefNode
             | SyntaxKind::IfExprNode

--- a/wdl-ast/tests/validation/hints-duplicate-keys/source.errors
+++ b/wdl-ast/tests/validation/hints-duplicate-keys/source.errors
@@ -1,0 +1,27 @@
+error: duplicate key `memory` in hints section
+   ┌─ tests/validation/hints-duplicate-keys/source.wdl:11:9
+   │
+ 9 │         memory: "first"
+   │         ------ first key with this name is here
+10 │ 
+11 │         memory: "dup"
+   │         ^^^^^^ this key is a duplicate
+
+error: duplicate key `container` in hints section
+   ┌─ tests/validation/hints-duplicate-keys/source.wdl:12:9
+   │
+ 7 │         container: "first"
+   │         --------- first key with this name is here
+   ·
+12 │         container: "dup"
+   │         ^^^^^^^^^ this key is a duplicate
+
+error: duplicate key `disks` in hints section
+   ┌─ tests/validation/hints-duplicate-keys/source.wdl:13:9
+   │
+ 8 │         disks: "first"
+   │         ----- first key with this name is here
+   ·
+13 │         disks: "dup"
+   │         ^^^^^ this key is a duplicate
+

--- a/wdl-ast/tests/validation/hints-duplicate-keys/source.wdl
+++ b/wdl-ast/tests/validation/hints-duplicate-keys/source.wdl
@@ -1,0 +1,17 @@
+# This is a test for duplicate keys in a hints section.
+
+version 1.2
+
+task test {
+    hints {
+        container: "first"
+        disks: "first"
+        memory: "first"
+
+        memory: "dup"
+        container: "dup"
+        disks: "dup"
+    }
+
+    command <<<>>>
+}

--- a/wdl-ast/tests/validation/hints-unsupported/source.errors
+++ b/wdl-ast/tests/validation/hints-unsupported/source.errors
@@ -1,0 +1,12 @@
+error: use of the `hints` section requires WDL version 1.2
+  ┌─ tests/validation/hints-unsupported/source.wdl:8:5
+  │
+8 │     hints {
+  │     ^^^^^
+
+error: use of the `hints` section requires WDL version 1.2
+   ┌─ tests/validation/hints-unsupported/source.wdl:18:5
+   │
+18 │     hints {
+   │     ^^^^^
+

--- a/wdl-ast/tests/validation/hints-unsupported/source.wdl
+++ b/wdl-ast/tests/validation/hints-unsupported/source.wdl
@@ -1,0 +1,25 @@
+## This is a test of using a hint section in a 1.1 document
+
+version 1.1
+
+task foo {
+    command <<<>>>
+
+    hints {
+        inputs: input {
+            a: hints {
+                foo: "bar"
+            }
+        }
+    }
+}
+
+workflow bar {
+    hints {
+        inputs: input {
+            a: hints {
+                foo: "bar"
+            }
+        }
+    }
+}

--- a/wdl-ast/tests/validation/hints/source.wdl
+++ b/wdl-ast/tests/validation/hints/source.wdl
@@ -1,0 +1,26 @@
+## This is a test of using a hint section in a 1.2 document
+## There should be no diagnostics emitted.
+
+version 1.2
+
+task foo {
+    command <<<>>>
+
+    hints {
+        inputs: input {
+            a: hints {
+                foo: "bar"
+            }
+        }
+    }
+}
+
+workflow bar {
+    hints {
+        inputs: input {
+            a: hints {
+                foo: "bar"
+            }
+        }
+    }
+}

--- a/wdl-ast/tests/validation/scoped-exprs/source.errors
+++ b/wdl-ast/tests/validation/scoped-exprs/source.errors
@@ -1,0 +1,154 @@
+error: `hints` literals can only be used within a hints section
+   ┌─ tests/validation/scoped-exprs/source.wdl:47:13
+   │
+47 │     Int a = hints {
+   │             ^^^^^
+
+error: `input` literals can only be used within a hints section
+   ┌─ tests/validation/scoped-exprs/source.wdl:51:13
+   │
+51 │     Int b = input {
+   │             ^^^^^
+
+error: `output` literals can only be used within a hints section
+   ┌─ tests/validation/scoped-exprs/source.wdl:55:13
+   │
+55 │     Int c = output {
+   │             ^^^^^^
+
+error: `hints` literals cannot be nested within `hints` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:61:18
+   │
+60 │         ok: hints {
+   │             ----- the outer `hints` literal is here
+61 │             bad: hints {
+   │                  ^^^^^ this `hints` literal cannot be nested
+
+error: `input` literals cannot be nested within `hints` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:62:22
+   │
+61 │             bad: hints {
+   │                  ----- the outer `hints` literal is here
+62 │                 bad: input {
+   │                      ^^^^^ this `input` literal cannot be nested
+
+error: `output` literals cannot be nested within `input` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:63:26
+   │
+62 │                 bad: input {
+   │                      ----- the outer `input` literal is here
+63 │                     bad: output {
+   │                          ^^^^^^ this `output` literal cannot be nested
+
+error: `hints` literals cannot be nested within `hints` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:71:22
+   │
+70 │             ok: hints {
+   │                 ----- the outer `hints` literal is here
+71 │                 bad: hints {
+   │                      ^^^^^ this `hints` literal cannot be nested
+
+error: `input` literals cannot be nested within `input` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:75:21
+   │
+69 │         inputs: input {
+   │                 ----- the outer `input` literal is here
+   ·
+75 │             inputs: input {
+   │                     ^^^^^ this `input` literal cannot be nested
+
+error: `input` literals cannot be nested within `input` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:76:20
+   │
+75 │             inputs: input {
+   │                     ----- the outer `input` literal is here
+76 │                 a: input {
+   │                    ^^^^^ this `input` literal cannot be nested
+
+error: `hints` literals cannot be nested within `input` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:79:20
+   │
+75 │             inputs: input {
+   │                     ----- the outer `input` literal is here
+   ·
+79 │                 b: hints {
+   │                    ^^^^^ this `hints` literal cannot be nested
+
+error: `input` literals cannot be nested within `hints` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:80:24
+   │
+79 │                 b: hints {
+   │                    ----- the outer `hints` literal is here
+80 │                     a: input {
+   │                        ^^^^^ this `input` literal cannot be nested
+
+error: `output` literals cannot be nested within `hints` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:83:24
+   │
+79 │                 b: hints {
+   │                    ----- the outer `hints` literal is here
+   ·
+83 │                     b: output {
+   │                        ^^^^^^ this `output` literal cannot be nested
+
+error: `hints` literals cannot be nested within `hints` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:86:24
+   │
+79 │                 b: hints {
+   │                    ----- the outer `hints` literal is here
+   ·
+86 │                     c: hints {
+   │                        ^^^^^ this `hints` literal cannot be nested
+
+error: `output` literals cannot be nested within `input` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:90:20
+   │
+75 │             inputs: input {
+   │                     ----- the outer `input` literal is here
+   ·
+90 │                 c: output {
+   │                    ^^^^^^ this `output` literal cannot be nested
+
+error: `input` literals cannot be nested within `output` literals
+   ┌─ tests/validation/scoped-exprs/source.wdl:96:16
+   │
+95 │         outputs: output {
+   │                  ------ the outer `output` literal is here
+96 │             a: input {
+   │                ^^^^^ this `input` literal cannot be nested
+
+error: `input` literals cannot be nested within `hints` literals
+    ┌─ tests/validation/scoped-exprs/source.wdl:100:20
+    │
+ 99 │             b: hints {
+    │                ----- the outer `hints` literal is here
+100 │                 a: input {
+    │                    ^^^^^ this `input` literal cannot be nested
+
+error: `output` literals cannot be nested within `hints` literals
+    ┌─ tests/validation/scoped-exprs/source.wdl:103:20
+    │
+ 99 │             b: hints {
+    │                ----- the outer `hints` literal is here
+    ·
+103 │                 b: output {
+    │                    ^^^^^^ this `output` literal cannot be nested
+
+error: `hints` literals cannot be nested within `hints` literals
+    ┌─ tests/validation/scoped-exprs/source.wdl:106:20
+    │
+ 99 │             b: hints {
+    │                ----- the outer `hints` literal is here
+    ·
+106 │                 c: hints {
+    │                    ^^^^^ this `hints` literal cannot be nested
+
+error: `output` literals cannot be nested within `output` literals
+    ┌─ tests/validation/scoped-exprs/source.wdl:110:16
+    │
+ 95 │         outputs: output {
+    │                  ------ the outer `output` literal is here
+    ·
+110 │             c: output {
+    │                ^^^^^^ this `output` literal cannot be nested
+

--- a/wdl-ast/tests/validation/scoped-exprs/source.wdl
+++ b/wdl-ast/tests/validation/scoped-exprs/source.wdl
@@ -1,0 +1,115 @@
+## This is a test of ensuring certain expressions can only be used in particular scopes.
+
+version 1.2
+
+task ok {
+    command <<<>>>
+
+    hints {
+        a: hints {
+            a: "a"
+            b: 1
+            c: 1.0
+            d: [1, 2, 3]
+        }
+        inputs: input {
+            foo: hints {
+                a: "a"
+                b: "b"
+                c: "c"
+            }
+            baz.bar.qux: hints {
+                foo: "foo"
+                bar: "bar"
+                baz: "baz"
+            }
+        }
+        c: "foo"
+        d: 1
+        outputs: output {
+            foo: hints {
+                a: "a"
+                b: "b"
+                c: "c"
+            }
+            baz.bar.qux: hints {
+                foo: "foo"
+                bar: "bar"
+                baz: "baz"
+            }
+        }
+    }
+}
+
+task bad {
+    command <<<>>>
+
+    Int a = hints {
+        foo: "bar"
+    }
+
+    Int b = input {
+        foo: "bar"
+    }
+
+    Int c = output {
+        foo: "bar"
+    }
+
+    hints {
+        ok: hints {
+            bad: hints {
+                bad: input {
+                    bad: output {
+
+                    }
+                }
+            }
+        }
+        inputs: input {
+            ok: hints {
+                bad: hints {
+
+                }
+            }
+            inputs: input {
+                a: input {
+
+                }
+                b: hints {
+                    a: input {
+
+                    }
+                    b: output {
+
+                    }
+                    c: hints {
+
+                    }
+                }
+                c: output {
+
+                }
+            }
+        }
+        outputs: output {
+            a: input {
+
+            }
+            b: hints {
+                a: input {
+
+                }
+                b: output {
+
+                }
+                c: hints {
+
+                }
+            }
+            c: output {
+
+            }
+        }
+    }
+}

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for `hints` sections in WDL 1.2 ([#121](https://github.com/stjude-rust-labs/wdl/pull/121)).
 * Add support for `requirements` sections in WDL 1.2 ([#117](https://github.com/stjude-rust-labs/wdl/pull/117)).
 * Add support for the exponentiation operator in WDL 1.2 ([#111](https://github.com/stjude-rust-labs/wdl/pull/111)).
 

--- a/wdl-grammar/src/grammar.rs
+++ b/wdl-grammar/src/grammar.rs
@@ -23,6 +23,11 @@ mod macros {
                 return Err(($marker, e));
             }
         };
+        ($parser:ident, $marker:ident, $token:expr, $name:literal) => {
+            if let Err(e) = $parser.expect_with_name($token, $name) {
+                return Err(($marker, e));
+            }
+        };
     }
 
     /// A macro for expecting the next token be in the given token set.

--- a/wdl-grammar/src/tree.rs
+++ b/wdl-grammar/src/tree.rs
@@ -217,6 +217,10 @@ pub enum SyntaxKind {
     RequirementsSectionNode,
     /// Represents a requirements item node.
     RequirementsItemNode,
+    /// Represents a hints section node.
+    HintsSectionNode,
+    /// Represents a hints item node.
+    HintsItemNode,
     /// Represents a runtime section node.
     RuntimeSectionNode,
     /// Represents a runtime item node.
@@ -271,6 +275,18 @@ pub enum SyntaxKind {
     LiteralStructNode,
     /// Represents a literal struct item node.
     LiteralStructItemNode,
+    /// Represents a literal hints node.
+    LiteralHintsNode,
+    /// Represents a literal hints item node.
+    LiteralHintsItemNode,
+    /// Represents a literal input node.
+    LiteralInputNode,
+    /// Represents a literal input item node.
+    LiteralInputItemNode,
+    /// Represents a literal output node.
+    LiteralOutputNode,
+    /// Represents a literal output item node.
+    LiteralOutputItemNode,
     /// Represents a parenthesized expression node.
     ParenthesizedExprNode,
     /// Represents a name reference node.

--- a/wdl-grammar/tests/parsing/hints-section/source.tree
+++ b/wdl-grammar/tests/parsing/hints-section/source.tree
@@ -1,0 +1,540 @@
+RootNode@0..1493
+  Comment@0..49 "## This is a test of  ..."
+  Whitespace@49..51 "\n\n"
+  VersionStatementNode@51..62
+    VersionKeyword@51..58 "version"
+    Whitespace@58..59 " "
+    Version@59..62 "1.2"
+  Whitespace@62..64 "\n\n"
+  TaskDefinitionNode@64..775
+    TaskKeyword@64..68 "task"
+    Whitespace@68..69 " "
+    Ident@69..72 "foo"
+    Whitespace@72..73 " "
+    OpenBrace@73..74 "{"
+    Whitespace@74..79 "\n    "
+    HintsSectionNode@79..773
+      HintsKeyword@79..84 "hints"
+      Whitespace@84..85 " "
+      OpenBrace@85..86 "{"
+      Whitespace@86..95 "\n        "
+      HintsItemNode@95..195
+        Ident@95..96 "a"
+        Colon@96..97 ":"
+        Whitespace@97..98 " "
+        LiteralHintsNode@98..195
+          HintsKeyword@98..103 "hints"
+          Whitespace@103..104 " "
+          OpenBrace@104..105 "{"
+          Whitespace@105..118 "\n            "
+          LiteralHintsItemNode@118..124
+            Ident@118..119 "a"
+            Colon@119..120 ":"
+            Whitespace@120..121 " "
+            LiteralStringNode@121..124
+              DoubleQuote@121..122 "\""
+              LiteralStringText@122..123 "a"
+              DoubleQuote@123..124 "\""
+          Whitespace@124..137 "\n            "
+          LiteralHintsItemNode@137..141
+            Ident@137..138 "b"
+            Colon@138..139 ":"
+            Whitespace@139..140 " "
+            LiteralIntegerNode@140..141
+              Integer@140..141 "1"
+          Whitespace@141..154 "\n            "
+          LiteralHintsItemNode@154..160
+            Ident@154..155 "c"
+            Colon@155..156 ":"
+            Whitespace@156..157 " "
+            LiteralFloatNode@157..160
+              Float@157..160 "1.0"
+          Whitespace@160..173 "\n            "
+          LiteralHintsItemNode@173..185
+            Ident@173..174 "d"
+            Colon@174..175 ":"
+            Whitespace@175..176 " "
+            LiteralArrayNode@176..185
+              OpenBracket@176..177 "["
+              LiteralIntegerNode@177..178
+                Integer@177..178 "1"
+              Comma@178..179 ","
+              Whitespace@179..180 " "
+              LiteralIntegerNode@180..181
+                Integer@180..181 "2"
+              Comma@181..182 ","
+              Whitespace@182..183 " "
+              LiteralIntegerNode@183..184
+                Integer@183..184 "3"
+              CloseBracket@184..185 "]"
+          Whitespace@185..194 "\n        "
+          CloseBrace@194..195 "}"
+      Whitespace@195..204 "\n        "
+      HintsItemNode@204..465
+        Ident@204..210 "inputs"
+        Colon@210..211 ":"
+        Whitespace@211..212 " "
+        LiteralInputNode@212..465
+          InputKeyword@212..217 "input"
+          Whitespace@217..218 " "
+          OpenBrace@218..219 "{"
+          Whitespace@219..232 "\n            "
+          LiteralInputItemNode@232..327
+            Ident@232..235 "foo"
+            Colon@235..236 ":"
+            Whitespace@236..237 " "
+            LiteralHintsNode@237..327
+              HintsKeyword@237..242 "hints"
+              Whitespace@242..243 " "
+              OpenBrace@243..244 "{"
+              Whitespace@244..261 "\n                "
+              LiteralHintsItemNode@261..267
+                Ident@261..262 "a"
+                Colon@262..263 ":"
+                Whitespace@263..264 " "
+                LiteralStringNode@264..267
+                  DoubleQuote@264..265 "\""
+                  LiteralStringText@265..266 "a"
+                  DoubleQuote@266..267 "\""
+              Whitespace@267..284 "\n                "
+              LiteralHintsItemNode@284..290
+                Ident@284..285 "b"
+                Colon@285..286 ":"
+                Whitespace@286..287 " "
+                LiteralStringNode@287..290
+                  DoubleQuote@287..288 "\""
+                  LiteralStringText@288..289 "b"
+                  DoubleQuote@289..290 "\""
+              Whitespace@290..307 "\n                "
+              LiteralHintsItemNode@307..313
+                Ident@307..308 "c"
+                Colon@308..309 ":"
+                Whitespace@309..310 " "
+                LiteralStringNode@310..313
+                  DoubleQuote@310..311 "\""
+                  LiteralStringText@311..312 "c"
+                  DoubleQuote@312..313 "\""
+              Whitespace@313..326 "\n            "
+              CloseBrace@326..327 "}"
+          Whitespace@327..340 "\n            "
+          LiteralInputItemNode@340..455
+            Ident@340..343 "baz"
+            Dot@343..344 "."
+            Ident@344..347 "bar"
+            Dot@347..348 "."
+            Ident@348..351 "qux"
+            Colon@351..352 ":"
+            Whitespace@352..353 " "
+            LiteralHintsNode@353..455
+              HintsKeyword@353..358 "hints"
+              Whitespace@358..359 " "
+              OpenBrace@359..360 "{"
+              Whitespace@360..377 "\n                "
+              LiteralHintsItemNode@377..387
+                Ident@377..380 "foo"
+                Colon@380..381 ":"
+                Whitespace@381..382 " "
+                LiteralStringNode@382..387
+                  DoubleQuote@382..383 "\""
+                  LiteralStringText@383..386 "foo"
+                  DoubleQuote@386..387 "\""
+              Whitespace@387..404 "\n                "
+              LiteralHintsItemNode@404..414
+                Ident@404..407 "bar"
+                Colon@407..408 ":"
+                Whitespace@408..409 " "
+                LiteralStringNode@409..414
+                  DoubleQuote@409..410 "\""
+                  LiteralStringText@410..413 "bar"
+                  DoubleQuote@413..414 "\""
+              Whitespace@414..431 "\n                "
+              LiteralHintsItemNode@431..441
+                Ident@431..434 "baz"
+                Colon@434..435 ":"
+                Whitespace@435..436 " "
+                LiteralStringNode@436..441
+                  DoubleQuote@436..437 "\""
+                  LiteralStringText@437..440 "baz"
+                  DoubleQuote@440..441 "\""
+              Whitespace@441..454 "\n            "
+              CloseBrace@454..455 "}"
+          Whitespace@455..464 "\n        "
+          CloseBrace@464..465 "}"
+      Whitespace@465..474 "\n        "
+      HintsItemNode@474..482
+        Ident@474..475 "c"
+        Colon@475..476 ":"
+        Whitespace@476..477 " "
+        LiteralStringNode@477..482
+          DoubleQuote@477..478 "\""
+          LiteralStringText@478..481 "foo"
+          DoubleQuote@481..482 "\""
+      Whitespace@482..491 "\n        "
+      HintsItemNode@491..495
+        Ident@491..492 "d"
+        Colon@492..493 ":"
+        Whitespace@493..494 " "
+        LiteralIntegerNode@494..495
+          Integer@494..495 "1"
+      Whitespace@495..504 "\n        "
+      HintsItemNode@504..767
+        Ident@504..511 "outputs"
+        Colon@511..512 ":"
+        Whitespace@512..513 " "
+        LiteralOutputNode@513..767
+          OutputKeyword@513..519 "output"
+          Whitespace@519..520 " "
+          OpenBrace@520..521 "{"
+          Whitespace@521..534 "\n            "
+          LiteralOutputItemNode@534..629
+            Ident@534..537 "foo"
+            Colon@537..538 ":"
+            Whitespace@538..539 " "
+            LiteralHintsNode@539..629
+              HintsKeyword@539..544 "hints"
+              Whitespace@544..545 " "
+              OpenBrace@545..546 "{"
+              Whitespace@546..563 "\n                "
+              LiteralHintsItemNode@563..569
+                Ident@563..564 "a"
+                Colon@564..565 ":"
+                Whitespace@565..566 " "
+                LiteralStringNode@566..569
+                  DoubleQuote@566..567 "\""
+                  LiteralStringText@567..568 "a"
+                  DoubleQuote@568..569 "\""
+              Whitespace@569..586 "\n                "
+              LiteralHintsItemNode@586..592
+                Ident@586..587 "b"
+                Colon@587..588 ":"
+                Whitespace@588..589 " "
+                LiteralStringNode@589..592
+                  DoubleQuote@589..590 "\""
+                  LiteralStringText@590..591 "b"
+                  DoubleQuote@591..592 "\""
+              Whitespace@592..609 "\n                "
+              LiteralHintsItemNode@609..615
+                Ident@609..610 "c"
+                Colon@610..611 ":"
+                Whitespace@611..612 " "
+                LiteralStringNode@612..615
+                  DoubleQuote@612..613 "\""
+                  LiteralStringText@613..614 "c"
+                  DoubleQuote@614..615 "\""
+              Whitespace@615..628 "\n            "
+              CloseBrace@628..629 "}"
+          Whitespace@629..642 "\n            "
+          LiteralOutputItemNode@642..757
+            Ident@642..645 "baz"
+            Dot@645..646 "."
+            Ident@646..649 "bar"
+            Dot@649..650 "."
+            Ident@650..653 "qux"
+            Colon@653..654 ":"
+            Whitespace@654..655 " "
+            LiteralHintsNode@655..757
+              HintsKeyword@655..660 "hints"
+              Whitespace@660..661 " "
+              OpenBrace@661..662 "{"
+              Whitespace@662..679 "\n                "
+              LiteralHintsItemNode@679..689
+                Ident@679..682 "foo"
+                Colon@682..683 ":"
+                Whitespace@683..684 " "
+                LiteralStringNode@684..689
+                  DoubleQuote@684..685 "\""
+                  LiteralStringText@685..688 "foo"
+                  DoubleQuote@688..689 "\""
+              Whitespace@689..706 "\n                "
+              LiteralHintsItemNode@706..716
+                Ident@706..709 "bar"
+                Colon@709..710 ":"
+                Whitespace@710..711 " "
+                LiteralStringNode@711..716
+                  DoubleQuote@711..712 "\""
+                  LiteralStringText@712..715 "bar"
+                  DoubleQuote@715..716 "\""
+              Whitespace@716..733 "\n                "
+              LiteralHintsItemNode@733..743
+                Ident@733..736 "baz"
+                Colon@736..737 ":"
+                Whitespace@737..738 " "
+                LiteralStringNode@738..743
+                  DoubleQuote@738..739 "\""
+                  LiteralStringText@739..742 "baz"
+                  DoubleQuote@742..743 "\""
+              Whitespace@743..756 "\n            "
+              CloseBrace@756..757 "}"
+          Whitespace@757..766 "\n        "
+          CloseBrace@766..767 "}"
+      Whitespace@767..772 "\n    "
+      CloseBrace@772..773 "}"
+    Whitespace@773..774 "\n"
+    CloseBrace@774..775 "}"
+  Whitespace@775..777 "\n\n"
+  WorkflowDefinitionNode@777..1492
+    WorkflowKeyword@777..785 "workflow"
+    Whitespace@785..786 " "
+    Ident@786..789 "bar"
+    Whitespace@789..790 " "
+    OpenBrace@790..791 "{"
+    Whitespace@791..796 "\n    "
+    HintsSectionNode@796..1490
+      HintsKeyword@796..801 "hints"
+      Whitespace@801..802 " "
+      OpenBrace@802..803 "{"
+      Whitespace@803..812 "\n        "
+      HintsItemNode@812..912
+        Ident@812..813 "a"
+        Colon@813..814 ":"
+        Whitespace@814..815 " "
+        LiteralHintsNode@815..912
+          HintsKeyword@815..820 "hints"
+          Whitespace@820..821 " "
+          OpenBrace@821..822 "{"
+          Whitespace@822..835 "\n            "
+          LiteralHintsItemNode@835..841
+            Ident@835..836 "a"
+            Colon@836..837 ":"
+            Whitespace@837..838 " "
+            LiteralStringNode@838..841
+              DoubleQuote@838..839 "\""
+              LiteralStringText@839..840 "a"
+              DoubleQuote@840..841 "\""
+          Whitespace@841..854 "\n            "
+          LiteralHintsItemNode@854..858
+            Ident@854..855 "b"
+            Colon@855..856 ":"
+            Whitespace@856..857 " "
+            LiteralIntegerNode@857..858
+              Integer@857..858 "1"
+          Whitespace@858..871 "\n            "
+          LiteralHintsItemNode@871..877
+            Ident@871..872 "c"
+            Colon@872..873 ":"
+            Whitespace@873..874 " "
+            LiteralFloatNode@874..877
+              Float@874..877 "1.0"
+          Whitespace@877..890 "\n            "
+          LiteralHintsItemNode@890..902
+            Ident@890..891 "d"
+            Colon@891..892 ":"
+            Whitespace@892..893 " "
+            LiteralArrayNode@893..902
+              OpenBracket@893..894 "["
+              LiteralIntegerNode@894..895
+                Integer@894..895 "1"
+              Comma@895..896 ","
+              Whitespace@896..897 " "
+              LiteralIntegerNode@897..898
+                Integer@897..898 "2"
+              Comma@898..899 ","
+              Whitespace@899..900 " "
+              LiteralIntegerNode@900..901
+                Integer@900..901 "3"
+              CloseBracket@901..902 "]"
+          Whitespace@902..911 "\n        "
+          CloseBrace@911..912 "}"
+      Whitespace@912..921 "\n        "
+      HintsItemNode@921..1182
+        Ident@921..927 "inputs"
+        Colon@927..928 ":"
+        Whitespace@928..929 " "
+        LiteralInputNode@929..1182
+          InputKeyword@929..934 "input"
+          Whitespace@934..935 " "
+          OpenBrace@935..936 "{"
+          Whitespace@936..949 "\n            "
+          LiteralInputItemNode@949..1044
+            Ident@949..952 "foo"
+            Colon@952..953 ":"
+            Whitespace@953..954 " "
+            LiteralHintsNode@954..1044
+              HintsKeyword@954..959 "hints"
+              Whitespace@959..960 " "
+              OpenBrace@960..961 "{"
+              Whitespace@961..978 "\n                "
+              LiteralHintsItemNode@978..984
+                Ident@978..979 "a"
+                Colon@979..980 ":"
+                Whitespace@980..981 " "
+                LiteralStringNode@981..984
+                  DoubleQuote@981..982 "\""
+                  LiteralStringText@982..983 "a"
+                  DoubleQuote@983..984 "\""
+              Whitespace@984..1001 "\n                "
+              LiteralHintsItemNode@1001..1007
+                Ident@1001..1002 "b"
+                Colon@1002..1003 ":"
+                Whitespace@1003..1004 " "
+                LiteralStringNode@1004..1007
+                  DoubleQuote@1004..1005 "\""
+                  LiteralStringText@1005..1006 "b"
+                  DoubleQuote@1006..1007 "\""
+              Whitespace@1007..1024 "\n                "
+              LiteralHintsItemNode@1024..1030
+                Ident@1024..1025 "c"
+                Colon@1025..1026 ":"
+                Whitespace@1026..1027 " "
+                LiteralStringNode@1027..1030
+                  DoubleQuote@1027..1028 "\""
+                  LiteralStringText@1028..1029 "c"
+                  DoubleQuote@1029..1030 "\""
+              Whitespace@1030..1043 "\n            "
+              CloseBrace@1043..1044 "}"
+          Whitespace@1044..1057 "\n            "
+          LiteralInputItemNode@1057..1172
+            Ident@1057..1060 "baz"
+            Dot@1060..1061 "."
+            Ident@1061..1064 "bar"
+            Dot@1064..1065 "."
+            Ident@1065..1068 "qux"
+            Colon@1068..1069 ":"
+            Whitespace@1069..1070 " "
+            LiteralHintsNode@1070..1172
+              HintsKeyword@1070..1075 "hints"
+              Whitespace@1075..1076 " "
+              OpenBrace@1076..1077 "{"
+              Whitespace@1077..1094 "\n                "
+              LiteralHintsItemNode@1094..1104
+                Ident@1094..1097 "foo"
+                Colon@1097..1098 ":"
+                Whitespace@1098..1099 " "
+                LiteralStringNode@1099..1104
+                  DoubleQuote@1099..1100 "\""
+                  LiteralStringText@1100..1103 "foo"
+                  DoubleQuote@1103..1104 "\""
+              Whitespace@1104..1121 "\n                "
+              LiteralHintsItemNode@1121..1131
+                Ident@1121..1124 "bar"
+                Colon@1124..1125 ":"
+                Whitespace@1125..1126 " "
+                LiteralStringNode@1126..1131
+                  DoubleQuote@1126..1127 "\""
+                  LiteralStringText@1127..1130 "bar"
+                  DoubleQuote@1130..1131 "\""
+              Whitespace@1131..1148 "\n                "
+              LiteralHintsItemNode@1148..1158
+                Ident@1148..1151 "baz"
+                Colon@1151..1152 ":"
+                Whitespace@1152..1153 " "
+                LiteralStringNode@1153..1158
+                  DoubleQuote@1153..1154 "\""
+                  LiteralStringText@1154..1157 "baz"
+                  DoubleQuote@1157..1158 "\""
+              Whitespace@1158..1171 "\n            "
+              CloseBrace@1171..1172 "}"
+          Whitespace@1172..1181 "\n        "
+          CloseBrace@1181..1182 "}"
+      Whitespace@1182..1191 "\n        "
+      HintsItemNode@1191..1199
+        Ident@1191..1192 "c"
+        Colon@1192..1193 ":"
+        Whitespace@1193..1194 " "
+        LiteralStringNode@1194..1199
+          DoubleQuote@1194..1195 "\""
+          LiteralStringText@1195..1198 "foo"
+          DoubleQuote@1198..1199 "\""
+      Whitespace@1199..1208 "\n        "
+      HintsItemNode@1208..1212
+        Ident@1208..1209 "d"
+        Colon@1209..1210 ":"
+        Whitespace@1210..1211 " "
+        LiteralIntegerNode@1211..1212
+          Integer@1211..1212 "1"
+      Whitespace@1212..1221 "\n        "
+      HintsItemNode@1221..1484
+        Ident@1221..1228 "outputs"
+        Colon@1228..1229 ":"
+        Whitespace@1229..1230 " "
+        LiteralOutputNode@1230..1484
+          OutputKeyword@1230..1236 "output"
+          Whitespace@1236..1237 " "
+          OpenBrace@1237..1238 "{"
+          Whitespace@1238..1251 "\n            "
+          LiteralOutputItemNode@1251..1346
+            Ident@1251..1254 "foo"
+            Colon@1254..1255 ":"
+            Whitespace@1255..1256 " "
+            LiteralHintsNode@1256..1346
+              HintsKeyword@1256..1261 "hints"
+              Whitespace@1261..1262 " "
+              OpenBrace@1262..1263 "{"
+              Whitespace@1263..1280 "\n                "
+              LiteralHintsItemNode@1280..1286
+                Ident@1280..1281 "a"
+                Colon@1281..1282 ":"
+                Whitespace@1282..1283 " "
+                LiteralStringNode@1283..1286
+                  DoubleQuote@1283..1284 "\""
+                  LiteralStringText@1284..1285 "a"
+                  DoubleQuote@1285..1286 "\""
+              Whitespace@1286..1303 "\n                "
+              LiteralHintsItemNode@1303..1309
+                Ident@1303..1304 "b"
+                Colon@1304..1305 ":"
+                Whitespace@1305..1306 " "
+                LiteralStringNode@1306..1309
+                  DoubleQuote@1306..1307 "\""
+                  LiteralStringText@1307..1308 "b"
+                  DoubleQuote@1308..1309 "\""
+              Whitespace@1309..1326 "\n                "
+              LiteralHintsItemNode@1326..1332
+                Ident@1326..1327 "c"
+                Colon@1327..1328 ":"
+                Whitespace@1328..1329 " "
+                LiteralStringNode@1329..1332
+                  DoubleQuote@1329..1330 "\""
+                  LiteralStringText@1330..1331 "c"
+                  DoubleQuote@1331..1332 "\""
+              Whitespace@1332..1345 "\n            "
+              CloseBrace@1345..1346 "}"
+          Whitespace@1346..1359 "\n            "
+          LiteralOutputItemNode@1359..1474
+            Ident@1359..1362 "baz"
+            Dot@1362..1363 "."
+            Ident@1363..1366 "bar"
+            Dot@1366..1367 "."
+            Ident@1367..1370 "qux"
+            Colon@1370..1371 ":"
+            Whitespace@1371..1372 " "
+            LiteralHintsNode@1372..1474
+              HintsKeyword@1372..1377 "hints"
+              Whitespace@1377..1378 " "
+              OpenBrace@1378..1379 "{"
+              Whitespace@1379..1396 "\n                "
+              LiteralHintsItemNode@1396..1406
+                Ident@1396..1399 "foo"
+                Colon@1399..1400 ":"
+                Whitespace@1400..1401 " "
+                LiteralStringNode@1401..1406
+                  DoubleQuote@1401..1402 "\""
+                  LiteralStringText@1402..1405 "foo"
+                  DoubleQuote@1405..1406 "\""
+              Whitespace@1406..1423 "\n                "
+              LiteralHintsItemNode@1423..1433
+                Ident@1423..1426 "bar"
+                Colon@1426..1427 ":"
+                Whitespace@1427..1428 " "
+                LiteralStringNode@1428..1433
+                  DoubleQuote@1428..1429 "\""
+                  LiteralStringText@1429..1432 "bar"
+                  DoubleQuote@1432..1433 "\""
+              Whitespace@1433..1450 "\n                "
+              LiteralHintsItemNode@1450..1460
+                Ident@1450..1453 "baz"
+                Colon@1453..1454 ":"
+                Whitespace@1454..1455 " "
+                LiteralStringNode@1455..1460
+                  DoubleQuote@1455..1456 "\""
+                  LiteralStringText@1456..1459 "baz"
+                  DoubleQuote@1459..1460 "\""
+              Whitespace@1460..1473 "\n            "
+              CloseBrace@1473..1474 "}"
+          Whitespace@1474..1483 "\n        "
+          CloseBrace@1483..1484 "}"
+      Whitespace@1484..1489 "\n    "
+      CloseBrace@1489..1490 "}"
+    Whitespace@1490..1491 "\n"
+    CloseBrace@1491..1492 "}"
+  Whitespace@1492..1493 "\n"

--- a/wdl-grammar/tests/parsing/hints-section/source.wdl
+++ b/wdl-grammar/tests/parsing/hints-section/source.wdl
@@ -1,0 +1,77 @@
+## This is a test of parsing task hints sections.
+
+version 1.2
+
+task foo {
+    hints {
+        a: hints {
+            a: "a"
+            b: 1
+            c: 1.0
+            d: [1, 2, 3]
+        }
+        inputs: input {
+            foo: hints {
+                a: "a"
+                b: "b"
+                c: "c"
+            }
+            baz.bar.qux: hints {
+                foo: "foo"
+                bar: "bar"
+                baz: "baz"
+            }
+        }
+        c: "foo"
+        d: 1
+        outputs: output {
+            foo: hints {
+                a: "a"
+                b: "b"
+                c: "c"
+            }
+            baz.bar.qux: hints {
+                foo: "foo"
+                bar: "bar"
+                baz: "baz"
+            }
+        }
+    }
+}
+
+workflow bar {
+    hints {
+        a: hints {
+            a: "a"
+            b: 1
+            c: 1.0
+            d: [1, 2, 3]
+        }
+        inputs: input {
+            foo: hints {
+                a: "a"
+                b: "b"
+                c: "c"
+            }
+            baz.bar.qux: hints {
+                foo: "foo"
+                bar: "bar"
+                baz: "baz"
+            }
+        }
+        c: "foo"
+        d: 1
+        outputs: output {
+            foo: hints {
+                a: "a"
+                b: "b"
+                c: "c"
+            }
+            baz.bar.qux: hints {
+                foo: "foo"
+                bar: "bar"
+                baz: "baz"
+            }
+        }
+    }
+}

--- a/wdl-lint/src/visitor.rs
+++ b/wdl-lint/src/visitor.rs
@@ -326,6 +326,17 @@ impl Visitor for LintVisitor {
         });
     }
 
+    fn hints_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &v1::HintsSection,
+    ) {
+        self.each_enabled_rule(state, reason, section.syntax(), |state, rule| {
+            rule.hints_section(state, reason, section)
+        });
+    }
+
     fn runtime_section(
         &mut self,
         state: &mut Self::State,


### PR DESCRIPTION
This commit implements `hints` sections from WDL 1.2.

Unlike `runtime` sections, a `hints` section also introduces three scoped types: `hints`, `input`, and `output`; each of these have matching literal expressions which can only be used in the context of a `hints` section.

Additionally, this commit introduces the restriction of reserved names on tasks, workflows, import aliases, call aliases, structs, and struct aliases.

Reserved names are still allowed as struct members and input and output items and also in name reference expressions.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
