### PR TITLE
feat: introduce support for the `task` variable from WDL 1.2.

### DIFF
--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Add support for the `task` variable in WDL 1.2 ([#168](https://github.com/stjude-rust-labs/wdl/pull/168)).
 * Full type checking support in task definitions ([#163](https://github.com/stjude-rust-labs/wdl/pull/163)).
 
 ### Changed

--- a/wdl-analysis/src/scope/v1.rs
+++ b/wdl-analysis/src/scope/v1.rs
@@ -222,8 +222,8 @@ fn unknown_type(name: &str, span: Span) -> Diagnostic {
 fn unknown_name(name: &str, span: Span) -> Diagnostic {
     // Handle special case names here
     let message = match name {
-        "task" => "the name `task` may only be used within a task command section or task output \
-                   section using WDL 1.2 or later"
+        "task" => "the `task` variable may only be used within a task command section or task \
+                   output section using WDL 1.2 or later"
             .to_string(),
         _ => format!("unknown name `{name}`"),
     };

--- a/wdl-analysis/src/scope/v1.rs
+++ b/wdl-analysis/src/scope/v1.rs
@@ -220,7 +220,15 @@ fn unknown_type(name: &str, span: Span) -> Diagnostic {
 
 /// Creates an "unknown name" diagnostic.
 fn unknown_name(name: &str, span: Span) -> Diagnostic {
-    Diagnostic::error(format!("unknown name `{name}`")).with_highlight(span)
+    // Handle special case names here
+    let message = match name {
+        "task" => "the name `task` may only be used within a task command section or task output \
+                   section using WDL 1.2 or later"
+            .to_string(),
+        _ => format!("unknown name `{name}`"),
+    };
+
+    Diagnostic::error(message).with_highlight(span)
 }
 
 /// Creates a "self-referential" diagnostic.

--- a/wdl-analysis/src/scope/v1.rs
+++ b/wdl-analysis/src/scope/v1.rs
@@ -25,6 +25,7 @@ use wdl_ast::v1::TaskItem;
 use wdl_ast::v1::WorkflowDefinition;
 use wdl_ast::v1::WorkflowItem;
 use wdl_ast::v1::WorkflowStatement;
+use wdl_ast::version::V1;
 use wdl_ast::AstNode;
 use wdl_ast::AstNodeExt;
 use wdl_ast::AstToken;
@@ -37,7 +38,8 @@ use wdl_ast::ToSpan;
 use wdl_ast::TokenStrHash;
 use wdl_ast::Version;
 
-use super::scope_span;
+use super::braced_scope_span;
+use super::heredoc_scope_span;
 use super::Context;
 use super::DocumentScope;
 use super::Name;
@@ -57,6 +59,10 @@ use crate::types::v1::AstTypeConverter;
 use crate::types::v1::ExprTypeEvaluator;
 use crate::types::Coercible;
 use crate::types::Type;
+
+/// The `task` variable name available in task command sections and outputs in
+/// WDL 1.2.
+const TASK_VAR_NAME: &str = "task";
 
 /// Creates a "name conflict" diagnostic
 fn name_conflict(name: &str, conflicting: Context, first: Context) -> Diagnostic {
@@ -529,10 +535,10 @@ fn add_task(
     }
 
     // Populate the task's scope and evaluation graph
-    let scope = document.add_scope(Scope::new(None, scope_span(task)));
+    let scope = document.add_scope(Scope::new(None, braced_scope_span(task)));
     let mut saw_input = false;
-    let mut saw_output = false;
-
+    let mut outputs = None;
+    let mut command = None;
     for item in task.items() {
         match item {
             TaskItem::Input(section) if !saw_input => {
@@ -541,16 +547,46 @@ fn add_task(
                     add_input(document.scope_mut(scope), decl, diagnostics)
                 }
             }
-            TaskItem::Output(section) if !saw_output => {
-                saw_output = true;
-                let outputs = document.add_scope(Scope::new(Some(scope), scope_span(&section)));
-                document.scope_mut(scope).add_child(outputs);
-                for decl in section.declarations() {
-                    add_output(document.scope_mut(outputs), decl, diagnostics);
+            TaskItem::Output(section) if outputs.is_none() => {
+                let child =
+                    document.add_scope(Scope::new(Some(scope), braced_scope_span(&section)));
+                document.scope_mut(scope).add_child(child);
+
+                if document.version >= Some(SupportedVersion::V1(V1::Two)) {
+                    document.scopes[child.0].names.insert(
+                        TASK_VAR_NAME.to_string(),
+                        Name {
+                            context: NameContext::Task(name.span()),
+                            ty: Some(Type::Task),
+                        },
+                    );
                 }
+
+                for decl in section.declarations() {
+                    add_output(document.scope_mut(child), decl, diagnostics);
+                }
+
+                outputs = Some(child);
             }
             TaskItem::Declaration(decl) => {
                 add_decl(document.scope_mut(scope), decl, diagnostics);
+            }
+            TaskItem::Command(section) if command.is_none() => {
+                let child =
+                    document.add_scope(Scope::new(Some(scope), heredoc_scope_span(&section)));
+                document.scope_mut(scope).add_child(child);
+
+                if document.version >= Some(SupportedVersion::V1(V1::Two)) {
+                    document.scopes[child.0].names.insert(
+                        TASK_VAR_NAME.to_string(),
+                        Name {
+                            context: NameContext::Task(name.span()),
+                            ty: Some(Type::Task),
+                        },
+                    );
+                }
+
+                command = Some(child);
             }
             TaskItem::Input(_)
             | TaskItem::Output(_)
@@ -568,6 +604,8 @@ fn add_task(
         Task {
             name_span: name.span(),
             scope,
+            outputs,
+            command,
         },
     );
 }
@@ -592,7 +630,7 @@ fn add_workflow(
         return;
     }
 
-    let scope = document.add_scope(Scope::new(None, scope_span(workflow)));
+    let scope = document.add_scope(Scope::new(None, braced_scope_span(workflow)));
     let mut saw_input = false;
     let mut saw_output = false;
     for item in workflow.items() {
@@ -605,7 +643,8 @@ fn add_workflow(
             }
             WorkflowItem::Output(section) if !saw_output => {
                 saw_output = true;
-                let outputs = document.add_scope(Scope::new(Some(scope), scope_span(&section)));
+                let outputs =
+                    document.add_scope(Scope::new(Some(scope), braced_scope_span(&section)));
                 document.scope_mut(scope).add_child(outputs);
                 for decl in section.declarations() {
                     add_output(document.scope_mut(outputs), decl, diagnostics);
@@ -667,7 +706,7 @@ fn add_workflow_statement_decls(
 ) {
     match stmt {
         WorkflowStatement::Conditional(stmt) => {
-            let scope = document.add_scope(Scope::new(Some(parent), scope_span(stmt)));
+            let scope = document.add_scope(Scope::new(Some(parent), braced_scope_span(stmt)));
             document.scope_mut(parent).add_child(scope);
 
             for stmt in stmt.statements() {
@@ -686,7 +725,7 @@ fn add_workflow_statement_decls(
             }
         }
         WorkflowStatement::Scatter(stmt) => {
-            let scope = document.add_scope(Scope::new(Some(parent), scope_span(stmt)));
+            let scope = document.add_scope(Scope::new(Some(parent), braced_scope_span(stmt)));
             document.scope_mut(parent).add_child(scope);
 
             // Introduce the scatter variable into the scope
@@ -919,8 +958,8 @@ fn type_check(document: &mut DocumentScope, ast: &Ast, diagnostics: &mut Vec<Dia
         match item {
             DocumentItem::Import(_) | DocumentItem::Struct(_) => continue,
             DocumentItem::Task(definition) => {
-                if let Some(task) = document.tasks.get(definition.name().as_str()) {
-                    type_check_task(document, &definition, task.scope, diagnostics);
+                if let Some(task) = document.tasks.get_index_of(definition.name().as_str()) {
+                    type_check_task(document, &definition, task, diagnostics);
                 }
             }
             DocumentItem::Workflow(_) => {
@@ -933,8 +972,8 @@ fn type_check(document: &mut DocumentScope, ast: &Ast, diagnostics: &mut Vec<Dia
 /// Performs a type check on a task.
 fn type_check_task(
     document: &mut DocumentScope,
-    task: &TaskDefinition,
-    scope: ScopeIndex,
+    definition: &TaskDefinition,
+    task_index: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     /// Represents a node in the name reference graph.
@@ -1043,6 +1082,11 @@ fn type_check_task(
 
                             // Look up the name, checking for cycles
                             if document.scope(scope).lookup(name.as_str()).is_some() {
+                                // Ignore task variables
+                                if name.as_str() == TASK_VAR_NAME {
+                                    continue;
+                                }
+
                                 let to = names[name.as_str()];
 
                                 // Check to see if the node is self-referential
@@ -1092,6 +1136,11 @@ fn type_check_task(
                                 // Look up the name; we don't check for cycles here as decls can't
                                 // reference the command
                                 if document.scope(scope).lookup(name.as_str()).is_some() {
+                                    // Ignore task variables
+                                    if name.as_str() == TASK_VAR_NAME {
+                                        continue;
+                                    }
+
                                     let to = names[name.as_str()];
                                     graph.update_edge(to, from, ());
                                 } else {
@@ -1111,21 +1160,26 @@ fn type_check_task(
     let mut command = None;
     let mut graph = DiGraph::new();
     let mut names = IndexMap::new();
-    for item in task.items() {
+    for item in definition.items() {
         match item {
             TaskItem::Input(section) if !saw_inputs => {
                 saw_inputs = true;
                 for decl in section.declarations() {
-                    add_decl_node(document, &mut graph, &mut names, scope, decl, diagnostics);
+                    add_decl_node(
+                        document,
+                        &mut graph,
+                        &mut names,
+                        document.tasks[task_index].scope,
+                        decl,
+                        diagnostics,
+                    );
                 }
             }
             TaskItem::Output(section) if !saw_outputs => {
                 saw_outputs = true;
-                let scope = document.scopes[scope.0]
-                    .children
-                    .first()
-                    .copied()
-                    .expect("expected output scope");
+                let scope = document.tasks[task_index]
+                    .outputs
+                    .expect("should have output scope");
                 for decl in section.declarations() {
                     add_decl_node(
                         document,
@@ -1142,13 +1196,20 @@ fn type_check_task(
                     document,
                     &mut graph,
                     &mut names,
-                    scope,
+                    document.tasks[task_index].scope,
                     Decl::Bound(decl),
                     diagnostics,
                 );
             }
             TaskItem::Command(section) if command.is_none() => {
-                command = Some(graph.add_node(GraphNode::Command { scope, section }));
+                command = Some(
+                    graph.add_node(GraphNode::Command {
+                        scope: document.tasks[task_index]
+                            .command
+                            .expect("should have command scope"),
+                        section,
+                    }),
+                );
             }
             _ => continue,
         }

--- a/wdl-analysis/src/stdlib.rs
+++ b/wdl-analysis/src/stdlib.rs
@@ -1384,6 +1384,10 @@ pub struct StandardLibrary {
     types: Types,
     /// A map of function name to function definition.
     functions: IndexMap<&'static str, Function>,
+    /// The type for `Array[String]`.
+    pub(crate) array_string: Type,
+    /// The type for `Map[String, Int]`.
+    pub(crate) map_string_int: Type,
 }
 
 impl StandardLibrary {
@@ -1406,7 +1410,6 @@ impl StandardLibrary {
 /// Represents the WDL standard library.
 pub static STDLIB: LazyLock<StandardLibrary> = LazyLock::new(|| {
     let mut types = Types::new();
-
     let array_int = types.add_array(ArrayType::new(PrimitiveTypeKind::Integer));
     let array_string = types.add_array(ArrayType::new(PrimitiveTypeKind::String));
     let array_file = types.add_array(ArrayType::new(PrimitiveTypeKind::File));
@@ -1416,6 +1419,10 @@ pub static STDLIB: LazyLock<StandardLibrary> = LazyLock::new(|| {
     let map_string_string = types.add_map(MapType::new(
         PrimitiveTypeKind::String,
         PrimitiveTypeKind::String,
+    ));
+    let map_string_int = types.add_map(MapType::new(
+        PrimitiveTypeKind::String,
+        PrimitiveTypeKind::Integer,
     ));
 
     let mut functions = IndexMap::new();
@@ -2620,7 +2627,12 @@ pub static STDLIB: LazyLock<StandardLibrary> = LazyLock::new(|| {
             .is_none()
     );
 
-    StandardLibrary { types, functions }
+    StandardLibrary {
+        types,
+        functions,
+        array_string,
+        map_string_int,
+    }
 });
 
 #[cfg(test)]

--- a/wdl-analysis/src/stdlib/constraints.rs
+++ b/wdl-analysis/src/stdlib/constraints.rs
@@ -85,6 +85,7 @@ impl Constraint for SizeableConstraint {
                 }
                 // Treat unions as sizable as they can only be checked at runtime
                 Type::Union | Type::None => true,
+                Type::Task => false,
             }
         }
 
@@ -147,7 +148,8 @@ impl Constraint for JsonSerializableConstraint {
                 | Type::Object
                 | Type::OptionalObject
                 | Type::Union
-                | Type::None => true,
+                | Type::None
+                | Type::Task => true,
                 Type::Compound(ty) => compound_type_is_serializable(types, ty),
             }
         }
@@ -170,7 +172,9 @@ impl Constraint for RequiredPrimitiveTypeConstraint {
             Type::Primitive(ty) => !ty.is_optional(),
             // Treat unions as primitive as they can only be checked at runtime
             Type::Union => true,
-            Type::Compound(_) | Type::Object | Type::OptionalObject | Type::None => false,
+            Type::Compound(_) | Type::Object | Type::OptionalObject | Type::None | Type::Task => {
+                false
+            }
         }
     }
 }
@@ -189,7 +193,7 @@ impl Constraint for AnyPrimitiveTypeConstraint {
             Type::Primitive(_) => true,
             // Treat unions as primitive as they can only be checked at runtime
             Type::Union | Type::None => true,
-            Type::Compound(_) | Type::Object | Type::OptionalObject => false,
+            Type::Compound(_) | Type::Object | Type::OptionalObject | Type::Task => false,
         }
     }
 }

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -195,6 +195,9 @@ pub enum Type {
     Union,
     /// A special type that behaves like an optional `Union`.
     None,
+    /// A special hidden type for `task` that is available in command and task
+    /// output sections in WDL 1.2.
+    Task,
 }
 
 impl Type {
@@ -235,6 +238,7 @@ impl Type {
                     Type::OptionalObject => write!(f, "Object?"),
                     Type::Union => write!(f, "Union"),
                     Type::None => write!(f, "None"),
+                    Type::Task => write!(f, "Task"),
                 }
             }
         }
@@ -254,8 +258,12 @@ impl Type {
                 );
                 ty.assert_valid(types);
             }
-            Self::Primitive(_) | Self::Object | Self::OptionalObject | Self::Union | Self::None => {
-            }
+            Self::Primitive(_)
+            | Self::Object
+            | Self::OptionalObject
+            | Self::Union
+            | Self::None
+            | Self::Task => {}
         }
     }
 }
@@ -266,7 +274,7 @@ impl Optional for Type {
             Self::Primitive(ty) => ty.is_optional(),
             Self::Compound(ty) => ty.is_optional(),
             Self::OptionalObject | Self::None => true,
-            Self::Object | Self::Union => false,
+            Self::Object | Self::Union | Self::Task => false,
         }
     }
 
@@ -275,7 +283,7 @@ impl Optional for Type {
             Self::Primitive(ty) => Self::Primitive(ty.optional()),
             Self::Compound(ty) => Self::Compound(ty.optional()),
             Self::Object | Self::OptionalObject => Self::OptionalObject,
-            Self::Union | Self::None => Self::None,
+            Self::Union | Self::None | Self::Task => Self::None,
         }
     }
 
@@ -285,6 +293,7 @@ impl Optional for Type {
             Self::Compound(ty) => Self::Compound(ty.require()),
             Self::Object | Self::OptionalObject => Self::Object,
             Self::Union | Self::None => Self::Union,
+            Self::Task => Self::Task,
         }
     }
 }
@@ -1091,6 +1100,7 @@ impl Types {
             Type::OptionalObject => Type::OptionalObject,
             Type::Union => Type::Union,
             Type::None => Type::None,
+            Type::Task => Type::Task,
         }
     }
 }

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -71,6 +71,15 @@ pub(crate) fn type_mismatch(
     )
 }
 
+/// Creates a "not a task member" diagnostic.
+fn not_a_task_member(member: &Ident) -> Diagnostic {
+    Diagnostic::error(format!(
+        "task variable does not have a member named `{member}`",
+        member = member.as_str()
+    ))
+    .with_highlight(member.span())
+}
+
 /// Creates a "not a struct member" diagnostic.
 fn not_a_struct_member(name: &str, member: &Ident) -> Diagnostic {
     Diagnostic::error(format!(
@@ -353,6 +362,24 @@ fn cannot_coerce_to_string(types: &Types, actual: Type, span: Span) -> Diagnosti
         format!("this is type `{actual}`", actual = actual.display(types)),
         span,
     )
+}
+
+/// Gets the type of a `task` variable member type.
+///
+/// `task` variables are supported in command and output sections in WDL 1.2.
+///
+/// Returns `None` if the given member name is unknown.
+pub fn task_member_type(name: &str) -> Option<Type> {
+    match name {
+        "name" | "id" | "container" => Some(PrimitiveTypeKind::String.into()),
+        "cpu" => Some(PrimitiveTypeKind::Float.into()),
+        "memory" | "attempt" => Some(PrimitiveTypeKind::Integer.into()),
+        "gpu" | "fpga" => Some(STDLIB.array_string),
+        "disks" => Some(STDLIB.map_string_int),
+        "end_time" | "return_code" => Some(Type::from(PrimitiveTypeKind::Integer).optional()),
+        "meta" | "parameter_meta" | "ext" => Some(Type::Object),
+        _ => None,
+    }
 }
 
 /// Represents a comparison operator.
@@ -1406,6 +1433,16 @@ where
     fn evaluate_access_expr(&mut self, scope: &ScopeRef<'_>, expr: &AccessExpr) -> Option<Type> {
         let (target, name) = expr.operands();
         let ty = self.evaluate_expr(scope, &target)?;
+
+        if Type::Task == ty {
+            return match task_member_type(name.as_str()) {
+                Some(ty) => Some(ty),
+                None => {
+                    self.diagnostics.push(not_a_task_member(&name));
+                    return None;
+                }
+            };
+        }
 
         // Check to see if it's a compound type
         if let Type::Compound(ty) = &ty {

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -74,7 +74,7 @@ pub(crate) fn type_mismatch(
 /// Creates a "not a task member" diagnostic.
 fn not_a_task_member(member: &Ident) -> Diagnostic {
     Diagnostic::error(format!(
-        "task variable does not have a member named `{member}`",
+        "the `task` variable does not have a member named `{member}`",
         member = member.as_str()
     ))
     .with_highlight(member.span())

--- a/wdl-analysis/tests/analysis/task-variable-unsupported/source.diagnostics
+++ b/wdl-analysis/tests/analysis/task-variable-unsupported/source.diagnostics
@@ -1,0 +1,12 @@
+error: unknown name `task`
+  ┌─ tests/analysis/task-variable-unsupported/source.wdl:7:28
+  │
+7 │         echo "Hello from ~{task.name}!"
+  │                            ^^^^
+
+error: unknown name `task`
+   ┌─ tests/analysis/task-variable-unsupported/source.wdl:11:23
+   │
+11 │         String name = task.name
+   │                       ^^^^
+

--- a/wdl-analysis/tests/analysis/task-variable-unsupported/source.diagnostics
+++ b/wdl-analysis/tests/analysis/task-variable-unsupported/source.diagnostics
@@ -1,10 +1,10 @@
-error: the name `task` may only be used within a task command section or task output section using WDL 1.2 or later
+error: the `task` variable may only be used within a task command section or task output section using WDL 1.2 or later
   ┌─ tests/analysis/task-variable-unsupported/source.wdl:7:28
   │
 7 │         echo "Hello from ~{task.name}!"
   │                            ^^^^
 
-error: the name `task` may only be used within a task command section or task output section using WDL 1.2 or later
+error: the `task` variable may only be used within a task command section or task output section using WDL 1.2 or later
    ┌─ tests/analysis/task-variable-unsupported/source.wdl:11:23
    │
 11 │         String name = task.name

--- a/wdl-analysis/tests/analysis/task-variable-unsupported/source.diagnostics
+++ b/wdl-analysis/tests/analysis/task-variable-unsupported/source.diagnostics
@@ -1,10 +1,10 @@
-error: unknown name `task`
+error: the name `task` may only be used within a task command section or task output section using WDL 1.2 or later
   ┌─ tests/analysis/task-variable-unsupported/source.wdl:7:28
   │
 7 │         echo "Hello from ~{task.name}!"
   │                            ^^^^
 
-error: unknown name `task`
+error: the name `task` may only be used within a task command section or task output section using WDL 1.2 or later
    ┌─ tests/analysis/task-variable-unsupported/source.wdl:11:23
    │
 11 │         String name = task.name

--- a/wdl-analysis/tests/analysis/task-variable-unsupported/source.wdl
+++ b/wdl-analysis/tests/analysis/task-variable-unsupported/source.wdl
@@ -1,0 +1,13 @@
+## This is a test of using a task variable in an unsupported WDL version.
+
+version 1.1
+
+task test {
+    command <<<
+        echo "Hello from ~{task.name}!"
+    >>>
+
+    output {
+        String name = task.name
+    }
+}

--- a/wdl-analysis/tests/analysis/task-variable/source.diagnostics
+++ b/wdl-analysis/tests/analysis/task-variable/source.diagnostics
@@ -1,4 +1,4 @@
-error: task variable does not have a member named `not_a_member`
+error: the `task` variable does not have a member named `not_a_member`
    ┌─ tests/analysis/task-variable/source.wdl:17:32
    │
 17 │     echo "Not a member: ~{task.not_a_member}"

--- a/wdl-analysis/tests/analysis/task-variable/source.diagnostics
+++ b/wdl-analysis/tests/analysis/task-variable/source.diagnostics
@@ -1,0 +1,6 @@
+error: task variable does not have a member named `not_a_member`
+   ┌─ tests/analysis/task-variable/source.wdl:17:32
+   │
+17 │     echo "Not a member: ~{task.not_a_member}"
+   │                                ^^^^^^^^^^^^
+

--- a/wdl-analysis/tests/analysis/task-variable/source.wdl
+++ b/wdl-analysis/tests/analysis/task-variable/source.wdl
@@ -1,0 +1,31 @@
+## This is a test for the `task` variable in a task block or command section.
+## Example taken directly from the WDL spec.
+
+version 1.2
+
+task test_runtime_info_task {
+  meta {
+    description: "Task that shows how to use the implicit 'task' declaration"
+  }
+
+  command <<<
+    echo "Task name: ~{task.name}"
+    echo "Task description: ~{task.meta.description}"
+    echo "Task container: ~{task.container}"
+    echo "Available cpus: ~{task.cpu}"
+    echo "Available memory: ~{task.memory / (1024 * 1024 * 1024)} GiB"
+    echo "Not a member: ~{task.not_a_member}"
+    exit 1
+  >>>
+  
+  output {
+    Boolean at_least_two_gb = task.memory >= (2 * 1024 * 1024 * 1024)
+    Int? return_code = task.return_code
+  }
+  
+  requirements {
+    container: ["ubuntu:latest", "quay.io/ubuntu:focal"]
+    memory: "2 GiB"
+    return_codes: [0, 1]
+  }
+}


### PR DESCRIPTION
This commit introduces support for the `task` variable in type checking for WDL 1.2 documents.

It resolves the `task` variable to type `Task`, which has a well-known list of members and their types.

This partially completes #164.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
