### PR TITLE
fix: CI on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - wdl-v*
 


### PR DESCRIPTION
The CI on `main` has turned red: https://github.com/stjude-rust-labs/wdl/actions/workflows/release.yml

The `Release` action should only run if there's a matching tag, but it currently runs on all `main` pushes.