### PR TITLE
feat: Trailing Comment Whitespace Lint

### DIFF
--- a/Arena.toml
+++ b/Arena.toml
@@ -32,7 +32,7 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
-message = "ww-fastq-to-cram.wdl:133:1: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-fastq-to-cram.wdl:133:46: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L133"
 
 [[diagnostics]]
@@ -162,17 +162,17 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:34:104: warning[Whitespace]: line contains trailing whitespace"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L34"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:34:1: note[LineWidth]: line exceeds maximum width of 90"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L34"
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:34:46: note[CommentWhitespace]: in-line comments should be preceded by two spaces"
-permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L34"
-
-[[diagnostics]]
-document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
-message = "ww-fastq-to-cram.wdl:34:46: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L34"
 
 [[diagnostics]]
@@ -302,7 +302,7 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
-message = "ww-fastq-to-cram.wdl:8:24: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-fastq-to-cram.wdl:8:42: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L8"
 
 [[diagnostics]]
@@ -632,12 +632,12 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:53:5: note[CommentWhitespace]: in-line comments should be preceded by two spaces"
+message = "ww-star-deseq2.wdl:53:18: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L53"
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:53:5: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:53:5: note[CommentWhitespace]: in-line comments should be preceded by two spaces"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L53"
 
 [[diagnostics]]
@@ -872,7 +872,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:16:1: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:16:3: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L16"
 
 [[diagnostics]]
@@ -982,12 +982,12 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:236:5: note[CommentWhitespace]: in-line comments should be preceded by two spaces"
+message = "ww-vc-trio.wdl:236:18: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L236"
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:236:5: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:236:5: note[CommentWhitespace]: in-line comments should be preceded by two spaces"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L236"
 
 [[diagnostics]]
@@ -1667,7 +1667,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:744:1: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:744:87: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L744"
 
 [[diagnostics]]

--- a/Arena.toml
+++ b/Arena.toml
@@ -32,6 +32,11 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:133:1: warning[Whitespace]: line contains trailing whitespace"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L133"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:134:6: note[MissingMetas]: task `ValidateCram` is missing a `meta` section"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L134"
 
@@ -167,6 +172,11 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:34:46: warning[Whitespace]: line contains trailing whitespace"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L34"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:35:112: note[CallInputSpacing]: call input not properly spaced"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L35"
 
@@ -288,6 +298,11 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
 message = "ww-fastq-to-cram.wdl:8:24: note[CommentWhitespace]: in-line comments should be preceded by two spaces"
+permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L8"
+
+[[diagnostics]]
+document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
+message = "ww-fastq-to-cram.wdl:8:24: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L8"
 
 [[diagnostics]]
@@ -622,6 +637,11 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
+message = "ww-star-deseq2.wdl:53:5: warning[Whitespace]: line contains trailing whitespace"
+permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L53"
+
+[[diagnostics]]
+document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
 message = "ww-star-deseq2.wdl:55:3: note[CommentWhitespace]: comment not sufficiently indented"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L55"
 
@@ -852,6 +872,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:16:1: warning[Whitespace]: line contains trailing whitespace"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L16"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:170:28: note[CallInputSpacing]: call input not properly spaced"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L170"
 
@@ -958,6 +983,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:236:5: note[CommentWhitespace]: in-line comments should be preceded by two spaces"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L236"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:236:5: warning[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L236"
 
 [[diagnostics]]
@@ -1634,6 +1664,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:733:10: note[DisallowedOutputName]: declaration identifier starts with 'output'"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L733"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:744:1: warning[Whitespace]: line contains trailing whitespace"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L744"
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"

--- a/Arena.toml
+++ b/Arena.toml
@@ -32,7 +32,7 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
-message = "ww-fastq-to-cram.wdl:133:46: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-fastq-to-cram.wdl:133:46: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L133"
 
 [[diagnostics]]
@@ -162,7 +162,7 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
-message = "ww-fastq-to-cram.wdl:34:104: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-fastq-to-cram.wdl:34:104: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L34"
 
 [[diagnostics]]
@@ -232,7 +232,7 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
-message = "ww-fastq-to-cram.wdl:57:13: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-fastq-to-cram.wdl:57:13: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L57"
 
 [[diagnostics]]
@@ -302,7 +302,7 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-fastq-to-cram:/ww-fastq-to-cram.wdl"
-message = "ww-fastq-to-cram.wdl:8:42: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-fastq-to-cram.wdl:8:42: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642c06d15f4b623ac66fd9ed7d/ww-fastq-to-cram.wdl/#L8"
 
 [[diagnostics]]
@@ -312,7 +312,7 @@ permalink = "https://github.com/getwilds/ww-fastq-to-cram/blob/2d1e1989a57402642
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:10:22: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:10:22: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L10"
 
 [[diagnostics]]
@@ -507,7 +507,7 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:25:36: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:25:36: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L25"
 
 [[diagnostics]]
@@ -532,7 +532,7 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:30:13: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:30:13: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L30"
 
 [[diagnostics]]
@@ -542,7 +542,7 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:31:43: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:31:43: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L31"
 
 [[diagnostics]]
@@ -552,7 +552,7 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:32:43: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:32:43: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L32"
 
 [[diagnostics]]
@@ -632,7 +632,7 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:53:18: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:53:18: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L53"
 
 [[diagnostics]]
@@ -782,7 +782,7 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
-message = "ww-star-deseq2.wdl:9:25: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-star-deseq2.wdl:9:25: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697c3f707f073177ddde7013/ww-star-deseq2.wdl/#L9"
 
 [[diagnostics]]
@@ -827,7 +827,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:136:13: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:136:13: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L136"
 
 [[diagnostics]]
@@ -842,7 +842,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:145:13: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:145:13: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L145"
 
 [[diagnostics]]
@@ -872,7 +872,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:16:3: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:16:3: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L16"
 
 [[diagnostics]]
@@ -952,7 +952,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:217:1: warning[Whitespace]: line contains only whitespace"
+message = "ww-vc-trio.wdl:217:1: note[Whitespace]: line contains only whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L217"
 
 [[diagnostics]]
@@ -982,7 +982,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:236:18: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:236:18: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L236"
 
 [[diagnostics]]
@@ -997,7 +997,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:240:76: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:240:76: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L240"
 
 [[diagnostics]]
@@ -1152,7 +1152,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:301:19: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:301:19: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L301"
 
 [[diagnostics]]
@@ -1377,7 +1377,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:49:53: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:49:53: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L49"
 
 [[diagnostics]]
@@ -1667,7 +1667,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:744:87: warning[Whitespace]: line contains trailing whitespace"
+message = "ww-vc-trio.wdl:744:87: note[Whitespace]: line contains trailing whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L744"
 
 [[diagnostics]]
@@ -1722,7 +1722,7 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:96:1: warning[Whitespace]: line contains only whitespace"
+message = "ww-vc-trio.wdl:96:1: note[Whitespace]: line contains only whitespace"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L96"
 
 [[diagnostics]]

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Added Trailing Comments lint rule as an extension of the `Whitespace` rule ([]())
+* Added Trailing Comments lint rule as an extension of the `Whitespace` rule ([177](https://github.com/stjude-rust-labs/wdl/pull/177))
 
 ## 0.6.0 - 09-16-2024
 

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+* Added Trailing Comments lint rule as an extension of the `Whitespace` rule ([]())
+
 ## 0.6.0 - 09-16-2024
 
 ### Fixed

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Added Trailing Comments lint rule as an extension of the `Whitespace` rule ([177](https://github.com/stjude-rust-labs/wdl/pull/177))
+* Added comments to the trailing whitespace check of the `Whitespace` rule ([177](https://github.com/stjude-rust-labs/wdl/pull/177))
 
 ## 0.6.0 - 09-16-2024
 

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Added comments to the trailing whitespace check of the `Whitespace` rule ([177](https://github.com/stjude-rust-labs/wdl/pull/177))
+* Added comments to the trailing whitespace check of the `Whitespace` rule ([#177](https://github.com/stjude-rust-labs/wdl/pull/177))
 
 ## 0.6.0 - 09-16-2024
 

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -34,7 +34,7 @@ fn trailing_whitespace(span: Span) -> Diagnostic {
     Diagnostic::warning("line contains trailing whitespace")
         .with_rule(ID)
         .with_highlight(span)
-        .with_fix("remove the trailing whitespace from this line")
+        .with_fix("remove this trailing whitespace")
 }
 
 /// Creates a "more than one blank line" diagnostic.

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -83,10 +83,15 @@ impl Visitor for WhitespaceRule {
 
     fn comment(&mut self, state: &mut Self::State, comment: &wdl_ast::Comment) {
         let comment_str = comment.as_str();
-        if comment_str.ends_with(|char: char| char.is_whitespace()) {
+        let span = comment.span();
+        let trimmed_end = comment_str.trim_end();
+        if comment_str != trimmed_end {
             // Trailing whitespace
             state.exceptable_add(
-                trailing_whitespace(comment.span()),
+                trailing_whitespace(Span::new(
+                    span.start() + trimmed_end.len(),
+                    comment_str.len() - trimmed_end.len(),
+                )),
                 SyntaxElement::from(comment.syntax().clone()),
                 &self.exceptable_nodes(),
             )

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -81,6 +81,18 @@ impl Rule for WhitespaceRule {
 impl Visitor for WhitespaceRule {
     type State = Diagnostics;
 
+    fn comment(&mut self, state: &mut Self::State, comment: &wdl_ast::Comment) {
+        let comment_str = comment.as_str();
+        if comment_str.ends_with(|char: char| char.is_whitespace()) {
+            // Trailing whitespace
+            state.exceptable_add(
+                trailing_whitespace(comment.span()),
+                SyntaxElement::from(comment.syntax().clone()),
+                &self.exceptable_nodes(),
+            )
+        }
+    }
+
     fn document(
         &mut self,
         _: &mut Self::State,

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -23,7 +23,7 @@ const ID: &str = "Whitespace";
 
 /// Creates an "only whitespace" diagnostic.
 fn only_whitespace(span: Span) -> Diagnostic {
-    Diagnostic::warning("line contains only whitespace")
+    Diagnostic::note("line contains only whitespace")
         .with_rule(ID)
         .with_highlight(span)
         .with_fix("remove the whitespace from this line")
@@ -31,7 +31,7 @@ fn only_whitespace(span: Span) -> Diagnostic {
 
 /// Creates a "trailing whitespace" diagnostic.
 fn trailing_whitespace(span: Span) -> Diagnostic {
-    Diagnostic::warning("line contains trailing whitespace")
+    Diagnostic::note("line contains trailing whitespace")
         .with_rule(ID)
         .with_highlight(span)
         .with_fix("remove this trailing whitespace")
@@ -39,7 +39,7 @@ fn trailing_whitespace(span: Span) -> Diagnostic {
 
 /// Creates a "more than one blank line" diagnostic.
 fn more_than_one_blank_line(span: Span) -> Diagnostic {
-    Diagnostic::warning("more than one blank line in a row")
+    Diagnostic::note("more than one blank line in a row")
         .with_rule(ID)
         .with_highlight(span)
         .with_fix("remove the unnecessary blank lines")

--- a/wdl-lint/tests/lints/between-import-whitespace/source.errors
+++ b/wdl-lint/tests/lints/between-import-whitespace/source.errors
@@ -42,7 +42,7 @@ note[ImportWhitespace]: blank lines are not allowed between imports
    │  
    = fix: remove any blank lines between imports
 
-warning[Whitespace]: more than one blank line in a row
+note[Whitespace]: more than one blank line in a row
    ┌─ tests/lints/between-import-whitespace/source.wdl:19:1
    │  
 19 │ ╭ 

--- a/wdl-lint/tests/lints/blank-lines-between-elements/source.errors
+++ b/wdl-lint/tests/lints/blank-lines-between-elements/source.errors
@@ -7,7 +7,7 @@ note[ImportWhitespace]: blank lines are not allowed between imports
   │  
   = fix: remove any blank lines between imports
 
-warning[Whitespace]: more than one blank line in a row
+note[Whitespace]: more than one blank line in a row
    ┌─ tests/lints/blank-lines-between-elements/source.wdl:11:1
    │  
 11 │ ╭ 
@@ -53,7 +53,7 @@ note[BlankLinesBetweenElements]: missing blank line
    │  
    = fix: add a blank line before this element
 
-warning[Whitespace]: more than one blank line in a row
+note[Whitespace]: more than one blank line in a row
    ┌─ tests/lints/blank-lines-between-elements/source.wdl:29:1
    │  
 29 │ ╭ 
@@ -62,7 +62,7 @@ warning[Whitespace]: more than one blank line in a row
    │  
    = fix: remove the unnecessary blank lines
 
-warning[Whitespace]: more than one blank line in a row
+note[Whitespace]: more than one blank line in a row
    ┌─ tests/lints/blank-lines-between-elements/source.wdl:35:1
    │  
 35 │ ╭ 
@@ -71,7 +71,7 @@ warning[Whitespace]: more than one blank line in a row
    │  
    = fix: remove the unnecessary blank lines
 
-warning[Whitespace]: more than one blank line in a row
+note[Whitespace]: more than one blank line in a row
    ┌─ tests/lints/blank-lines-between-elements/source.wdl:40:1
    │  
 40 │ ╭ 
@@ -149,7 +149,7 @@ note[BlankLinesBetweenElements]: extra blank line(s) found
    │  
    = fix: remove the blank line(s)
 
-warning[Whitespace]: more than one blank line in a row
+note[Whitespace]: more than one blank line in a row
    ┌─ tests/lints/blank-lines-between-elements/source.wdl:79:1
    │  
 79 │ ╭ 

--- a/wdl-lint/tests/lints/one-line-after-version/source.wdl
+++ b/wdl-lint/tests/lints/one-line-after-version/source.wdl
@@ -1,5 +1,5 @@
 ## This is a test of having just a single line after a version
 ## There should only be a single diagnostic in the output about
-## needing a task/workflow/struct. 
+## needing a task/workflow/struct.
 
 version 1.1

--- a/wdl-lint/tests/lints/only-whitespace/source.errors
+++ b/wdl-lint/tests/lints/only-whitespace/source.errors
@@ -1,4 +1,4 @@
-warning[Whitespace]: line contains only whitespace
+note[Whitespace]: line contains only whitespace
   ┌─ tests/lints/only-whitespace/source.wdl:7:1
   │
 7 │     
@@ -6,7 +6,7 @@ warning[Whitespace]: line contains only whitespace
   │
   = fix: remove the whitespace from this line
 
-warning[Whitespace]: line contains only whitespace
+note[Whitespace]: line contains only whitespace
    ┌─ tests/lints/only-whitespace/source.wdl:10:1
    │
 10 │           
@@ -14,7 +14,7 @@ warning[Whitespace]: line contains only whitespace
    │
    = fix: remove the whitespace from this line
 
-warning[Whitespace]: more than one blank line in a row
+note[Whitespace]: more than one blank line in a row
    ┌─ tests/lints/only-whitespace/source.wdl:10:1
    │  
 10 │ ╭           
@@ -25,7 +25,7 @@ warning[Whitespace]: more than one blank line in a row
    │  
    = fix: remove the unnecessary blank lines
 
-warning[Whitespace]: line contains trailing whitespace
+note[Whitespace]: line contains trailing whitespace
    ┌─ tests/lints/only-whitespace/source.wdl:13:16
    │
 13 │ workflow test {    
@@ -33,7 +33,7 @@ warning[Whitespace]: line contains trailing whitespace
    │
    = fix: remove this trailing whitespace
 
-warning[Whitespace]: line contains only whitespace
+note[Whitespace]: line contains only whitespace
    ┌─ tests/lints/only-whitespace/source.wdl:14:1
    │
 14 │     
@@ -41,7 +41,7 @@ warning[Whitespace]: line contains only whitespace
    │
    = fix: remove the whitespace from this line
 
-warning[Whitespace]: line contains trailing whitespace
+note[Whitespace]: line contains trailing whitespace
    ┌─ tests/lints/only-whitespace/source.wdl:18:18
    │
 18 │     String x = ""           
@@ -49,7 +49,7 @@ warning[Whitespace]: line contains trailing whitespace
    │
    = fix: remove this trailing whitespace
 
-warning[Whitespace]: line contains only whitespace
+note[Whitespace]: line contains only whitespace
    ┌─ tests/lints/only-whitespace/source.wdl:20:1
    │
 20 │      

--- a/wdl-lint/tests/lints/only-whitespace/source.errors
+++ b/wdl-lint/tests/lints/only-whitespace/source.errors
@@ -31,7 +31,7 @@ warning[Whitespace]: line contains trailing whitespace
 13 │ workflow test {    
    │                ^^^^
    │
-   = fix: remove the trailing whitespace from this line
+   = fix: remove this trailing whitespace
 
 warning[Whitespace]: line contains only whitespace
    ┌─ tests/lints/only-whitespace/source.wdl:14:1
@@ -47,7 +47,7 @@ warning[Whitespace]: line contains trailing whitespace
 18 │     String x = ""           
    │                  ^^^^^^^^^^^
    │
-   = fix: remove the trailing whitespace from this line
+   = fix: remove this trailing whitespace
 
 warning[Whitespace]: line contains only whitespace
    ┌─ tests/lints/only-whitespace/source.wdl:20:1

--- a/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
+++ b/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
@@ -1,24 +1,32 @@
 warning[Whitespace]: line contains trailing whitespace
-  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:1:1
+  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:1:57
   │
 1 │ #@ except: BlankLinesBetweenElements, DescriptionMissing 
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                                                         ^
   │
   = fix: remove the trailing whitespace from this line
 
 warning[Whitespace]: line contains trailing whitespace
-  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:2:1
+  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:2:55
   │
 2 │ ## This is a preamble comment with whitespace trailing 
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                                                       ^
   │
   = fix: remove the trailing whitespace from this line
 
 warning[Whitespace]: line contains trailing whitespace
-  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:6:1
+  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:6:54
   │
 6 │ # This is a workflow comment with trailing whitespace 
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                                                      ^
+  │
+  = fix: remove the trailing whitespace from this line
+
+warning[Whitespace]: line contains trailing whitespace
+  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:7:65
+  │
+7 │ # This is a workflow comment with a bunch of trailing whitespace                 
+  │                                                                 ^^^^^^^^^^^^^^^^^
   │
   = fix: remove the trailing whitespace from this line
 

--- a/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
+++ b/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
@@ -1,0 +1,24 @@
+warning[Whitespace]: line contains trailing whitespace
+  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:1:1
+  │
+1 │ #@ except: BlankLinesBetweenElements, DescriptionMissing 
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: remove the trailing whitespace from this line
+
+warning[Whitespace]: line contains trailing whitespace
+  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:2:1
+  │
+2 │ ## This is a preamble comment with whitespace trailing 
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: remove the trailing whitespace from this line
+
+warning[Whitespace]: line contains trailing whitespace
+  ┌─ tests/lints/trailing-comment-whitespace/source.wdl:6:1
+  │
+6 │ # This is a workflow comment with trailing whitespace 
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = fix: remove the trailing whitespace from this line
+

--- a/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
+++ b/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
@@ -1,4 +1,4 @@
-warning[Whitespace]: line contains trailing whitespace
+note[Whitespace]: line contains trailing whitespace
   ┌─ tests/lints/trailing-comment-whitespace/source.wdl:1:57
   │
 1 │ #@ except: BlankLinesBetweenElements, DescriptionMissing 
@@ -6,7 +6,7 @@ warning[Whitespace]: line contains trailing whitespace
   │
   = fix: remove this trailing whitespace
 
-warning[Whitespace]: line contains trailing whitespace
+note[Whitespace]: line contains trailing whitespace
   ┌─ tests/lints/trailing-comment-whitespace/source.wdl:2:55
   │
 2 │ ## This is a preamble comment with whitespace trailing 
@@ -14,7 +14,7 @@ warning[Whitespace]: line contains trailing whitespace
   │
   = fix: remove this trailing whitespace
 
-warning[Whitespace]: line contains trailing whitespace
+note[Whitespace]: line contains trailing whitespace
   ┌─ tests/lints/trailing-comment-whitespace/source.wdl:6:54
   │
 6 │ # This is a workflow comment with trailing whitespace 
@@ -22,7 +22,7 @@ warning[Whitespace]: line contains trailing whitespace
   │
   = fix: remove this trailing whitespace
 
-warning[Whitespace]: line contains trailing whitespace
+note[Whitespace]: line contains trailing whitespace
   ┌─ tests/lints/trailing-comment-whitespace/source.wdl:7:65
   │
 7 │ # This is a workflow comment with a bunch of trailing whitespace                 

--- a/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
+++ b/wdl-lint/tests/lints/trailing-comment-whitespace/source.errors
@@ -4,7 +4,7 @@ warning[Whitespace]: line contains trailing whitespace
 1 │ #@ except: BlankLinesBetweenElements, DescriptionMissing 
   │                                                         ^
   │
-  = fix: remove the trailing whitespace from this line
+  = fix: remove this trailing whitespace
 
 warning[Whitespace]: line contains trailing whitespace
   ┌─ tests/lints/trailing-comment-whitespace/source.wdl:2:55
@@ -12,7 +12,7 @@ warning[Whitespace]: line contains trailing whitespace
 2 │ ## This is a preamble comment with whitespace trailing 
   │                                                       ^
   │
-  = fix: remove the trailing whitespace from this line
+  = fix: remove this trailing whitespace
 
 warning[Whitespace]: line contains trailing whitespace
   ┌─ tests/lints/trailing-comment-whitespace/source.wdl:6:54
@@ -20,7 +20,7 @@ warning[Whitespace]: line contains trailing whitespace
 6 │ # This is a workflow comment with trailing whitespace 
   │                                                      ^
   │
-  = fix: remove the trailing whitespace from this line
+  = fix: remove this trailing whitespace
 
 warning[Whitespace]: line contains trailing whitespace
   ┌─ tests/lints/trailing-comment-whitespace/source.wdl:7:65
@@ -28,5 +28,5 @@ warning[Whitespace]: line contains trailing whitespace
 7 │ # This is a workflow comment with a bunch of trailing whitespace                 
   │                                                                 ^^^^^^^^^^^^^^^^^
   │
-  = fix: remove the trailing whitespace from this line
+  = fix: remove this trailing whitespace
 

--- a/wdl-lint/tests/lints/trailing-comment-whitespace/source.wdl
+++ b/wdl-lint/tests/lints/trailing-comment-whitespace/source.wdl
@@ -4,6 +4,7 @@
 version 1.1
 
 # This is a workflow comment with trailing whitespace 
+# This is a workflow comment with a bunch of trailing whitespace                 
 workflow test {
     meta {}
     parameter_meta {}

--- a/wdl-lint/tests/lints/trailing-comment-whitespace/source.wdl
+++ b/wdl-lint/tests/lints/trailing-comment-whitespace/source.wdl
@@ -1,0 +1,11 @@
+#@ except: BlankLinesBetweenElements, DescriptionMissing 
+## This is a preamble comment with whitespace trailing 
+
+version 1.1
+
+# This is a workflow comment with trailing whitespace 
+workflow test {
+    meta {}
+    parameter_meta {}
+    output {}
+}


### PR DESCRIPTION
This pull request adds a new rule to `wdl-lint`.

This PR adds a new check to the `Whitespace` linting rule that checks for trailing whitespace in all types of comments. It is tested against preamble comments, linting directives and normal comments to ensure this behavior. 

Issue: [174](https://github.com/stjude-rust-labs/wdl/issues/174)

Before submitting this PR, please make sure:

- [X] You have added a few sentences describing the PR here.
- [X] You have added yourself or the appropriate individual as the assignee.
- [X] You have added at least one relevant code reviewer to the PR.
- [X] Your code builds clean without any errors or warnings.
- [X] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [X] Your commit messages follow the [conventional commit] style.

Rule specific checks:

- [X] ~You have added the rule as an entry within `RULES.md`.~
- [X] ~You have added the rule to the `rules()` function in `wdl-lint/src/lib.rs`.~
- [X] You have added a test case in `wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
- [X] ~If you have implemented a new `Visitor` callback, you have also
      overridden that callback method for the special `Validator`
      (`wdl-ast/src/validation.rs`) and `LintVisitor`
      (`wdl-lint/src/visitor.rs`) visitors. These are required to ensure the new
      visitor callback will execute.~
- [X] You have run `wdl-gauntlet --refresh` to ensure that there are no 
      unintended changes to the baseline configuration file (`Gauntlet.toml`).
- [X] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the 
      rules added/removed are now reflected in the baseline configuration file 
      (`Arena.toml`).

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
