### PR TITLE
refactor: change section methods to return `Option<T>`.

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Moved validation of import statements to `wdl-ast` ([#158](https://github.com/stjude-rust-labs/wdl/pull/158)).
 
+### Changed
+
+* Section methods on `TaskDefinition` and `WorkflowDefinition` now return
+  `Option` instead of iterator. ([#157](https://github.com/stjude-rust-labs/wdl/pull/157)).
+
 ## 0.5.0 - 07-17-2024
 
 ### Added

--- a/wdl-ast/src/v1/decls.rs
+++ b/wdl-ast/src/v1/decls.rs
@@ -804,9 +804,8 @@ task test {
         assert_eq!(tasks[0].name().as_str(), "test");
 
         // Inputs
-        let inputs: Vec<_> = tasks[0].inputs().collect();
-        assert_eq!(inputs.len(), 1);
-        let decls: Vec<_> = inputs[0].declarations().collect();
+        let input = tasks[0].input().expect("task should have an input section");
+        let decls: Vec<_> = input.declarations().collect();
         assert_eq!(decls.len(), 11);
 
         // First input declaration

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -4765,9 +4765,8 @@ task test {
         assert_eq!(tasks[0].name().as_str(), "test");
 
         // Task hints
-        let hints: Vec<_> = tasks[0].hints().collect();
-        assert_eq!(hints.len(), 1);
-        let items: Vec<_> = hints[0].items().collect();
+        let hints = tasks[0].hints().expect("should have a hints section");
+        let items: Vec<_> = hints.items().collect();
         assert_eq!(items.len(), 3);
 
         // First hints item
@@ -4920,9 +4919,8 @@ task test {
         assert_eq!(tasks[0].name().as_str(), "test");
 
         // Task hints
-        let hints: Vec<_> = tasks[0].hints().collect();
-        assert_eq!(hints.len(), 1);
-        let items: Vec<_> = hints[0].items().collect();
+        let hints = tasks[0].hints().expect("task should have hints section");
+        let items: Vec<_> = hints.items().collect();
         assert_eq!(items.len(), 1);
 
         // First hints item
@@ -5043,9 +5041,8 @@ task test {
         assert_eq!(tasks[0].name().as_str(), "test");
 
         // Task hints
-        let hints: Vec<_> = tasks[0].hints().collect();
-        assert_eq!(hints.len(), 1);
-        let items: Vec<_> = hints[0].items().collect();
+        let hints = tasks[0].hints().expect("task should have a hints section");
+        let items: Vec<_> = hints.items().collect();
         assert_eq!(items.len(), 1);
 
         // First hints item

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -43,44 +43,44 @@ impl TaskDefinition {
         children(&self.0)
     }
 
-    /// Gets the input sections of the task.
-    pub fn inputs(&self) -> AstChildren<InputSection> {
-        children(&self.0)
+    /// Gets the input section of the task.
+    pub fn input(&self) -> Option<InputSection> {
+        child(&self.0)
     }
 
-    /// Gets the output sections of the task.
-    pub fn outputs(&self) -> AstChildren<OutputSection> {
-        children(&self.0)
+    /// Gets the output section of the task.
+    pub fn output(&self) -> Option<OutputSection> {
+        child(&self.0)
     }
 
-    /// Gets the command sections of the task.
-    pub fn commands(&self) -> AstChildren<CommandSection> {
-        children(&self.0)
+    /// Gets the command section of the task.
+    pub fn command(&self) -> Option<CommandSection> {
+        child(&self.0)
     }
 
     /// Gets the requirements sections of the task.
-    pub fn requirements(&self) -> AstChildren<RequirementsSection> {
-        children(&self.0)
+    pub fn requirements(&self) -> Option<RequirementsSection> {
+        child(&self.0)
     }
 
-    /// Gets the hints sections of the task.
-    pub fn hints(&self) -> AstChildren<HintsSection> {
-        children(&self.0)
+    /// Gets the hints section of the task.
+    pub fn hints(&self) -> Option<HintsSection> {
+        child(&self.0)
     }
 
-    /// Gets the runtime sections of the task.
-    pub fn runtimes(&self) -> AstChildren<RuntimeSection> {
-        children(&self.0)
+    /// Gets the runtime section of the task.
+    pub fn runtime(&self) -> Option<RuntimeSection> {
+        child(&self.0)
     }
 
-    /// Gets the metadata sections of the task.
-    pub fn metadata(&self) -> AstChildren<MetadataSection> {
-        children(&self.0)
+    /// Gets the metadata section of the task.
+    pub fn metadata(&self) -> Option<MetadataSection> {
+        child(&self.0)
     }
 
-    /// Gets the parameter sections of the task.
-    pub fn parameter_metadata(&self) -> AstChildren<ParameterMetadataSection> {
-        children(&self.0)
+    /// Gets the parameter section of the task.
+    pub fn parameter_metadata(&self) -> Option<ParameterMetadataSection> {
+        child(&self.0)
     }
 
     /// Gets the private declarations of the task.
@@ -1226,13 +1226,10 @@ task test {
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].name().as_str(), "test");
 
-        // Task inputs
-        let inputs: Vec<_> = tasks[0].inputs().collect();
-        assert_eq!(inputs.len(), 1);
-
-        // First task input
-        assert_eq!(inputs[0].parent().unwrap_task().name().as_str(), "test");
-        let decls: Vec<_> = inputs[0].declarations().collect();
+        // Task input
+        let input = tasks[0].input().expect("should have an input section");
+        assert_eq!(input.parent().unwrap_task().name().as_str(), "test");
+        let decls: Vec<_> = input.declarations().collect();
         assert_eq!(decls.len(), 1);
         assert_eq!(
             decls[0].clone().unwrap_unbound_decl().ty().to_string(),
@@ -1243,13 +1240,10 @@ task test {
             "name"
         );
 
-        // Task outputs
-        let outputs: Vec<_> = tasks[0].outputs().collect();
-        assert_eq!(outputs.len(), 1);
-
-        // First task output
-        assert_eq!(outputs[0].parent().unwrap_task().name().as_str(), "test");
-        let decls: Vec<_> = outputs[0].declarations().collect();
+        // Task output
+        let output = tasks[0].output().expect("should have an output section");
+        assert_eq!(output.parent().unwrap_task().name().as_str(), "test");
+        let decls: Vec<_> = output.declarations().collect();
         assert_eq!(decls.len(), 1);
         assert_eq!(decls[0].ty().to_string(), "String");
         assert_eq!(decls[0].name().as_str(), "output");
@@ -1264,14 +1258,11 @@ task test {
             "stdout"
         );
 
-        // Task commands
-        let commands: Vec<_> = tasks[0].commands().collect();
-        assert_eq!(commands.len(), 1);
-
-        // First task command
-        assert_eq!(commands[0].parent().name().as_str(), "test");
-        assert!(commands[0].is_heredoc());
-        let parts: Vec<_> = commands[0].parts().collect();
+        // Task command
+        let command = tasks[0].command().expect("should have a command section");
+        assert_eq!(command.parent().name().as_str(), "test");
+        assert!(command.is_heredoc());
+        let parts: Vec<_> = command.parts().collect();
         assert_eq!(parts.len(), 3);
         assert_eq!(
             parts[0].clone().unwrap_text().as_str(),
@@ -1290,12 +1281,11 @@ task test {
         assert_eq!(parts[2].clone().unwrap_text().as_str(), "!\n    ");
 
         // Task requirements
-        let requirements: Vec<_> = tasks[0].requirements().collect();
-        assert_eq!(requirements.len(), 1);
-
-        // First task requirements
-        assert_eq!(requirements[0].parent().name().as_str(), "test");
-        let items: Vec<_> = requirements[0].items().collect();
+        let requirements = tasks[0]
+            .requirements()
+            .expect("should have a requirements section");
+        assert_eq!(requirements.parent().name().as_str(), "test");
+        let items: Vec<_> = requirements.items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "container");
         assert_eq!(
@@ -1310,12 +1300,9 @@ task test {
         );
 
         // Task hints
-        let hints: Vec<_> = tasks[0].hints().collect();
-        assert_eq!(hints.len(), 1);
-
-        // First task hints
-        assert_eq!(hints[0].parent().unwrap_task().name().as_str(), "test");
-        let items: Vec<_> = hints[0].items().collect();
+        let hints = tasks[0].hints().expect("should have a hints section");
+        assert_eq!(hints.parent().unwrap_task().name().as_str(), "test");
+        let items: Vec<_> = hints.items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "foo");
         assert_eq!(
@@ -1330,12 +1317,9 @@ task test {
         );
 
         // Task runtimes
-        let runtimes: Vec<_> = tasks[0].runtimes().collect();
-        assert_eq!(runtimes.len(), 1);
-
-        // First task runtime
-        assert_eq!(runtimes[0].parent().name().as_str(), "test");
-        let items: Vec<_> = runtimes[0].items().collect();
+        let runtime = tasks[0].runtime().expect("should have a runtime section");
+        assert_eq!(runtime.parent().name().as_str(), "test");
+        let items: Vec<_> = runtime.items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "container");
         assert_eq!(
@@ -1350,12 +1334,9 @@ task test {
         );
 
         // Task metadata
-        let metadata: Vec<_> = tasks[0].metadata().collect();
-        assert_eq!(metadata.len(), 1);
-
-        // First metadata
-        assert_eq!(metadata[0].parent().unwrap_task().name().as_str(), "test");
-        let items: Vec<_> = metadata[0].items().collect();
+        let metadata = tasks[0].metadata().expect("should have a metadata section");
+        assert_eq!(metadata.parent().unwrap_task().name().as_str(), "test");
+        let items: Vec<_> = metadata.items().collect();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].name().as_str(), "description");
         assert_eq!(
@@ -1368,12 +1349,11 @@ task test {
         items[1].value().unwrap_null();
 
         // Task parameter metadata
-        let param_meta: Vec<_> = tasks[0].parameter_metadata().collect();
-        assert_eq!(param_meta.len(), 1);
-
-        // First task parameter metadata
-        assert_eq!(param_meta[0].parent().unwrap_task().name().as_str(), "test");
-        let items: Vec<_> = param_meta[0].items().collect();
+        let param_meta = tasks[0]
+            .parameter_metadata()
+            .expect("should have a parameter metadata section");
+        assert_eq!(param_meta.parent().unwrap_task().name().as_str(), "test");
+        let items: Vec<_> = param_meta.items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "name");
         let items: Vec<_> = items[0].value().unwrap_object().items().collect();

--- a/wdl-ast/src/v1/task/common/container/value.rs
+++ b/wdl-ast/src/v1/task/common/container/value.rs
@@ -309,7 +309,6 @@ mod tests {
             .next()
             .expect("the 'hello' task to exist")
             .requirements()
-            .next()
             .expect("the 'requirements' block to exist")
             .items()
             .find_map(|p| p.into_container())

--- a/wdl-ast/src/v1/task/requirements/item/container.rs
+++ b/wdl-ast/src/v1/task/requirements/item/container.rs
@@ -82,7 +82,6 @@ task hello {
             .next()
             .expect("the 'hello' task to exist")
             .requirements()
-            .next()
             .expect("the 'requirements' block to exist")
             .items()
             .filter_map(|p| p.into_container());
@@ -112,7 +111,6 @@ task hello {
             .next()
             .expect("the 'hello' task to exist")
             .requirements()
-            .next()
             .expect("the 'requirements' block to exist")
             .items()
             .filter_map(|p| p.into_container());
@@ -144,7 +142,6 @@ task hello {
             .next()
             .expect("the 'hello' task to exist")
             .requirements()
-            .next()
             .expect("the 'requirements' block to exist")
             .items()
             .filter_map(|p| p.into_container());

--- a/wdl-ast/src/v1/task/runtime/item/container.rs
+++ b/wdl-ast/src/v1/task/runtime/item/container.rs
@@ -84,8 +84,7 @@ task hello {
             .tasks()
             .next()
             .expect("the 'hello' task to exist")
-            .runtimes()
-            .next()
+            .runtime()
             .expect("the 'runtime' block to exist")
             .items()
             .filter_map(|p| p.into_container());
@@ -114,8 +113,7 @@ task hello {
             .tasks()
             .next()
             .expect("the 'hello' task to exist")
-            .runtimes()
-            .next()
+            .runtime()
             .expect("the 'runtime' block to exist")
             .items()
             .filter_map(|p| p.into_container());
@@ -144,8 +142,7 @@ task hello {
             .tasks()
             .next()
             .expect("the 'hello' task to exist")
-            .runtimes()
-            .next()
+            .runtime()
             .expect("the 'runtime' block to exist")
             .items()
             .filter_map(|p| p.into_container());

--- a/wdl-ast/src/v1/workflow.rs
+++ b/wdl-ast/src/v1/workflow.rs
@@ -34,14 +34,14 @@ impl WorkflowDefinition {
         children(&self.0)
     }
 
-    /// Gets the input sections of the workflow.
-    pub fn inputs(&self) -> AstChildren<InputSection> {
-        children(&self.0)
+    /// Gets the input section of the workflow.
+    pub fn input(&self) -> Option<InputSection> {
+        child(&self.0)
     }
 
-    /// Gets the output sections of the workflow.
-    pub fn outputs(&self) -> AstChildren<OutputSection> {
-        children(&self.0)
+    /// Gets the output section of the workflow.
+    pub fn output(&self) -> Option<OutputSection> {
+        child(&self.0)
     }
 
     /// Gets the statements of the workflow.
@@ -49,19 +49,19 @@ impl WorkflowDefinition {
         children(&self.0)
     }
 
-    /// Gets the metadata sections of the workflow.
-    pub fn metadata(&self) -> AstChildren<MetadataSection> {
-        children(&self.0)
+    /// Gets the metadata section of the workflow.
+    pub fn metadata(&self) -> Option<MetadataSection> {
+        child(&self.0)
     }
 
-    /// Gets the parameter sections of the workflow.
-    pub fn parameter_metadata(&self) -> AstChildren<ParameterMetadataSection> {
-        children(&self.0)
+    /// Gets the parameter section of the workflow.
+    pub fn parameter_metadata(&self) -> Option<ParameterMetadataSection> {
+        child(&self.0)
     }
 
-    /// Gets the hints sections of the workflow.
-    pub fn hints(&self) -> AstChildren<HintsSection> {
-        children(&self.0)
+    /// Gets the hints section of the workflow.
+    pub fn hints(&self) -> Option<HintsSection> {
+        child(&self.0)
     }
 
     /// Gets the private declarations of the workflow.
@@ -640,12 +640,11 @@ workflow test {
         assert_eq!(workflows[0].name().as_str(), "test");
 
         // Workflow inputs
-        let inputs: Vec<_> = workflows[0].inputs().collect();
-        assert_eq!(inputs.len(), 1);
-
-        // First input declarations
-        assert_eq!(inputs[0].parent().unwrap_workflow().name().as_str(), "test");
-        let decls: Vec<_> = inputs[0].declarations().collect();
+        let input = workflows[0]
+            .input()
+            .expect("workflow should have an input section");
+        assert_eq!(input.parent().unwrap_workflow().name().as_str(), "test");
+        let decls: Vec<_> = input.declarations().collect();
         assert_eq!(decls.len(), 2);
 
         // First declaration
@@ -669,15 +668,11 @@ workflow test {
         );
 
         // Workflow outputs
-        let outputs: Vec<_> = workflows[0].outputs().collect();
-        assert_eq!(outputs.len(), 1);
-
-        // First output declarations
-        assert_eq!(
-            outputs[0].parent().unwrap_workflow().name().as_str(),
-            "test"
-        );
-        let decls: Vec<_> = outputs[0].declarations().collect();
+        let output = workflows[0]
+            .output()
+            .expect("workflow should have an output section");
+        assert_eq!(output.parent().unwrap_workflow().name().as_str(), "test");
+        let decls: Vec<_> = output.declarations().collect();
         assert_eq!(decls.len(), 1);
 
         // First declaration
@@ -851,15 +846,11 @@ workflow test {
         assert_eq!(inner.len(), 0);
 
         // Workflow metadata
-        let metadata: Vec<_> = workflows[0].metadata().collect();
-        assert_eq!(metadata.len(), 1);
-
-        // First metadata
-        assert_eq!(
-            metadata[0].parent().unwrap_workflow().name().as_str(),
-            "test"
-        );
-        let items: Vec<_> = metadata[0].items().collect();
+        let metadata = workflows[0]
+            .metadata()
+            .expect("workflow should have a metadata section");
+        assert_eq!(metadata.parent().unwrap_workflow().name().as_str(), "test");
+        let items: Vec<_> = metadata.items().collect();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].name().as_str(), "description");
         assert_eq!(
@@ -870,15 +861,14 @@ workflow test {
         items[1].value().unwrap_null();
 
         // Workflow parameter metadata
-        let param_meta: Vec<_> = workflows[0].parameter_metadata().collect();
-        assert_eq!(param_meta.len(), 1);
-
-        // First parameter metadata
+        let param_meta = workflows[0]
+            .parameter_metadata()
+            .expect("workflow should have a parameter metadata section");
         assert_eq!(
-            param_meta[0].parent().unwrap_workflow().name().as_str(),
+            param_meta.parent().unwrap_workflow().name().as_str(),
             "test"
         );
-        let items: Vec<_> = param_meta[0].items().collect();
+        let items: Vec<_> = param_meta.items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "name");
         let items: Vec<_> = items[0].value().unwrap_object().items().collect();
@@ -890,12 +880,11 @@ workflow test {
         );
 
         // Workflow hints
-        let hints: Vec<_> = workflows[0].hints().collect();
-        assert_eq!(hints.len(), 1);
-
-        // First workflow hints
-        assert_eq!(hints[0].parent().unwrap_workflow().name().as_str(), "test");
-        let items: Vec<_> = hints[0].items().collect();
+        let hints = workflows[0]
+            .hints()
+            .expect("workflow should have a hints section");
+        assert_eq!(hints.parent().unwrap_workflow().name().as_str(), "test");
+        let items: Vec<_> = hints.items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].name().as_str(), "foo");
         assert_eq!(

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -155,11 +155,11 @@ impl Visitor for MatchingParameterMetaRule {
 
         // Note that only the first input and parameter_meta sections are checked as any
         // additional sections is considered a validation error
-        match task.parameter_metadata().next() {
+        match task.parameter_metadata() {
             Some(param_meta) => {
                 check_parameter_meta(
                     &SectionParent::Task(task.clone()),
-                    task.inputs().next().iter().flat_map(|i| {
+                    task.input().iter().flat_map(|i| {
                         i.declarations().map(|d| {
                             let name = d.name();
                             let span = name.span();
@@ -189,11 +189,11 @@ impl Visitor for MatchingParameterMetaRule {
 
         // Note that only the first input and parameter_meta sections are checked as any
         // additional sections is considered a validation error
-        match workflow.parameter_metadata().next() {
+        match workflow.parameter_metadata() {
             Some(param_meta) => {
                 check_parameter_meta(
                     &SectionParent::Workflow(workflow.clone()),
-                    workflow.inputs().next().iter().flat_map(|i| {
+                    workflow.input().iter().flat_map(|i| {
                         i.declarations().map(|d| {
                             let name = d.name();
                             let span = name.span();

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -144,16 +144,13 @@ impl Visitor for MissingMetasRule {
             return;
         }
 
-        let inputs_present = task.inputs().next().is_some();
+        let inputs_present = task.input().is_some();
 
-        if inputs_present
-            && task.metadata().next().is_none()
-            && task.parameter_metadata().next().is_none()
-        {
+        if inputs_present && task.metadata().is_none() && task.parameter_metadata().is_none() {
             state.add(missing_sections(task.name(), Context::Task));
-        } else if task.metadata().next().is_none() {
+        } else if task.metadata().is_none() {
             state.add(missing_section(task.name(), Section::Meta, Context::Task));
-        } else if inputs_present && task.parameter_metadata().next().is_none() {
+        } else if inputs_present && task.parameter_metadata().is_none() {
             state.add(missing_section(
                 task.name(),
                 Section::ParameterMeta,
@@ -172,20 +169,20 @@ impl Visitor for MissingMetasRule {
             return;
         }
 
-        let inputs_present = workflow.inputs().next().is_some();
+        let inputs_present = workflow.input().is_some();
 
         if inputs_present
-            && workflow.metadata().next().is_none()
-            && workflow.parameter_metadata().next().is_none()
+            && workflow.metadata().is_none()
+            && workflow.parameter_metadata().is_none()
         {
             state.add(missing_sections(workflow.name(), Context::Workflow));
-        } else if workflow.metadata().next().is_none() {
+        } else if workflow.metadata().is_none() {
             state.add(missing_section(
                 workflow.name(),
                 Section::Meta,
                 Context::Workflow,
             ));
-        } else if inputs_present && workflow.parameter_metadata().next().is_none() {
+        } else if inputs_present && workflow.parameter_metadata().is_none() {
             state.add(missing_section(
                 workflow.name(),
                 Section::ParameterMeta,

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -97,7 +97,7 @@ impl Visitor for MissingOutputRule {
             return;
         }
 
-        if task.outputs().next().is_none() {
+        if task.output().is_none() {
             let name = task.name();
             state.add(missing_output_section(
                 name.as_str(),
@@ -117,7 +117,7 @@ impl Visitor for MissingOutputRule {
             return;
         }
 
-        if workflow.outputs().next().is_none() {
+        if workflow.output().is_none() {
             let name = workflow.name();
             state.add(missing_output_section(
                 name.as_str(),

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -94,12 +94,12 @@ impl Visitor for MissingRequirementsRule {
         // version, the `runtime` section was recommended.
         if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here") {
             if minor_version >= V1::Two {
-                if task.requirements().next().is_none() {
+                if task.requirements().is_none() {
                     let name = task.name();
                     state.add(missing_requirements_section(name.as_str(), name.span()));
                 }
 
-                if let Some(runtime) = task.runtimes().next() {
+                if let Some(runtime) = task.runtime() {
                     let name = task.name();
                     state.add(deprecated_runtime_section(name.as_str(), span_of(&runtime)))
                 }

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -79,7 +79,7 @@ impl Visitor for MissingRuntimeRule {
         // This rule should only be present for WDL v1.1 or earlier, as the
         // `requirements` section replaces it in WDL v1.2.
         if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here") {
-            if minor_version <= V1::One && task.runtimes().next().is_none() {
+            if minor_version <= V1::One && task.runtime().is_none() {
                 let name = task.name();
                 state.add(missing_runtime_section(name.as_str(), name.span()));
             }

--- a/wdl/examples/explore.rs
+++ b/wdl/examples/explore.rs
@@ -142,27 +142,18 @@ fn explore_output(output: &OutputSection) {
 fn explore_task(task: &TaskDefinition) {
     println!("## Task `{name}`", name = task.name().as_str());
 
-    for (i, metadata) in task.metadata().enumerate() {
-        if i == 0 {
-            println!("\n### Metadata");
-        }
-
+    if let Some(metadata) = task.metadata() {
+        println!("\n### Metadata");
         explore_metadata(&metadata);
     }
 
-    for (i, input) in task.inputs().enumerate() {
-        if i == 0 {
-            println!("\n### Inputs");
-        }
-
+    if let Some(input) = task.input() {
+        println!("\n### Inputs");
         explore_input(&input);
     }
 
-    for (i, output) in task.outputs().enumerate() {
-        if i == 0 {
-            println!("\n### Outputs");
-        }
-
+    if let Some(output) = task.output() {
+        println!("\n### Outputs");
         explore_output(&output);
     }
 }
@@ -171,27 +162,18 @@ fn explore_task(task: &TaskDefinition) {
 fn explore_workflow(workflow: &WorkflowDefinition) {
     println!("## Workflow `{name}`", name = workflow.name().as_str());
 
-    for (i, metadata) in workflow.metadata().enumerate() {
-        if i == 0 {
-            println!("\n### Metadata");
-        }
-
+    if let Some(metadata) = workflow.metadata() {
+        println!("\n### Metadata");
         explore_metadata(&metadata);
     }
 
-    for (i, input) in workflow.inputs().enumerate() {
-        if i == 0 {
-            println!("\n### Inputs");
-        }
-
+    if let Some(input) = workflow.input() {
+        println!("\n### Inputs");
         explore_input(&input);
     }
 
-    for (i, output) in workflow.outputs().enumerate() {
-        if i == 0 {
-            println!("\n### Outputs");
-        }
-
+    if let Some(output) = workflow.output() {
+        println!("\n### Outputs");
         explore_output(&output);
     }
 }


### PR DESCRIPTION
This commit refactors both `TaskDefinition` and `WorkflowDefinition` in the AST to return `Option<T>` for the section methods rather than iterator.

Therefore, only the first section in the AST is returned.

If multiple sections are present, validation will still flag the duplicate sections as errors.

Fixes #149.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
