### PR TITLE
fix: remove the `Send` and `Sync` requirement on `Visitor`.

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Removed `Send` and `Sync` constraints from the `Visitor` trait
+  ([#128](https://github.com/stjude-rust-labs/wdl/pull/128)).
 * Changed the API for parsing documents; `Document::parse` now returns
   `(Document, Vec<Diagnostic>)` rather than a `Parse` type ([#110](https://github.com/stjude-rust-labs/wdl/pull/110)).
 * The `Type` enumeration, and friends, in `wdl-ast` no longer implement

--- a/wdl-ast/src/lib.rs
+++ b/wdl-ast/src/lib.rs
@@ -393,3 +393,44 @@ impl AstToken for Ident {
         &self.0
     }
 }
+
+/// Helper for hashing any AST token on string representation alone.
+///
+/// Normally an AST token's equality and hash implementation work by comparing
+/// the token's element in the AST; thus, two `Ident` tokens with the same name
+/// but different positions in the tree will compare and hash differently.
+#[derive(Debug, Clone)]
+pub struct TokenStrHash<T>(T);
+
+impl<T: AstToken> TokenStrHash<T> {
+    /// Constructs a new token hash for the given token.
+    pub fn new(token: T) -> Self {
+        Self(token)
+    }
+}
+
+impl<T: AstToken> PartialEq for TokenStrHash<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl<T: AstToken> Eq for TokenStrHash<T> {}
+
+impl<T: AstToken> std::hash::Hash for TokenStrHash<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.as_str().hash(state);
+    }
+}
+
+impl<T: AstToken> std::borrow::Borrow<str> for TokenStrHash<T> {
+    fn borrow(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<T: AstToken> AsRef<T> for TokenStrHash<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}

--- a/wdl-ast/src/visitor.rs
+++ b/wdl-ast/src/visitor.rs
@@ -63,7 +63,7 @@ use crate::Whitespace;
 /// that receives both a [VisitReason::Enter] call and a
 /// matching [VisitReason::Exit] call.
 #[allow(unused_variables)]
-pub trait Visitor: Send + Sync {
+pub trait Visitor {
     /// Represents the external visitation state.
     type State;
 


### PR DESCRIPTION
This removes the restriction on `Visitor` to be `Send` and `Sync`.

Originally the restriction was put in place in the hopes that they would be needed to implement `wdl-analysis`; however, that turned out to not be the case.

The restriction prevents visitors from storing AST elements as they are not `Send` (only green nodes and tokens are `Send` and `Sync`).

Thus, rules would previously have to clone token string representations if they were needed.

With these changes comes a `TokenStrHash` helper that can be used to hash an AST token by its string representation; a few rules were updated to use it to prevent unnecessary string clones.

Fixes #122.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
