### PR TITLE
feat: promotes `wdl-analysis` to `wdl::analysis`

### DIFF
--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Promoted `wdl-analysis` to `wdl::analysis` (available behind the `analysis` feature,
+  [#140](https://github.com/stjude-rust-labs/wdl/pull/140)).
+
 ## 0.6.0 - 07-17-2024
 
 ### Changed
@@ -13,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added an `analysis` command to perform full analysis and to also print the 
-  result of the analysis; currently it just outputs a debug representation of 
+* Added an `analysis` command to perform full analysis and to also print the
+  result of the analysis; currently it just outputs a debug representation of
   the analysis results, but that will change in the future ([#110](https://github.com/stjude-rust-labs/wdl/pull/110)).
 
 ## 0.5.0 - 06-28-2024

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -29,12 +29,23 @@ anyhow = { workspace = true }
 codespan-reporting = { workspace = true }
 
 [features]
-default = ["ast", "grammar", "lint"]
+default = ["analysis", "ast", "grammar", "lint"]
+analysis = ["dep:wdl-analysis"]
 ast = ["dep:wdl-ast"]
 grammar = ["dep:wdl-grammar"]
 lint = ["dep:wdl-lint"]
 codespan = ["ast", "wdl-ast/codespan", "dep:codespan-reporting"]
-cli = ["codespan", "lint", "dep:wdl-analysis", "dep:clap", "dep:anyhow", "dep:colored", "dep:env_logger", "dep:indicatif", "dep:tokio"]
+cli = [
+    "analysis",
+    "codespan",
+    "lint",
+    "dep:clap",
+    "dep:anyhow",
+    "dep:colored",
+    "dep:env_logger",
+    "dep:indicatif",
+    "dep:tokio",
+]
 
 [[example]]
 name = "explore"

--- a/wdl/src/lib.rs
+++ b/wdl/src/lib.rs
@@ -72,6 +72,9 @@
 
 #![warn(missing_docs)]
 
+#[cfg(feature = "analysis")]
+#[doc(inline)]
+pub use wdl_analysis as analysis;
 #[cfg(feature = "ast")]
 #[doc(inline)]
 pub use wdl_ast as ast;


### PR DESCRIPTION
This PR promotes the `wdl-analysis` crate to be available under the `wdl` crate at `wdl::analysis`. This allows `wdl-analysis` to be used externally (albeit with the pre-v1 conditions).

cc: @peterhuene 

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
