### PR TITLE
Feat/blanks between elements

### DIFF
--- a/Arena.toml
+++ b/Arena.toml
@@ -17,6 +17,11 @@ filters = ["/template/task-templates.wdl"]
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:127:60: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L127"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:129:5: note[MatchingParameterMeta]: task `FastqToUnmappedBam` has an extraneous parameter metadata key named `unmapped_bam`"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L129"
 
@@ -42,6 +47,11 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:163:60: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L163"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:165:5: note[MatchingParameterMeta]: task `ValidateCram` has an extraneous parameter metadata key named `validation`"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L165"
 
@@ -64,6 +74,11 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:170:6: warning[SnakeCase]: task name `MergeBamsToCram` is not snake_case"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L170"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:200:67: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L200"
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
@@ -142,6 +157,11 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:72:94: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L72"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:74:5: note[MatchingParameterMeta]: workflow `PairedFastqsToUnmappedCram` has an extraneous parameter metadata key named `unmapped_crams`"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L74"
 
@@ -174,6 +194,11 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
 message = "ww-star-deseq2.wdl:10:22: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L10"
+
+[[diagnostics]]
+document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
+message = "ww-star-deseq2.wdl:117:92: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L117"
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
@@ -217,6 +242,11 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
+message = "ww-star-deseq2.wdl:151:61: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L151"
+
+[[diagnostics]]
+document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
 message = "ww-star-deseq2.wdl:153:5: note[MatchingParameterMeta]: task `ConcatenateFastQs` has an extraneous parameter metadata key named `r1fastq`"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L153"
 
@@ -254,6 +284,11 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
 message = "ww-star-deseq2.wdl:196:10: warning[SnakeCase]: output name `SJout` is not snake_case"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L196"
+
+[[diagnostics]]
+document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
+message = "ww-star-deseq2.wdl:210:58: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L210"
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
@@ -314,6 +349,11 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
 message = "ww-star-deseq2.wdl:23:22: note[CallInputSpacing]: call input not properly spaced"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L23"
+
+[[diagnostics]]
+document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
+message = "ww-star-deseq2.wdl:253:64: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L253"
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
@@ -454,6 +494,11 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
 message = "ww-star-deseq2.wdl:6:10: warning[SnakeCase]: workflow name `STAR2Pass` is not snake_case"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L6"
+
+[[diagnostics]]
+document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
+message = "ww-star-deseq2.wdl:71:100: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L71"
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
@@ -709,6 +754,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:299:3: warning[InputSorting]: input not sorted"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L299"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:2:1: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L2"
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
@@ -1012,6 +1062,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:63:3: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L63"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:643:6: note[MissingMetas]: task `SamToFastq` is missing both meta and parameter_meta sections"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L643"
 
@@ -1307,6 +1362,11 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
+message = "gatk4.wdl:155:10: note[BlanksBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/tools/gatk4.wdl/#L155"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:188:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/tools/gatk4.wdl/#L188"
 
@@ -1394,6 +1454,11 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:306:75: note[Todo]: remaining `TODO` item found"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/tools/kraken2.wdl/#L306"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/tools/librarian.wdl"
+message = "librarian.wdl:20:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/tools/librarian.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/librarian.wdl"
@@ -1682,8 +1747,23 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:103:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L103"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:105:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L105"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:10:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L10"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:112:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L112"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
@@ -1706,9 +1786,49 @@ message = "chipseq-standard.wdl:15:10: note[SectionOrdering]: sections are not i
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L15"
 
 [[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:60:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L60"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:92:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L92"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:99:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/chipseq/chipseq-standard.wdl/#L99"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
+message = "dnaseq-core.wdl:105:13: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-core.wdl/#L105"
+
+[[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:115:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-core.wdl/#L115"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
+message = "dnaseq-core.wdl:121:13: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-core.wdl/#L121"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
+message = "dnaseq-core.wdl:126:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-core.wdl/#L126"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
+message = "dnaseq-core.wdl:22:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-core.wdl/#L22"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
+message = "dnaseq-core.wdl:36:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-core.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
@@ -1722,8 +1842,28 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
+message = "dnaseq-standard-fastq.wdl:18:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L18"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
+message = "dnaseq-standard-fastq.wdl:36:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L36"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:51:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L51"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
+message = "dnaseq-standard-fastq.wdl:65:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L65"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
+message = "dnaseq-standard-fastq.wdl:73:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L73"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
@@ -1741,9 +1881,34 @@ message = "dnaseq-standard.wdl:126:5: warning[RuntimeSectionKeys]: the following
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard.wdl/#L126"
 
 [[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
+message = "dnaseq-standard.wdl:20:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard.wdl/#L20"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
+message = "dnaseq-standard.wdl:34:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard.wdl/#L34"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
+message = "dnaseq-standard.wdl:63:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/dnaseq/dnaseq-standard.wdl/#L63"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
+message = "alignment-post.wdl:60:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/alignment-post.wdl/#L60"
+
+[[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:6:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/alignment-post.wdl/#L6"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
+message = "alignment-post.wdl:76:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/alignment-post.wdl/#L76"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
@@ -1754,6 +1919,21 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:8:10: note[SectionOrdering]: sections are not in order for workflow `alignment_post`"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/alignment-post.wdl/#L8"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
+message = "bam-to-fastqs.wdl:33:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/bam-to-fastqs.wdl/#L33"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
+message = "samtools-merge.wdl:15:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/samtools-merge.wdl/#L15"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
+message = "samtools-merge.wdl:21:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/samtools-merge.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
@@ -1772,8 +1952,28 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
+message = "samtools-merge.wdl:36:17: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/samtools-merge.wdl/#L36"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
+message = "samtools-merge.wdl:41:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/samtools-merge.wdl/#L41"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
+message = "samtools-merge.wdl:50:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/samtools-merge.wdl/#L50"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
 message = "samtools-merge.wdl:7:10: note[SectionOrdering]: sections are not in order for workflow `samtools_merge`"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/general/samtools-merge.wdl/#L7"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/markdups-post.wdl"
+message = "markdups-post.wdl:60:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/markdups-post.wdl/#L60"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
@@ -1787,8 +1987,23 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:150:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L150"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:151:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L151"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:168:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L168"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:177:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L177"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
@@ -1799,6 +2014,36 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:23:9: warning[NonmatchingOutput]: `outputs` section of `meta` for the workflow `quality_check` is out of order"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L23"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:266:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L266"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:315:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L315"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:345:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L345"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:352:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L352"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:355:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L355"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:369:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/qc/quality-check-standard.wdl/#L369"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
@@ -1832,6 +2077,11 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
+message = "make-qc-reference.wdl:126:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/reference/make-qc-reference.wdl/#L126"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:6:10: note[SectionOrdering]: sections are not in order for workflow `make_qc_reference`"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/reference/make-qc-reference.wdl/#L6"
 
@@ -1844,6 +2094,21 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:87:34: note[Todo]: remaining `TODO` item found"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/rnaseq/rnaseq-core.wdl/#L87"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
+message = "rnaseq-standard-fastq.wdl:118:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L118"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
+message = "rnaseq-standard-fastq.wdl:133:9: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L133"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
+message = "rnaseq-standard-fastq.wdl:141:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L141"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
@@ -1862,6 +2127,11 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
+message = "rnaseq-standard.wdl:89:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/rnaseq/rnaseq-standard.wdl/#L89"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:94:10: note[Todo]: remaining `TODO` item found"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/rnaseq/rnaseq-standard.wdl/#L94"
 
@@ -1874,6 +2144,16 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:6:10: note[SectionOrdering]: sections are not in order for workflow `rnaseq_variant_calling`"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/rnaseq/rnaseq-variant-calling.wdl/#L6"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "10x-bam-to-fastqs.wdl:104:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L104"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "10x-bam-to-fastqs.wdl:109:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L109"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
@@ -1914,6 +2194,16 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:38:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L38"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "10x-bam-to-fastqs.wdl:58:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L58"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "10x-bam-to-fastqs.wdl:82:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L82"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
@@ -1959,3 +2249,13 @@ permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
 message = "scrnaseq-standard.wdl:5:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/scrnaseq-standard.wdl/#L5"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
+message = "scrnaseq-standard.wdl:62:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/scrnaseq-standard.wdl/#L62"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
+message = "scrnaseq-standard.wdl:95:5: note[BlanksBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/833b97fb582fe7d4f6df9d29a645d0289f1fc92e/workflows/scrnaseq/scrnaseq-standard.wdl/#L95"

--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -24,7 +24,7 @@ commit_hash = "4e7fdfa7992dd1bf4c4721e77c81e4d7b8ecf4fe"
 
 [repositories."broadinstitute/warp"]
 identifier = "broadinstitute/warp"
-commit_hash = "9942eed7d6c8aba87ddf096fc77cddc6f5052e54"
+commit_hash = "25a98392991857f4a8be429075c0c7496834aa88"
 
 [repositories."chanzuckerberg/czid-workflows"]
 identifier = "chanzuckerberg/czid-workflows"
@@ -384,32 +384,32 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/4e7fdfa79
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/scATAC/scATAC.wdl"
 message = "scATAC.wdl:203:9: error: duplicate key `cpu` in runtime section"
-permalink = "https://github.com/broadinstitute/warp/blob/9942eed7d6c8aba87ddf096fc77cddc6f5052e54/pipelines/skylab/scATAC/scATAC.wdl/#L203"
+permalink = "https://github.com/broadinstitute/warp/blob/25a98392991857f4a8be429075c0c7496834aa88/pipelines/skylab/scATAC/scATAC.wdl/#L203"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:140:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/9942eed7d6c8aba87ddf096fc77cddc6f5052e54/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
+permalink = "https://github.com/broadinstitute/warp/blob/25a98392991857f4a8be429075c0c7496834aa88/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:67:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/9942eed7d6c8aba87ddf096fc77cddc6f5052e54/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
+permalink = "https://github.com/broadinstitute/warp/blob/25a98392991857f4a8be429075c0c7496834aa88/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:814:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/9942eed7d6c8aba87ddf096fc77cddc6f5052e54/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
+permalink = "https://github.com/broadinstitute/warp/blob/25a98392991857f4a8be429075c0c7496834aa88/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:866:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/9942eed7d6c8aba87ddf096fc77cddc6f5052e54/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
+permalink = "https://github.com/broadinstitute/warp/blob/25a98392991857f4a8be429075c0c7496834aa88/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/cemba/pr/CheckCembaOutputs.wdl"
 message = "CheckCembaOutputs.wdl:1:1: error: a WDL document must start with a version statement"
-permalink = "https://github.com/broadinstitute/warp/blob/9942eed7d6c8aba87ddf096fc77cddc6f5052e54/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
+permalink = "https://github.com/broadinstitute/warp/blob/25a98392991857f4a8be429075c0c7496834aa88/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/index-generation/index-generation.wdl"

--- a/wdl-lint/Cargo.toml
+++ b/wdl-lint/Cargo.toml
@@ -14,6 +14,7 @@ readme = "../README.md"
 wdl-ast = { path = "../wdl-ast", version = "0.4.0" }
 convert_case = { workspace = true }
 indexmap = { workspace = true }
+rowan.workspace = true
 
 [dev-dependencies]
 codespan-reporting = { workspace = true }

--- a/wdl-lint/RULES.md
+++ b/wdl-lint/RULES.md
@@ -8,6 +8,7 @@ be out of sync with released packages.
 
 | Name                             | Tags                          | Description                                                                           |
 | :------------------------------- | :---------------------------- | :------------------------------------------------------------------------------------ |
+| `BlanksBetweenElements`          | Spacing                       | Ensures proper blank space between elements                                           |
 | `CallInputSpacing`               | Style, Clarity, Spacing       | Ensures proper spacing for call inputs                                                |
 | `CommandSectionMixedIndentation` | Clarity, Correctness, Spacing | Ensures that lines within a command do not mix spaces and tabs.                       |
 | `DeprecatedObject`               | Deprecated                    | Ensures that the deprecated `Object` construct is not used.                           |

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -96,6 +96,7 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
         Box::<rules::RuntimeSectionKeysRule>::default(),
         Box::<rules::TodoRule>::default(),
         Box::<rules::NonmatchingOutputRule<'_>>::default(),
+        Box::<rules::BlanksBetweenElementsRule>::default(),
     ];
 
     // Ensure all the rule ids are unique and pascal case

--- a/wdl-lint/src/rules.rs
+++ b/wdl-lint/src/rules.rs
@@ -1,5 +1,6 @@
 //! Module for the lint rules.
 
+mod blanks_between_elements;
 mod call_input_spacing;
 mod command_mixed_indentation;
 mod deprecated_object;
@@ -28,6 +29,7 @@ mod snake_case;
 mod todo;
 mod whitespace;
 
+pub use blanks_between_elements::*;
 pub use call_input_spacing::*;
 pub use command_mixed_indentation::*;
 pub use deprecated_object::*;

--- a/wdl-lint/src/rules/blanks_between_elements.rs
+++ b/wdl-lint/src/rules/blanks_between_elements.rs
@@ -1,0 +1,274 @@
+//! A lint rule for blank spacing between elements.
+
+use wdl_ast::AstNode;
+use wdl_ast::Diagnostic;
+use wdl_ast::Diagnostics;
+use wdl_ast::Document;
+use wdl_ast::Span;
+use wdl_ast::SyntaxKind;
+use wdl_ast::SyntaxNode;
+use wdl_ast::ToSpan;
+use wdl_ast::VisitReason;
+use wdl_ast::Visitor;
+
+use crate::Rule;
+use crate::Tag;
+use crate::TagSet;
+
+/// The identifier for the blanks between elements rule.
+const ID: &str = "BlanksBetweenElements";
+
+/// Creates an excessive blank line diagnostic.
+fn excess_blank_line(span: Span) -> Diagnostic {
+    Diagnostic::note("extra blank line(s) found")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("remove blank line(s)")
+}
+
+/// Creates a missing blank line diagnostic.
+fn missing_blank_line(span: Span) -> Diagnostic {
+    Diagnostic::note("missing blank line")
+        .with_rule(ID)
+        .with_highlight(span)
+        .with_fix("add blank line before this element")
+}
+
+
+
+/// Detects unsorted input declarations.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct BlanksBetweenElementsRule;
+
+impl Rule for BlanksBetweenElementsRule {
+    fn id(&self) -> &'static str {
+        ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that WDL elements are spaced appropriately."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "There should be a blank line between each WDL element at the root indentation level (such \
+         as the import block and any task/workflow definitions) and between sections of a WDL task \
+         or workflow. Never have a blank line when indentation levels are changing (such as \
+         between the opening of a workflow definition and the meta section). There should also \
+         never be blanks within a meta, parameter meta, input, output, or runtime section. See \
+         example for a complete WDL document with proper spacing between elements. Note the blank \
+         lines between meta, parameter meta, input, the first call or first private declaration, \
+         output, and runtime for the example task. The blank line between the workflow definition \
+         and the task definition is also important."
+    }
+
+    fn tags(&self) -> TagSet {
+        TagSet::new(&[Tag::Spacing])
+    }
+}
+
+/// Check for blank lines between elements.
+fn check_blank_lines(syntax: &SyntaxNode, state: &mut Diagnostics){
+    let mut newline_seen = 0;
+    let mut blank_start = None;
+    syntax.descendants_with_tokens()
+        .for_each(|c| match c.kind() {
+            SyntaxKind::Whitespace => {
+                let count = c.to_string().chars().filter(|c| *c == '\n').count();
+                blank_start = Some(c.text_range().to_span().start());
+                newline_seen += count;
+            }
+            _ => {
+                if newline_seen > 1 {
+                    if let Some(start) = blank_start {
+                        state.add(excess_blank_line(
+                            Span::new(start, c.text_range().to_span().start() - start),
+                        ));
+                    }
+                }
+                newline_seen = 0;
+                blank_start = None;
+            }
+    });
+}
+
+/// Check blank lines in definitions (workflow and task).
+fn check_blank_lines_definition(syntax: &SyntaxNode, state: &mut Diagnostics){
+    let mut newline_seen = 0;
+    let mut blank_start = None;
+    syntax.children_with_tokens()
+        .for_each(|c| match c.kind() {
+            SyntaxKind::Whitespace => {
+                let count = c.to_string().chars().filter(|c| *c == '\n').count();
+                blank_start = Some(c.text_range().to_span().start());
+                newline_seen += count;
+            }
+            SyntaxKind::OpenBrace => {
+                if let Some(next) = c.next_sibling_or_token() {
+                    if next.kind() == SyntaxKind::Whitespace {
+                        let count = next.to_string().chars().filter(|c| *c == '\n').count();
+                        if count > 1 {
+                            let end = c.text_range().to_span().end();
+                            state.add(excess_blank_line(Span::new(
+                                end,
+                                next.text_range().to_span().start() - end,
+                            )));
+                        }
+                    }
+                }
+            }
+            SyntaxKind::CloseBrace => {
+                if newline_seen > 1 {
+                    if let Some(start) = blank_start {
+                        state.add(excess_blank_line(
+                            Span::new(start, c.text_range().to_span().start() - start),
+                        ));
+                    }
+                }
+                newline_seen = 0;
+                blank_start = None;
+            }
+            _ => {
+                if newline_seen > 2 {
+                    if let Some(start) = blank_start {
+                        state.add(excess_blank_line(
+                            Span::new(start, c.text_range().to_span().start() - start),
+                        ));
+                    }
+                }
+                if newline_seen < 2 && newline_seen > 0 {
+                    let start = c.prev_sibling_or_token().unwrap().text_range().to_span().end();
+                    state.add(missing_blank_line(
+                        Span::new(start, c.text_range().to_span().start() - start),
+                    ));
+                }
+                newline_seen = 0;
+                blank_start = None;
+            }
+    });
+}
+
+impl Visitor for BlanksBetweenElementsRule {
+    type State = Diagnostics;
+
+    fn document(&mut self, state: &mut Self::State, reason: VisitReason, doc: &Document) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        if reason == VisitReason::Enter {
+            // Reset the visitor upon document entry
+            *self = Default::default();
+        }
+
+        let mut newline_seen = 0;
+        let mut blank_start = None;
+        doc.syntax().children_with_tokens().for_each(|c| match c.kind(){
+            SyntaxKind::ImportStatementNode => {
+                newline_seen = 0;
+                blank_start = None;
+            }
+            SyntaxKind::Whitespace => {
+                let count = c.to_string().chars().filter(|c| *c == '\n').count();
+                blank_start = Some(c.text_range().to_span().start());
+                newline_seen += count;
+            }
+            _ => {
+                if newline_seen > 2 {
+                    if let Some(start) = blank_start {
+                        state.add(excess_blank_line(
+                            Span::new(start, c.text_range().to_span().start() - start),
+                        ));
+                    }
+                }
+                else if newline_seen < 2 && newline_seen > 0 {
+                    let start = c.prev_sibling_or_token().unwrap().text_range().to_span().end();
+                    state.add(missing_blank_line(
+                        Span::new(start, c.text_range().to_span().start() - start),
+                    ));
+                }
+                newline_seen = 0;
+                blank_start = None;
+            }
+        });
+
+    }
+
+    fn metadata_section(
+            &mut self,
+            state: &mut Self::State,
+            reason: VisitReason,
+            section: &wdl_ast::v1::MetadataSection,
+        ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+        
+        check_blank_lines(section.syntax(), state);
+    }
+
+    fn parameter_metadata_section(
+            &mut self,
+            state: &mut Self::State,
+            reason: VisitReason,
+            section: &wdl_ast::v1::ParameterMetadataSection,
+        ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+        
+        check_blank_lines(section.syntax(), state);
+        
+    }
+
+    fn input_section(
+            &mut self,
+            state: &mut Self::State,
+            reason: VisitReason,
+            section: &wdl_ast::v1::InputSection,
+        ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_blank_lines(section.syntax(), state);
+    }
+    
+    fn output_section(
+            &mut self,
+            state: &mut Self::State,
+            reason: VisitReason,
+            section: &wdl_ast::v1::OutputSection,
+        ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_blank_lines(section.syntax(), state);
+    }
+
+    fn task_definition(
+            &mut self,
+            state: &mut Self::State,
+            reason: VisitReason,
+            task: &wdl_ast::v1::TaskDefinition,
+        ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_blank_lines_definition(task.syntax(), state);
+    }
+
+    fn workflow_definition(
+            &mut self,
+            state: &mut Self::State,
+            reason: VisitReason,
+            workflow: &wdl_ast::v1::WorkflowDefinition,
+        ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_blank_lines_definition(workflow.syntax(), state);
+    }
+}

--- a/wdl-lint/src/rules/blanks_between_elements.rs
+++ b/wdl-lint/src/rules/blanks_between_elements.rs
@@ -34,8 +34,6 @@ fn missing_blank_line(span: Span) -> Diagnostic {
         .with_fix("add blank line before this element")
 }
 
-
-
 /// Detects unsorted input declarations.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct BlanksBetweenElementsRule;
@@ -66,11 +64,13 @@ impl Rule for BlanksBetweenElementsRule {
     }
 }
 
-/// Check for blank lines between elements.
-fn check_blank_lines(syntax: &SyntaxNode, state: &mut Diagnostics){
+/// Check for blank lines between elements of `meta`, `parameter_meta`,
+/// `input`, `output`, and `runtime` sections.
+fn check_blank_lines(syntax: &SyntaxNode, state: &mut Diagnostics) {
     let mut newline_seen = 0;
     let mut blank_start = None;
-    syntax.descendants_with_tokens()
+    syntax
+        .descendants_with_tokens()
         .for_each(|c| match c.kind() {
             SyntaxKind::Whitespace => {
                 let count = c.to_string().chars().filter(|c| *c == '\n').count();
@@ -78,64 +78,77 @@ fn check_blank_lines(syntax: &SyntaxNode, state: &mut Diagnostics){
                 newline_seen += count;
             }
             _ => {
+                // Blank lines are not allowed between elements
                 if newline_seen > 1 {
                     if let Some(start) = blank_start {
-                        state.add(excess_blank_line(
-                            Span::new(start, c.text_range().to_span().start() - start),
-                        ));
+                        state.add(excess_blank_line(Span::new(
+                            start,
+                            c.text_range().to_span().start() - start,
+                        )));
                     }
                 }
                 newline_seen = 0;
                 blank_start = None;
             }
-    });
+        });
 }
 
 /// Check blank lines in definitions (workflow and task).
-fn check_blank_lines_definition(syntax: &SyntaxNode, state: &mut Diagnostics){
+fn check_blank_lines_definition(syntax: &SyntaxNode, state: &mut Diagnostics) {
     let mut newline_seen = 0;
     let mut blank_start = None;
-    syntax.children_with_tokens()
-        .for_each(|c| match c.kind() {
-            SyntaxKind::Whitespace => {
-                let count = c.to_string().chars().filter(|c| *c == '\n').count();
-                blank_start = Some(c.text_range().to_span().start());
-                newline_seen += count;
-            }
-            SyntaxKind::OpenBrace => {
-                if let Some(next) = c.next_sibling_or_token() {
-                    if next.kind() == SyntaxKind::Whitespace {
-                        let count = next.to_string().chars().filter(|c| *c == '\n').count();
-                        if count > 1 {
-                            let end = c.text_range().to_span().end();
-                            state.add(excess_blank_line(Span::new(
-                                end,
-                                next.text_range().to_span().start() - end,
-                            )));
-                        }
+    syntax.children_with_tokens().for_each(|c| match c.kind() {
+        SyntaxKind::Whitespace => {
+            let count = c.to_string().chars().filter(|c| *c == '\n').count();
+            blank_start = Some(c.text_range().to_span().start());
+            newline_seen += count;
+        }
+        SyntaxKind::OpenBrace => {
+            if let Some(next) = c.next_sibling_or_token() {
+                if next.kind() == SyntaxKind::Whitespace {
+                    let count = next.to_string().chars().filter(|c| *c == '\n').count();
+                    if count > 1 {
+                        let end = c.text_range().to_span().end();
+                        state.add(excess_blank_line(Span::new(
+                            end,
+                            next.text_range().to_span().end() - end,
+                        )));
                     }
                 }
             }
-            SyntaxKind::CloseBrace => {
-                if newline_seen > 1 {
-                    if let Some(start) = blank_start {
-                        state.add(excess_blank_line(
-                            Span::new(start, c.text_range().to_span().start() - start),
-                        ));
-                    }
+        }
+        SyntaxKind::CloseBrace => {
+            if newline_seen > 1 {
+                if let Some(start) = blank_start {
+                    state.add(excess_blank_line(Span::new(
+                        start,
+                        c.text_range().to_span().start() - start,
+                    )));
                 }
-                newline_seen = 0;
-                blank_start = None;
             }
-            _ => {
-                if newline_seen > 2 {
-                    if let Some(start) = blank_start {
-                        state.add(excess_blank_line(
-                            Span::new(start, c.text_range().to_span().start() - start),
-                        ));
-                    }
+            newline_seen = 0;
+            blank_start = None;
+        }
+        SyntaxKind::BoundDeclNode => {
+            if newline_seen > 2 {
+                if let Some(start) = blank_start {
+                    state.add(excess_blank_line(Span::new(
+                        start,
+                        c.text_range().to_span().start() - start,
+                    )));
                 }
-                if newline_seen < 2 && newline_seen > 0 {
+            }
+            newline_seen = 0;
+            blank_start = None;
+        }
+        SyntaxKind::Comment => {
+            newline_seen = 0;
+            blank_start = None;
+        }
+        _ => {
+                // 2 newlines == 1 blank line between elements
+                // > 2 newlines / Consecutive blank lines will be handled by the Whitespace rule.
+                if newline_seen == 1 {
                     let start = c.prev_sibling_or_token().unwrap().text_range().to_span().end();
                     state.add(missing_blank_line(
                         Span::new(start, c.text_range().to_span().start() - start),
@@ -162,25 +175,33 @@ impl Visitor for BlanksBetweenElementsRule {
 
         let mut newline_seen = 0;
         let mut blank_start = None;
-        doc.syntax().children_with_tokens().for_each(|c| match c.kind(){
-            SyntaxKind::ImportStatementNode => {
-                newline_seen = 0;
-                blank_start = None;
-            }
-            SyntaxKind::Whitespace => {
-                let count = c.to_string().chars().filter(|c| *c == '\n').count();
-                blank_start = Some(c.text_range().to_span().start());
-                newline_seen += count;
-            }
-            _ => {
-                if newline_seen > 2 {
-                    if let Some(start) = blank_start {
-                        state.add(excess_blank_line(
-                            Span::new(start, c.text_range().to_span().start() - start),
-                        ));
-                    }
+
+        let mut prior_comment = false;
+
+        doc.syntax()
+            .children_with_tokens()
+            .for_each(|c| match c.kind() {
+                // Don't require blank lines between `import` statements.
+                SyntaxKind::ImportStatementNode => {
+                    newline_seen = 0;
+                    blank_start = None;
+                    prior_comment = false;
                 }
-                else if newline_seen < 2 && newline_seen > 0 {
+                SyntaxKind::Whitespace => {
+                    let count = c.to_string().chars().filter(|c| *c == '\n').count();
+                    blank_start = Some(c.text_range().to_span().start());
+                    newline_seen += count;
+                    // prior_comment = false;
+                }
+                SyntaxKind::Comment => {
+                    newline_seen = 0;
+                    blank_start = None;
+                    prior_comment = true;
+                }
+                _ => {
+                // 2 newlines == 1 blank line between elements
+                // > 2 newlines / Consecutive blank lines will be handled by the Whitespace rule.
+                if newline_seen == 1 && !prior_comment {
                     let start = c.prev_sibling_or_token().unwrap().text_range().to_span().end();
                     state.add(missing_blank_line(
                         Span::new(start, c.text_range().to_span().start() - start),
@@ -188,70 +209,108 @@ impl Visitor for BlanksBetweenElementsRule {
                 }
                 newline_seen = 0;
                 blank_start = None;
+                prior_comment = false;
             }
-        });
-
+            });
     }
 
     fn metadata_section(
-            &mut self,
-            state: &mut Self::State,
-            reason: VisitReason,
-            section: &wdl_ast::v1::MetadataSection,
-        ) {
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &wdl_ast::v1::MetadataSection,
+    ) {
         if reason == VisitReason::Exit {
             return;
         }
-        
+
         check_blank_lines(section.syntax(), state);
     }
 
     fn parameter_metadata_section(
-            &mut self,
-            state: &mut Self::State,
-            reason: VisitReason,
-            section: &wdl_ast::v1::ParameterMetadataSection,
-        ) {
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &wdl_ast::v1::ParameterMetadataSection,
+    ) {
         if reason == VisitReason::Exit {
             return;
         }
-        
+
         check_blank_lines(section.syntax(), state);
-        
     }
 
     fn input_section(
-            &mut self,
-            state: &mut Self::State,
-            reason: VisitReason,
-            section: &wdl_ast::v1::InputSection,
-        ) {
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &wdl_ast::v1::InputSection,
+    ) {
         if reason == VisitReason::Exit {
             return;
         }
 
         check_blank_lines(section.syntax(), state);
     }
-    
+
     fn output_section(
-            &mut self,
-            state: &mut Self::State,
-            reason: VisitReason,
-            section: &wdl_ast::v1::OutputSection,
-        ) {
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &wdl_ast::v1::OutputSection,
+    ) {
         if reason == VisitReason::Exit {
             return;
         }
 
         check_blank_lines(section.syntax(), state);
+    }
+
+    fn runtime_section(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        section: &wdl_ast::v1::RuntimeSection,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_blank_lines(section.syntax(), state);
+    }
+
+    fn call_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &wdl_ast::v1::CallStatement,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_blank_lines(stmt.syntax(), state);
+    }
+
+    fn scatter_statement(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        stmt: &wdl_ast::v1::ScatterStatement,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        check_blank_lines(stmt.syntax(), state);
     }
 
     fn task_definition(
-            &mut self,
-            state: &mut Self::State,
-            reason: VisitReason,
-            task: &wdl_ast::v1::TaskDefinition,
-        ) {
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        task: &wdl_ast::v1::TaskDefinition,
+    ) {
         if reason == VisitReason::Exit {
             return;
         }
@@ -260,11 +319,11 @@ impl Visitor for BlanksBetweenElementsRule {
     }
 
     fn workflow_definition(
-            &mut self,
-            state: &mut Self::State,
-            reason: VisitReason,
-            workflow: &wdl_ast::v1::WorkflowDefinition,
-        ) {
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        workflow: &wdl_ast::v1::WorkflowDefinition,
+    ) {
         if reason == VisitReason::Exit {
             return;
         }

--- a/wdl-lint/tests/lints/between-import-whitespace/source.errors
+++ b/wdl-lint/tests/lints/between-import-whitespace/source.errors
@@ -51,19 +51,3 @@ warning[Whitespace]: more than one blank line in a row
    │  
    = fix: remove the unnecessary blank lines
 
-note[BlanksBetweenElements]: missing blank line
-   ┌─ tests/lints/between-import-whitespace/source.wdl:23:5
-   │
-23 │     meta {}
-   │     ^
-   │
-   = fix: add blank line before this element
-
-note[BlanksBetweenElements]: missing blank line
-   ┌─ tests/lints/between-import-whitespace/source.wdl:24:5
-   │
-24 │     output {}
-   │     ^
-   │
-   = fix: add blank line before this element
-

--- a/wdl-lint/tests/lints/between-import-whitespace/source.errors
+++ b/wdl-lint/tests/lints/between-import-whitespace/source.errors
@@ -51,3 +51,19 @@ warning[Whitespace]: more than one blank line in a row
    │  
    = fix: remove the unnecessary blank lines
 
+note[BlanksBetweenElements]: missing blank line
+   ┌─ tests/lints/between-import-whitespace/source.wdl:23:5
+   │
+23 │     meta {}
+   │     ^
+   │
+   = fix: add blank line before this element
+
+note[BlanksBetweenElements]: missing blank line
+   ┌─ tests/lints/between-import-whitespace/source.wdl:24:5
+   │
+24 │     output {}
+   │     ^
+   │
+   = fix: add blank line before this element
+

--- a/wdl-lint/tests/lints/between-import-whitespace/source.wdl
+++ b/wdl-lint/tests/lints/between-import-whitespace/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of whitespace between import statements.
 
 version 1.1

--- a/wdl-lint/tests/lints/blanks-between-elements/source.errors
+++ b/wdl-lint/tests/lints/blanks-between-elements/source.errors
@@ -1,110 +1,129 @@
 note[BlanksBetweenElements]: extra blank line(s) found
-   ┌─ tests/lints/blanks-between-elements/source.wdl:9:15
+   ┌─ tests/lints/blanks-between-elements/source.wdl:11:15
    │  
- 9 │   workflow foo {
+11 │   workflow foo {
    │ ╭──────────────^
-10 │ │ 
-11 │ │     meta {}
+12 │ │ 
+13 │ │     # This is OK.(but the prior line is not)
    │ ╰────^
    │  
    = fix: remove blank line(s)
 
 note[BlanksBetweenElements]: missing blank line
-   ┌─ tests/lints/blanks-between-elements/source.wdl:12:5
+   ┌─ tests/lints/blanks-between-elements/source.wdl:16:5
    │
-12 │     parameter_meta {}
-   │     ^
+16 │     parameter_meta {}
+   │     ^^^^^^^^^^^^^^^^^
    │
    = fix: add blank line before this element
 
 note[BlanksBetweenElements]: missing blank line
-   ┌─ tests/lints/blanks-between-elements/source.wdl:13:5
+   ┌─ tests/lints/blanks-between-elements/source.wdl:17:5
    │
-13 │     input {}
-   │     ^
+17 │     # what about this comment?
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
+   = fix: add blank line before this element
+
+note[BlanksBetweenElements]: missing blank line
+   ┌─ tests/lints/blanks-between-elements/source.wdl:41:1
+   │  
+41 │ ╭ task bar {
+42 │ │ 
+43 │ │     meta {
+44 │ │         
+   · │
+64 │ │ 
+65 │ │ }
+   │ ╰─^
+   │  
    = fix: add blank line before this element
 
 note[BlanksBetweenElements]: extra blank line(s) found
-   ┌─ tests/lints/blanks-between-elements/source.wdl:15:21
+   ┌─ tests/lints/blanks-between-elements/source.wdl:41:11
    │  
-15 │       String p = "pip"
-   │ ╭────────────────────^
-16 │ │ 
-17 │ │     
-18 │ │     String q = "bar" # The following whitespace is allowable between private declarations
-   │ ╰────^
-   │  
-   = fix: remove blank line(s)
-
-note[BlanksBetweenElements]: missing blank line
-   ┌─ tests/lints/blanks-between-elements/source.wdl:32:5
-   │
-32 │     call bar as qux { input: # Calls must be separated by whitespace.
-   │     ^
-   │
-   = fix: add blank line before this element
-
-note[BlanksBetweenElements]: missing blank line
-   ┌─ tests/lints/blanks-between-elements/source.wdl:36:1
-   │
-36 │ task bar {
-   │ ^
-   │
-   = fix: add blank line before this element
-
-note[BlanksBetweenElements]: extra blank line(s) found
-   ┌─ tests/lints/blanks-between-elements/source.wdl:36:11
-   │  
-36 │   task bar {
+41 │   task bar {
    │ ╭──────────^
-37 │ │ 
-38 │ │     meta {
+42 │ │ 
+43 │ │     meta {
    │ ╰────^
    │  
    = fix: remove blank line(s)
 
 note[BlanksBetweenElements]: extra blank line(s) found
-   ┌─ tests/lints/blanks-between-elements/source.wdl:39:27
+   ┌─ tests/lints/blanks-between-elements/source.wdl:43:11
    │  
-39 │           description: "bar"
-   │ ╭──────────────────────────^
-40 │ │ 
-41 │ │         outputs: {
+43 │       meta {
+   │ ╭──────────^
+44 │ │         
+45 │ │         description: "bar"
    │ ╰────────^
    │  
    = fix: remove blank line(s)
 
 note[BlanksBetweenElements]: extra blank line(s) found
-   ┌─ tests/lints/blanks-between-elements/source.wdl:42:19
+   ┌─ tests/lints/blanks-between-elements/source.wdl:45:27
    │  
-42 │               u: "u"
+45 │           description: "bar"
+   │ ╭──────────────────────────^
+46 │ │ 
+47 │ │         outputs: {
+   │ ╰────────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:48:19
+   │  
+48 │               u: "u"
    │ ╭──────────────────^
-43 │ │ 
-44 │ │         }
-   │ ╰────────^
-   │  
-   = fix: remove blank line(s)
-
-note[BlanksBetweenElements]: extra blank line(s) found
-   ┌─ tests/lints/blanks-between-elements/source.wdl:48:27
-   │  
-48 │           String s = "hello"
-   │ ╭──────────────────────────^
 49 │ │ 
-50 │ │         String? t
+50 │ │         }
    │ ╰────────^
    │  
    = fix: remove blank line(s)
 
 note[BlanksBetweenElements]: extra blank line(s) found
-   ┌─ tests/lints/blanks-between-elements/source.wdl:57:6
+   ┌─ tests/lints/blanks-between-elements/source.wdl:54:27
    │  
-57 │       }
-   │ ╭─────^
-58 │ │ 
-59 │ │ }
-   │ ╰^
+54 │           String s = "hello"
+   │ ╭──────────────────────────^
+55 │ │ 
+56 │ │         String? t
+   │ ╰────────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:79:14
+   │  
+79 │       runtime {
+   │ ╭─────────────^
+80 │ │ 
+81 │ │         disks: "50 GB"
+   │ ╰────────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:82:23
+   │  
+82 │           memory: "4 GB"
+   │ ╭──────────────────────^
+83 │ │ 
+84 │ │         container: "ubuntu:latest"
+   │ ╰────────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:84:35
+   │  
+84 │           container: "ubuntu:latest"
+   │ ╭──────────────────────────────────^
+85 │ │         
+86 │ │     }
+   │ ╰────^
    │  
    = fix: remove blank line(s)
 

--- a/wdl-lint/tests/lints/blanks-between-elements/source.errors
+++ b/wdl-lint/tests/lints/blanks-between-elements/source.errors
@@ -1,0 +1,110 @@
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:9:15
+   │  
+ 9 │   workflow foo {
+   │ ╭──────────────^
+10 │ │ 
+11 │ │     meta {}
+   │ ╰────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: missing blank line
+   ┌─ tests/lints/blanks-between-elements/source.wdl:12:5
+   │
+12 │     parameter_meta {}
+   │     ^
+   │
+   = fix: add blank line before this element
+
+note[BlanksBetweenElements]: missing blank line
+   ┌─ tests/lints/blanks-between-elements/source.wdl:13:5
+   │
+13 │     input {}
+   │     ^
+   │
+   = fix: add blank line before this element
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:15:21
+   │  
+15 │       String p = "pip"
+   │ ╭────────────────────^
+16 │ │ 
+17 │ │     
+18 │ │     String q = "bar" # The following whitespace is allowable between private declarations
+   │ ╰────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: missing blank line
+   ┌─ tests/lints/blanks-between-elements/source.wdl:32:5
+   │
+32 │     call bar as qux { input: # Calls must be separated by whitespace.
+   │     ^
+   │
+   = fix: add blank line before this element
+
+note[BlanksBetweenElements]: missing blank line
+   ┌─ tests/lints/blanks-between-elements/source.wdl:36:1
+   │
+36 │ task bar {
+   │ ^
+   │
+   = fix: add blank line before this element
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:36:11
+   │  
+36 │   task bar {
+   │ ╭──────────^
+37 │ │ 
+38 │ │     meta {
+   │ ╰────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:39:27
+   │  
+39 │           description: "bar"
+   │ ╭──────────────────────────^
+40 │ │ 
+41 │ │         outputs: {
+   │ ╰────────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:42:19
+   │  
+42 │               u: "u"
+   │ ╭──────────────────^
+43 │ │ 
+44 │ │         }
+   │ ╰────────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:48:27
+   │  
+48 │           String s = "hello"
+   │ ╭──────────────────────────^
+49 │ │ 
+50 │ │         String? t
+   │ ╰────────^
+   │  
+   = fix: remove blank line(s)
+
+note[BlanksBetweenElements]: extra blank line(s) found
+   ┌─ tests/lints/blanks-between-elements/source.wdl:57:6
+   │  
+57 │       }
+   │ ╭─────^
+58 │ │ 
+59 │ │ }
+   │ ╰^
+   │  
+   = fix: remove blank line(s)
+

--- a/wdl-lint/tests/lints/blanks-between-elements/source.wdl
+++ b/wdl-lint/tests/lints/blanks-between-elements/source.wdl
@@ -1,13 +1,15 @@
-#@ except: DescriptionMissing, InputSorting, LineWidth, MissingMetas, MissingOutput, MissingRuntime, Whitespace
+#@ except: DescriptionMissing, ImportWhitespace, InputSorting, LineWidth, MissingMetas, MissingOutput, MissingRuntime, Whitespace
 
 version 1.1
 
-import "baz"
+import "baz" # following whitespace will be caught by ImportWhitespace rule
+
 import "qux" # following whitespace duplication is caught be Whitespace rule
 
 
+# test comment
 workflow foo {
-
+    # This is OK.
     meta {}
     parameter_meta {}
     input {}
@@ -56,4 +58,26 @@ task bar {
         String u = "u"
     }
 
+}
+
+task bax {
+    meta {}
+
+    parameter_meta {}
+
+
+    input {}
+
+    command <<< >>>
+
+    output {}
+
+    runtime {
+
+        disks: "50 GB"
+        memory: "4 GB"
+
+        docker: "ubuntu:latest"
+        
+    }
 }

--- a/wdl-lint/tests/lints/blanks-between-elements/source.wdl
+++ b/wdl-lint/tests/lints/blanks-between-elements/source.wdl
@@ -1,24 +1,35 @@
-#@ except: DescriptionMissing, InputSorting, MissingMetas, MissingOutput, MissingRuntime
+#@ except: DescriptionMissing, InputSorting, LineWidth, MissingMetas, MissingOutput, MissingRuntime, Whitespace
 
 version 1.1
 
 import "baz"
-import "qux"
+import "qux" # following whitespace duplication is caught be Whitespace rule
 
 
 workflow foo {
+
     meta {}
     parameter_meta {}
     input {}
 
-    String s = "hello"
+    String p = "pip"
+
+    
+    String q = "bar" # The following whitespace is allowable between private declarations
+
+    String r = "world"
+    String s = "hello" # following whitespace duplication is caught be Whitespace rule
+
 
     call bar { input:
         s = s
-    }
+    } # following whitespace duplication is caught be Whitespace rule
 
 
     call bar as baz { input:
+        s = s
+    }
+    call bar as qux { input: # Calls must be separated by whitespace.
         s = s
     }
 }

--- a/wdl-lint/tests/lints/blanks-between-elements/source.wdl
+++ b/wdl-lint/tests/lints/blanks-between-elements/source.wdl
@@ -9,9 +9,12 @@ import "qux" # following whitespace duplication is caught be Whitespace rule
 
 # test comment
 workflow foo {
-    # This is OK.
+
+    # This is OK.(but the prior line is not)
+    # So is this.
     meta {}
     parameter_meta {}
+    # what about this comment?
     input {}
 
     String p = "pip"
@@ -38,6 +41,7 @@ workflow foo {
 task bar {
 
     meta {
+        
         description: "bar"
 
         outputs: {
@@ -77,7 +81,7 @@ task bax {
         disks: "50 GB"
         memory: "4 GB"
 
-        docker: "ubuntu:latest"
+        container: "ubuntu:latest"
         
     }
 }

--- a/wdl-lint/tests/lints/blanks-between-elements/source.wdl
+++ b/wdl-lint/tests/lints/blanks-between-elements/source.wdl
@@ -1,0 +1,48 @@
+#@ except: DescriptionMissing, InputSorting, MissingMetas, MissingOutput, MissingRuntime
+
+version 1.1
+
+import "baz"
+import "qux"
+
+
+workflow foo {
+    meta {}
+    parameter_meta {}
+    input {}
+
+    String s = "hello"
+
+    call bar { input:
+        s = s
+    }
+
+
+    call bar as baz { input:
+        s = s
+    }
+}
+task bar {
+
+    meta {
+        description: "bar"
+
+        outputs: {
+            u: "u"
+
+        }
+    }
+
+    input {
+        String s = "hello"
+
+        String? t
+    }
+
+    command <<< >>>
+
+    output {
+        String u = "u"
+    }
+
+}

--- a/wdl-lint/tests/lints/command-mixed-line-cont/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-line-cont/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, NoCurlyCommands, NonmatchingOutput, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, NoCurlyCommands, NonmatchingOutput, RuntimeSectionKeys
 ## This is a test of having mixed indentation in a line continuation.
 
 version 1.1

--- a/wdl-lint/tests/lints/command-mixed-line-cont/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-line-cont/source.wdl
@@ -1,4 +1,4 @@
-#@ except: BlanksBetweenElements, DescriptionMissing, NoCurlyCommands, NonmatchingOutput, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, LineWidth, NoCurlyCommands, NonmatchingOutput, RuntimeSectionKeys
 ## This is a test of having mixed indentation in a line continuation.
 
 version 1.1

--- a/wdl-lint/tests/lints/command-mixed-spaces-first/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-spaces-first/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
 ## This is a test of having spaces before tabs in command sections.
 
 version 1.1

--- a/wdl-lint/tests/lints/command-mixed-tabs-first/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-tabs-first/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
 ## This is a test of having tabs before spaces in command sections.
 
 version 1.1

--- a/wdl-lint/tests/lints/command-mixed-trailing/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-trailing/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
 ## This is a test of having mixed _trailing_ indentation in command sections.
 ## There should be no warnings from the `CommandSectionMixedIndentation` rule.
 

--- a/wdl-lint/tests/lints/command-mixed-ws-ok/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed-ws-ok/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, NoCurlyCommands, RuntimeSectionKeys
 ## This is a test of having mixed indentation inside of a placeholder.
 ## This should not cause a warning for the `CommandSectionMixedIndentation` rule.
 

--- a/wdl-lint/tests/lints/command-mixed/source.wdl
+++ b/wdl-lint/tests/lints/command-mixed/source.wdl
@@ -1,4 +1,4 @@
-#@ except: NoCurlyCommands, DescriptionMissing, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, NoCurlyCommands, DescriptionMissing, RuntimeSectionKeys
 ## This is a test of having mixed indentation on the same line in command sections.
 
 version 1.1

--- a/wdl-lint/tests/lints/curly-command/source.wdl
+++ b/wdl-lint/tests/lints/curly-command/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, SectionOrdering, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, SectionOrdering, RuntimeSectionKeys
 ## This is a test of the `NoCurlyCommands` lint
 
 version 1.1

--- a/wdl-lint/tests/lints/deprecated-object/source.wdl
+++ b/wdl-lint/tests/lints/deprecated-object/source.wdl
@@ -1,4 +1,4 @@
-#@ except: BlanksBetweenElements, DescriptionMissing, MissingMetas, NonmatchingOutput, SectionOrdering
+#@ except: BlanksBetweenElements, DescriptionMissing, LineWidth, MissingMetas, NonmatchingOutput, SectionOrdering
 ## This is a test of the `DeprecatedObject` lint
 
 version 1.1

--- a/wdl-lint/tests/lints/deprecated-object/source.wdl
+++ b/wdl-lint/tests/lints/deprecated-object/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, MissingMetas, NonmatchingOutput, SectionOrdering
+#@ except: BlanksBetweenElements, DescriptionMissing, MissingMetas, NonmatchingOutput, SectionOrdering
 ## This is a test of the `DeprecatedObject` lint
 
 version 1.1

--- a/wdl-lint/tests/lints/deprecated-placeholder-options-v1.0/source.wdl
+++ b/wdl-lint/tests/lints/deprecated-placeholder-options-v1.0/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing,RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing,RuntimeSectionKeys
 ##
 ## This is a test of the `DeprecatedPlaceholderOption` lint.
 

--- a/wdl-lint/tests/lints/deprecated-placeholder-options-v1.1/source.wdl
+++ b/wdl-lint/tests/lints/deprecated-placeholder-options-v1.1/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing,RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, RuntimeSectionKeys
 ##
 ## This is a test of the `DeprecatedPlaceholderOption` lint.
 

--- a/wdl-lint/tests/lints/description-missing/source.errors
+++ b/wdl-lint/tests/lints/description-missing/source.errors
@@ -1,23 +1,23 @@
 note[DescriptionMissing]: task `foo` is missing a description key
-  ┌─ tests/lints/description-missing/source.wdl:6:5
+  ┌─ tests/lints/description-missing/source.wdl:7:5
   │
-6 │     meta {
+7 │     meta {
   │     ^^^^
   │
   = fix: add a `description` key to this meta section
 
 note[DescriptionMissing]: workflow `bar` is missing a description key
-   ┌─ tests/lints/description-missing/source.wdl:22:5
+   ┌─ tests/lints/description-missing/source.wdl:23:5
    │
-22 │     meta {
+23 │     meta {
    │     ^^^^
    │
    = fix: add a `description` key to this meta section
 
 note[DescriptionMissing]: struct `Baz` is missing a description key
-   ┌─ tests/lints/description-missing/source.wdl:34:5
+   ┌─ tests/lints/description-missing/source.wdl:35:5
    │
-34 │     meta {
+35 │     meta {
    │     ^^^^
    │
    = fix: add a `description` key to this meta section

--- a/wdl-lint/tests/lints/description-missing/source.wdl
+++ b/wdl-lint/tests/lints/description-missing/source.wdl
@@ -1,3 +1,4 @@
+#@ except: BlanksBetweenElements, MissingRuntime, MissingOutput
 ## This is a test for a missing description in a `meta` section.
 
 version 1.2

--- a/wdl-lint/tests/lints/double-quotes/source.wdl
+++ b/wdl-lint/tests/lints/double-quotes/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of the `DoubleQuotes` lint
 
 version 1.1

--- a/wdl-lint/tests/lints/import-placements/source.wdl
+++ b/wdl-lint/tests/lints/import-placements/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of import placements.
 
 version 1.1

--- a/wdl-lint/tests/lints/input-not-sorted/source.wdl
+++ b/wdl-lint/tests/lints/input-not-sorted/source.wdl
@@ -1,4 +1,4 @@
-#@ except: BlanksBetweenElements, DeprecatedObject, DescriptionMissing, SectionOrdering, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DeprecatedObject, DescriptionMissing, LineWidth, SectionOrdering, RuntimeSectionKeys
 
 version 1.2
 

--- a/wdl-lint/tests/lints/input-not-sorted/source.wdl
+++ b/wdl-lint/tests/lints/input-not-sorted/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DeprecatedObject, DescriptionMissing, SectionOrdering, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DeprecatedObject, DescriptionMissing, SectionOrdering, RuntimeSectionKeys
 
 version 1.2
 

--- a/wdl-lint/tests/lints/input-spacing/source.wdl
+++ b/wdl-lint/tests/lints/input-spacing/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, SectionOrdering, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, SectionOrdering, RuntimeSectionKeys
 
 version 1.1
 

--- a/wdl-lint/tests/lints/invalid-preamble-comment/source.wdl
+++ b/wdl-lint/tests/lints/invalid-preamble-comment/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 # This is an invalid preamble comment.
 ## This one is fine
 # This one is invalid too!

--- a/wdl-lint/tests/lints/matching-param-meta/source.wdl
+++ b/wdl-lint/tests/lints/matching-param-meta/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, RuntimeSectionKeys, SectionOrdering
+#@ except: BlanksBetweenElements, DescriptionMissing, RuntimeSectionKeys, SectionOrdering
 ## This is a test for checking for missing and extraneous entries
 ## in a `parameter_meta` section.
 

--- a/wdl-lint/tests/lints/missing-blank-line-after-version/source.wdl
+++ b/wdl-lint/tests/lints/missing-blank-line-after-version/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of a missing blank line following the version statement.
 
 version 1.1

--- a/wdl-lint/tests/lints/missing-comment-space/source.wdl
+++ b/wdl-lint/tests/lints/missing-comment-space/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ##This preamble comment is missing a space.
 ##
 ## But this one isn't and neither are the empty ones

--- a/wdl-lint/tests/lints/missing-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/missing-eof-newline/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of a missing EOF newline lint
 
 version 1.1

--- a/wdl-lint/tests/lints/missing-meta-and-parameter_meta/source.errors
+++ b/wdl-lint/tests/lints/missing-meta-and-parameter_meta/source.errors
@@ -1,7 +1,7 @@
 note[MissingMetas]: workflow `test` is missing both meta and parameter_meta sections
-  ┌─ tests/lints/missing-meta-and-parameter_meta/source.wdl:5:10
+  ┌─ tests/lints/missing-meta-and-parameter_meta/source.wdl:6:10
   │
-5 │ workflow test {
+6 │ workflow test {
   │          ^^^^ this workflow is missing both meta and parameter_meta sections
   │
   = fix: add meta and parameter_meta sections to the workflow

--- a/wdl-lint/tests/lints/missing-meta-and-parameter_meta/source.wdl
+++ b/wdl-lint/tests/lints/missing-meta-and-parameter_meta/source.wdl
@@ -1,3 +1,4 @@
+#@ except: BlanksBetweenElements
 ## This is a test of missing both the meta and parameter_meta
 
 version 1.0

--- a/wdl-lint/tests/lints/missing-meta/source.wdl
+++ b/wdl-lint/tests/lints/missing-meta/source.wdl
@@ -1,4 +1,4 @@
-#@ except: RuntimeSectionKeys, SectionOrdering
+#@ except: BlanksBetweenElements, RuntimeSectionKeys, SectionOrdering
 
 version 1.0
 

--- a/wdl-lint/tests/lints/missing-output/source.wdl
+++ b/wdl-lint/tests/lints/missing-output/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 
 version 1.0
 

--- a/wdl-lint/tests/lints/missing-parameter_meta/source.wdl
+++ b/wdl-lint/tests/lints/missing-parameter_meta/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, SectionOrdering
+#@ except: BlanksBetweenElements, DescriptionMissing, SectionOrdering
 
 version 1.0
 

--- a/wdl-lint/tests/lints/missing-preamble-ws/source.wdl
+++ b/wdl-lint/tests/lints/missing-preamble-ws/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of missing preamble whitespace.
 version 1.1
 

--- a/wdl-lint/tests/lints/missing-runtime-block/source.wdl
+++ b/wdl-lint/tests/lints/missing-runtime-block/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, RuntimeSectionKeys, SectionOrdering
+#@ except: BlanksBetweenElements, DescriptionMissing, RuntimeSectionKeys, SectionOrdering
 ## This is a test of the `missing_runtime_block` lint
 
 version 1.1

--- a/wdl-lint/tests/lints/multiple-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/multiple-eof-newline/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of multiple EOF newlines lint
 
 version 1.1

--- a/wdl-lint/tests/lints/no-preamble-comments/source.wdl
+++ b/wdl-lint/tests/lints/no-preamble-comments/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 
 version 1.1
 

--- a/wdl-lint/tests/lints/nonmatching-output/source.wdl
+++ b/wdl-lint/tests/lints/nonmatching-output/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, MissingRuntime
+#@ except: BlanksBetweenElements, DescriptionMissing, MissingRuntime
 
 version 1.1
 

--- a/wdl-lint/tests/lints/one-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/one-eof-newline/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of the missing EOF newline lint
 ## `source.errors` should be empty
 

--- a/wdl-lint/tests/lints/one-invalid-preamble-comment/source.wdl
+++ b/wdl-lint/tests/lints/one-invalid-preamble-comment/source.wdl
@@ -1,4 +1,4 @@
-#@ except: PreambleWhitespace, DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing, PreambleWhitespace
 # This is a test of having one big invalid preamble comment.
 #
 

--- a/wdl-lint/tests/lints/only-whitespace/source.wdl
+++ b/wdl-lint/tests/lints/only-whitespace/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, SectionOrdering
+#@ except: BlanksBetweenElements, DescriptionMissing, SectionOrdering
 ## This is a test of lines that only contain whitespace
 
 version 1.1

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a normal preamble comment.
        ## Bad leading whitespace!
 

--- a/wdl-lint/tests/lints/preamble-ws/source.wdl
+++ b/wdl-lint/tests/lints/preamble-ws/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of both missing and extraneous preamble whitespace.
         version 1.1
 

--- a/wdl-lint/tests/lints/runtime-keys-engine-keys/source.wdl
+++ b/wdl-lint/tests/lints/runtime-keys-engine-keys/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 
 version 1.1
 

--- a/wdl-lint/tests/lints/runtime-keys-multiple-runtime-sections/source.wdl
+++ b/wdl-lint/tests/lints/runtime-keys-multiple-runtime-sections/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 
 version 1.1
 

--- a/wdl-lint/tests/lints/runtime-keys-wdl-1.0/source.wdl
+++ b/wdl-lint/tests/lints/runtime-keys-wdl-1.0/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 
 version 1.0
 

--- a/wdl-lint/tests/lints/runtime-keys-wdl-1.1/source.wdl
+++ b/wdl-lint/tests/lints/runtime-keys-wdl-1.1/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 
 version 1.1
 

--- a/wdl-lint/tests/lints/runtime-keys-wdl-1.2/source.wdl
+++ b/wdl-lint/tests/lints/runtime-keys-wdl-1.2/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 
 version 1.2
 

--- a/wdl-lint/tests/lints/section-ordering/source.wdl
+++ b/wdl-lint/tests/lints/section-ordering/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, MissingRuntime, MissingOutput
+#@ except: BlanksBetweenElements, DescriptionMissing, MissingRuntime, MissingOutput
 
 version 1.2
 

--- a/wdl-lint/tests/lints/snake-case/source.wdl
+++ b/wdl-lint/tests/lints/snake-case/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing, NonmatchingOutput, SectionOrdering, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, NonmatchingOutput, SectionOrdering, RuntimeSectionKeys
 ## Test SnakeCase rule
 
 version 1.0

--- a/wdl-lint/tests/lints/snake-case/source.wdl
+++ b/wdl-lint/tests/lints/snake-case/source.wdl
@@ -1,4 +1,4 @@
-#@ except: BlanksBetweenElements, DescriptionMissing, NonmatchingOutput, SectionOrdering, RuntimeSectionKeys
+#@ except: BlanksBetweenElements, DescriptionMissing, LineWidth, NonmatchingOutput, SectionOrdering, RuntimeSectionKeys
 ## Test SnakeCase rule
 
 version 1.0

--- a/wdl-lint/tests/lints/todo/source.wdl
+++ b/wdl-lint/tests/lints/todo/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of the todo rule.
 
 version 1.1

--- a/wdl-lint/tests/lints/too-many-pounds-preamble/source.wdl
+++ b/wdl-lint/tests/lints/too-many-pounds-preamble/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ### This comment has too many pound signs!
 ## This one is fine though.
 ###### This comment also has too many pound signs!

--- a/wdl-lint/tests/lints/two-eof-newline/source.wdl
+++ b/wdl-lint/tests/lints/two-eof-newline/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of two EOF newlines lint
 
 version 1.1

--- a/wdl-lint/tests/lints/unnecessary-preamble-ws/source.wdl
+++ b/wdl-lint/tests/lints/unnecessary-preamble-ws/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of ensuring that we print two diagnostics:
 ## The first is for the whitespace following the last comment
 ## The second is for the whitespace between the end of that line to the version keyword

--- a/wdl-lint/tests/lints/within-import-whitespace/source.wdl
+++ b/wdl-lint/tests/lints/within-import-whitespace/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of whitespace within import statements and sort order.
 ## There should only ever be one diagnostic reported for a bad sort order.
 

--- a/wdl-lint/tests/lints/ws-after-blank-line/source.wdl
+++ b/wdl-lint/tests/lints/ws-after-blank-line/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of whitespace after a blank line.
 
      

--- a/wdl-lint/tests/lints/ws-before-version/source.wdl
+++ b/wdl-lint/tests/lints/ws-before-version/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
     
 
   

--- a/wdl-lint/tests/lints/ws-preamble-comments/source.wdl
+++ b/wdl-lint/tests/lints/ws-preamble-comments/source.wdl
@@ -1,4 +1,4 @@
-#@ except: DescriptionMissing
+#@ except: BlanksBetweenElements, DescriptionMissing
 ## This is a test of whitespace between preamble comments
 
   


### PR DESCRIPTION
This pull request adds a new rule to `wdl-lint`.

- **Rule Name**: `BlanksBetweenElements`

This rule ensures that blank lines are present between elements when required.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Rule specific checks:

- [x] You have added the rule as an entry within `RULES.md`.
- [x] You have added the rule to the `rules()` function in `wdl-lint/src/lib.rs`.
- [x] You have added a test case in `wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
- [ ] If you have implemented a new `Visitor` callback, you have also
      overridden that callback method for the special `Validator`
      (`wdl-ast/src/validation.rs`) and `LintVisitor`
      (`wdl-lint/src/visitor.rs`) visitors. These are required to ensure the new
      visitor callback will execute.
- [x] You have run `wdl-gauntlet --refresh` to ensure that there are no 
      unintended changes to the baseline configuration file (`Gauntlet.toml`).
- [x] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the 
      rules added/removed are now reflected in the baseline configuration file 
      (`Arena.toml`).