### PR TITLE
feat: Replace all Log instances with Tracing events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ rust-version = "1.80.0"
 clap = { version = "4.5.7", features = ["derive"] }
 colored = "2.1.0"
 convert_case = "0.6.0"
-env_logger = "0.11.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
-log = "0.4.21"
 regex = "1.10.5"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.8.1"
 tokio = { version = "1.38.0", features = ["full"] }
 toml = "0.8.14"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 logos = "0.14.0"
 rowan = "0.15.15"
 pretty_assertions = "1.4.0"

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Use `tracing` events instead of the `log` crate
+* Use `tracing` events instead of the `log` crate ([#172](https://github.com/stjude-rust-labs/wdl/pull/172))
 * Refactored crate layout ([#163](https://github.com/stjude-rust-labs/wdl/pull/163)).
 
 ### Fixed

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Use `tracing` events instead of the `log` crate
 * Refactored crate layout ([#163](https://github.com/stjude-rust-labs/wdl/pull/163)).
 
 ### Fixed

--- a/wdl-analysis/Cargo.toml
+++ b/wdl-analysis/Cargo.toml
@@ -18,7 +18,6 @@ rowan = { workspace = true }
 url = { workspace = true }
 tokio = { workspace = true }
 parking_lot = { workspace = true }
-log = { workspace = true }
 rayon = { workspace = true }
 reqwest = { workspace = true }
 petgraph = { workspace = true }
@@ -29,6 +28,7 @@ line-index = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 walkdir = { workspace = true }
 id-arena = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/wdl-gauntlet/CHANGELOG.md
+++ b/wdl-gauntlet/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-* Use `tracing` events instead of the `log` crate
+* Use `tracing` events instead of the `log` crate ([#172](https://github.com/stjude-rust-labs/wdl/pull/172))
 
 
 ## 0.5.0 - 08-22-2024

--- a/wdl-gauntlet/CHANGELOG.md
+++ b/wdl-gauntlet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+* Use `tracing` events instead of the `log` crate
+
+
 ## 0.5.0 - 08-22-2024
 
 ### Changed

--- a/wdl-gauntlet/Cargo.toml
+++ b/wdl-gauntlet/Cargo.toml
@@ -13,15 +13,15 @@ wdl-lint = { path = "../wdl-lint", version = "0.5.0", features = ["codespan"] }
 clap.workspace = true
 colored.workspace = true
 dirs.workspace = true
-env_logger.workspace = true
 faster-hex.workspace = true
 git2.workspace = true
 indexmap.workspace = true
-log.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 anyhow.workspace = true
 codespan-reporting.workspace = true

--- a/wdl-gauntlet/src/config.rs
+++ b/wdl-gauntlet/src/config.rs
@@ -4,9 +4,8 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
-use log::debug;
-use log::log_enabled;
-use log::trace;
+use tracing::debug;
+use tracing::trace;
 
 pub mod inner;
 
@@ -137,14 +136,12 @@ impl Config {
             inner,
         };
 
-        if log_enabled!(log::Level::Trace) {
-            trace!("Loaded configuration file with the following:");
-            trace!("  -> {} repositories.", result.inner().repositories().len());
-            trace!(
-                "  -> {} ignored diagnostics.",
-                result.inner().diagnostics().len()
+        trace!("Loaded configuration file with the following:");
+        trace!("  -> {} repositories.", result.inner().repositories().len());
+        trace!(
+            "  -> {} ignored diagnostics.",
+            result.inner().diagnostics().len()
             );
-        }
 
         Ok(result)
     }
@@ -164,12 +161,10 @@ impl Config {
     /// [`Config`].
     pub fn save(&self) -> Result<()> {
         if let Some(ref path) = self.path {
-            if log_enabled!(log::Level::Debug) {
-                if path.exists() {
-                    debug!("overwriting configuration at {}", path.display());
-                } else {
-                    debug!("saving configuration to {}", path.display());
-                }
+            if path.exists() {
+                debug!("overwriting configuration at {}", path.display());
+            } else {
+                debug!("saving configuration to {}", path.display());
             }
 
             let mut file = File::create(path).map_err(Error::InputOutput)?;

--- a/wdl-gauntlet/src/config.rs
+++ b/wdl-gauntlet/src/config.rs
@@ -141,7 +141,7 @@ impl Config {
         trace!(
             "  -> {} ignored diagnostics.",
             result.inner().diagnostics().len()
-            );
+        );
 
         Ok(result)
     }

--- a/wdl-gauntlet/src/lib.rs
+++ b/wdl-gauntlet/src/lib.rs
@@ -25,9 +25,9 @@ use codespan_reporting::term::termcolor::StandardStream;
 use codespan_reporting::term::DisplayStyle;
 use colored::Colorize;
 use indexmap::IndexSet;
-use log::debug;
-use log::info;
-use log::trace;
+use tracing::debug;
+use tracing::info;
+use tracing::trace;
 
 pub mod config;
 pub mod document;

--- a/wdl-gauntlet/src/main.rs
+++ b/wdl-gauntlet/src/main.rs
@@ -33,14 +33,10 @@ async fn inner() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         LevelFilter::WARN
     };
-    
+
     let filter = match args.log_all_modules {
-        true => {
-            EnvFilter::default().add_directive(level.into())
-        },
-        false => {
-            EnvFilter::default().add_directive(format!("wdl_gauntlet={}", level).parse()?)
-        }
+        true => EnvFilter::default().add_directive(level.into()),
+        false => EnvFilter::default().add_directive(format!("wdl_gauntlet={}", level).parse()?),
     };
 
     tracing_subscriber::fmt().with_env_filter(filter).init();

--- a/wdl-gauntlet/src/main.rs
+++ b/wdl-gauntlet/src/main.rs
@@ -14,7 +14,8 @@
 #![warn(rustdoc::broken_intra_doc_links)]
 
 use clap::Parser as _;
-use log::LevelFilter;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
 use wdl_gauntlet as gauntlet;
 
 /// The inner function for `wdl-gauntlet`.
@@ -22,23 +23,28 @@ async fn inner() -> Result<(), Box<dyn std::error::Error>> {
     let args = gauntlet::Args::parse();
 
     let level = if args.trace {
-        LevelFilter::max()
+        LevelFilter::TRACE
     } else if args.debug {
-        LevelFilter::Debug
+        LevelFilter::DEBUG
     } else if args.verbose {
-        LevelFilter::Info
+        LevelFilter::INFO
     } else if args.quiet {
-        LevelFilter::Error
+        LevelFilter::ERROR
     } else {
-        LevelFilter::Warn
+        LevelFilter::WARN
+    };
+    
+    let filter = match args.log_all_modules {
+        true => {
+            EnvFilter::default().add_directive(level.into())
+        },
+        false => {
+            EnvFilter::default().add_directive(format!("wdl_gauntlet={}", level).parse()?)
+        }
     };
 
-    let module = match args.log_all_modules {
-        true => None,
-        false => Some("wdl_gauntlet"),
-    };
+    tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    env_logger::builder().filter(module, level).init();
     gauntlet::gauntlet(args).await?;
 
     Ok(())

--- a/wdl-gauntlet/src/repository.rs
+++ b/wdl-gauntlet/src/repository.rs
@@ -8,9 +8,9 @@ use faster_hex;
 use git2::build::RepoBuilder;
 use git2::FetchOptions;
 use indexmap::IndexMap;
-use tracing::info;
 use serde::Deserialize;
 use serde::Serialize;
+use tracing::info;
 
 pub mod identifier;
 pub mod work_dir;

--- a/wdl-gauntlet/src/repository.rs
+++ b/wdl-gauntlet/src/repository.rs
@@ -8,7 +8,7 @@ use faster_hex;
 use git2::build::RepoBuilder;
 use git2::FetchOptions;
 use indexmap::IndexMap;
-use log::info;
+use tracing::info;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+* Updated iter method in lines_with_offset util function to apply new clippy lint ([#172](https://github.com/stjude-rust-labs/wdl/pull/172))
+
 ## 0.5.0 - 08-22-2024
 
 ### Added

--- a/wdl-lint/src/util.rs
+++ b/wdl-lint/src/util.rs
@@ -11,7 +11,7 @@ pub fn lines_with_offset(s: &str) -> impl Iterator<Item = (&str, usize, usize)> 
 
         let start = offset;
         loop {
-            match s[offset..].find(|c| c == '\r' || c == '\n') {
+            match s[offset..].find(|c| ['\r', '\n'].contains(&c)) {
                 Some(i) => {
                     let end = offset + i;
                     offset = end + 1;

--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+* Use `tracing` events instead of the `log` crate
+
 ## 0.2.0 - 08-22-2024
 
 * bump wdl-* dependency versions

--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-* Use `tracing` events instead of the `log` crate
+* Use `tracing` events instead of the `log` crate ([#172](https://github.com/stjude-rust-labs/wdl/pull/172))
 
 ## 0.2.0 - 08-22-2024
 

--- a/wdl-lsp/Cargo.toml
+++ b/wdl-lsp/Cargo.toml
@@ -17,7 +17,7 @@ wdl-analysis = { path = "../wdl-analysis", version = "0.2.0" }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tower-lsp = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }
 parking_lot = { workspace = true }
 line-index = { workspace = true }

--- a/wdl-lsp/src/proto.rs
+++ b/wdl-lsp/src/proto.rs
@@ -26,6 +26,7 @@ use tower_lsp::lsp_types::WorkspaceDiagnosticReportResult;
 use tower_lsp::lsp_types::WorkspaceDocumentDiagnosticReport;
 use tower_lsp::lsp_types::WorkspaceFullDocumentDiagnosticReport;
 use tower_lsp::lsp_types::WorkspaceUnchangedDocumentDiagnosticReport;
+use tracing::debug;
 use url::Url;
 use wdl_analysis::AnalysisResult;
 use wdl_ast::Severity;
@@ -113,7 +114,7 @@ pub fn document_diagnostic_report(
 
     if let Some(previous) = params.previous_result_id {
         if &previous == result.id().as_ref() {
-            log::debug!(
+            debug!(
                 "diagnostics for document `{uri}` have not changed (client has latest)",
                 uri = params.text_document.uri,
             );
@@ -127,7 +128,7 @@ pub fn document_diagnostic_report(
             ));
         }
 
-        log::debug!(
+        debug!(
             "diagnostics for document `{uri}` have changed since last client request",
             uri = params.text_document.uri
         );
@@ -182,7 +183,7 @@ pub fn workspace_diagnostic_report(
 
         if let Some(previous) = ids.get(result.uri()) {
             if previous == result.id().as_ref() {
-                log::debug!(
+                debug!(
                     "diagnostics for document `{uri}` have not changed (client has latest)",
                     uri = result.uri(),
                 );
@@ -200,7 +201,7 @@ pub fn workspace_diagnostic_report(
             }
         }
 
-        log::debug!(
+        debug!(
             "diagnostics for document `{uri}` have changed since last client request",
             uri = result.uri()
         );

--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed CLI tool to not output colors when stdio is not a terminal ([#163](https://github.com/stjude-rust-labs/wdl/pull/163)).
 
+### Changed
+* Use `tracing-subscriber` to configure tracing env ([#172](https://github.com/stjude-rust-labs/wdl/pull/172))
+
 ## 0.7.0 - 08-22-2024
 
 ### Added

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -21,7 +21,6 @@ clap = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 colored = { workspace = true, optional = true }
 codespan-reporting = { workspace = true, optional = true }
-env_logger = { workspace = true, optional = true }
 indicatif = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
@@ -45,7 +44,6 @@ cli = [
     "dep:clap",
     "dep:anyhow",
     "dep:colored",
-    "dep:env_logger",
     "dep:indicatif",
     "dep:tokio",
 ]

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -17,6 +17,7 @@ wdl-ast = { path = "../wdl-ast", version = "0.6.0", optional = true }
 wdl-lint = { path = "../wdl-lint", version = "0.5.0", optional = true }
 wdl-analysis = { path = "../wdl-analysis", version = "0.2.0", optional = true }
 wdl-lsp = { path = "../wdl-lsp", version = "0.2.0", optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 colored = { workspace = true, optional = true }
@@ -42,6 +43,7 @@ cli = [
     "codespan",
     "lint",
     "dep:clap",
+    "dep:tracing-subscriber",
     "dep:anyhow",
     "dep:colored",
     "dep:indicatif",

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -256,10 +256,8 @@ enum App {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_target(false)
-        .init();
-    
+    tracing_subscriber::fmt().with_target(false).init();
+
     if let Err(e) = match App::parse() {
         App::Parse(cmd) => cmd.exec().await,
         App::Check(cmd) => cmd.exec().await,

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -256,11 +256,10 @@ enum App {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::builder()
-        .format_module_path(false)
-        .format_target(false)
+    tracing_subscriber::fmt()
+        .with_target(false)
         .init();
-
+    
     if let Err(e) = match App::parse() {
         App::Parse(cmd) => cmd.exec().await,
         App::Check(cmd) => cmd.exec().await,


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

This PR replaces all uses of the `log` crate with the same functionality from `tracing` events. In most spots this means we just replace `log::info!`/`debug!`/`error!` with `tracing`'s versions of these macros. 

It removes the need to use `if log_enabled!(...) { ... }` as `tracing` automatically does this, and requires us to use `tracing-subscriber` instead of `env_logger` for configuring a log filter. 

Closes #150 

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
