### PR TITLE
fix: allow reuse for `LintVisitor`.

### DIFF
--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the `CommentWhitespace` lint rule ([#136](https://github.com/stjude-rust-labs/wdl/pull/136)).
 * Added the `TrailingComma` lint rule ([#137](https://github.com/stjude-rust-labs/wdl/pull/137)).
 
+### Fixed
+
+* Fixed `LintVisitor` to support reuse ([#147](https://github.com/stjude-rust-labs/wdl/pull/147)).
+
 ## 0.4.0 - 07-17-2024
 
 ### Added


### PR DESCRIPTION
Currently `LintVisitor` will remove rules from the rule set upon document entry when there's a "global" exception.

This works for a single document visit, but if the visitor is reused, the subsequent visitation will treat any previously globally excepted rules as unknown rules.

The fix is to use the `each_enabled_rule` for the `document` method so that globally excepted rules behave like locally excepted rules and the rule set doesn't change.

Fixes #145.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
