### PR TITLE
 feat: complete type checking of tasks.

### DIFF
--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Implemented type checking in task runtime, requirements, and hints sections
+  ([#170](https://github.com/stjude-rust-labs/wdl/pull/170)).
 * Add support for the `task` variable in WDL 1.2 ([#168](https://github.com/stjude-rust-labs/wdl/pull/168)).
 * Full type checking support in task definitions ([#163](https://github.com/stjude-rust-labs/wdl/pull/163)).
 

--- a/wdl-analysis/src/scope/v1.rs
+++ b/wdl-analysis/src/scope/v1.rs
@@ -585,8 +585,13 @@ fn add_task(
                 add_decl(document.scope_mut(scope), decl, diagnostics);
             }
             TaskItem::Command(section) if command.is_none() => {
-                let child =
-                    document.add_scope(Scope::new(Some(scope), heredoc_scope_span(&section)));
+                let span = if section.is_heredoc() {
+                    heredoc_scope_span(&section)
+                } else {
+                    braced_scope_span(&section)
+                };
+
+                let child = document.add_scope(Scope::new(Some(scope), span));
                 document.scope_mut(scope).add_child(child);
 
                 if document.version >= Some(SupportedVersion::V1(V1::Two)) {

--- a/wdl-analysis/src/stdlib.rs
+++ b/wdl-analysis/src/stdlib.rs
@@ -1386,8 +1386,12 @@ pub struct StandardLibrary {
     functions: IndexMap<&'static str, Function>,
     /// The type for `Array[String]`.
     pub(crate) array_string: Type,
+    /// The type for `Array[Int]`.
+    pub(crate) array_int: Type,
     /// The type for `Map[String, Int]`.
     pub(crate) map_string_int: Type,
+    /// The type for `Map[String, String]`.
+    pub(crate) map_string_string: Type,
 }
 
 impl StandardLibrary {
@@ -2631,7 +2635,9 @@ pub static STDLIB: LazyLock<StandardLibrary> = LazyLock::new(|| {
         types,
         functions,
         array_string,
+        array_int,
         map_string_int,
+        map_string_string,
     }
 });
 

--- a/wdl-analysis/src/stdlib/constraints.rs
+++ b/wdl-analysis/src/stdlib/constraints.rs
@@ -85,7 +85,7 @@ impl Constraint for SizeableConstraint {
                 }
                 // Treat unions as sizable as they can only be checked at runtime
                 Type::Union | Type::None => true,
-                Type::Task => false,
+                Type::Task | Type::Hints | Type::Input | Type::Output => false,
             }
         }
 
@@ -148,8 +148,8 @@ impl Constraint for JsonSerializableConstraint {
                 | Type::Object
                 | Type::OptionalObject
                 | Type::Union
-                | Type::None
-                | Type::Task => true,
+                | Type::None => true,
+                Type::Task | Type::Hints | Type::Input | Type::Output => false,
                 Type::Compound(ty) => compound_type_is_serializable(types, ty),
             }
         }
@@ -172,9 +172,14 @@ impl Constraint for RequiredPrimitiveTypeConstraint {
             Type::Primitive(ty) => !ty.is_optional(),
             // Treat unions as primitive as they can only be checked at runtime
             Type::Union => true,
-            Type::Compound(_) | Type::Object | Type::OptionalObject | Type::None | Type::Task => {
-                false
-            }
+            Type::Compound(_)
+            | Type::Object
+            | Type::OptionalObject
+            | Type::None
+            | Type::Task
+            | Type::Hints
+            | Type::Input
+            | Type::Output => false,
         }
     }
 }
@@ -193,7 +198,13 @@ impl Constraint for AnyPrimitiveTypeConstraint {
             Type::Primitive(_) => true,
             // Treat unions as primitive as they can only be checked at runtime
             Type::Union | Type::None => true,
-            Type::Compound(_) | Type::Object | Type::OptionalObject | Type::Task => false,
+            Type::Compound(_)
+            | Type::Object
+            | Type::OptionalObject
+            | Type::Task
+            | Type::Hints
+            | Type::Input
+            | Type::Output => false,
         }
     }
 }

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -198,6 +198,15 @@ pub enum Type {
     /// A special hidden type for `task` that is available in command and task
     /// output sections in WDL 1.2.
     Task,
+    /// A special hidden type for `hints` that is available in task hints
+    /// sections.
+    Hints,
+    /// A special hidden type for `input` that is available in task hints
+    /// sections.
+    Input,
+    /// A special hidden type for `output` that is available in task hints
+    /// sections.
+    Output,
 }
 
 impl Type {
@@ -238,7 +247,10 @@ impl Type {
                     Type::OptionalObject => write!(f, "Object?"),
                     Type::Union => write!(f, "Union"),
                     Type::None => write!(f, "None"),
-                    Type::Task => write!(f, "Task"),
+                    Type::Task => write!(f, "task"),
+                    Type::Hints => write!(f, "hints"),
+                    Type::Input => write!(f, "input"),
+                    Type::Output => write!(f, "output"),
                 }
             }
         }
@@ -263,7 +275,10 @@ impl Type {
             | Self::OptionalObject
             | Self::Union
             | Self::None
-            | Self::Task => {}
+            | Self::Task
+            | Self::Hints
+            | Self::Input
+            | Self::Output => {}
         }
     }
 }
@@ -274,7 +289,9 @@ impl Optional for Type {
             Self::Primitive(ty) => ty.is_optional(),
             Self::Compound(ty) => ty.is_optional(),
             Self::OptionalObject | Self::None => true,
-            Self::Object | Self::Union | Self::Task => false,
+            Self::Object | Self::Union | Self::Task | Self::Hints | Self::Input | Self::Output => {
+                false
+            }
         }
     }
 
@@ -283,7 +300,9 @@ impl Optional for Type {
             Self::Primitive(ty) => Self::Primitive(ty.optional()),
             Self::Compound(ty) => Self::Compound(ty.optional()),
             Self::Object | Self::OptionalObject => Self::OptionalObject,
-            Self::Union | Self::None | Self::Task => Self::None,
+            Self::Union | Self::None | Self::Task | Self::Hints | Self::Input | Self::Output => {
+                Self::None
+            }
         }
     }
 
@@ -294,6 +313,9 @@ impl Optional for Type {
             Self::Object | Self::OptionalObject => Self::Object,
             Self::Union | Self::None => Self::Union,
             Self::Task => Self::Task,
+            Self::Hints => Self::Hints,
+            Self::Input => Self::Input,
+            Self::Output => Self::Output,
         }
     }
 }
@@ -376,13 +398,13 @@ impl Coercible for Type {
 
 impl TypeEq for Type {
     fn type_eq(&self, types: &Types, other: &Self) -> bool {
+        if self == other {
+            return true;
+        }
+
         match (self, other) {
             (Self::Primitive(a), Self::Primitive(b)) => a.type_eq(types, b),
             (Self::Compound(a), Self::Compound(b)) => a.type_eq(types, b),
-            (Self::Object, Self::Object) => true,
-            (Self::OptionalObject, Self::OptionalObject) => true,
-            (Self::Union, Self::Union) => true,
-            (Self::None, Self::None) => true,
             _ => false,
         }
     }
@@ -1101,6 +1123,9 @@ impl Types {
             Type::Union => Type::Union,
             Type::None => Type::None,
             Type::Task => Type::Task,
+            Type::Hints => Type::Hints,
+            Type::Input => Type::Input,
+            Type::Output => Type::Output,
         }
     }
 }

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -75,6 +75,32 @@ pub(crate) fn type_mismatch(
     )
 }
 
+/// Creates a "element type mismatch" diagnostic.
+pub(crate) fn element_type_mismatch(
+    types: &Types,
+    expected: Type,
+    expected_span: Span,
+    actual: Type,
+    actual_span: Span,
+) -> Diagnostic {
+    Diagnostic::error(format!(
+        "type mismatch: expected all elements to be type `{expected}`, but found type `{actual}`",
+        expected = expected.display(types),
+        actual = actual.display(types)
+    ))
+    .with_label(
+        format!("this is type `{actual}`", actual = actual.display(types)),
+        actual_span,
+    )
+    .with_label(
+        format!(
+            "the first element is type `{expected}`",
+            expected = expected.display(types)
+        ),
+        expected_span,
+    )
+}
+
 /// Creates a custom "type mismatch" diagnostic.
 fn type_mismatch_custom(
     types: &Types,
@@ -846,7 +872,7 @@ where
                 for expr in elements {
                     if let Some(actual) = self.evaluate_expr(scope, &expr) {
                         if !actual.is_coercible_to(self.types, &expected) {
-                            self.diagnostics.push(type_mismatch(
+                            self.diagnostics.push(element_type_mismatch(
                                 self.types,
                                 expected,
                                 expected_span,
@@ -919,7 +945,7 @@ where
                             }
 
                             if !actual_value.is_coercible_to(self.types, &expected_value) {
-                                self.diagnostics.push(type_mismatch(
+                                self.diagnostics.push(element_type_mismatch(
                                     self.types,
                                     expected_value,
                                     expected_value_span,

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -68,7 +68,7 @@ pub(crate) fn type_mismatch(
     )
     .with_label(
         format!(
-            "this is type `{expected}`",
+            "this expects type `{expected}`",
             expected = expected.display(types)
         ),
         expected_span,

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -11,8 +11,11 @@ use wdl_ast::v1::IfExpr;
 use wdl_ast::v1::IndexExpr;
 use wdl_ast::v1::LiteralArray;
 use wdl_ast::v1::LiteralExpr;
+use wdl_ast::v1::LiteralHints;
+use wdl_ast::v1::LiteralInput;
 use wdl_ast::v1::LiteralMap;
 use wdl_ast::v1::LiteralMapItem;
+use wdl_ast::v1::LiteralOutput;
 use wdl_ast::v1::LiteralPair;
 use wdl_ast::v1::LiteralStruct;
 use wdl_ast::v1::LogicalAndExpr;
@@ -22,6 +25,7 @@ use wdl_ast::v1::NegationExpr;
 use wdl_ast::v1::Placeholder;
 use wdl_ast::v1::PlaceholderOption;
 use wdl_ast::v1::StringPart;
+use wdl_ast::version::V1;
 use wdl_ast::AstNodeExt;
 use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
@@ -71,10 +75,49 @@ pub(crate) fn type_mismatch(
     )
 }
 
+/// Creates a custom "type mismatch" diagnostic.
+fn type_mismatch_custom(
+    types: &Types,
+    expected: &str,
+    expected_span: Span,
+    actual: Type,
+    actual_span: Span,
+) -> Diagnostic {
+    Diagnostic::error(format!(
+        "type mismatch: expected {expected}, but found type `{actual}`",
+        actual = actual.display(types)
+    ))
+    .with_label(
+        format!("this is type `{actual}`", actual = actual.display(types)),
+        actual_span,
+    )
+    .with_label(format!("this expects {expected}"), expected_span)
+}
+
 /// Creates a "not a task member" diagnostic.
 fn not_a_task_member(member: &Ident) -> Diagnostic {
     Diagnostic::error(format!(
         "the `task` variable does not have a member named `{member}`",
+        member = member.as_str()
+    ))
+    .with_highlight(member.span())
+}
+
+/// Creates a "not an I/O name" diagnostic.
+fn not_io_name(name: &Ident, input: bool) -> Diagnostic {
+    Diagnostic::error(format!(
+        "an {kind} with name `{name}` does not exist",
+        kind = if input { "input" } else { "output" },
+        name = name.as_str(),
+    ))
+    .with_highlight(name.span())
+}
+
+/// Creates a "not a struct" diagnostic.
+fn not_a_struct(member: &Ident, input: bool) -> Diagnostic {
+    Diagnostic::error(format!(
+        "{kind} `{member}` is not a struct",
+        kind = if input { "input" } else { "struct member" },
         member = member.as_str()
     ))
     .with_highlight(member.span())
@@ -741,10 +784,9 @@ where
             LiteralExpr::Object(_) => Some(Type::Object),
             LiteralExpr::Struct(expr) => self.evaluate_literal_struct(scope, expr),
             LiteralExpr::None(_) => Some(Type::None),
-            LiteralExpr::Input(_) | LiteralExpr::Output(_) | LiteralExpr::Hints(_) => {
-                // TODO: implement for full 1.2 support
-                None
-            }
+            LiteralExpr::Hints(expr) => self.evaluate_literal_hints(scope, expr),
+            LiteralExpr::Input(expr) => self.evaluate_literal_inputs(scope, expr),
+            LiteralExpr::Output(expr) => self.evaluate_literal_outputs(scope, expr),
         }
     }
 
@@ -1001,6 +1043,472 @@ where
                 self.diagnostics.push(diagnostic);
                 None
             }
+        }
+    }
+
+    /// Evaluates a `runtime` section item.
+    pub(crate) fn evaluate_runtime_item(
+        &mut self,
+        scope: &ScopeRef<'_>,
+        name: &Ident,
+        expr: &Expr,
+    ) {
+        let expr_ty = self.evaluate_expr(scope, expr).unwrap_or(Type::Union);
+        if !self.evaluate_requirement(name, expr, expr_ty) {
+            // Always use object types for `runtime` section `inputs` and `outputs` keys as
+            // only `hints` sections can use input/output hidden types
+            self.evaluate_hint(name, expr, expr_ty, true);
+        }
+    }
+
+    /// Evaluates a `requirements` section item.
+    pub(crate) fn evaluate_requirements_item(
+        &mut self,
+        scope: &ScopeRef<'_>,
+        name: &Ident,
+        expr: &Expr,
+    ) {
+        let expr_ty = self.evaluate_expr(scope, expr).unwrap_or(Type::Union);
+        self.evaluate_requirement(name, expr, expr_ty);
+    }
+
+    /// Evaluates a requirement in either a `requirements` section or a legacy
+    /// `runtime` section.
+    ///
+    /// Returns `true` if the name matched a requirement or `false` if it did
+    /// not.
+    fn evaluate_requirement(&mut self, name: &Ident, expr: &Expr, expr_ty: Type) -> bool {
+        match name.as_str() {
+            "container" | "docker" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                    && !expr_ty.is_coercible_to(self.types, &STDLIB.array_string)
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `String` or type `Array[String]`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "cpu" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Float.into()) {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int` or type `Float`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "memory" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into())
+                    && !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int` or type `String`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "gpu" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Boolean.into()) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        PrimitiveTypeKind::Boolean.into(),
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "fpga" if self.version >= SupportedVersion::V1(V1::Two) => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Boolean.into()) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        PrimitiveTypeKind::Boolean.into(),
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "disks" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into())
+                    && !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                    && !expr_ty.is_coercible_to(self.types, &STDLIB.array_string)
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int`, type `String`, or type `Array[String]`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "max_retries" if self.version >= SupportedVersion::V1(V1::Two) => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into()) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        PrimitiveTypeKind::Integer.into(),
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "maxRetries" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into()) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        PrimitiveTypeKind::Integer.into(),
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "return_codes" if self.version >= SupportedVersion::V1(V1::Two) => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into())
+                    && !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                    && !expr_ty.is_coercible_to(self.types, &STDLIB.array_int)
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int`, type `String`, or type `Array[Int]`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            "returnCodes" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into())
+                    && !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                    && !expr_ty.is_coercible_to(self.types, &STDLIB.array_int)
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int`, type `String`, or type `Array[Int]`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+
+                true
+            }
+            _ => {
+                // Invalid requirements key; we report on this during validation
+                false
+            }
+        }
+    }
+
+    /// Evaluates the type of a literal hints expression.
+    fn evaluate_literal_hints(
+        &mut self,
+        scope: &ScopeRef<'_>,
+        expr: &LiteralHints,
+    ) -> Option<Type> {
+        if !scope.supports_hints() {
+            return None;
+        }
+
+        for item in expr.items() {
+            self.evaluate_hints_item(scope, &item.name(), &item.expr())
+        }
+
+        Some(Type::Hints)
+    }
+
+    /// Evaluates a hints item, whether in task `hints` section or a `hints`
+    /// literal expression.
+    pub(crate) fn evaluate_hints_item(&mut self, scope: &ScopeRef<'_>, name: &Ident, expr: &Expr) {
+        let expr_ty = self.evaluate_expr(scope, expr).unwrap_or(Type::Union);
+        // For an item in a hints section or literal, the expected types of `inputs` and
+        // `outputs` is `input` and `output` respectively
+        self.evaluate_hint(name, expr, expr_ty, false);
+    }
+
+    /// Evaluates a hint in either a `hints` section or a legacy `runtime`
+    /// section.
+    fn evaluate_hint(&mut self, name: &Ident, expr: &Expr, expr_ty: Type, io_object_type: bool) {
+        match name.as_str() {
+            "max_cpu" if self.version >= SupportedVersion::V1(V1::Two) => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Float.into()) {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int` or type `Float`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "maxCpu" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Float.into()) {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int` or type `Float`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "max_memory" | "fpga" if self.version >= SupportedVersion::V1(V1::Two) => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into())
+                    && !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int` or type `String`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "maxMemory" | "gpu" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Integer.into())
+                    && !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `Int` or type `String`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "disks" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::String.into())
+                    && !expr_ty.is_coercible_to(self.types, &STDLIB.map_string_string)
+                {
+                    self.diagnostics.push(type_mismatch_custom(
+                        self.types,
+                        "type `String` or type `Map[String, String]`",
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "short_task" | "localization_optional"
+                if self.version >= SupportedVersion::V1(V1::Two) =>
+            {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Boolean.into()) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        PrimitiveTypeKind::Boolean.into(),
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "shortTask" | "localizationOptional" => {
+                if !expr_ty.is_coercible_to(self.types, &PrimitiveTypeKind::Boolean.into()) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        PrimitiveTypeKind::Boolean.into(),
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "inputs" => {
+                let expected = if io_object_type {
+                    Type::Object
+                } else {
+                    Type::Input
+                };
+
+                if !expr_ty.is_coercible_to(self.types, &expected) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        expected,
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            "outputs" => {
+                let expected = if io_object_type {
+                    Type::Object
+                } else {
+                    Type::Output
+                };
+
+                if !expr_ty.is_coercible_to(self.types, &expected) {
+                    self.diagnostics.push(type_mismatch(
+                        self.types,
+                        expected,
+                        name.span(),
+                        expr_ty,
+                        expr.span(),
+                    ));
+                }
+            }
+            _ => {
+                // Accept non-reserved names
+            }
+        }
+    }
+
+    /// Evaluates the type of a literal inputs expression.
+    fn evaluate_literal_inputs(
+        &mut self,
+        scope: &ScopeRef<'_>,
+        expr: &LiteralInput,
+    ) -> Option<Type> {
+        // Check to see if inputs literals are supported in the evaluation scope
+        if !scope.supports_inputs() {
+            return None;
+        }
+
+        // Evaluate the items of the literal
+        for item in expr.items() {
+            self.evaluate_literal_io_item(scope, item.names(), item.expr(), true);
+        }
+
+        Some(Type::Input)
+    }
+
+    /// Evaluates the type of a literal outputs expression.
+    fn evaluate_literal_outputs(
+        &mut self,
+        scope: &ScopeRef<'_>,
+        expr: &LiteralOutput,
+    ) -> Option<Type> {
+        // Check to see if output literals are supported in the evaluation scope
+        if !scope.supports_outputs() {
+            return None;
+        }
+
+        // Evaluate the items of the literal
+        for item in expr.items() {
+            self.evaluate_literal_io_item(scope, item.names(), item.expr(), false);
+        }
+
+        Some(Type::Output)
+    }
+
+    /// Evaluates a literal input/output item.
+    fn evaluate_literal_io_item(
+        &mut self,
+        scope: &ScopeRef<'_>,
+        names: impl Iterator<Item = Ident>,
+        expr: Expr,
+        input: bool,
+    ) {
+        let mut names = names.enumerate().peekable();
+        let expr_ty = self.evaluate_expr(scope, &expr).unwrap_or(Type::Union);
+
+        // The first name should be an input/output and then the remainder should be a
+        // struct member
+        let mut span = None;
+        let mut s: Option<&StructType> = None;
+        while let Some((i, name)) = names.next() {
+            // The first name is an input or an output
+            let ty = if i == 0 {
+                span = Some(name.span());
+
+                match if input {
+                    scope.input(name.as_str()).unwrap()
+                } else {
+                    scope.output(name.as_str()).unwrap()
+                } {
+                    Some(n) => match n.ty() {
+                        Some(ty) => ty,
+                        None => break,
+                    },
+                    None => {
+                        self.diagnostics.push(not_io_name(&name, input));
+                        break;
+                    }
+                }
+            } else {
+                // Every other name is a struct member
+                let start = span.unwrap().start();
+                span = Some(Span::new(start, name.span().end() - start));
+                let s = s.unwrap();
+                match s.members.get(name.as_str()) {
+                    Some(ty) => *ty,
+                    None => {
+                        self.diagnostics.push(not_a_struct_member(&s.name, &name));
+                        break;
+                    }
+                }
+            };
+
+            match ty {
+                Type::Compound(ty)
+                    if matches!(
+                        self.types.type_definition(ty.definition()),
+                        CompoundTypeDef::Struct(_)
+                    ) =>
+                {
+                    s = Some(
+                        self.types
+                            .type_definition(ty.definition())
+                            .as_struct()
+                            .unwrap(),
+                    );
+                }
+                _ if names.peek().is_some() => {
+                    self.diagnostics.push(not_a_struct(&name, i == 0));
+                    break;
+                }
+                _ => {
+                    // It's ok for the last one to not name a struct
+                }
+            }
+        }
+
+        // If we bailed out early above, calculate the entire span of the name
+        if let Some((_, last)) = names.last() {
+            let start = span.unwrap().start();
+            span = Some(Span::new(start, last.span().end() - start));
+        }
+
+        // The type of every item should be `hints`
+        if !expr_ty.is_coercible_to(self.types, &Type::Hints) {
+            self.diagnostics.push(type_mismatch(
+                self.types,
+                Type::Hints,
+                span.expect("should have span"),
+                expr_ty,
+                expr.span(),
+            ));
         }
     }
 

--- a/wdl-analysis/tests/analysis/braced-command/source.diagnostics
+++ b/wdl-analysis/tests/analysis/braced-command/source.diagnostics
@@ -1,0 +1,6 @@
+error: unknown name `unknown`
+  ┌─ tests/analysis/braced-command/source.wdl:8:16
+  │
+8 │         echo ~{unknown}
+  │                ^^^^^^^
+

--- a/wdl-analysis/tests/analysis/braced-command/source.wdl
+++ b/wdl-analysis/tests/analysis/braced-command/source.wdl
@@ -1,0 +1,12 @@
+## This is a test of analyzing a braced command.
+
+version 1.1
+
+task test {
+    command {
+        echo ${x}
+        echo ~{unknown}
+    }
+
+    String x = "hi"
+}

--- a/wdl-analysis/tests/analysis/duplicate-task/source.diagnostics
+++ b/wdl-analysis/tests/analysis/duplicate-task/source.diagnostics
@@ -1,0 +1,9 @@
+error: conflicting task name `foo`
+   ┌─ tests/analysis/duplicate-task/source.wdl:14:6
+   │
+ 6 │ task foo {
+   │      --- the task with the conflicting name is here
+   ·
+14 │ task foo {
+   │      ^^^ this task conflicts with a previously used name
+

--- a/wdl-analysis/tests/analysis/duplicate-task/source.wdl
+++ b/wdl-analysis/tests/analysis/duplicate-task/source.wdl
@@ -1,0 +1,22 @@
+## This checks to ensure that validation and analysis of duplicate tasks
+## is effectively ignored beyond reporting the duplicate
+
+version 1.1
+
+task foo {
+    # OK
+    Int i = 0
+
+    command <<<>>>
+}
+
+# NOT OK (not ignored)
+task foo {
+    # NOT OK (but ignored)
+    Int i = "0"
+
+    command <<<>>>
+
+    # NOT OK (but ignored)
+    command <<<>>>
+}

--- a/wdl-analysis/tests/analysis/forward-reference/source.diagnostics
+++ b/wdl-analysis/tests/analysis/forward-reference/source.diagnostics
@@ -4,5 +4,5 @@ error: type mismatch: expected type `Int`, but found type `String`
 13 │         Int y = z
    │             -   ^ this is type `String`
    │             │    
-   │             this is type `Int`
+   │             this expects type `Int`
 

--- a/wdl-analysis/tests/analysis/forward-reference/source.wdl
+++ b/wdl-analysis/tests/analysis/forward-reference/source.wdl
@@ -1,6 +1,6 @@
 ## This is a test for forward references in a WDL task.
 
-version 1.1
+version 1.2
 
 task forward_reference {
     # OK as the forward reference is to a string
@@ -14,6 +14,14 @@ task forward_reference {
     }
 
     String z = "5"
+
+    requirements {
+        cpu: y
+    }
+
+    hints {
+        max_cpu: y
+    }
 
     command <<<>>>
 }

--- a/wdl-analysis/tests/analysis/hints-section/source.diagnostics
+++ b/wdl-analysis/tests/analysis/hints-section/source.diagnostics
@@ -1,0 +1,108 @@
+error: type mismatch: expected type `Int` or type `Float`, but found type `Boolean`
+    ┌─ tests/analysis/hints-section/source.wdl:114:18
+    │
+114 │         max_cpu: true
+    │         -------  ^^^^ this is type `Boolean`
+    │         │         
+    │         this expects type `Int` or type `Float`
+
+error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
+    ┌─ tests/analysis/hints-section/source.wdl:115:21
+    │
+115 │         max_memory: false
+    │         ----------  ^^^^^ this is type `Boolean`
+    │         │            
+    │         this expects type `Int` or type `String`
+
+error: type mismatch: expected type `String` or type `Map[String, String]`, but found type `Boolean`
+    ┌─ tests/analysis/hints-section/source.wdl:116:16
+    │
+116 │         disks: true
+    │         -----  ^^^^ this is type `Boolean`
+    │         │       
+    │         this expects type `String` or type `Map[String, String]`
+
+error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
+    ┌─ tests/analysis/hints-section/source.wdl:117:14
+    │
+117 │         gpu: false
+    │         ---  ^^^^^ this is type `Boolean`
+    │         │     
+    │         this expects type `Int` or type `String`
+
+error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
+    ┌─ tests/analysis/hints-section/source.wdl:118:15
+    │
+118 │         fpga: true
+    │         ----  ^^^^ this is type `Boolean`
+    │         │      
+    │         this expects type `Int` or type `String`
+
+error: type mismatch: expected type `Boolean`, but found type `String`
+    ┌─ tests/analysis/hints-section/source.wdl:119:21
+    │
+119 │         short_task: "false"
+    │         ----------  ^^^^^^^ this is type `String`
+    │         │            
+    │         this is type `Boolean`
+
+error: type mismatch: expected type `Boolean`, but found type `String`
+    ┌─ tests/analysis/hints-section/source.wdl:120:32
+    │
+120 │         localization_optional: "true"
+    │         ---------------------  ^^^^^^ this is type `String`
+    │         │                       
+    │         this is type `Boolean`
+
+error: an input with name `wrong` does not exist
+    ┌─ tests/analysis/hints-section/source.wdl:122:13
+    │
+122 │             wrong: hints {
+    │             ^^^^^
+
+error: struct `Foo` does not have a member named `wrong`
+    ┌─ tests/analysis/hints-section/source.wdl:125:17
+    │
+125 │             baz.wrong: hints {
+    │                 ^^^^^
+
+error: struct member `foo` is not a struct
+    ┌─ tests/analysis/hints-section/source.wdl:128:17
+    │
+128 │             baz.foo.wrong: hints {
+    │                 ^^^
+
+error: type mismatch: expected type `hints`, but found type `String`
+    ┌─ tests/analysis/hints-section/source.wdl:131:18
+    │
+131 │             foo: "wrong"
+    │             ---  ^^^^^^^ this is type `String`
+    │             │     
+    │             this is type `hints`
+
+error: an output with name `wrong` does not exist
+    ┌─ tests/analysis/hints-section/source.wdl:134:13
+    │
+134 │             wrong: hints {
+    │             ^^^^^
+
+error: struct `Foo` does not have a member named `wrong`
+    ┌─ tests/analysis/hints-section/source.wdl:137:19
+    │
+137 │             corge.wrong: hints {
+    │                   ^^^^^
+
+error: struct member `foo` is not a struct
+    ┌─ tests/analysis/hints-section/source.wdl:140:19
+    │
+140 │             corge.foo.wrong: hints {
+    │                   ^^^
+
+error: type mismatch: expected type `hints`, but found type `String`
+    ┌─ tests/analysis/hints-section/source.wdl:143:18
+    │
+143 │             qux: "wrong"
+    │             ---  ^^^^^^^ this is type `String`
+    │             │     
+    │             this is type `hints`
+

--- a/wdl-analysis/tests/analysis/hints-section/source.diagnostics
+++ b/wdl-analysis/tests/analysis/hints-section/source.diagnostics
@@ -44,7 +44,7 @@ error: type mismatch: expected type `Boolean`, but found type `String`
 119 │         short_task: "false"
     │         ----------  ^^^^^^^ this is type `String`
     │         │            
-    │         this is type `Boolean`
+    │         this expects type `Boolean`
 
 error: type mismatch: expected type `Boolean`, but found type `String`
     ┌─ tests/analysis/hints-section/source.wdl:120:32
@@ -52,7 +52,7 @@ error: type mismatch: expected type `Boolean`, but found type `String`
 120 │         localization_optional: "true"
     │         ---------------------  ^^^^^^ this is type `String`
     │         │                       
-    │         this is type `Boolean`
+    │         this expects type `Boolean`
 
 error: an input with name `wrong` does not exist
     ┌─ tests/analysis/hints-section/source.wdl:122:13
@@ -78,7 +78,7 @@ error: type mismatch: expected type `hints`, but found type `String`
 131 │             foo: "wrong"
     │             ---  ^^^^^^^ this is type `String`
     │             │     
-    │             this is type `hints`
+    │             this expects type `hints`
 
 error: an output with name `wrong` does not exist
     ┌─ tests/analysis/hints-section/source.wdl:134:13
@@ -104,5 +104,5 @@ error: type mismatch: expected type `hints`, but found type `String`
 143 │             qux: "wrong"
     │             ---  ^^^^^^^ this is type `String`
     │             │     
-    │             this is type `hints`
+    │             this expects type `hints`
 

--- a/wdl-analysis/tests/analysis/hints-section/source.wdl
+++ b/wdl-analysis/tests/analysis/hints-section/source.wdl
@@ -1,0 +1,147 @@
+## This is a test of type checking `requirements` keys. 
+
+version 1.2
+
+struct Foo {
+    String foo
+    Int bar
+}
+
+task foo {
+    command <<<>>>
+
+    input {
+        String foo
+        Int bar
+        Foo baz
+    }
+
+    output {
+        String qux = "hi"
+        Int quux = 1
+        Foo corge = Foo { foo: "hi", bar: 1 }
+    }
+
+    hints {
+        max_cpu: 1
+        max_memory: 1
+        disks: "1GiB"
+        gpu: 1
+        fpga: 1
+        short_task: true
+        localization_optional: false
+        inputs: input {
+            foo: hints {
+                max_cpu: 1
+            },
+            bar: hints {
+                max_cpu: 1
+            },
+            baz: hints {
+                max_cpu: 1
+            },
+            baz.foo: hints {
+                max_cpu: 1
+            },
+            baz.bar: hints {
+                max_cpu: 1
+            },
+        }
+        outputs: output {
+            qux: hints {
+                max_cpu: 1
+            },
+            quux: hints {
+                max_cpu: 1
+            },
+            corge: hints {
+                max_cpu: 1
+            },
+            corge.foo: hints {
+                max_cpu: 1
+            },
+            corge.bar: hints {
+                max_cpu: 1
+            },
+        }
+        unsupported: false
+    }
+}
+
+task bar {
+    command <<<>>>
+
+    input {
+        String foo
+        Int bar
+        Foo baz
+    }
+
+    output {
+        String qux = "hi"
+        Int quux = 1
+        Foo corge = Foo { foo: "hi", bar: 1 }
+    }
+
+    hints {
+        maxCpu: 1.0
+        maxMemory: "1"
+        disks: { "foo": "1GiB" }
+        gpu: "1"
+        fpga: "1"
+        shortTask: false
+        localizationOptional: true
+        unsupported: false
+    }
+}
+
+task baz {
+    command <<<>>>
+
+    input {
+        String foo
+        Int bar
+        Foo baz
+    }
+
+    output {
+        String qux = "hi"
+        Int quux = 1
+        Foo corge = Foo { foo: "hi", bar: 1 }
+    }
+
+    hints {
+        max_cpu: true
+        max_memory: false
+        disks: true
+        gpu: false
+        fpga: true
+        short_task: "false"
+        localization_optional: "true"
+        inputs: input {
+            wrong: hints {
+                max_cpu: 1
+            },
+            baz.wrong: hints {
+                max_cpu: 1
+            },
+            baz.foo.wrong: hints {
+                max_cpu: 1
+            },
+            foo: "wrong"
+        }
+        outputs: output {
+            wrong: hints {
+                max_cpu: 1
+            },
+            corge.wrong: hints {
+                max_cpu: 1
+            },
+            corge.foo.wrong: hints {
+                max_cpu: 1
+            },
+            qux: "wrong"
+        }
+        unsupported: false
+    }
+}

--- a/wdl-analysis/tests/analysis/requirements-section/source.diagnostics
+++ b/wdl-analysis/tests/analysis/requirements-section/source.diagnostics
@@ -1,0 +1,88 @@
+error: unsupported requirements key `unsupported`
+   ┌─ tests/analysis/requirements-section/source.wdl:17:9
+   │
+17 │         unsupported: false
+   │         ^^^^^^^^^^^
+
+error: unsupported requirements key `unsupported`
+   ┌─ tests/analysis/requirements-section/source.wdl:33:9
+   │
+33 │         unsupported: false
+   │         ^^^^^^^^^^^
+
+error: unsupported requirements key `unsupported`
+   ┌─ tests/analysis/requirements-section/source.wdl:44:9
+   │
+44 │         unsupported: false
+   │         ^^^^^^^^^^^
+
+error: unsupported requirements key `unsupported`
+   ┌─ tests/analysis/requirements-section/source.wdl:54:9
+   │
+54 │         unsupported: false
+   │         ^^^^^^^^^^^
+
+error: type mismatch: expected type `String` or type `Array[String]`, but found type `Boolean`
+   ┌─ tests/analysis/requirements-section/source.wdl:62:20
+   │
+62 │         container: false
+   │         ---------  ^^^^^ this is type `Boolean`
+   │         │           
+   │         this expects type `String` or type `Array[String]`
+
+error: type mismatch: expected type `Int` or type `Float`, but found type `Boolean`
+   ┌─ tests/analysis/requirements-section/source.wdl:63:14
+   │
+63 │         cpu: false
+   │         ---  ^^^^^ this is type `Boolean`
+   │         │     
+   │         this expects type `Int` or type `Float`
+
+error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
+   ┌─ tests/analysis/requirements-section/source.wdl:64:17
+   │
+64 │         memory: false
+   │         ------  ^^^^^ this is type `Boolean`
+   │         │        
+   │         this expects type `Int` or type `String`
+
+error: type mismatch: expected type `Boolean`, but found type `String`
+   ┌─ tests/analysis/requirements-section/source.wdl:65:14
+   │
+65 │         gpu: "false"
+   │         ---  ^^^^^^^ this is type `String`
+   │         │     
+   │         this is type `Boolean`
+
+error: type mismatch: expected type `Boolean`, but found type `String`
+   ┌─ tests/analysis/requirements-section/source.wdl:66:15
+   │
+66 │         fpga: "false"
+   │         ----  ^^^^^^^ this is type `String`
+   │         │      
+   │         this is type `Boolean`
+
+error: type mismatch: expected type `Int`, type `String`, or type `Array[String]`, but found type `Boolean`
+   ┌─ tests/analysis/requirements-section/source.wdl:67:16
+   │
+67 │         disks: false
+   │         -----  ^^^^^ this is type `Boolean`
+   │         │       
+   │         this expects type `Int`, type `String`, or type `Array[String]`
+
+error: type mismatch: expected type `Int`, but found type `Boolean`
+   ┌─ tests/analysis/requirements-section/source.wdl:68:22
+   │
+68 │         max_retries: false
+   │         -----------  ^^^^^ this is type `Boolean`
+   │         │             
+   │         this is type `Int`
+
+error: type mismatch: expected type `Int`, type `String`, or type `Array[Int]`, but found type `Boolean`
+   ┌─ tests/analysis/requirements-section/source.wdl:69:23
+   │
+69 │         return_codes: false
+   │         ------------  ^^^^^ this is type `Boolean`
+   │         │              
+   │         this expects type `Int`, type `String`, or type `Array[Int]`
+

--- a/wdl-analysis/tests/analysis/requirements-section/source.diagnostics
+++ b/wdl-analysis/tests/analysis/requirements-section/source.diagnostics
@@ -52,7 +52,7 @@ error: type mismatch: expected type `Boolean`, but found type `String`
 65 │         gpu: "false"
    │         ---  ^^^^^^^ this is type `String`
    │         │     
-   │         this is type `Boolean`
+   │         this expects type `Boolean`
 
 error: type mismatch: expected type `Boolean`, but found type `String`
    ┌─ tests/analysis/requirements-section/source.wdl:66:15
@@ -60,7 +60,7 @@ error: type mismatch: expected type `Boolean`, but found type `String`
 66 │         fpga: "false"
    │         ----  ^^^^^^^ this is type `String`
    │         │      
-   │         this is type `Boolean`
+   │         this expects type `Boolean`
 
 error: type mismatch: expected type `Int`, type `String`, or type `Array[String]`, but found type `Boolean`
    ┌─ tests/analysis/requirements-section/source.wdl:67:16
@@ -76,7 +76,7 @@ error: type mismatch: expected type `Int`, but found type `Boolean`
 68 │         max_retries: false
    │         -----------  ^^^^^ this is type `Boolean`
    │         │             
-   │         this is type `Int`
+   │         this expects type `Int`
 
 error: type mismatch: expected type `Int`, type `String`, or type `Array[Int]`, but found type `Boolean`
    ┌─ tests/analysis/requirements-section/source.wdl:69:23

--- a/wdl-analysis/tests/analysis/requirements-section/source.wdl
+++ b/wdl-analysis/tests/analysis/requirements-section/source.wdl
@@ -1,0 +1,71 @@
+## This is a test of type checking `requirements` keys. 
+
+version 1.2
+
+task foo {
+    command <<<>>>
+
+    requirements {
+        container: "foo/bar"
+        cpu: 1
+        memory: 1
+        gpu: true
+        fpga: false
+        disks: 1
+        max_retries: 0
+        return_codes: 0
+        unsupported: false
+    }
+}
+
+task bar {
+    command <<<>>>
+
+    requirements {
+        container: ["foo/bar", "bar/baz"]
+        cpu: 1.0
+        memory: "1GiB"
+        gpu: false
+        fpga: true
+        disks: "1GiB"
+        maxRetries: 1
+        return_codes: "0"
+        unsupported: false
+    }
+}
+
+task baz {
+    command <<<>>>
+
+    requirements {
+        docker: "foo/bar"
+        disks: ["1GiB", "2GiB"]
+        return_codes: [1, 2, 3]
+        unsupported: false
+    }
+}
+
+task jam {
+    command <<<>>>
+
+    requirements {
+        docker: ["foo/bar"]
+        returnCodes: 1
+        unsupported: false
+    }
+}
+
+task incorrect {
+    command <<<>>>
+    
+    requirements {
+        container: false
+        cpu: false
+        memory: false
+        gpu: "false"
+        fpga: "false"
+        disks: false
+        max_retries: false
+        return_codes: false
+    }
+}

--- a/wdl-analysis/tests/analysis/runtime-section/source.diagnostics
+++ b/wdl-analysis/tests/analysis/runtime-section/source.diagnostics
@@ -28,7 +28,7 @@ error: type mismatch: expected type `Boolean`, but found type `String`
 65 │         gpu: "false"
    │         ---  ^^^^^^^ this is type `String`
    │         │     
-   │         this is type `Boolean`
+   │         this expects type `Boolean`
 
 error: type mismatch: expected type `Int`, type `String`, or type `Array[String]`, but found type `Boolean`
    ┌─ tests/analysis/runtime-section/source.wdl:67:16

--- a/wdl-analysis/tests/analysis/runtime-section/source.diagnostics
+++ b/wdl-analysis/tests/analysis/runtime-section/source.diagnostics
@@ -1,0 +1,40 @@
+error: type mismatch: expected type `String` or type `Array[String]`, but found type `Boolean`
+   ┌─ tests/analysis/runtime-section/source.wdl:62:20
+   │
+62 │         container: false
+   │         ---------  ^^^^^ this is type `Boolean`
+   │         │           
+   │         this expects type `String` or type `Array[String]`
+
+error: type mismatch: expected type `Int` or type `Float`, but found type `Boolean`
+   ┌─ tests/analysis/runtime-section/source.wdl:63:14
+   │
+63 │         cpu: false
+   │         ---  ^^^^^ this is type `Boolean`
+   │         │     
+   │         this expects type `Int` or type `Float`
+
+error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
+   ┌─ tests/analysis/runtime-section/source.wdl:64:17
+   │
+64 │         memory: false
+   │         ------  ^^^^^ this is type `Boolean`
+   │         │        
+   │         this expects type `Int` or type `String`
+
+error: type mismatch: expected type `Boolean`, but found type `String`
+   ┌─ tests/analysis/runtime-section/source.wdl:65:14
+   │
+65 │         gpu: "false"
+   │         ---  ^^^^^^^ this is type `String`
+   │         │     
+   │         this is type `Boolean`
+
+error: type mismatch: expected type `Int`, type `String`, or type `Array[String]`, but found type `Boolean`
+   ┌─ tests/analysis/runtime-section/source.wdl:67:16
+   │
+67 │         disks: false
+   │         -----  ^^^^^ this is type `Boolean`
+   │         │       
+   │         this expects type `Int`, type `String`, or type `Array[String]`
+

--- a/wdl-analysis/tests/analysis/runtime-section/source.wdl
+++ b/wdl-analysis/tests/analysis/runtime-section/source.wdl
@@ -1,0 +1,71 @@
+## This is a test of type checking `runtime` keys. 
+
+version 1.1
+
+task foo {
+    command <<<>>>
+
+    runtime {
+        container: "foo/bar"
+        cpu: 1
+        memory: 1
+        gpu: true
+        fpga: false
+        disks: 1
+        max_retries: 0
+        return_codes: 0
+        unsupported: false
+    }
+}
+
+task bar {
+    command <<<>>>
+
+    runtime {
+        container: ["foo/bar", "bar/baz"]
+        cpu: 1.0
+        memory: "1GiB"
+        gpu: false
+        fpga: true
+        disks: "1GiB"
+        maxRetries: 1
+        return_codes: "0"
+        unsupported: false
+    }
+}
+
+task baz {
+    command <<<>>>
+
+    runtime {
+        docker: "foo/bar"
+        disks: ["1GiB", "2GiB"]
+        return_codes: [1, 2, 3]
+        unsupported: false
+    }
+}
+
+task jam {
+    command <<<>>>
+
+    runtime {
+        docker: ["foo/bar"]
+        returnCodes: 1
+        unsupported: false
+    }
+}
+
+task incorrect {
+    command <<<>>>
+    
+    runtime {
+        container: false
+        cpu: false
+        memory: false
+        gpu: "false"
+        fpga: "false"
+        disks: false
+        max_retries: false
+        return_codes: false
+    }
+}

--- a/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
@@ -4,7 +4,7 @@ error: type mismatch: expected type `Int`, but found type `String`
 10 │     Int a = "hello"
    │         -   ^^^^^^^ this is type `String`
    │         │    
-   │         this is type `Int`
+   │         this expects type `Int`
 
 error: type mismatch: expected type `String`, but found type `Int`
    ┌─ tests/analysis/type-mismatch/source.wdl:11:16
@@ -12,7 +12,7 @@ error: type mismatch: expected type `String`, but found type `Int`
 11 │     String b = 5
    │            -   ^ this is type `Int`
    │            │    
-   │            this is type `String`
+   │            this expects type `String`
 
 error: type mismatch: expected type `Array[String]`, but found type `Map[Int, String]`
    ┌─ tests/analysis/type-mismatch/source.wdl:12:23
@@ -20,7 +20,7 @@ error: type mismatch: expected type `Array[String]`, but found type `Map[Int, St
 12 │     Array[String] c = { 1: "one", 2: "two" }
    │                   -   ^^^^^^^^^^^^^^^^^^^^^^ this is type `Map[Int, String]`
    │                   │    
-   │                   this is type `Array[String]`
+   │                   this expects type `Array[String]`
 
 error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`
    ┌─ tests/analysis/type-mismatch/source.wdl:13:20
@@ -28,7 +28,7 @@ error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`
 13 │     Array[Int] d = ["a", "b", "c"]
    │                -   ^^^^^^^^^^^^^^^ this is type `Array[String]`
    │                │    
-   │                this is type `Array[Int]`
+   │                this expects type `Array[Int]`
 
 error: type mismatch: expected type `Map[Int, String]`, but found type `Map[String, Int]`
    ┌─ tests/analysis/type-mismatch/source.wdl:14:26
@@ -36,7 +36,7 @@ error: type mismatch: expected type `Map[Int, String]`, but found type `Map[Stri
 14 │     Map[Int, String] e = { "a": 1, "b": 2, "c": 3 }
    │                      -   ^^^^^^^^^^^^^^^^^^^^^^^^^^ this is type `Map[String, Int]`
    │                      │    
-   │                      this is type `Map[Int, String]`
+   │                      this expects type `Map[Int, String]`
 
 error: type mismatch: expected type `Int`, but found type `String`
    ┌─ tests/analysis/type-mismatch/source.wdl:15:24
@@ -44,7 +44,7 @@ error: type mismatch: expected type `Int`, but found type `String`
 15 │     Array[Int] f = [1, "2", "3"]
    │                     -  ^^^ this is type `String`
    │                     │   
-   │                     this is type `Int`
+   │                     this expects type `Int`
 
 error: type mismatch: expected type `Int`, but found type `String`
    ┌─ tests/analysis/type-mismatch/source.wdl:15:29
@@ -52,7 +52,7 @@ error: type mismatch: expected type `Int`, but found type `String`
 15 │     Array[Int] f = [1, "2", "3"]
    │                     -       ^^^ this is type `String`
    │                     │        
-   │                     this is type `Int`
+   │                     this expects type `Int`
 
 error: type mismatch: expected type `String`, but found type `Int`
    ┌─ tests/analysis/type-mismatch/source.wdl:16:46
@@ -60,7 +60,7 @@ error: type mismatch: expected type `String`, but found type `Int`
 16 │     Map[String, String] g = { "a": "1", "b": 2, "c": "3" }
    │                                    ---       ^ this is type `Int`
    │                                    │          
-   │                                    this is type `String`
+   │                                    this expects type `String`
 
 error: type mismatch: expected type `Int`, but found type `Array[Int]`
    ┌─ tests/analysis/type-mismatch/source.wdl:17:22
@@ -68,5 +68,5 @@ error: type mismatch: expected type `Int`, but found type `Array[Int]`
 17 │     Foo h = Foo { x: [1] }
    │                   -  ^^^ this is type `Array[Int]`
    │                   │   
-   │                   this is type `Int`
+   │                   this expects type `Int`
 

--- a/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
@@ -38,29 +38,29 @@ error: type mismatch: expected type `Map[Int, String]`, but found type `Map[Stri
    │                      │    
    │                      this expects type `Map[Int, String]`
 
-error: type mismatch: expected type `Int`, but found type `String`
+error: type mismatch: expected all elements to be type `Int`, but found type `String`
    ┌─ tests/analysis/type-mismatch/source.wdl:15:24
    │
 15 │     Array[Int] f = [1, "2", "3"]
    │                     -  ^^^ this is type `String`
    │                     │   
-   │                     this expects type `Int`
+   │                     the first element is type `Int`
 
-error: type mismatch: expected type `Int`, but found type `String`
+error: type mismatch: expected all elements to be type `Int`, but found type `String`
    ┌─ tests/analysis/type-mismatch/source.wdl:15:29
    │
 15 │     Array[Int] f = [1, "2", "3"]
    │                     -       ^^^ this is type `String`
    │                     │        
-   │                     this expects type `Int`
+   │                     the first element is type `Int`
 
-error: type mismatch: expected type `String`, but found type `Int`
+error: type mismatch: expected all elements to be type `String`, but found type `Int`
    ┌─ tests/analysis/type-mismatch/source.wdl:16:46
    │
 16 │     Map[String, String] g = { "a": "1", "b": 2, "c": "3" }
    │                                    ---       ^ this is type `Int`
    │                                    │          
-   │                                    this expects type `String`
+   │                                    the first element is type `String`
 
 error: type mismatch: expected type `Int`, but found type `Array[Int]`
    ┌─ tests/analysis/type-mismatch/source.wdl:17:22

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Removed `span_of` function in favor of `AstNode` extension trait ([#163](https://github.com/stjude-rust-labs/wdl/pull/163)).
 
+### Fixed
+
+* Fixed detection of duplicate aliased keys in a task `hints` section ([#170](https://github.com/stjude-rust-labs/wdl/pull/170)).
+* Fixed ignoring duplicate task definitions for the "counts" validation ([#170](https://github.com/stjude-rust-labs/wdl/pull/170)).
+
 ## 0.6.0 - 08-22-2024
 
 ### Added

--- a/wdl-ast/src/validation/keys.rs
+++ b/wdl-ast/src/validation/keys.rs
@@ -178,7 +178,11 @@ impl Visitor for UniqueKeysVisitor {
 
         check_duplicate_keys(
             &mut self.0,
-            &[],
+            &[
+                ("max_cpu", "maxCpu"),
+                ("max_memory", "maxMemory"),
+                ("localization_optional", "localizationOptional"),
+            ],
             section.items().map(|i| i.name()),
             Context::HintsSection,
             state,
@@ -197,7 +201,7 @@ impl Visitor for UniqueKeysVisitor {
 
         check_duplicate_keys(
             &mut self.0,
-            &[],
+            &[("container", "docker")],
             section.items().map(|i| i.name()),
             Context::RuntimeSection,
             state,

--- a/wdl-ast/tests/validation/duplicate-command/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-command/source.wdl
@@ -6,3 +6,9 @@ task test {
     command <<<>>>
     command <<<>>>
 }
+
+# This duplicate task should be ignored.
+task test {
+    command <<<>>>
+    command <<<>>>
+}

--- a/wdl-ast/tests/validation/duplicate-input/source.errors
+++ b/wdl-ast/tests/validation/duplicate-input/source.errors
@@ -8,11 +8,11 @@ error: task `t` contains a duplicate input section
    │     ^^^^^ this input section is a duplicate
 
 error: workflow `w` contains a duplicate input section
-   ┌─ tests/validation/duplicate-input/source.wdl:22:5
+   ┌─ tests/validation/duplicate-input/source.wdl:35:5
    │
-18 │     input {
+31 │     input {
    │     ----- first input section is defined here
    ·
-22 │     input {
+35 │     input {
    │     ^^^^^ this input section is a duplicate
 

--- a/wdl-ast/tests/validation/duplicate-input/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-input/source.wdl
@@ -14,6 +14,19 @@ task t {
     command <<<>>>
 }
 
+# This duplicate task should be ignored.
+task t {
+    input {
+
+    }
+
+    input {
+
+    }
+
+    command <<<>>>
+}
+
 workflow w {
     input {
 

--- a/wdl-ast/tests/validation/duplicate-meta/source.errors
+++ b/wdl-ast/tests/validation/duplicate-meta/source.errors
@@ -8,20 +8,20 @@ error: task `t` contains a duplicate metadata section
    │     ^^^^ this metadata section is a duplicate
 
 error: workflow `w` contains a duplicate metadata section
-   ┌─ tests/validation/duplicate-meta/source.wdl:22:5
+   ┌─ tests/validation/duplicate-meta/source.wdl:35:5
    │
-18 │     meta {
+31 │     meta {
    │     ---- first metadata section is defined here
    ·
-22 │     meta {
+35 │     meta {
    │     ^^^^ this metadata section is a duplicate
 
 error: struct `X` contains a duplicate metadata section
-   ┌─ tests/validation/duplicate-meta/source.wdl:34:5
+   ┌─ tests/validation/duplicate-meta/source.wdl:47:5
    │
-30 │     meta {
+43 │     meta {
    │     ---- first metadata section is defined here
    ·
-34 │     meta {
+47 │     meta {
    │     ^^^^ this metadata section is a duplicate
 

--- a/wdl-ast/tests/validation/duplicate-meta/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-meta/source.wdl
@@ -14,6 +14,19 @@ task t {
     command <<<>>>
 }
 
+# This duplicate task should be ignored.
+task t {
+    meta {
+
+    }
+
+    meta {
+
+    }
+
+    command <<<>>>
+}
+
 workflow w {
     meta {
 

--- a/wdl-ast/tests/validation/duplicate-output/source.errors
+++ b/wdl-ast/tests/validation/duplicate-output/source.errors
@@ -8,11 +8,11 @@ error: task `t` contains a duplicate output section
    │     ^^^^^^ this output section is a duplicate
 
 error: workflow `w` contains a duplicate output section
-   ┌─ tests/validation/duplicate-output/source.wdl:22:5
+   ┌─ tests/validation/duplicate-output/source.wdl:35:5
    │
-18 │     output {
+31 │     output {
    │     ------ first output section is defined here
    ·
-22 │     output {
+35 │     output {
    │     ^^^^^^ this output section is a duplicate
 

--- a/wdl-ast/tests/validation/duplicate-output/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-output/source.wdl
@@ -14,6 +14,19 @@ task t {
     command <<<>>>
 }
 
+# This duplicate task should be ignored.
+task t {
+    output {
+
+    }
+
+    output {
+
+    }
+
+    command <<<>>>
+}
+
 workflow w {
     output {
 

--- a/wdl-ast/tests/validation/duplicate-param-meta/source.errors
+++ b/wdl-ast/tests/validation/duplicate-param-meta/source.errors
@@ -8,20 +8,20 @@ error: task `t` contains a duplicate parameter metadata section
    │     ^^^^^^^^^^^^^^ this parameter metadata section is a duplicate
 
 error: workflow `w` contains a duplicate parameter metadata section
-   ┌─ tests/validation/duplicate-param-meta/source.wdl:22:5
+   ┌─ tests/validation/duplicate-param-meta/source.wdl:35:5
    │
-18 │     parameter_meta {
+31 │     parameter_meta {
    │     -------------- first parameter metadata section is defined here
    ·
-22 │     parameter_meta {
+35 │     parameter_meta {
    │     ^^^^^^^^^^^^^^ this parameter metadata section is a duplicate
 
 error: struct `X` contains a duplicate parameter metadata section
-   ┌─ tests/validation/duplicate-param-meta/source.wdl:34:5
+   ┌─ tests/validation/duplicate-param-meta/source.wdl:47:5
    │
-30 │     parameter_meta {
+43 │     parameter_meta {
    │     -------------- first parameter metadata section is defined here
    ·
-34 │     parameter_meta {
+47 │     parameter_meta {
    │     ^^^^^^^^^^^^^^ this parameter metadata section is a duplicate
 

--- a/wdl-ast/tests/validation/duplicate-param-meta/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-param-meta/source.wdl
@@ -14,6 +14,19 @@ task t {
     command <<<>>>
 }
 
+# This duplicate task should be ignored.
+task t {
+    parameter_meta {
+
+    }
+
+    parameter_meta {
+
+    }
+
+    command <<<>>>
+}
+
 workflow w {
     parameter_meta {
 

--- a/wdl-ast/tests/validation/duplicate-runtime/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-runtime/source.wdl
@@ -13,3 +13,16 @@ task t {
 
     command <<<>>>
 }
+
+# This duplicate task should be ignored.
+task t {
+    runtime {
+
+    }
+
+    runtime {
+
+    }
+
+    command <<<>>>
+}

--- a/wdl-ast/tests/validation/hints-conflicting-keys/source.errors
+++ b/wdl-ast/tests/validation/hints-conflicting-keys/source.errors
@@ -1,0 +1,24 @@
+error: conflicting key `maxCpu` in hints section
+   ┌─ tests/validation/hints-conflicting-keys/source.wdl:11:9
+   │
+10 │         max_cpu: 1
+   │         ------- the conflicting alias is here
+11 │         maxCpu: 1
+   │         ^^^^^^ this key conflicts with an alias
+
+error: conflicting key `maxMemory` in hints section
+   ┌─ tests/validation/hints-conflicting-keys/source.wdl:13:9
+   │
+12 │         max_memory: 1
+   │         ---------- the conflicting alias is here
+13 │         maxMemory: 1
+   │         ^^^^^^^^^ this key conflicts with an alias
+
+error: conflicting key `localizationOptional` in hints section
+   ┌─ tests/validation/hints-conflicting-keys/source.wdl:15:9
+   │
+14 │         localization_optional: true
+   │         --------------------- the conflicting alias is here
+15 │         localizationOptional: true
+   │         ^^^^^^^^^^^^^^^^^^^^ this key conflicts with an alias
+

--- a/wdl-ast/tests/validation/hints-conflicting-keys/source.wdl
+++ b/wdl-ast/tests/validation/hints-conflicting-keys/source.wdl
@@ -1,0 +1,17 @@
+## This is a test of conflicting `hints` keys.
+
+version 1.2
+
+task test {
+    command <<<>>>
+
+    # Check for conflicting keys
+    hints {
+        max_cpu: 1
+        maxCpu: 1
+        max_memory: 1
+        maxMemory: 1
+        localization_optional: true
+        localizationOptional: true
+    }
+}

--- a/wdl-ast/tests/validation/requirements-keys/source.wdl
+++ b/wdl-ast/tests/validation/requirements-keys/source.wdl
@@ -1,4 +1,4 @@
-## This is a test of unsupported validation keys
+## This is a test of unsupported requirements keys.
 
 version 1.2
 

--- a/wdl-ast/tests/validation/runtime-duplicate-keys/source.errors
+++ b/wdl-ast/tests/validation/runtime-duplicate-keys/source.errors
@@ -25,3 +25,11 @@ error: duplicate key `foo` in runtime section
 13 │         foo: "dup"
    │         ^^^ this key is a duplicate
 
+error: conflicting key `container` in runtime section
+   ┌─ tests/validation/runtime-duplicate-keys/source.wdl:23:9
+   │
+22 │         docker: "foo"
+   │         ------ the conflicting alias is here
+23 │         container: "bar"
+   │         ^^^^^^^^^ this key conflicts with an alias
+

--- a/wdl-ast/tests/validation/runtime-duplicate-keys/source.wdl
+++ b/wdl-ast/tests/validation/runtime-duplicate-keys/source.wdl
@@ -15,3 +15,13 @@ task test {
 
     command <<<>>>
 }
+
+# Check for duplicated aliases in the runtime section.
+task test2 {
+    runtime {
+        docker: "foo"
+        container: "bar"
+    }
+
+    command <<<>>>
+}


### PR DESCRIPTION
This commit completes the type checking in tasks to include expressions in
`requirements`, `hints`, and `runtime` sections.

Type checking works off of the "known" keys of those sections and the types
each key supports for an acceptable value.

For the `hints` section, this also includes supporting the hidden `input`,
`output`, and `hints` types and their literal expressions. For `input` and
`output` types, this means ensuring the input and output keys match a declared
input or output and also resolving any dotted form of the names when inputs and
outputs are structs.

Also fixed with these changes:

* Fixed a bug where duplicate tasks were generating duplicate section
  diagnostics instead of being ignored.
* Fixed a bug where duplicate tasks were being type checked with the wrong
  scope instead of being ignored.
* Fixed a failure to detect duplicate aliased items in task `hints` section.

Closes #166 and #164.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
