### PR TITLE
feat: implement multi-line strings from WDL 1.2. 

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for multi-line strings in WDL 1.2 ([#123](https://github.com/stjude-rust-labs/wdl/pull/123)).
 * Add support for `hints` sections in WDL 1.2 ([#121](https://github.com/stjude-rust-labs/wdl/pull/121)).
 * Add support for `requirements` sections in WDL 1.2 ([#117](https://github.com/stjude-rust-labs/wdl/pull/117)).
 * Add support for the exponentiation operator in WDL 1.2 ([#111](https://github.com/stjude-rust-labs/wdl/pull/111)).

--- a/wdl-ast/src/validation/strings.rs
+++ b/wdl-ast/src/validation/strings.rs
@@ -146,6 +146,8 @@ impl Visitor for LiteralTextVisitor {
             .expect("node should cast");
         match string.kind() {
             LiteralStringKind::SingleQuoted | LiteralStringKind::DoubleQuoted => {
+                // Check the text of a normal string to ensure escape sequences are correct and
+                // characters that are required to be escaped are actually escaped.
                 check_text(
                     state,
                     text.syntax().text_range().start().into(),
@@ -153,7 +155,11 @@ impl Visitor for LiteralTextVisitor {
                 );
             }
             LiteralStringKind::Multiline => {
-                // Don't check the text of multiline strings
+                // Don't check the text of multiline strings as they are treated
+                // like commands where almost all of the text is literal and the
+                // only escape is escaping the closing `>>>`; the only
+                // difference between a multiline string and a command is how
+                // line continuation whitespace is normalized.
             }
         }
     }

--- a/wdl-ast/tests/validation/multiline-strings-unsupported/source.errors
+++ b/wdl-ast/tests/validation/multiline-strings-unsupported/source.errors
@@ -1,0 +1,12 @@
+error: use of multi-line strings requires WDL version 1.2
+   ┌─ tests/validation/multiline-strings-unsupported/source.wdl:11:14
+   │
+11 │         foo: <<< not supported! >>>
+   │              ^^^^^^^^^^^^^^^^^^^^^^
+
+error: use of multi-line strings requires WDL version 1.2
+   ┌─ tests/validation/multiline-strings-unsupported/source.wdl:14:16
+   │
+14 │     String x = <<< not supported! >>>
+   │                ^^^^^^^^^^^^^^^^^^^^^^
+

--- a/wdl-ast/tests/validation/multiline-strings-unsupported/source.wdl
+++ b/wdl-ast/tests/validation/multiline-strings-unsupported/source.wdl
@@ -1,0 +1,15 @@
+## This is a test of detecting unsupported multi-line strings.
+
+version 1.1
+
+task foo {
+    command <<<>>>
+}
+
+workflow test {
+    meta {
+        foo: <<< not supported! >>>
+    }
+
+    String x = <<< not supported! >>>
+}

--- a/wdl-ast/tests/validation/multiline-strings/source.wdl
+++ b/wdl-ast/tests/validation/multiline-strings/source.wdl
@@ -6,7 +6,7 @@ version 1.2
 workflow ok {
     String ok = <<<
         This is a multi-line string.
-        It may contain either ${<<<dollar>>>} or ${"tilde"} placeholders.
+        It may contain either ${<<<dollar>>>} or ~{"tilde"} placeholders.
         It may contain line continuations \
         And escaped endings \>>>.
     >>>

--- a/wdl-ast/tests/validation/multiline-strings/source.wdl
+++ b/wdl-ast/tests/validation/multiline-strings/source.wdl
@@ -1,0 +1,13 @@
+## This is a test of multi-line strings from WDL 1.2
+## There should be no diagnostics for this test.
+
+version 1.2
+
+workflow ok {
+    String ok = <<<
+        This is a multi-line string.
+        It may contain either ${<<<dollar>>>} or ${"tilde"} placeholders.
+        It may contain line continuations \
+        And escaped endings \>>>.
+    >>>
+}

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for multi-line strings in WDL 1.2 ([#123](https://github.com/stjude-rust-labs/wdl/pull/123)).
 * Add support for `hints` sections in WDL 1.2 ([#121](https://github.com/stjude-rust-labs/wdl/pull/121)).
 * Add support for `requirements` sections in WDL 1.2 ([#117](https://github.com/stjude-rust-labs/wdl/pull/117)).
 * Add support for the exponentiation operator in WDL 1.2 ([#111](https://github.com/stjude-rust-labs/wdl/pull/111)).

--- a/wdl-grammar/src/parser.rs
+++ b/wdl-grammar/src/parser.rs
@@ -112,9 +112,22 @@ pub(crate) fn unterminated_string(span: Span) -> Diagnostic {
         .with_label("this quote is not matched", span)
 }
 
-/// Creates an "unterminated command" diagnostic error.
-pub(crate) fn unterminated_command(opening: &str, span: Span) -> Diagnostic {
-    Diagnostic::error("an unterminated command was encountered")
+/// Creates an "unterminated heredoc" diagnostic error.
+pub(crate) fn unterminated_heredoc(opening: &str, span: Span, command: bool) -> Diagnostic {
+    Diagnostic::error(format!(
+        "an unterminated {kind} was encountered",
+        kind = if command {
+            "heredoc command"
+        } else {
+            "multi-line string"
+        }
+    ))
+    .with_label(format!("this {opening} is not matched"), span)
+}
+
+/// Creates an "unterminated braced command" diagnostic error.
+pub(crate) fn unterminated_braced_command(opening: &str, span: Span) -> Diagnostic {
+    Diagnostic::error("an unterminated braced command was encountered")
         .with_label(format!("this {opening} is not matched"), span)
 }
 

--- a/wdl-grammar/tests/parsing/metadata/source.tree
+++ b/wdl-grammar/tests/parsing/metadata/source.tree
@@ -1,4 +1,4 @@
-RootNode@0..2459
+RootNode@0..3160
   Comment@0..64 "# This is a test of p ..."
   Whitespace@64..66 "\n\n"
   VersionStatementNode@66..77
@@ -6,14 +6,14 @@ RootNode@0..2459
     Whitespace@73..74 " "
     Version@74..77 "1.1"
   Whitespace@77..79 "\n\n"
-  TaskDefinitionNode@79..1267
+  TaskDefinitionNode@79..1618
     TaskKeyword@79..83 "task"
     Whitespace@83..84 " "
     Ident@84..88 "test"
     Whitespace@88..89 " "
     OpenBrace@89..90 "{"
     Whitespace@90..95 "\n    "
-    MetadataSectionNode@95..670
+    MetadataSectionNode@95..846
       MetaKeyword@95..99 "meta"
       Whitespace@99..100 " "
       OpenBrace@100..101 "{"
@@ -253,746 +253,854 @@ RootNode@0..2459
             CloseBrace@653..654 "}"
           Whitespace@654..663 "\n        "
           CloseBracket@663..664 "]"
-      Whitespace@664..669 "\n    "
-      CloseBrace@669..670 "}"
-    Whitespace@670..680 "\n    \n    "
-    ParameterMetadataSectionNode@680..1265
-      ParameterMetaKeyword@680..694 "parameter_meta"
-      Whitespace@694..695 " "
-      OpenBrace@695..696 "{"
-      Whitespace@696..705 "\n        "
-      MetadataObjectItemNode@705..715
-        Ident@705..706 "a"
-        Colon@706..707 ":"
-        Whitespace@707..708 " "
-        LiteralStringNode@708..715
-          DoubleQuote@708..709 "\""
-          LiteralStringText@709..714 "hello"
-          DoubleQuote@714..715 "\""
-      Whitespace@715..724 "\n        "
-      MetadataObjectItemNode@724..734
-        Ident@724..725 "b"
-        Colon@725..726 ":"
-        Whitespace@726..727 " "
-        LiteralStringNode@727..734
-          SingleQuote@727..728 "'"
-          LiteralStringText@728..733 "world"
-          SingleQuote@733..734 "'"
-      Whitespace@734..743 "\n        "
-      MetadataObjectItemNode@743..747
-        Ident@743..744 "c"
-        Colon@744..745 ":"
-        Whitespace@745..746 " "
-        LiteralIntegerNode@746..747
-          Integer@746..747 "5"
-      Whitespace@747..756 "\n        "
-      MetadataObjectItemNode@756..763
-        Ident@756..757 "d"
-        Colon@757..758 ":"
-        Whitespace@758..759 " "
-        LiteralIntegerNode@759..763
-          Minus@759..760 "-"
-          Integer@760..763 "0xf"
-      Whitespace@763..772 "\n        "
-      MetadataObjectItemNode@772..781
-        Ident@772..773 "e"
-        Colon@773..774 ":"
-        Whitespace@774..775 " "
-        LiteralFloatNode@775..781
-          Float@775..781 "1.0e10"
-      Whitespace@781..790 "\n        "
-      MetadataObjectItemNode@790..796
-        Ident@790..791 "f"
-        Colon@791..792 ":"
-        Whitespace@792..793 " "
-        LiteralFloatNode@793..796
-          Minus@793..794 "-"
-          Float@794..796 "2."
-      Whitespace@796..805 "\n        "
-      MetadataObjectItemNode@805..812
-        Ident@805..806 "g"
-        Colon@806..807 ":"
-        Whitespace@807..808 " "
-        LiteralBooleanNode@808..812
-          TrueKeyword@808..812 "true"
-      Whitespace@812..821 "\n        "
-      MetadataObjectItemNode@821..829
-        Ident@821..822 "h"
-        Colon@822..823 ":"
-        Whitespace@823..824 " "
-        LiteralBooleanNode@824..829
-          FalseKeyword@824..829 "false"
-      Whitespace@829..838 "\n        "
-      MetadataObjectItemNode@838..845
-        Ident@838..839 "i"
-        Colon@839..840 ":"
-        Whitespace@840..841 " "
-        LiteralNullNode@841..845
-          NullKeyword@841..845 "null"
-      Whitespace@845..854 "\n        "
-      MetadataObjectItemNode@854..1030
-        Ident@854..855 "j"
-        Colon@855..856 ":"
-        Whitespace@856..857 " "
-        MetadataObjectNode@857..1030
-          OpenBrace@857..858 "{"
-          Whitespace@858..871 "\n            "
-          MetadataObjectItemNode@871..883
-            Ident@871..872 "a"
-            Colon@872..873 ":"
-            Whitespace@873..874 " "
-            MetadataArrayNode@874..883
-              OpenBracket@874..875 "["
-              LiteralIntegerNode@875..876
-                Integer@875..876 "1"
-              Comma@876..877 ","
-              Whitespace@877..878 " "
-              LiteralIntegerNode@878..879
-                Integer@878..879 "2"
-              Comma@879..880 ","
-              Whitespace@880..881 " "
-              LiteralIntegerNode@881..882
-                Integer@881..882 "3"
-              CloseBracket@882..883 "]"
-          Comma@883..884 ","
-          Whitespace@884..897 "\n            "
-          MetadataObjectItemNode@897..923
-            Ident@897..898 "b"
-            Colon@898..899 ":"
-            Whitespace@899..900 " "
-            MetadataArrayNode@900..923
-              OpenBracket@900..901 "["
-              LiteralStringNode@901..908
-                DoubleQuote@901..902 "\""
-                LiteralStringText@902..907 "hello"
-                DoubleQuote@907..908 "\""
-              Comma@908..909 ","
-              Whitespace@909..910 " "
-              LiteralStringNode@910..917
-                DoubleQuote@910..911 "\""
-                LiteralStringText@911..916 "world"
-                DoubleQuote@916..917 "\""
-              Comma@917..918 ","
-              Whitespace@918..919 " "
-              LiteralStringNode@919..922
-                DoubleQuote@919..920 "\""
-                LiteralStringText@920..921 "!"
-                DoubleQuote@921..922 "\""
-              CloseBracket@922..923 "]"
-          Comma@923..924 ","
-          Whitespace@924..937 "\n            "
-          MetadataObjectItemNode@937..1020
-            Ident@937..938 "c"
-            Colon@938..939 ":"
-            Whitespace@939..940 " "
-            MetadataObjectNode@940..1020
-              OpenBrace@940..941 "{"
-              Whitespace@941..958 "\n                "
-              MetadataObjectItemNode@958..962
-                Ident@958..959 "x"
-                Colon@959..960 ":"
-                Whitespace@960..961 " "
-                LiteralIntegerNode@961..962
-                  Integer@961..962 "1"
-              Comma@962..963 ","
-              Whitespace@963..980 "\n                "
-              MetadataObjectItemNode@980..984
-                Ident@980..981 "y"
-                Colon@981..982 ":"
-                Whitespace@982..983 " "
-                LiteralIntegerNode@983..984
-                  Integer@983..984 "2"
-              Comma@984..985 ","
-              Whitespace@985..1002 "\n                "
-              MetadataObjectItemNode@1002..1006
-                Ident@1002..1003 "z"
-                Colon@1003..1004 ":"
-                Whitespace@1004..1005 " "
-                LiteralIntegerNode@1005..1006
-                  Integer@1005..1006 "3"
-              Whitespace@1006..1019 "\n            "
-              CloseBrace@1019..1020 "}"
-          Whitespace@1020..1029 "\n        "
-          CloseBrace@1029..1030 "}"
-      Whitespace@1030..1039 "\n        "
-      MetadataObjectItemNode@1039..1259
-        Ident@1039..1040 "k"
-        Colon@1040..1041 ":"
-        Whitespace@1041..1042 " "
-        MetadataArrayNode@1042..1259
-          OpenBracket@1042..1043 "["
-          Whitespace@1043..1056 "\n            "
-          MetadataObjectNode@1056..1185
-            OpenBrace@1056..1057 "{"
-            Whitespace@1057..1074 "\n                "
-            MetadataObjectItemNode@1074..1079
-              Ident@1074..1075 "a"
-              Colon@1075..1076 ":"
-              Whitespace@1076..1077 " "
-              MetadataObjectNode@1077..1079
-                OpenBrace@1077..1078 "{"
-                CloseBrace@1078..1079 "}"
-            Comma@1079..1080 ","
-            Whitespace@1080..1097 "\n                "
-            MetadataObjectItemNode@1097..1101
-              Ident@1097..1098 "b"
-              Colon@1098..1099 ":"
-              Whitespace@1099..1100 " "
-              LiteralIntegerNode@1100..1101
-                Integer@1100..1101 "0"
-            Comma@1101..1102 ","
-            Whitespace@1102..1119 "\n                "
-            MetadataObjectItemNode@1119..1124
-              Ident@1119..1120 "c"
-              Colon@1120..1121 ":"
-              Whitespace@1121..1122 " "
-              LiteralStringNode@1122..1124
-                DoubleQuote@1122..1123 "\""
-                DoubleQuote@1123..1124 "\""
-            Comma@1124..1125 ","
-            Whitespace@1125..1142 "\n                "
-            MetadataObjectItemNode@1142..1147
-              Ident@1142..1143 "d"
-              Colon@1143..1144 ":"
-              Whitespace@1144..1145 " "
-              LiteralStringNode@1145..1147
-                SingleQuote@1145..1146 "'"
-                SingleQuote@1146..1147 "'"
-            Comma@1147..1148 ","
-            Whitespace@1148..1165 "\n                "
-            MetadataObjectItemNode@1165..1170
-              Ident@1165..1166 "e"
-              Colon@1166..1167 ":"
-              Whitespace@1167..1168 " "
-              MetadataArrayNode@1168..1170
-                OpenBracket@1168..1169 "["
-                CloseBracket@1169..1170 "]"
-            Comma@1170..1171 ","
-            Whitespace@1171..1184 "\n            "
-            CloseBrace@1184..1185 "}"
-          Comma@1185..1186 ","
-          Whitespace@1186..1199 "\n            "
-          MetadataObjectNode@1199..1249
-            OpenBrace@1199..1200 "{"
-            Whitespace@1200..1217 "\n                "
-            MetadataObjectItemNode@1217..1235
-              Ident@1217..1218 "x"
-              Colon@1218..1219 ":"
-              Whitespace@1219..1220 " "
-              MetadataArrayNode@1220..1235
-                OpenBracket@1220..1221 "["
-                LiteralFloatNode@1221..1224
-                  Float@1221..1224 "1.0"
-                Comma@1224..1225 ","
-                Whitespace@1225..1226 " "
-                LiteralFloatNode@1226..1229
-                  Float@1226..1229 "2.0"
-                Comma@1229..1230 ","
-                Whitespace@1230..1231 " "
-                LiteralFloatNode@1231..1234
-                  Float@1231..1234 "3.0"
-                CloseBracket@1234..1235 "]"
-            Whitespace@1235..1248 "\n            "
-            CloseBrace@1248..1249 "}"
-          Whitespace@1249..1258 "\n        "
-          CloseBracket@1258..1259 "]"
-      Whitespace@1259..1264 "\n    "
-      CloseBrace@1264..1265 "}"
-    Whitespace@1265..1266 "\n"
-    CloseBrace@1266..1267 "}"
-  Whitespace@1267..1269 "\n\n"
-  WorkflowDefinitionNode@1269..2458
-    WorkflowKeyword@1269..1277 "workflow"
-    Whitespace@1277..1278 " "
-    Ident@1278..1279 "w"
-    Whitespace@1279..1280 " "
-    OpenBrace@1280..1281 "{"
-    Whitespace@1281..1286 "\n    "
-    MetadataSectionNode@1286..1861
-      MetaKeyword@1286..1290 "meta"
-      Whitespace@1290..1291 " "
-      OpenBrace@1291..1292 "{"
-      Whitespace@1292..1301 "\n        "
-      MetadataObjectItemNode@1301..1311
-        Ident@1301..1302 "a"
-        Colon@1302..1303 ":"
-        Whitespace@1303..1304 " "
-        LiteralStringNode@1304..1311
-          DoubleQuote@1304..1305 "\""
-          LiteralStringText@1305..1310 "hello"
-          DoubleQuote@1310..1311 "\""
-      Whitespace@1311..1320 "\n        "
-      MetadataObjectItemNode@1320..1330
-        Ident@1320..1321 "b"
-        Colon@1321..1322 ":"
-        Whitespace@1322..1323 " "
-        LiteralStringNode@1323..1330
-          SingleQuote@1323..1324 "'"
-          LiteralStringText@1324..1329 "world"
-          SingleQuote@1329..1330 "'"
-      Whitespace@1330..1339 "\n        "
-      MetadataObjectItemNode@1339..1343
-        Ident@1339..1340 "c"
-        Colon@1340..1341 ":"
-        Whitespace@1341..1342 " "
-        LiteralIntegerNode@1342..1343
-          Integer@1342..1343 "5"
-      Whitespace@1343..1352 "\n        "
-      MetadataObjectItemNode@1352..1359
-        Ident@1352..1353 "d"
-        Colon@1353..1354 ":"
-        Whitespace@1354..1355 " "
-        LiteralIntegerNode@1355..1359
-          Minus@1355..1356 "-"
-          Integer@1356..1359 "0xf"
-      Whitespace@1359..1368 "\n        "
-      MetadataObjectItemNode@1368..1377
-        Ident@1368..1369 "e"
-        Colon@1369..1370 ":"
-        Whitespace@1370..1371 " "
-        LiteralFloatNode@1371..1377
-          Float@1371..1377 "1.0e10"
-      Whitespace@1377..1386 "\n        "
-      MetadataObjectItemNode@1386..1392
-        Ident@1386..1387 "f"
-        Colon@1387..1388 ":"
-        Whitespace@1388..1389 " "
-        LiteralFloatNode@1389..1392
-          Minus@1389..1390 "-"
-          Float@1390..1392 "2."
-      Whitespace@1392..1401 "\n        "
-      MetadataObjectItemNode@1401..1408
-        Ident@1401..1402 "g"
-        Colon@1402..1403 ":"
-        Whitespace@1403..1404 " "
-        LiteralBooleanNode@1404..1408
-          TrueKeyword@1404..1408 "true"
-      Whitespace@1408..1417 "\n        "
-      MetadataObjectItemNode@1417..1425
-        Ident@1417..1418 "h"
-        Colon@1418..1419 ":"
-        Whitespace@1419..1420 " "
-        LiteralBooleanNode@1420..1425
-          FalseKeyword@1420..1425 "false"
-      Whitespace@1425..1434 "\n        "
-      MetadataObjectItemNode@1434..1441
-        Ident@1434..1435 "i"
-        Colon@1435..1436 ":"
-        Whitespace@1436..1437 " "
-        LiteralNullNode@1437..1441
-          NullKeyword@1437..1441 "null"
-      Whitespace@1441..1450 "\n        "
-      MetadataObjectItemNode@1450..1626
-        Ident@1450..1451 "j"
-        Colon@1451..1452 ":"
-        Whitespace@1452..1453 " "
-        MetadataObjectNode@1453..1626
-          OpenBrace@1453..1454 "{"
-          Whitespace@1454..1467 "\n            "
-          MetadataObjectItemNode@1467..1479
-            Ident@1467..1468 "a"
-            Colon@1468..1469 ":"
-            Whitespace@1469..1470 " "
-            MetadataArrayNode@1470..1479
-              OpenBracket@1470..1471 "["
-              LiteralIntegerNode@1471..1472
-                Integer@1471..1472 "1"
-              Comma@1472..1473 ","
-              Whitespace@1473..1474 " "
-              LiteralIntegerNode@1474..1475
-                Integer@1474..1475 "2"
-              Comma@1475..1476 ","
-              Whitespace@1476..1477 " "
-              LiteralIntegerNode@1477..1478
-                Integer@1477..1478 "3"
-              CloseBracket@1478..1479 "]"
-          Comma@1479..1480 ","
-          Whitespace@1480..1493 "\n            "
-          MetadataObjectItemNode@1493..1519
-            Ident@1493..1494 "b"
-            Colon@1494..1495 ":"
-            Whitespace@1495..1496 " "
-            MetadataArrayNode@1496..1519
-              OpenBracket@1496..1497 "["
-              LiteralStringNode@1497..1504
-                DoubleQuote@1497..1498 "\""
-                LiteralStringText@1498..1503 "hello"
-                DoubleQuote@1503..1504 "\""
-              Comma@1504..1505 ","
-              Whitespace@1505..1506 " "
-              LiteralStringNode@1506..1513
-                DoubleQuote@1506..1507 "\""
-                LiteralStringText@1507..1512 "world"
-                DoubleQuote@1512..1513 "\""
-              Comma@1513..1514 ","
-              Whitespace@1514..1515 " "
-              LiteralStringNode@1515..1518
-                DoubleQuote@1515..1516 "\""
-                LiteralStringText@1516..1517 "!"
-                DoubleQuote@1517..1518 "\""
-              CloseBracket@1518..1519 "]"
-          Comma@1519..1520 ","
-          Whitespace@1520..1533 "\n            "
-          MetadataObjectItemNode@1533..1616
-            Ident@1533..1534 "c"
-            Colon@1534..1535 ":"
-            Whitespace@1535..1536 " "
-            MetadataObjectNode@1536..1616
-              OpenBrace@1536..1537 "{"
-              Whitespace@1537..1554 "\n                "
-              MetadataObjectItemNode@1554..1558
-                Ident@1554..1555 "x"
-                Colon@1555..1556 ":"
-                Whitespace@1556..1557 " "
-                LiteralIntegerNode@1557..1558
-                  Integer@1557..1558 "1"
-              Comma@1558..1559 ","
-              Whitespace@1559..1576 "\n                "
-              MetadataObjectItemNode@1576..1580
-                Ident@1576..1577 "y"
-                Colon@1577..1578 ":"
-                Whitespace@1578..1579 " "
-                LiteralIntegerNode@1579..1580
-                  Integer@1579..1580 "2"
-              Comma@1580..1581 ","
-              Whitespace@1581..1598 "\n                "
-              MetadataObjectItemNode@1598..1602
-                Ident@1598..1599 "z"
-                Colon@1599..1600 ":"
-                Whitespace@1600..1601 " "
-                LiteralIntegerNode@1601..1602
-                  Integer@1601..1602 "3"
-              Whitespace@1602..1615 "\n            "
-              CloseBrace@1615..1616 "}"
-          Whitespace@1616..1625 "\n        "
-          CloseBrace@1625..1626 "}"
-      Whitespace@1626..1635 "\n        "
-      MetadataObjectItemNode@1635..1855
-        Ident@1635..1636 "k"
-        Colon@1636..1637 ":"
-        Whitespace@1637..1638 " "
-        MetadataArrayNode@1638..1855
-          OpenBracket@1638..1639 "["
-          Whitespace@1639..1652 "\n            "
-          MetadataObjectNode@1652..1781
-            OpenBrace@1652..1653 "{"
-            Whitespace@1653..1670 "\n                "
-            MetadataObjectItemNode@1670..1675
-              Ident@1670..1671 "a"
-              Colon@1671..1672 ":"
-              Whitespace@1672..1673 " "
-              MetadataObjectNode@1673..1675
-                OpenBrace@1673..1674 "{"
-                CloseBrace@1674..1675 "}"
-            Comma@1675..1676 ","
-            Whitespace@1676..1693 "\n                "
-            MetadataObjectItemNode@1693..1697
-              Ident@1693..1694 "b"
-              Colon@1694..1695 ":"
-              Whitespace@1695..1696 " "
-              LiteralIntegerNode@1696..1697
-                Integer@1696..1697 "0"
-            Comma@1697..1698 ","
-            Whitespace@1698..1715 "\n                "
-            MetadataObjectItemNode@1715..1720
-              Ident@1715..1716 "c"
-              Colon@1716..1717 ":"
-              Whitespace@1717..1718 " "
-              LiteralStringNode@1718..1720
-                DoubleQuote@1718..1719 "\""
-                DoubleQuote@1719..1720 "\""
-            Comma@1720..1721 ","
-            Whitespace@1721..1738 "\n                "
-            MetadataObjectItemNode@1738..1743
-              Ident@1738..1739 "d"
-              Colon@1739..1740 ":"
-              Whitespace@1740..1741 " "
-              LiteralStringNode@1741..1743
-                SingleQuote@1741..1742 "'"
-                SingleQuote@1742..1743 "'"
-            Comma@1743..1744 ","
-            Whitespace@1744..1761 "\n                "
-            MetadataObjectItemNode@1761..1766
-              Ident@1761..1762 "e"
-              Colon@1762..1763 ":"
-              Whitespace@1763..1764 " "
-              MetadataArrayNode@1764..1766
-                OpenBracket@1764..1765 "["
-                CloseBracket@1765..1766 "]"
-            Comma@1766..1767 ","
-            Whitespace@1767..1780 "\n            "
-            CloseBrace@1780..1781 "}"
-          Comma@1781..1782 ","
-          Whitespace@1782..1795 "\n            "
-          MetadataObjectNode@1795..1845
-            OpenBrace@1795..1796 "{"
-            Whitespace@1796..1813 "\n                "
-            MetadataObjectItemNode@1813..1831
-              Ident@1813..1814 "x"
-              Colon@1814..1815 ":"
-              Whitespace@1815..1816 " "
-              MetadataArrayNode@1816..1831
-                OpenBracket@1816..1817 "["
-                LiteralFloatNode@1817..1820
-                  Float@1817..1820 "1.0"
-                Comma@1820..1821 ","
-                Whitespace@1821..1822 " "
-                LiteralFloatNode@1822..1825
-                  Float@1822..1825 "2.0"
-                Comma@1825..1826 ","
-                Whitespace@1826..1827 " "
-                LiteralFloatNode@1827..1830
-                  Float@1827..1830 "3.0"
-                CloseBracket@1830..1831 "]"
-            Whitespace@1831..1844 "\n            "
-            CloseBrace@1844..1845 "}"
-          Whitespace@1845..1854 "\n        "
-          CloseBracket@1854..1855 "]"
-      Whitespace@1855..1860 "\n    "
-      CloseBrace@1860..1861 "}"
-    Whitespace@1861..1871 "\n    \n    "
-    ParameterMetadataSectionNode@1871..2456
-      ParameterMetaKeyword@1871..1885 "parameter_meta"
-      Whitespace@1885..1886 " "
-      OpenBrace@1886..1887 "{"
-      Whitespace@1887..1896 "\n        "
-      MetadataObjectItemNode@1896..1906
-        Ident@1896..1897 "a"
-        Colon@1897..1898 ":"
-        Whitespace@1898..1899 " "
-        LiteralStringNode@1899..1906
-          DoubleQuote@1899..1900 "\""
-          LiteralStringText@1900..1905 "hello"
-          DoubleQuote@1905..1906 "\""
-      Whitespace@1906..1915 "\n        "
-      MetadataObjectItemNode@1915..1925
-        Ident@1915..1916 "b"
-        Colon@1916..1917 ":"
-        Whitespace@1917..1918 " "
-        LiteralStringNode@1918..1925
-          SingleQuote@1918..1919 "'"
-          LiteralStringText@1919..1924 "world"
-          SingleQuote@1924..1925 "'"
-      Whitespace@1925..1934 "\n        "
-      MetadataObjectItemNode@1934..1938
-        Ident@1934..1935 "c"
-        Colon@1935..1936 ":"
-        Whitespace@1936..1937 " "
-        LiteralIntegerNode@1937..1938
-          Integer@1937..1938 "5"
-      Whitespace@1938..1947 "\n        "
-      MetadataObjectItemNode@1947..1954
-        Ident@1947..1948 "d"
-        Colon@1948..1949 ":"
-        Whitespace@1949..1950 " "
-        LiteralIntegerNode@1950..1954
-          Minus@1950..1951 "-"
-          Integer@1951..1954 "0xf"
-      Whitespace@1954..1963 "\n        "
-      MetadataObjectItemNode@1963..1972
-        Ident@1963..1964 "e"
-        Colon@1964..1965 ":"
-        Whitespace@1965..1966 " "
-        LiteralFloatNode@1966..1972
-          Float@1966..1972 "1.0e10"
-      Whitespace@1972..1981 "\n        "
-      MetadataObjectItemNode@1981..1987
-        Ident@1981..1982 "f"
-        Colon@1982..1983 ":"
-        Whitespace@1983..1984 " "
-        LiteralFloatNode@1984..1987
-          Minus@1984..1985 "-"
-          Float@1985..1987 "2."
-      Whitespace@1987..1996 "\n        "
-      MetadataObjectItemNode@1996..2003
-        Ident@1996..1997 "g"
-        Colon@1997..1998 ":"
-        Whitespace@1998..1999 " "
-        LiteralBooleanNode@1999..2003
-          TrueKeyword@1999..2003 "true"
-      Whitespace@2003..2012 "\n        "
-      MetadataObjectItemNode@2012..2020
-        Ident@2012..2013 "h"
-        Colon@2013..2014 ":"
-        Whitespace@2014..2015 " "
-        LiteralBooleanNode@2015..2020
-          FalseKeyword@2015..2020 "false"
-      Whitespace@2020..2029 "\n        "
-      MetadataObjectItemNode@2029..2036
-        Ident@2029..2030 "i"
-        Colon@2030..2031 ":"
-        Whitespace@2031..2032 " "
-        LiteralNullNode@2032..2036
-          NullKeyword@2032..2036 "null"
-      Whitespace@2036..2045 "\n        "
-      MetadataObjectItemNode@2045..2221
-        Ident@2045..2046 "j"
-        Colon@2046..2047 ":"
-        Whitespace@2047..2048 " "
-        MetadataObjectNode@2048..2221
-          OpenBrace@2048..2049 "{"
-          Whitespace@2049..2062 "\n            "
-          MetadataObjectItemNode@2062..2074
-            Ident@2062..2063 "a"
-            Colon@2063..2064 ":"
-            Whitespace@2064..2065 " "
-            MetadataArrayNode@2065..2074
-              OpenBracket@2065..2066 "["
-              LiteralIntegerNode@2066..2067
-                Integer@2066..2067 "1"
-              Comma@2067..2068 ","
+      Whitespace@664..673 "\n        "
+      MetadataObjectItemNode@673..721
+        Ident@673..674 "x"
+        Colon@674..675 ":"
+        Whitespace@675..676 " "
+        LiteralStringNode@676..721
+          SingleQuote@676..677 "'"
+          LiteralStringText@677..720 "No ~{interpolation} i ..."
+          SingleQuote@720..721 "'"
+      Whitespace@721..730 "\n        "
+      MetadataObjectItemNode@730..778
+        Ident@730..731 "y"
+        Colon@731..732 ":"
+        Whitespace@732..733 " "
+        LiteralStringNode@733..778
+          DoubleQuote@733..734 "\""
+          LiteralStringText@734..777 "No ~{interpolation} i ..."
+          DoubleQuote@777..778 "\""
+      Whitespace@778..787 "\n        "
+      MetadataObjectItemNode@787..839
+        Ident@787..788 "z"
+        Colon@788..789 ":"
+        Whitespace@789..790 " "
+        LiteralStringNode@790..839
+          OpenHeredoc@790..793 "<<<"
+          LiteralStringText@793..836 "No ~{interpolation} i ..."
+          CloseHeredoc@836..839 ">>>"
+      Whitespace@839..845 " \n    "
+      CloseBrace@845..846 "}"
+    Whitespace@846..856 "\n    \n    "
+    ParameterMetadataSectionNode@856..1616
+      ParameterMetaKeyword@856..870 "parameter_meta"
+      Whitespace@870..871 " "
+      OpenBrace@871..872 "{"
+      Whitespace@872..881 "\n        "
+      MetadataObjectItemNode@881..891
+        Ident@881..882 "a"
+        Colon@882..883 ":"
+        Whitespace@883..884 " "
+        LiteralStringNode@884..891
+          DoubleQuote@884..885 "\""
+          LiteralStringText@885..890 "hello"
+          DoubleQuote@890..891 "\""
+      Whitespace@891..900 "\n        "
+      MetadataObjectItemNode@900..910
+        Ident@900..901 "b"
+        Colon@901..902 ":"
+        Whitespace@902..903 " "
+        LiteralStringNode@903..910
+          SingleQuote@903..904 "'"
+          LiteralStringText@904..909 "world"
+          SingleQuote@909..910 "'"
+      Whitespace@910..919 "\n        "
+      MetadataObjectItemNode@919..923
+        Ident@919..920 "c"
+        Colon@920..921 ":"
+        Whitespace@921..922 " "
+        LiteralIntegerNode@922..923
+          Integer@922..923 "5"
+      Whitespace@923..932 "\n        "
+      MetadataObjectItemNode@932..939
+        Ident@932..933 "d"
+        Colon@933..934 ":"
+        Whitespace@934..935 " "
+        LiteralIntegerNode@935..939
+          Minus@935..936 "-"
+          Integer@936..939 "0xf"
+      Whitespace@939..948 "\n        "
+      MetadataObjectItemNode@948..957
+        Ident@948..949 "e"
+        Colon@949..950 ":"
+        Whitespace@950..951 " "
+        LiteralFloatNode@951..957
+          Float@951..957 "1.0e10"
+      Whitespace@957..966 "\n        "
+      MetadataObjectItemNode@966..972
+        Ident@966..967 "f"
+        Colon@967..968 ":"
+        Whitespace@968..969 " "
+        LiteralFloatNode@969..972
+          Minus@969..970 "-"
+          Float@970..972 "2."
+      Whitespace@972..981 "\n        "
+      MetadataObjectItemNode@981..988
+        Ident@981..982 "g"
+        Colon@982..983 ":"
+        Whitespace@983..984 " "
+        LiteralBooleanNode@984..988
+          TrueKeyword@984..988 "true"
+      Whitespace@988..997 "\n        "
+      MetadataObjectItemNode@997..1005
+        Ident@997..998 "h"
+        Colon@998..999 ":"
+        Whitespace@999..1000 " "
+        LiteralBooleanNode@1000..1005
+          FalseKeyword@1000..1005 "false"
+      Whitespace@1005..1014 "\n        "
+      MetadataObjectItemNode@1014..1021
+        Ident@1014..1015 "i"
+        Colon@1015..1016 ":"
+        Whitespace@1016..1017 " "
+        LiteralNullNode@1017..1021
+          NullKeyword@1017..1021 "null"
+      Whitespace@1021..1030 "\n        "
+      MetadataObjectItemNode@1030..1206
+        Ident@1030..1031 "j"
+        Colon@1031..1032 ":"
+        Whitespace@1032..1033 " "
+        MetadataObjectNode@1033..1206
+          OpenBrace@1033..1034 "{"
+          Whitespace@1034..1047 "\n            "
+          MetadataObjectItemNode@1047..1059
+            Ident@1047..1048 "a"
+            Colon@1048..1049 ":"
+            Whitespace@1049..1050 " "
+            MetadataArrayNode@1050..1059
+              OpenBracket@1050..1051 "["
+              LiteralIntegerNode@1051..1052
+                Integer@1051..1052 "1"
+              Comma@1052..1053 ","
+              Whitespace@1053..1054 " "
+              LiteralIntegerNode@1054..1055
+                Integer@1054..1055 "2"
+              Comma@1055..1056 ","
+              Whitespace@1056..1057 " "
+              LiteralIntegerNode@1057..1058
+                Integer@1057..1058 "3"
+              CloseBracket@1058..1059 "]"
+          Comma@1059..1060 ","
+          Whitespace@1060..1073 "\n            "
+          MetadataObjectItemNode@1073..1099
+            Ident@1073..1074 "b"
+            Colon@1074..1075 ":"
+            Whitespace@1075..1076 " "
+            MetadataArrayNode@1076..1099
+              OpenBracket@1076..1077 "["
+              LiteralStringNode@1077..1084
+                DoubleQuote@1077..1078 "\""
+                LiteralStringText@1078..1083 "hello"
+                DoubleQuote@1083..1084 "\""
+              Comma@1084..1085 ","
+              Whitespace@1085..1086 " "
+              LiteralStringNode@1086..1093
+                DoubleQuote@1086..1087 "\""
+                LiteralStringText@1087..1092 "world"
+                DoubleQuote@1092..1093 "\""
+              Comma@1093..1094 ","
+              Whitespace@1094..1095 " "
+              LiteralStringNode@1095..1098
+                DoubleQuote@1095..1096 "\""
+                LiteralStringText@1096..1097 "!"
+                DoubleQuote@1097..1098 "\""
+              CloseBracket@1098..1099 "]"
+          Comma@1099..1100 ","
+          Whitespace@1100..1113 "\n            "
+          MetadataObjectItemNode@1113..1196
+            Ident@1113..1114 "c"
+            Colon@1114..1115 ":"
+            Whitespace@1115..1116 " "
+            MetadataObjectNode@1116..1196
+              OpenBrace@1116..1117 "{"
+              Whitespace@1117..1134 "\n                "
+              MetadataObjectItemNode@1134..1138
+                Ident@1134..1135 "x"
+                Colon@1135..1136 ":"
+                Whitespace@1136..1137 " "
+                LiteralIntegerNode@1137..1138
+                  Integer@1137..1138 "1"
+              Comma@1138..1139 ","
+              Whitespace@1139..1156 "\n                "
+              MetadataObjectItemNode@1156..1160
+                Ident@1156..1157 "y"
+                Colon@1157..1158 ":"
+                Whitespace@1158..1159 " "
+                LiteralIntegerNode@1159..1160
+                  Integer@1159..1160 "2"
+              Comma@1160..1161 ","
+              Whitespace@1161..1178 "\n                "
+              MetadataObjectItemNode@1178..1182
+                Ident@1178..1179 "z"
+                Colon@1179..1180 ":"
+                Whitespace@1180..1181 " "
+                LiteralIntegerNode@1181..1182
+                  Integer@1181..1182 "3"
+              Whitespace@1182..1195 "\n            "
+              CloseBrace@1195..1196 "}"
+          Whitespace@1196..1205 "\n        "
+          CloseBrace@1205..1206 "}"
+      Whitespace@1206..1215 "\n        "
+      MetadataObjectItemNode@1215..1435
+        Ident@1215..1216 "k"
+        Colon@1216..1217 ":"
+        Whitespace@1217..1218 " "
+        MetadataArrayNode@1218..1435
+          OpenBracket@1218..1219 "["
+          Whitespace@1219..1232 "\n            "
+          MetadataObjectNode@1232..1361
+            OpenBrace@1232..1233 "{"
+            Whitespace@1233..1250 "\n                "
+            MetadataObjectItemNode@1250..1255
+              Ident@1250..1251 "a"
+              Colon@1251..1252 ":"
+              Whitespace@1252..1253 " "
+              MetadataObjectNode@1253..1255
+                OpenBrace@1253..1254 "{"
+                CloseBrace@1254..1255 "}"
+            Comma@1255..1256 ","
+            Whitespace@1256..1273 "\n                "
+            MetadataObjectItemNode@1273..1277
+              Ident@1273..1274 "b"
+              Colon@1274..1275 ":"
+              Whitespace@1275..1276 " "
+              LiteralIntegerNode@1276..1277
+                Integer@1276..1277 "0"
+            Comma@1277..1278 ","
+            Whitespace@1278..1295 "\n                "
+            MetadataObjectItemNode@1295..1300
+              Ident@1295..1296 "c"
+              Colon@1296..1297 ":"
+              Whitespace@1297..1298 " "
+              LiteralStringNode@1298..1300
+                DoubleQuote@1298..1299 "\""
+                DoubleQuote@1299..1300 "\""
+            Comma@1300..1301 ","
+            Whitespace@1301..1318 "\n                "
+            MetadataObjectItemNode@1318..1323
+              Ident@1318..1319 "d"
+              Colon@1319..1320 ":"
+              Whitespace@1320..1321 " "
+              LiteralStringNode@1321..1323
+                SingleQuote@1321..1322 "'"
+                SingleQuote@1322..1323 "'"
+            Comma@1323..1324 ","
+            Whitespace@1324..1341 "\n                "
+            MetadataObjectItemNode@1341..1346
+              Ident@1341..1342 "e"
+              Colon@1342..1343 ":"
+              Whitespace@1343..1344 " "
+              MetadataArrayNode@1344..1346
+                OpenBracket@1344..1345 "["
+                CloseBracket@1345..1346 "]"
+            Comma@1346..1347 ","
+            Whitespace@1347..1360 "\n            "
+            CloseBrace@1360..1361 "}"
+          Comma@1361..1362 ","
+          Whitespace@1362..1375 "\n            "
+          MetadataObjectNode@1375..1425
+            OpenBrace@1375..1376 "{"
+            Whitespace@1376..1393 "\n                "
+            MetadataObjectItemNode@1393..1411
+              Ident@1393..1394 "x"
+              Colon@1394..1395 ":"
+              Whitespace@1395..1396 " "
+              MetadataArrayNode@1396..1411
+                OpenBracket@1396..1397 "["
+                LiteralFloatNode@1397..1400
+                  Float@1397..1400 "1.0"
+                Comma@1400..1401 ","
+                Whitespace@1401..1402 " "
+                LiteralFloatNode@1402..1405
+                  Float@1402..1405 "2.0"
+                Comma@1405..1406 ","
+                Whitespace@1406..1407 " "
+                LiteralFloatNode@1407..1410
+                  Float@1407..1410 "3.0"
+                CloseBracket@1410..1411 "]"
+            Whitespace@1411..1424 "\n            "
+            CloseBrace@1424..1425 "}"
+          Whitespace@1425..1434 "\n        "
+          CloseBracket@1434..1435 "]"
+      Whitespace@1435..1444 "\n        "
+      MetadataObjectItemNode@1444..1492
+        Ident@1444..1445 "x"
+        Colon@1445..1446 ":"
+        Whitespace@1446..1447 " "
+        LiteralStringNode@1447..1492
+          SingleQuote@1447..1448 "'"
+          LiteralStringText@1448..1491 "No ~{interpolation} i ..."
+          SingleQuote@1491..1492 "'"
+      Whitespace@1492..1501 "\n        "
+      MetadataObjectItemNode@1501..1549
+        Ident@1501..1502 "y"
+        Colon@1502..1503 ":"
+        Whitespace@1503..1504 " "
+        LiteralStringNode@1504..1549
+          DoubleQuote@1504..1505 "\""
+          LiteralStringText@1505..1548 "No ~{interpolation} i ..."
+          DoubleQuote@1548..1549 "\""
+      Whitespace@1549..1558 "\n        "
+      MetadataObjectItemNode@1558..1610
+        Ident@1558..1559 "z"
+        Colon@1559..1560 ":"
+        Whitespace@1560..1561 " "
+        LiteralStringNode@1561..1610
+          OpenHeredoc@1561..1564 "<<<"
+          LiteralStringText@1564..1607 "No ~{interpolation} i ..."
+          CloseHeredoc@1607..1610 ">>>"
+      Whitespace@1610..1615 "\n    "
+      CloseBrace@1615..1616 "}"
+    Whitespace@1616..1617 "\n"
+    CloseBrace@1617..1618 "}"
+  Whitespace@1618..1620 "\n\n"
+  WorkflowDefinitionNode@1620..3159
+    WorkflowKeyword@1620..1628 "workflow"
+    Whitespace@1628..1629 " "
+    Ident@1629..1630 "w"
+    Whitespace@1630..1631 " "
+    OpenBrace@1631..1632 "{"
+    Whitespace@1632..1637 "\n    "
+    MetadataSectionNode@1637..2387
+      MetaKeyword@1637..1641 "meta"
+      Whitespace@1641..1642 " "
+      OpenBrace@1642..1643 "{"
+      Whitespace@1643..1652 "\n        "
+      MetadataObjectItemNode@1652..1662
+        Ident@1652..1653 "a"
+        Colon@1653..1654 ":"
+        Whitespace@1654..1655 " "
+        LiteralStringNode@1655..1662
+          DoubleQuote@1655..1656 "\""
+          LiteralStringText@1656..1661 "hello"
+          DoubleQuote@1661..1662 "\""
+      Whitespace@1662..1671 "\n        "
+      MetadataObjectItemNode@1671..1681
+        Ident@1671..1672 "b"
+        Colon@1672..1673 ":"
+        Whitespace@1673..1674 " "
+        LiteralStringNode@1674..1681
+          SingleQuote@1674..1675 "'"
+          LiteralStringText@1675..1680 "world"
+          SingleQuote@1680..1681 "'"
+      Whitespace@1681..1690 "\n        "
+      MetadataObjectItemNode@1690..1694
+        Ident@1690..1691 "c"
+        Colon@1691..1692 ":"
+        Whitespace@1692..1693 " "
+        LiteralIntegerNode@1693..1694
+          Integer@1693..1694 "5"
+      Whitespace@1694..1703 "\n        "
+      MetadataObjectItemNode@1703..1710
+        Ident@1703..1704 "d"
+        Colon@1704..1705 ":"
+        Whitespace@1705..1706 " "
+        LiteralIntegerNode@1706..1710
+          Minus@1706..1707 "-"
+          Integer@1707..1710 "0xf"
+      Whitespace@1710..1719 "\n        "
+      MetadataObjectItemNode@1719..1728
+        Ident@1719..1720 "e"
+        Colon@1720..1721 ":"
+        Whitespace@1721..1722 " "
+        LiteralFloatNode@1722..1728
+          Float@1722..1728 "1.0e10"
+      Whitespace@1728..1737 "\n        "
+      MetadataObjectItemNode@1737..1743
+        Ident@1737..1738 "f"
+        Colon@1738..1739 ":"
+        Whitespace@1739..1740 " "
+        LiteralFloatNode@1740..1743
+          Minus@1740..1741 "-"
+          Float@1741..1743 "2."
+      Whitespace@1743..1752 "\n        "
+      MetadataObjectItemNode@1752..1759
+        Ident@1752..1753 "g"
+        Colon@1753..1754 ":"
+        Whitespace@1754..1755 " "
+        LiteralBooleanNode@1755..1759
+          TrueKeyword@1755..1759 "true"
+      Whitespace@1759..1768 "\n        "
+      MetadataObjectItemNode@1768..1776
+        Ident@1768..1769 "h"
+        Colon@1769..1770 ":"
+        Whitespace@1770..1771 " "
+        LiteralBooleanNode@1771..1776
+          FalseKeyword@1771..1776 "false"
+      Whitespace@1776..1785 "\n        "
+      MetadataObjectItemNode@1785..1792
+        Ident@1785..1786 "i"
+        Colon@1786..1787 ":"
+        Whitespace@1787..1788 " "
+        LiteralNullNode@1788..1792
+          NullKeyword@1788..1792 "null"
+      Whitespace@1792..1801 "\n        "
+      MetadataObjectItemNode@1801..1977
+        Ident@1801..1802 "j"
+        Colon@1802..1803 ":"
+        Whitespace@1803..1804 " "
+        MetadataObjectNode@1804..1977
+          OpenBrace@1804..1805 "{"
+          Whitespace@1805..1818 "\n            "
+          MetadataObjectItemNode@1818..1830
+            Ident@1818..1819 "a"
+            Colon@1819..1820 ":"
+            Whitespace@1820..1821 " "
+            MetadataArrayNode@1821..1830
+              OpenBracket@1821..1822 "["
+              LiteralIntegerNode@1822..1823
+                Integer@1822..1823 "1"
+              Comma@1823..1824 ","
+              Whitespace@1824..1825 " "
+              LiteralIntegerNode@1825..1826
+                Integer@1825..1826 "2"
+              Comma@1826..1827 ","
+              Whitespace@1827..1828 " "
+              LiteralIntegerNode@1828..1829
+                Integer@1828..1829 "3"
+              CloseBracket@1829..1830 "]"
+          Comma@1830..1831 ","
+          Whitespace@1831..1844 "\n            "
+          MetadataObjectItemNode@1844..1870
+            Ident@1844..1845 "b"
+            Colon@1845..1846 ":"
+            Whitespace@1846..1847 " "
+            MetadataArrayNode@1847..1870
+              OpenBracket@1847..1848 "["
+              LiteralStringNode@1848..1855
+                DoubleQuote@1848..1849 "\""
+                LiteralStringText@1849..1854 "hello"
+                DoubleQuote@1854..1855 "\""
+              Comma@1855..1856 ","
+              Whitespace@1856..1857 " "
+              LiteralStringNode@1857..1864
+                DoubleQuote@1857..1858 "\""
+                LiteralStringText@1858..1863 "world"
+                DoubleQuote@1863..1864 "\""
+              Comma@1864..1865 ","
+              Whitespace@1865..1866 " "
+              LiteralStringNode@1866..1869
+                DoubleQuote@1866..1867 "\""
+                LiteralStringText@1867..1868 "!"
+                DoubleQuote@1868..1869 "\""
+              CloseBracket@1869..1870 "]"
+          Comma@1870..1871 ","
+          Whitespace@1871..1884 "\n            "
+          MetadataObjectItemNode@1884..1967
+            Ident@1884..1885 "c"
+            Colon@1885..1886 ":"
+            Whitespace@1886..1887 " "
+            MetadataObjectNode@1887..1967
+              OpenBrace@1887..1888 "{"
+              Whitespace@1888..1905 "\n                "
+              MetadataObjectItemNode@1905..1909
+                Ident@1905..1906 "x"
+                Colon@1906..1907 ":"
+                Whitespace@1907..1908 " "
+                LiteralIntegerNode@1908..1909
+                  Integer@1908..1909 "1"
+              Comma@1909..1910 ","
+              Whitespace@1910..1927 "\n                "
+              MetadataObjectItemNode@1927..1931
+                Ident@1927..1928 "y"
+                Colon@1928..1929 ":"
+                Whitespace@1929..1930 " "
+                LiteralIntegerNode@1930..1931
+                  Integer@1930..1931 "2"
+              Comma@1931..1932 ","
+              Whitespace@1932..1949 "\n                "
+              MetadataObjectItemNode@1949..1953
+                Ident@1949..1950 "z"
+                Colon@1950..1951 ":"
+                Whitespace@1951..1952 " "
+                LiteralIntegerNode@1952..1953
+                  Integer@1952..1953 "3"
+              Whitespace@1953..1966 "\n            "
+              CloseBrace@1966..1967 "}"
+          Whitespace@1967..1976 "\n        "
+          CloseBrace@1976..1977 "}"
+      Whitespace@1977..1986 "\n        "
+      MetadataObjectItemNode@1986..2206
+        Ident@1986..1987 "k"
+        Colon@1987..1988 ":"
+        Whitespace@1988..1989 " "
+        MetadataArrayNode@1989..2206
+          OpenBracket@1989..1990 "["
+          Whitespace@1990..2003 "\n            "
+          MetadataObjectNode@2003..2132
+            OpenBrace@2003..2004 "{"
+            Whitespace@2004..2021 "\n                "
+            MetadataObjectItemNode@2021..2026
+              Ident@2021..2022 "a"
+              Colon@2022..2023 ":"
+              Whitespace@2023..2024 " "
+              MetadataObjectNode@2024..2026
+                OpenBrace@2024..2025 "{"
+                CloseBrace@2025..2026 "}"
+            Comma@2026..2027 ","
+            Whitespace@2027..2044 "\n                "
+            MetadataObjectItemNode@2044..2048
+              Ident@2044..2045 "b"
+              Colon@2045..2046 ":"
+              Whitespace@2046..2047 " "
+              LiteralIntegerNode@2047..2048
+                Integer@2047..2048 "0"
+            Comma@2048..2049 ","
+            Whitespace@2049..2066 "\n                "
+            MetadataObjectItemNode@2066..2071
+              Ident@2066..2067 "c"
+              Colon@2067..2068 ":"
               Whitespace@2068..2069 " "
-              LiteralIntegerNode@2069..2070
-                Integer@2069..2070 "2"
-              Comma@2070..2071 ","
-              Whitespace@2071..2072 " "
-              LiteralIntegerNode@2072..2073
-                Integer@2072..2073 "3"
-              CloseBracket@2073..2074 "]"
-          Comma@2074..2075 ","
-          Whitespace@2075..2088 "\n            "
-          MetadataObjectItemNode@2088..2114
-            Ident@2088..2089 "b"
-            Colon@2089..2090 ":"
-            Whitespace@2090..2091 " "
-            MetadataArrayNode@2091..2114
-              OpenBracket@2091..2092 "["
-              LiteralStringNode@2092..2099
-                DoubleQuote@2092..2093 "\""
-                LiteralStringText@2093..2098 "hello"
-                DoubleQuote@2098..2099 "\""
-              Comma@2099..2100 ","
-              Whitespace@2100..2101 " "
-              LiteralStringNode@2101..2108
-                DoubleQuote@2101..2102 "\""
-                LiteralStringText@2102..2107 "world"
-                DoubleQuote@2107..2108 "\""
-              Comma@2108..2109 ","
-              Whitespace@2109..2110 " "
-              LiteralStringNode@2110..2113
-                DoubleQuote@2110..2111 "\""
-                LiteralStringText@2111..2112 "!"
-                DoubleQuote@2112..2113 "\""
-              CloseBracket@2113..2114 "]"
-          Comma@2114..2115 ","
-          Whitespace@2115..2128 "\n            "
-          MetadataObjectItemNode@2128..2211
-            Ident@2128..2129 "c"
-            Colon@2129..2130 ":"
-            Whitespace@2130..2131 " "
-            MetadataObjectNode@2131..2211
-              OpenBrace@2131..2132 "{"
-              Whitespace@2132..2149 "\n                "
-              MetadataObjectItemNode@2149..2153
-                Ident@2149..2150 "x"
-                Colon@2150..2151 ":"
-                Whitespace@2151..2152 " "
-                LiteralIntegerNode@2152..2153
-                  Integer@2152..2153 "1"
-              Comma@2153..2154 ","
-              Whitespace@2154..2171 "\n                "
-              MetadataObjectItemNode@2171..2175
-                Ident@2171..2172 "y"
-                Colon@2172..2173 ":"
-                Whitespace@2173..2174 " "
-                LiteralIntegerNode@2174..2175
-                  Integer@2174..2175 "2"
-              Comma@2175..2176 ","
-              Whitespace@2176..2193 "\n                "
-              MetadataObjectItemNode@2193..2197
-                Ident@2193..2194 "z"
-                Colon@2194..2195 ":"
-                Whitespace@2195..2196 " "
-                LiteralIntegerNode@2196..2197
-                  Integer@2196..2197 "3"
-              Whitespace@2197..2210 "\n            "
-              CloseBrace@2210..2211 "}"
-          Whitespace@2211..2220 "\n        "
-          CloseBrace@2220..2221 "}"
-      Whitespace@2221..2230 "\n        "
-      MetadataObjectItemNode@2230..2450
-        Ident@2230..2231 "k"
-        Colon@2231..2232 ":"
-        Whitespace@2232..2233 " "
-        MetadataArrayNode@2233..2450
-          OpenBracket@2233..2234 "["
-          Whitespace@2234..2247 "\n            "
-          MetadataObjectNode@2247..2376
-            OpenBrace@2247..2248 "{"
-            Whitespace@2248..2265 "\n                "
-            MetadataObjectItemNode@2265..2270
-              Ident@2265..2266 "a"
-              Colon@2266..2267 ":"
-              Whitespace@2267..2268 " "
-              MetadataObjectNode@2268..2270
-                OpenBrace@2268..2269 "{"
-                CloseBrace@2269..2270 "}"
-            Comma@2270..2271 ","
-            Whitespace@2271..2288 "\n                "
-            MetadataObjectItemNode@2288..2292
-              Ident@2288..2289 "b"
-              Colon@2289..2290 ":"
-              Whitespace@2290..2291 " "
-              LiteralIntegerNode@2291..2292
-                Integer@2291..2292 "0"
-            Comma@2292..2293 ","
-            Whitespace@2293..2310 "\n                "
-            MetadataObjectItemNode@2310..2315
-              Ident@2310..2311 "c"
-              Colon@2311..2312 ":"
-              Whitespace@2312..2313 " "
-              LiteralStringNode@2313..2315
-                DoubleQuote@2313..2314 "\""
-                DoubleQuote@2314..2315 "\""
-            Comma@2315..2316 ","
-            Whitespace@2316..2333 "\n                "
-            MetadataObjectItemNode@2333..2338
-              Ident@2333..2334 "d"
-              Colon@2334..2335 ":"
-              Whitespace@2335..2336 " "
-              LiteralStringNode@2336..2338
-                SingleQuote@2336..2337 "'"
-                SingleQuote@2337..2338 "'"
-            Comma@2338..2339 ","
-            Whitespace@2339..2356 "\n                "
-            MetadataObjectItemNode@2356..2361
-              Ident@2356..2357 "e"
-              Colon@2357..2358 ":"
-              Whitespace@2358..2359 " "
-              MetadataArrayNode@2359..2361
-                OpenBracket@2359..2360 "["
-                CloseBracket@2360..2361 "]"
-            Comma@2361..2362 ","
-            Whitespace@2362..2375 "\n            "
-            CloseBrace@2375..2376 "}"
-          Comma@2376..2377 ","
-          Whitespace@2377..2390 "\n            "
-          MetadataObjectNode@2390..2440
-            OpenBrace@2390..2391 "{"
-            Whitespace@2391..2408 "\n                "
-            MetadataObjectItemNode@2408..2426
-              Ident@2408..2409 "x"
-              Colon@2409..2410 ":"
-              Whitespace@2410..2411 " "
-              MetadataArrayNode@2411..2426
-                OpenBracket@2411..2412 "["
-                LiteralFloatNode@2412..2415
-                  Float@2412..2415 "1.0"
-                Comma@2415..2416 ","
-                Whitespace@2416..2417 " "
-                LiteralFloatNode@2417..2420
-                  Float@2417..2420 "2.0"
-                Comma@2420..2421 ","
-                Whitespace@2421..2422 " "
-                LiteralFloatNode@2422..2425
-                  Float@2422..2425 "3.0"
-                CloseBracket@2425..2426 "]"
-            Whitespace@2426..2439 "\n            "
-            CloseBrace@2439..2440 "}"
-          Whitespace@2440..2449 "\n        "
-          CloseBracket@2449..2450 "]"
-      Whitespace@2450..2455 "\n    "
-      CloseBrace@2455..2456 "}"
-    Whitespace@2456..2457 "\n"
-    CloseBrace@2457..2458 "}"
-  Whitespace@2458..2459 "\n"
+              LiteralStringNode@2069..2071
+                DoubleQuote@2069..2070 "\""
+                DoubleQuote@2070..2071 "\""
+            Comma@2071..2072 ","
+            Whitespace@2072..2089 "\n                "
+            MetadataObjectItemNode@2089..2094
+              Ident@2089..2090 "d"
+              Colon@2090..2091 ":"
+              Whitespace@2091..2092 " "
+              LiteralStringNode@2092..2094
+                SingleQuote@2092..2093 "'"
+                SingleQuote@2093..2094 "'"
+            Comma@2094..2095 ","
+            Whitespace@2095..2112 "\n                "
+            MetadataObjectItemNode@2112..2117
+              Ident@2112..2113 "e"
+              Colon@2113..2114 ":"
+              Whitespace@2114..2115 " "
+              MetadataArrayNode@2115..2117
+                OpenBracket@2115..2116 "["
+                CloseBracket@2116..2117 "]"
+            Comma@2117..2118 ","
+            Whitespace@2118..2131 "\n            "
+            CloseBrace@2131..2132 "}"
+          Comma@2132..2133 ","
+          Whitespace@2133..2146 "\n            "
+          MetadataObjectNode@2146..2196
+            OpenBrace@2146..2147 "{"
+            Whitespace@2147..2164 "\n                "
+            MetadataObjectItemNode@2164..2182
+              Ident@2164..2165 "x"
+              Colon@2165..2166 ":"
+              Whitespace@2166..2167 " "
+              MetadataArrayNode@2167..2182
+                OpenBracket@2167..2168 "["
+                LiteralFloatNode@2168..2171
+                  Float@2168..2171 "1.0"
+                Comma@2171..2172 ","
+                Whitespace@2172..2173 " "
+                LiteralFloatNode@2173..2176
+                  Float@2173..2176 "2.0"
+                Comma@2176..2177 ","
+                Whitespace@2177..2178 " "
+                LiteralFloatNode@2178..2181
+                  Float@2178..2181 "3.0"
+                CloseBracket@2181..2182 "]"
+            Whitespace@2182..2195 "\n            "
+            CloseBrace@2195..2196 "}"
+          Whitespace@2196..2205 "\n        "
+          CloseBracket@2205..2206 "]"
+      Whitespace@2206..2215 "\n        "
+      MetadataObjectItemNode@2215..2263
+        Ident@2215..2216 "x"
+        Colon@2216..2217 ":"
+        Whitespace@2217..2218 " "
+        LiteralStringNode@2218..2263
+          SingleQuote@2218..2219 "'"
+          LiteralStringText@2219..2262 "No ~{interpolation} i ..."
+          SingleQuote@2262..2263 "'"
+      Whitespace@2263..2272 "\n        "
+      MetadataObjectItemNode@2272..2320
+        Ident@2272..2273 "y"
+        Colon@2273..2274 ":"
+        Whitespace@2274..2275 " "
+        LiteralStringNode@2275..2320
+          DoubleQuote@2275..2276 "\""
+          LiteralStringText@2276..2319 "No ~{interpolation} i ..."
+          DoubleQuote@2319..2320 "\""
+      Whitespace@2320..2329 "\n        "
+      MetadataObjectItemNode@2329..2381
+        Ident@2329..2330 "z"
+        Colon@2330..2331 ":"
+        Whitespace@2331..2332 " "
+        LiteralStringNode@2332..2381
+          OpenHeredoc@2332..2335 "<<<"
+          LiteralStringText@2335..2378 "No ~{interpolation} i ..."
+          CloseHeredoc@2378..2381 ">>>"
+      Whitespace@2381..2386 "\n    "
+      CloseBrace@2386..2387 "}"
+    Whitespace@2387..2397 "\n    \n    "
+    ParameterMetadataSectionNode@2397..3157
+      ParameterMetaKeyword@2397..2411 "parameter_meta"
+      Whitespace@2411..2412 " "
+      OpenBrace@2412..2413 "{"
+      Whitespace@2413..2422 "\n        "
+      MetadataObjectItemNode@2422..2432
+        Ident@2422..2423 "a"
+        Colon@2423..2424 ":"
+        Whitespace@2424..2425 " "
+        LiteralStringNode@2425..2432
+          DoubleQuote@2425..2426 "\""
+          LiteralStringText@2426..2431 "hello"
+          DoubleQuote@2431..2432 "\""
+      Whitespace@2432..2441 "\n        "
+      MetadataObjectItemNode@2441..2451
+        Ident@2441..2442 "b"
+        Colon@2442..2443 ":"
+        Whitespace@2443..2444 " "
+        LiteralStringNode@2444..2451
+          SingleQuote@2444..2445 "'"
+          LiteralStringText@2445..2450 "world"
+          SingleQuote@2450..2451 "'"
+      Whitespace@2451..2460 "\n        "
+      MetadataObjectItemNode@2460..2464
+        Ident@2460..2461 "c"
+        Colon@2461..2462 ":"
+        Whitespace@2462..2463 " "
+        LiteralIntegerNode@2463..2464
+          Integer@2463..2464 "5"
+      Whitespace@2464..2473 "\n        "
+      MetadataObjectItemNode@2473..2480
+        Ident@2473..2474 "d"
+        Colon@2474..2475 ":"
+        Whitespace@2475..2476 " "
+        LiteralIntegerNode@2476..2480
+          Minus@2476..2477 "-"
+          Integer@2477..2480 "0xf"
+      Whitespace@2480..2489 "\n        "
+      MetadataObjectItemNode@2489..2498
+        Ident@2489..2490 "e"
+        Colon@2490..2491 ":"
+        Whitespace@2491..2492 " "
+        LiteralFloatNode@2492..2498
+          Float@2492..2498 "1.0e10"
+      Whitespace@2498..2507 "\n        "
+      MetadataObjectItemNode@2507..2513
+        Ident@2507..2508 "f"
+        Colon@2508..2509 ":"
+        Whitespace@2509..2510 " "
+        LiteralFloatNode@2510..2513
+          Minus@2510..2511 "-"
+          Float@2511..2513 "2."
+      Whitespace@2513..2522 "\n        "
+      MetadataObjectItemNode@2522..2529
+        Ident@2522..2523 "g"
+        Colon@2523..2524 ":"
+        Whitespace@2524..2525 " "
+        LiteralBooleanNode@2525..2529
+          TrueKeyword@2525..2529 "true"
+      Whitespace@2529..2538 "\n        "
+      MetadataObjectItemNode@2538..2546
+        Ident@2538..2539 "h"
+        Colon@2539..2540 ":"
+        Whitespace@2540..2541 " "
+        LiteralBooleanNode@2541..2546
+          FalseKeyword@2541..2546 "false"
+      Whitespace@2546..2555 "\n        "
+      MetadataObjectItemNode@2555..2562
+        Ident@2555..2556 "i"
+        Colon@2556..2557 ":"
+        Whitespace@2557..2558 " "
+        LiteralNullNode@2558..2562
+          NullKeyword@2558..2562 "null"
+      Whitespace@2562..2571 "\n        "
+      MetadataObjectItemNode@2571..2747
+        Ident@2571..2572 "j"
+        Colon@2572..2573 ":"
+        Whitespace@2573..2574 " "
+        MetadataObjectNode@2574..2747
+          OpenBrace@2574..2575 "{"
+          Whitespace@2575..2588 "\n            "
+          MetadataObjectItemNode@2588..2600
+            Ident@2588..2589 "a"
+            Colon@2589..2590 ":"
+            Whitespace@2590..2591 " "
+            MetadataArrayNode@2591..2600
+              OpenBracket@2591..2592 "["
+              LiteralIntegerNode@2592..2593
+                Integer@2592..2593 "1"
+              Comma@2593..2594 ","
+              Whitespace@2594..2595 " "
+              LiteralIntegerNode@2595..2596
+                Integer@2595..2596 "2"
+              Comma@2596..2597 ","
+              Whitespace@2597..2598 " "
+              LiteralIntegerNode@2598..2599
+                Integer@2598..2599 "3"
+              CloseBracket@2599..2600 "]"
+          Comma@2600..2601 ","
+          Whitespace@2601..2614 "\n            "
+          MetadataObjectItemNode@2614..2640
+            Ident@2614..2615 "b"
+            Colon@2615..2616 ":"
+            Whitespace@2616..2617 " "
+            MetadataArrayNode@2617..2640
+              OpenBracket@2617..2618 "["
+              LiteralStringNode@2618..2625
+                DoubleQuote@2618..2619 "\""
+                LiteralStringText@2619..2624 "hello"
+                DoubleQuote@2624..2625 "\""
+              Comma@2625..2626 ","
+              Whitespace@2626..2627 " "
+              LiteralStringNode@2627..2634
+                DoubleQuote@2627..2628 "\""
+                LiteralStringText@2628..2633 "world"
+                DoubleQuote@2633..2634 "\""
+              Comma@2634..2635 ","
+              Whitespace@2635..2636 " "
+              LiteralStringNode@2636..2639
+                DoubleQuote@2636..2637 "\""
+                LiteralStringText@2637..2638 "!"
+                DoubleQuote@2638..2639 "\""
+              CloseBracket@2639..2640 "]"
+          Comma@2640..2641 ","
+          Whitespace@2641..2654 "\n            "
+          MetadataObjectItemNode@2654..2737
+            Ident@2654..2655 "c"
+            Colon@2655..2656 ":"
+            Whitespace@2656..2657 " "
+            MetadataObjectNode@2657..2737
+              OpenBrace@2657..2658 "{"
+              Whitespace@2658..2675 "\n                "
+              MetadataObjectItemNode@2675..2679
+                Ident@2675..2676 "x"
+                Colon@2676..2677 ":"
+                Whitespace@2677..2678 " "
+                LiteralIntegerNode@2678..2679
+                  Integer@2678..2679 "1"
+              Comma@2679..2680 ","
+              Whitespace@2680..2697 "\n                "
+              MetadataObjectItemNode@2697..2701
+                Ident@2697..2698 "y"
+                Colon@2698..2699 ":"
+                Whitespace@2699..2700 " "
+                LiteralIntegerNode@2700..2701
+                  Integer@2700..2701 "2"
+              Comma@2701..2702 ","
+              Whitespace@2702..2719 "\n                "
+              MetadataObjectItemNode@2719..2723
+                Ident@2719..2720 "z"
+                Colon@2720..2721 ":"
+                Whitespace@2721..2722 " "
+                LiteralIntegerNode@2722..2723
+                  Integer@2722..2723 "3"
+              Whitespace@2723..2736 "\n            "
+              CloseBrace@2736..2737 "}"
+          Whitespace@2737..2746 "\n        "
+          CloseBrace@2746..2747 "}"
+      Whitespace@2747..2756 "\n        "
+      MetadataObjectItemNode@2756..2976
+        Ident@2756..2757 "k"
+        Colon@2757..2758 ":"
+        Whitespace@2758..2759 " "
+        MetadataArrayNode@2759..2976
+          OpenBracket@2759..2760 "["
+          Whitespace@2760..2773 "\n            "
+          MetadataObjectNode@2773..2902
+            OpenBrace@2773..2774 "{"
+            Whitespace@2774..2791 "\n                "
+            MetadataObjectItemNode@2791..2796
+              Ident@2791..2792 "a"
+              Colon@2792..2793 ":"
+              Whitespace@2793..2794 " "
+              MetadataObjectNode@2794..2796
+                OpenBrace@2794..2795 "{"
+                CloseBrace@2795..2796 "}"
+            Comma@2796..2797 ","
+            Whitespace@2797..2814 "\n                "
+            MetadataObjectItemNode@2814..2818
+              Ident@2814..2815 "b"
+              Colon@2815..2816 ":"
+              Whitespace@2816..2817 " "
+              LiteralIntegerNode@2817..2818
+                Integer@2817..2818 "0"
+            Comma@2818..2819 ","
+            Whitespace@2819..2836 "\n                "
+            MetadataObjectItemNode@2836..2841
+              Ident@2836..2837 "c"
+              Colon@2837..2838 ":"
+              Whitespace@2838..2839 " "
+              LiteralStringNode@2839..2841
+                DoubleQuote@2839..2840 "\""
+                DoubleQuote@2840..2841 "\""
+            Comma@2841..2842 ","
+            Whitespace@2842..2859 "\n                "
+            MetadataObjectItemNode@2859..2864
+              Ident@2859..2860 "d"
+              Colon@2860..2861 ":"
+              Whitespace@2861..2862 " "
+              LiteralStringNode@2862..2864
+                SingleQuote@2862..2863 "'"
+                SingleQuote@2863..2864 "'"
+            Comma@2864..2865 ","
+            Whitespace@2865..2882 "\n                "
+            MetadataObjectItemNode@2882..2887
+              Ident@2882..2883 "e"
+              Colon@2883..2884 ":"
+              Whitespace@2884..2885 " "
+              MetadataArrayNode@2885..2887
+                OpenBracket@2885..2886 "["
+                CloseBracket@2886..2887 "]"
+            Comma@2887..2888 ","
+            Whitespace@2888..2901 "\n            "
+            CloseBrace@2901..2902 "}"
+          Comma@2902..2903 ","
+          Whitespace@2903..2916 "\n            "
+          MetadataObjectNode@2916..2966
+            OpenBrace@2916..2917 "{"
+            Whitespace@2917..2934 "\n                "
+            MetadataObjectItemNode@2934..2952
+              Ident@2934..2935 "x"
+              Colon@2935..2936 ":"
+              Whitespace@2936..2937 " "
+              MetadataArrayNode@2937..2952
+                OpenBracket@2937..2938 "["
+                LiteralFloatNode@2938..2941
+                  Float@2938..2941 "1.0"
+                Comma@2941..2942 ","
+                Whitespace@2942..2943 " "
+                LiteralFloatNode@2943..2946
+                  Float@2943..2946 "2.0"
+                Comma@2946..2947 ","
+                Whitespace@2947..2948 " "
+                LiteralFloatNode@2948..2951
+                  Float@2948..2951 "3.0"
+                CloseBracket@2951..2952 "]"
+            Whitespace@2952..2965 "\n            "
+            CloseBrace@2965..2966 "}"
+          Whitespace@2966..2975 "\n        "
+          CloseBracket@2975..2976 "]"
+      Whitespace@2976..2985 "\n        "
+      MetadataObjectItemNode@2985..3033
+        Ident@2985..2986 "x"
+        Colon@2986..2987 ":"
+        Whitespace@2987..2988 " "
+        LiteralStringNode@2988..3033
+          SingleQuote@2988..2989 "'"
+          LiteralStringText@2989..3032 "No ~{interpolation} i ..."
+          SingleQuote@3032..3033 "'"
+      Whitespace@3033..3042 "\n        "
+      MetadataObjectItemNode@3042..3090
+        Ident@3042..3043 "y"
+        Colon@3043..3044 ":"
+        Whitespace@3044..3045 " "
+        LiteralStringNode@3045..3090
+          DoubleQuote@3045..3046 "\""
+          LiteralStringText@3046..3089 "No ~{interpolation} i ..."
+          DoubleQuote@3089..3090 "\""
+      Whitespace@3090..3099 "\n        "
+      MetadataObjectItemNode@3099..3151
+        Ident@3099..3100 "z"
+        Colon@3100..3101 ":"
+        Whitespace@3101..3102 " "
+        LiteralStringNode@3102..3151
+          OpenHeredoc@3102..3105 "<<<"
+          LiteralStringText@3105..3148 "No ~{interpolation} i ..."
+          CloseHeredoc@3148..3151 ">>>"
+      Whitespace@3151..3156 "\n    "
+      CloseBrace@3156..3157 "}"
+    Whitespace@3157..3158 "\n"
+    CloseBrace@3158..3159 "}"
+  Whitespace@3159..3160 "\n"

--- a/wdl-grammar/tests/parsing/metadata/source.wdl
+++ b/wdl-grammar/tests/parsing/metadata/source.wdl
@@ -34,6 +34,9 @@ task test {
                 x: [1.0, 2.0, 3.0]
             }
         ]
+        x: 'No ~{interpolation} in ${metadata} strings!'
+        y: "No ~{interpolation} in ${metadata} strings!"
+        z: <<<No ~{interpolation} in ${metadata} strings!>>> 
     }
     
     parameter_meta {
@@ -67,6 +70,9 @@ task test {
                 x: [1.0, 2.0, 3.0]
             }
         ]
+        x: 'No ~{interpolation} in ${metadata} strings!'
+        y: "No ~{interpolation} in ${metadata} strings!"
+        z: <<<No ~{interpolation} in ${metadata} strings!>>>
     }
 }
 
@@ -102,6 +108,9 @@ workflow w {
                 x: [1.0, 2.0, 3.0]
             }
         ]
+        x: 'No ~{interpolation} in ${metadata} strings!'
+        y: "No ~{interpolation} in ${metadata} strings!"
+        z: <<<No ~{interpolation} in ${metadata} strings!>>>
     }
     
     parameter_meta {
@@ -135,5 +144,8 @@ workflow w {
                 x: [1.0, 2.0, 3.0]
             }
         ]
+        x: 'No ~{interpolation} in ${metadata} strings!'
+        y: "No ~{interpolation} in ${metadata} strings!"
+        z: <<<No ~{interpolation} in ${metadata} strings!>>>
     }
 }

--- a/wdl-grammar/tests/parsing/multiline-strings/source.tree
+++ b/wdl-grammar/tests/parsing/multiline-strings/source.tree
@@ -1,0 +1,42 @@
+RootNode@0..291
+  Comment@0..52 "## This is a test of  ..."
+  Whitespace@52..54 "\n\n"
+  VersionStatementNode@54..65
+    VersionKeyword@54..61 "version"
+    Whitespace@61..62 " "
+    Version@62..65 "1.2"
+  Whitespace@65..67 "\n\n"
+  WorkflowDefinitionNode@67..290
+    WorkflowKeyword@67..75 "workflow"
+    Whitespace@75..76 " "
+    Ident@76..80 "test"
+    Whitespace@80..81 " "
+    OpenBrace@81..82 "{"
+    Whitespace@82..87 "\n    "
+    BoundDeclNode@87..288
+      PrimitiveTypeNode@87..93
+        StringTypeKeyword@87..93 "String"
+      Whitespace@93..94 " "
+      Ident@94..95 "a"
+      Whitespace@95..96 " "
+      Assignment@96..97 "="
+      Whitespace@97..98 " "
+      LiteralStringNode@98..288
+        OpenHeredoc@98..101 "<<<"
+        LiteralStringText@101..241 "\n        Hello! This  ..."
+        PlaceholderNode@241..249
+          PlaceholderOpen@241..243 "${"
+          NameRefNode@243..248
+            Ident@243..248 "value"
+          CloseBrace@248..249 "}"
+        LiteralStringText@249..253 " or "
+        PlaceholderNode@253..261
+          PlaceholderOpen@253..255 "~{"
+          NameRefNode@255..260
+            Ident@255..260 "value"
+          CloseBrace@260..261 "}"
+        LiteralStringText@261..285 " for interpolations\n    "
+        CloseHeredoc@285..288 ">>>"
+    Whitespace@288..289 "\n"
+    CloseBrace@289..290 "}"
+  Whitespace@290..291 "\n"

--- a/wdl-grammar/tests/parsing/multiline-strings/source.wdl
+++ b/wdl-grammar/tests/parsing/multiline-strings/source.wdl
@@ -1,0 +1,12 @@
+## This is a test of multi-line strings from WDL 1.2
+
+version 1.2
+
+workflow test {
+    String a = <<<
+        Hello! This is a multi-line string!
+        We can have line continuations \
+        And escaped \>>>!
+        But also use either ${value} or ~{value} for interpolations
+    >>>
+}

--- a/wdl-grammar/tests/parsing/recovery-past-string/source.errors
+++ b/wdl-grammar/tests/parsing/recovery-past-string/source.errors
@@ -4,3 +4,9 @@ error: expected metadata key, but found string
 7 │         "invalid": "~{value}"
   │         ^^^^^^^^^ unexpected string
 
+error: expected metadata key, but found multi-line string
+  ┌─ tests/parsing/recovery-past-string/source.wdl:9:9
+  │
+9 │         <<<invalid>>>: <<<~{value} ${value}>>>
+  │         ^^^^^^^^^^^ unexpected multi-line string
+

--- a/wdl-grammar/tests/parsing/recovery-past-string/source.tree
+++ b/wdl-grammar/tests/parsing/recovery-past-string/source.tree
@@ -1,4 +1,4 @@
-RootNode@0..168
+RootNode@0..235
   Comment@0..67 "# This is a test of r ..."
   Whitespace@67..69 "\n\n"
   VersionStatementNode@69..80
@@ -6,14 +6,14 @@ RootNode@0..168
     Whitespace@76..77 " "
     Version@77..80 "1.1"
   Whitespace@80..82 "\n\n"
-  TaskDefinitionNode@82..167
+  TaskDefinitionNode@82..234
     TaskKeyword@82..86 "task"
     Whitespace@86..87 " "
     Ident@87..91 "test"
     Whitespace@91..92 " "
     OpenBrace@92..93 "{"
     Whitespace@93..98 "\n    "
-    MetadataSectionNode@98..165
+    MetadataSectionNode@98..232
       MetaKeyword@98..102 "meta"
       Whitespace@102..103 " "
       OpenBrace@103..104 "{"
@@ -39,8 +39,36 @@ RootNode@0..168
           DoubleQuote@152..153 "\""
           LiteralStringText@153..158 "value"
           DoubleQuote@158..159 "\""
-      Whitespace@159..164 "\n    "
-      CloseBrace@164..165 "}"
-    Whitespace@165..166 "\n"
-    CloseBrace@166..167 "}"
-  Whitespace@167..168 "\n"
+      Whitespace@159..168 "\n        "
+      OpenHeredoc@168..171 "<<<"
+      LiteralStringText@171..178 "invalid"
+      CloseHeredoc@178..181 ">>>"
+      Colon@181..182 ":"
+      Whitespace@182..183 " "
+      OpenHeredoc@183..186 "<<<"
+      PlaceholderNode@186..194
+        PlaceholderOpen@186..188 "~{"
+        NameRefNode@188..193
+          Ident@188..193 "value"
+        CloseBrace@193..194 "}"
+      LiteralStringText@194..195 " "
+      PlaceholderNode@195..203
+        PlaceholderOpen@195..197 "${"
+        NameRefNode@197..202
+          Ident@197..202 "value"
+        CloseBrace@202..203 "}"
+      CloseHeredoc@203..206 ">>>"
+      Whitespace@206..215 "\n        "
+      MetadataObjectItemNode@215..226
+        Ident@215..217 "ok"
+        Colon@217..218 ":"
+        Whitespace@218..219 " "
+        LiteralStringNode@219..226
+          DoubleQuote@219..220 "\""
+          LiteralStringText@220..225 "value"
+          DoubleQuote@225..226 "\""
+      Whitespace@226..231 "\n    "
+      CloseBrace@231..232 "}"
+    Whitespace@232..233 "\n"
+    CloseBrace@233..234 "}"
+  Whitespace@234..235 "\n"

--- a/wdl-grammar/tests/parsing/recovery-past-string/source.wdl
+++ b/wdl-grammar/tests/parsing/recovery-past-string/source.wdl
@@ -6,5 +6,7 @@ task test {
     meta {
         "invalid": "~{value}"
         correct: "value"
+        <<<invalid>>>: <<<~{value} ${value}>>>
+        ok: "value"
     }
 }

--- a/wdl-lint/src/rules/double_quotes.rs
+++ b/wdl-lint/src/rules/double_quotes.rs
@@ -3,6 +3,7 @@
 use wdl_ast::span_of;
 use wdl_ast::v1::Expr;
 use wdl_ast::v1::LiteralExpr;
+use wdl_ast::v1::LiteralStringKind;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
@@ -74,7 +75,7 @@ impl Visitor for DoubleQuotesRule {
         }
 
         if let Expr::Literal(LiteralExpr::String(s)) = expr {
-            if s.quote() != '"' {
+            if s.kind() == LiteralStringKind::SingleQuoted {
                 state.add(use_double_quotes(span_of(s)));
             }
         }


### PR DESCRIPTION
This commit implements support for multi-line strings that borrows from the
heredoc command syntax.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
