### PR TITLE
ci: release

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,30 @@
+name: Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      crate:
+        description: Crate to bump (anything which depends on this crate will also be bumped)
+        type: choice
+        default: wdl-grammar
+        options:
+          - wdl-grammar
+          - wdl-ast
+          - wdl-lint
+          - wdl-analysis
+          - wdl-lsp
+          - wdl
+
+jobs:
+  bump:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Rust
+        run: rustup update stable && rustup default stable
+      - run: cargo run --release --bin ci -- bump --crates-to-bump ${{ inputs.crate }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/bump
+          title: "release: bump versions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,24 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      crate:
-        description: Crate to bump (anything which depends on this crate will also be bumped)
-        type: choice
-        default: wdl-grammar
-        options:
-          - wdl-grammar
-          - wdl-ast
-          - wdl-lint
-          - wdl-analysis
-          - wdl-lsp
-          - wdl
+  push:
+    branches:
+      - main
+    tags:
+      - wdl-v*
 
 jobs:
-  bump:
+  release:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo run --release --bin ci -- bump --crates-to-bump ${{ inputs.crate }}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+      - run: cargo run --release --bin ci -- publish --dry-run
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
         with:
-          branch: chore/bump
-          title: "release: bump versions"
+          generate_release_notes: true
+          make_latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo run --release --bin ci -- publish --dry-run
+      - run: cargo run --release --bin ci -- publish
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
       - name: Release

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -10,7 +10,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+chrono = "0.4.38"
 clap.workspace = true
-reqwest = { workspace = true, features = ["blocking"] }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
 toml.workspace = true
 toml_edit = { version = "0.22.21", features = ["serde"] }


### PR DESCRIPTION
Part 2 of the new release process!

When there's a tag matching`wdl-v*` pushed to `main`, this kicks off publishing to crates.io and creating a GitHub release. The GitHub release will have auto-generated release notes based on the merged PRs since the last release. Example [here](https://github.com/stjude-rust-labs/wdl/releases/tag/untagged-db7e6b7505c9a55fa426)

This also features a change to the previous `bump` step where CHANGELOGS are now updated as well.

<!-- 
When creating a pull request, you should uncomment the section below that 
describes the type of pull request you are submitting.
-->

<!-- START SECTION: adding a new linting rule

This pull request adds a new rule to `wdl-lint`.

- **Rule Name**: `MyLintRule`

_Describe the rules you have implemented and link to any relevant issues._

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.

Rule specific checks:

- [ ] You have added the rule as an entry within `RULES.md`.
- [ ] You have added the rule to the `rules()` function in `wdl-lint/src/lib.rs`.
- [ ] You have added a test case in `wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
- [ ] If you have implemented a new `Visitor` callback, you have also
      overridden that callback method for the special `Validator`
      (`wdl-ast/src/validation.rs`) and `LintVisitor`
      (`wdl-lint/src/visitor.rs`) visitors. These are required to ensure the new
      visitor callback will execute.
- [ ] You have run `wdl-gauntlet --refresh` to ensure that there are no 
      unintended changes to the baseline configuration file (`Gauntlet.toml`).
- [ ] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the 
      rules added/removed are now reflected in the baseline configuration file 
      (`Arena.toml`).

END SECTION -->

<!-- START SECTION: any other pull request

_Describe the problem or feature in addition to a link to the issues._

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.

END SECTION -->

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
