### PR TITLE
feat: unused import/input/decl/call analysis warnings.

### DIFF
--- a/Arena.toml
+++ b/Arena.toml
@@ -1227,11 +1227,6 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:362:10: warning[UnusedInput]: unused input `dbSNP_vcf`"
-permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L362"
-
-[[diagnostics]]
-document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:36:17: warning[SnakeCase]: input name `known_indels_sites_VCFs` is not snake_case"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L36"
 
@@ -1289,36 +1284,6 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:422:10: note[DisallowedInputName]: declaration identifier starts with 'input'"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L422"
-
-[[diagnostics]]
-document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:427:11: warning[UnusedInput]: unused input `ref_alt`"
-permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L427"
-
-[[diagnostics]]
-document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:428:10: warning[UnusedInput]: unused input `ref_amb`"
-permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L428"
-
-[[diagnostics]]
-document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:429:10: warning[UnusedInput]: unused input `ref_ann`"
-permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L429"
-
-[[diagnostics]]
-document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:430:10: warning[UnusedInput]: unused input `ref_bwt`"
-permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L430"
-
-[[diagnostics]]
-document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:431:10: warning[UnusedInput]: unused input `ref_pac`"
-permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L431"
-
-[[diagnostics]]
-document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
-message = "ww-vc-trio.wdl:432:10: warning[UnusedInput]: unused input `ref_sa`"
-permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L432"
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
@@ -1774,26 +1739,6 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:119:20: note[ContainerValue]: container URI uses a mutable tag"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L119"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
-message = "flag_filter.wdl:140:53: warning[UnusedCall]: unused call `validate_include_if_any`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L140"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
-message = "flag_filter.wdl:143:53: warning[UnusedCall]: unused call `validate_include_if_all`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L143"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
-message = "flag_filter.wdl:146:53: warning[UnusedCall]: unused call `validate_exclude_if_any`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L146"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
-message = "flag_filter.wdl:149:53: warning[UnusedCall]: unused call `validate_exclude_if_all`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L149"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
@@ -4062,18 +4007,8 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
-message = "chipseq-standard.wdl:130:17: warning[UnusedCall]: unused call `validate_bam`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L130"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:21:13: note[TrailingComma]: item missing trailing comma"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L21"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
-message = "chipseq-standard.wdl:76:20: warning[UnusedCall]: unused call `read_length`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L76"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
@@ -4164,11 +4099,6 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:36:5: note[BlankLinesBetweenElements]: missing blank line"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L36"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
-message = "dnaseq-standard-fastq.wdl:49:10: warning[UnusedCall]: unused call `parse_input`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L49"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
@@ -4271,11 +4201,6 @@ message = "bam-to-fastqs.wdl:11:13: note[TrailingComma]: item missing trailing c
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/bam-to-fastqs.wdl/#L11"
 
 [[diagnostics]]
-document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
-message = "bam-to-fastqs.wdl:28:19: warning[UnusedCall]: unused call `quickcheck`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/bam-to-fastqs.wdl/#L28"
-
-[[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
 message = "samtools-merge.wdl:15:5: note[BlankLinesBetweenElements]: missing blank line"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/samtools-merge.wdl/#L15"
@@ -4289,11 +4214,6 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 document = "stjudecloud/workflows:/workflows/qc/markdups-post.wdl"
 message = "markdups-post.wdl:25:13: note[TrailingComma]: item missing trailing comma"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/markdups-post.wdl/#L25"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
-message = "quality-check-standard.wdl:161:15: warning[UnusedCall]: unused call `compression_integrity`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L161"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
@@ -4687,11 +4607,6 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
-message = "10x-bam-to-fastqs.wdl:34:19: warning[UnusedCall]: unused call `quickcheck`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L34"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:64:5: note[BlankLinesBetweenElements]: missing blank line"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L64"
 
@@ -4709,11 +4624,6 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
 message = "scrnaseq-standard.wdl:32:5: note[BlankLinesBetweenElements]: missing blank line"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L32"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
-message = "scrnaseq-standard.wdl:78:17: warning[UnusedCall]: unused call `validate_bam`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L78"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"

--- a/Arena.toml
+++ b/Arena.toml
@@ -12,7 +12,7 @@ commit_hash = "c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
-commit_hash = "8a709b25b8a0d0b850c4adb1ba915293d9d024d1"
+commit_hash = "a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a"
 filters = ["/template/task-templates.wdl"]
 
 [[diagnostics]]
@@ -1227,6 +1227,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:362:10: warning[UnusedInput]: unused input `dbSNP_vcf`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L362"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:36:17: warning[SnakeCase]: input name `known_indels_sites_VCFs` is not snake_case"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L36"
 
@@ -1284,6 +1289,36 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:422:10: note[DisallowedInputName]: declaration identifier starts with 'input'"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L422"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:427:11: warning[UnusedInput]: unused input `ref_alt`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L427"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:428:10: warning[UnusedInput]: unused input `ref_amb`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L428"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:429:10: warning[UnusedInput]: unused input `ref_ann`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L429"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:430:10: warning[UnusedInput]: unused input `ref_bwt`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L430"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:431:10: warning[UnusedInput]: unused input `ref_pac`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L431"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:432:10: warning[UnusedInput]: unused input `ref_sa`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L432"
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
@@ -1738,2899 +1773,2949 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:119:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/data_structures/flag_filter.wdl/#L119"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L119"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:140:53: warning[UnusedCall]: unused call `validate_include_if_any`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L140"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:143:53: warning[UnusedCall]: unused call `validate_include_if_all`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L143"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:146:53: warning[UnusedCall]: unused call `validate_exclude_if_any`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L146"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:149:53: warning[UnusedCall]: unused call `validate_exclude_if_all`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L149"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:155:6: note[BlankLinesBetweenElements]: extra blank line(s) found"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/data_structures/flag_filter.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:107:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/data_structures/read_group.wdl/#L107"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L107"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:159:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/data_structures/read_group.wdl/#L159"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L159"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:192:47: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/data_structures/read_group.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:444:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/data_structures/read_group.wdl/#L444"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L444"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:102:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L102"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L102"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:142:79: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L142"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L142"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:22:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:245:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L245"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L245"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:298:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L298"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L298"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:308:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L308"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L308"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:30:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:347:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L347"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L347"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:34:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:38:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L38"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L38"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:397:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L397"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L397"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:44:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L44"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L44"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:80:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L80"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L80"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:87:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L87"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:93:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L93"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L93"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:97:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/arriba.wdl/#L97"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L97"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:105:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L105"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L105"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:109:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L109"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L109"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:115:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L115"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L115"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:119:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L119"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L119"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:123:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L123"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L123"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:171:46: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L171"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L171"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:171:57: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L171"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L171"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:190:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L190"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L190"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:210:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L210"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L210"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:214:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L214"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L214"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:218:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L218"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L218"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:264:55: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L264"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L264"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:264:73: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L264"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L264"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:268:46: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L268"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L268"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:268:57: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L268"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L268"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:27:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L27"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L27"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:286:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L286"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L286"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:303:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L303"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L303"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:337:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L337"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L337"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:89:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/bwa.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:113:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L113"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L113"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:154:23: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L154"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L154"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:154:41: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L154"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L154"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:155:25: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:155:30: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:155:48: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:156:25: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:156:30: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:156:43: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:157:25: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L157"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L157"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:184:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L184"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L184"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:43:16: note[DisallowedInputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L43"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L43"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:5:1: note[PreambleFormatting]: lint directives must come before preamble comments"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L5"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L5"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:95:14: note[DisallowedOutputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/cellranger.wdl/#L95"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L95"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/deeptools.wdl"
 message = "deeptools.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/deeptools.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/deeptools.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/deeptools.wdl"
 message = "deeptools.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/deeptools.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/deeptools.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/deeptools.wdl"
 message = "deeptools.wdl:70:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/deeptools.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/deeptools.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/estimate.wdl"
 message = "estimate.wdl:39:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/estimate.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/estimate.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/estimate.wdl"
 message = "estimate.wdl:53:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/estimate.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/estimate.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:10:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fastqc.wdl/#L10"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L10"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fastqc.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fastqc.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:67:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fastqc.wdl/#L67"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L67"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:106:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L106"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L106"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:116:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L116"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L116"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:120:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L120"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L120"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:143:30: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L143"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L143"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:145:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L145"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L145"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:156:15: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:158:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L158"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L158"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:16:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L16"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L16"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:172:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L172"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L172"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:20:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:24:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L24"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L24"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:32:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L32"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L32"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:37:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L37"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L37"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:40:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:45:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:48:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L48"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L48"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:53:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:96:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/fq.wdl/#L96"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L96"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:12:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L12"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:152:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L152"
+message = "gatk4.wdl:150:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L150"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:163:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L163"
+message = "gatk4.wdl:161:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L161"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:164:10: note[BlankLinesBetweenElements]: extra blank line(s) found"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L164"
+message = "gatk4.wdl:162:10: note[BlankLinesBetweenElements]: extra blank line(s) found"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L162"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:216:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L216"
+message = "gatk4.wdl:214:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L214"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:227:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L227"
+message = "gatk4.wdl:225:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L225"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:236:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L236"
+message = "gatk4.wdl:234:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L234"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:246:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L246"
+message = "gatk4.wdl:244:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L244"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:302:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L302"
+message = "gatk4.wdl:300:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L300"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:313:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L313"
+message = "gatk4.wdl:311:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:326:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L326"
+message = "gatk4.wdl:324:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:330:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L330"
+message = "gatk4.wdl:328:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L328"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:375:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L375"
+message = "gatk4.wdl:373:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L373"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:387:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L387"
+message = "gatk4.wdl:385:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L385"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:399:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L399"
+message = "gatk4.wdl:397:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L397"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:402:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L402"
+message = "gatk4.wdl:400:17: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L400"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:411:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L411"
+message = "gatk4.wdl:409:17: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L409"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:419:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L419"
+message = "gatk4.wdl:417:17: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L417"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:425:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L425"
+message = "gatk4.wdl:423:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L423"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:488:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L488"
+message = "gatk4.wdl:486:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L486"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
-message = "gatk4.wdl:71:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/gatk4.wdl/#L71"
+message = "gatk4.wdl:69:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L69"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:135:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L135"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L135"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:206:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L206"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L206"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:22:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:28:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L28"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L28"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:32:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L32"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L32"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:37:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L37"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L37"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:40:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:45:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:49:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L49"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L49"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:53:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:57:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:61:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L61"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L61"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:65:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/htseq.wdl/#L65"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L65"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:118:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L118"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L118"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:175:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L175"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L175"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:192:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:197:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L197"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L197"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:205:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L205"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L205"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:259:15: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L259"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L259"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:261:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L261"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L261"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:284:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L284"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L284"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:295:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L295"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L295"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:297:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L297"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L297"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:299:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L299"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L299"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:311:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L311"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:316:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L316"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L316"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:321:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L321"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L321"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:330:14: note[DisallowedInputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L330"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L330"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:351:24: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L351"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L351"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:353:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L353"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L353"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:398:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L398"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L398"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:44:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L44"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L44"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:60:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L60"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L60"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:72:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L72"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L72"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:85:32: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L85"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L85"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:85:45: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L85"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L85"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:89:28: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:89:41: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:90:18: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:90:33: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:90:40: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:13: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:18: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:33: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:40: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:92:13: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/kraken2.wdl/#L92"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L92"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/librarian.wdl"
 message = "librarian.wdl:20:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/librarian.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/librarian.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/librarian.wdl"
 message = "librarian.wdl:52:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/librarian.wdl/#L52"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/librarian.wdl/#L52"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/md5sum.wdl"
 message = "md5sum.wdl:39:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/md5sum.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/md5sum.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/mosdepth.wdl"
 message = "mosdepth.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/mosdepth.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/mosdepth.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/mosdepth.wdl"
 message = "mosdepth.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/mosdepth.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/mosdepth.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/mosdepth.wdl"
 message = "mosdepth.wdl:69:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/mosdepth.wdl/#L69"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/mosdepth.wdl/#L69"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/multiqc.wdl"
 message = "multiqc.wdl:21:21: note[DisallowedInputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/multiqc.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/multiqc.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/multiqc.wdl"
 message = "multiqc.wdl:68:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/multiqc.wdl/#L68"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/multiqc.wdl/#L68"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:106:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L106"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L106"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:140:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L140"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L140"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:159:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L159"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L159"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:163:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L163"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L163"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:204:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L204"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L204"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:21:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:223:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L223"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L223"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:25:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L25"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L25"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:281:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L281"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L281"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:29:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L29"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L29"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:303:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L303"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L303"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:307:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L307"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L307"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:311:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L311"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:315:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L315"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L315"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:33:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L33"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L33"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:369:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L369"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L369"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:387:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L387"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L387"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:391:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L391"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L391"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:395:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L395"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L395"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:399:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L399"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L399"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:403:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L403"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L403"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:407:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L407"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L407"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:427:21: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L427"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L427"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:427:33: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L427"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L427"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:429:7: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L429"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L429"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:429:7: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L429"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L429"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:451:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L451"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L451"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:87:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/ngsderive.wdl/#L87"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:1037:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L1037"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L1037"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:125:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L125"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L125"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:145:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L145"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L145"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:14:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L14"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L14"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:153:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L153"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L153"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:159:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L159"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L159"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:163:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L163"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L163"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:167:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L167"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L167"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:190:28: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L190"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L190"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:192:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:194:29: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L194"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L194"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:196:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L196"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L196"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:247:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L247"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L247"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:259:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L259"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L259"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:270:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L270"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L270"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:272:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L272"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L272"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:280:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L280"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L280"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:29:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L29"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L29"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:330:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L330"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L330"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:342:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L342"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L342"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:355:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L355"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L355"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:357:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L357"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L357"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:364:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L364"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L364"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:38:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L38"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L38"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:417:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L417"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L417"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:429:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L429"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L429"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:441:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L441"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L441"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:46:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L46"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L46"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:485:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L485"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L485"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:497:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L497"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L497"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:511:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L511"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L511"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:52:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L52"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L52"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:548:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L548"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L548"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:560:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L560"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L560"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:562:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L562"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L562"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:574:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L574"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L574"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:610:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L610"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L610"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:622:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L622"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L622"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:626:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L626"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L626"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:628:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L628"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L628"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:641:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L641"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L641"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:681:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L681"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L681"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:693:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L693"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L693"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:695:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L695"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L695"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:707:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L707"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L707"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:743:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L743"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L743"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:754:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L754"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L754"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:766:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L766"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L766"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:802:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L802"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L802"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:819:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L819"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L819"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:842:49: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L842"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L842"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:842:56: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L842"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L842"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:847:36: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L847"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L847"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:858:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L858"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L858"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:869:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L869"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L869"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:897:14: note[DisallowedOutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L897"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L897"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:898:14: note[DisallowedOutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L898"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L898"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:904:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L904"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L904"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:915:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L915"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L915"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:923:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L923"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L923"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:926:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L926"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L926"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:976:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/picard.wdl/#L976"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L976"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/qualimap.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:157:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/qualimap.wdl/#L157"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L157"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:22:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/qualimap.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/qualimap.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:89:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/qualimap.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:117:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L117"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L117"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:135:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L135"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L135"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:172:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L172"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L172"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:17:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L17"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L17"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:183:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L183"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L183"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:192:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:21:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:228:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L228"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L228"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:246:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L246"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L246"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:250:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L250"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L250"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:285:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L285"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L285"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:57:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:75:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L75"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L75"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:79:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/sambamba.wdl/#L79"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L79"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1003:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1003"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1003"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1054:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1054"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1054"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1158:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1158"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1158"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1176:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1176"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1176"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1188:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1188"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1188"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1202:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1202"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1202"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1208:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1208"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1208"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1278:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1278"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1278"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1324:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L1324"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:153:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L153"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L153"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:171:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L171"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L171"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:175:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L175"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L175"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:211:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L211"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L211"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:228:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L228"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L228"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:232:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L232"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L232"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:270:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L270"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L270"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:281:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L281"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L281"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:291:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L291"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L291"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:295:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L295"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L295"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:39:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:416:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L416"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L416"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:436:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L436"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L436"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:440:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L440"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L440"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:503:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L503"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L503"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:523:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L523"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L523"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:527:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L527"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L527"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:531:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L531"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L531"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:535:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L535"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L535"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:539:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L539"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L539"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:543:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L543"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L543"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:55:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L55"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L55"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:605:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L605"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L605"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:60:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L60"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L60"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:623:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L623"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L623"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:628:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L628"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L628"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:632:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L632"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L632"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:636:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L636"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L636"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:640:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L640"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L640"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:64:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L64"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L64"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:68:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L68"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L68"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:690:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L690"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L690"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:708:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L708"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L708"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:712:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L712"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L712"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:716:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L716"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L716"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:72:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L72"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L72"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:763:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L763"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L763"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:788:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L788"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L788"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:792:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L792"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L792"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:796:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L796"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L796"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:800:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L800"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L800"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:804:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L804"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L804"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:808:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L808"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L808"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:814:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L814"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L814"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:818:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L818"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L818"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:822:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L822"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L822"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:894:15: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L894"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L894"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:896:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L896"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L896"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:899:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L899"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L899"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:899:31: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L899"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L899"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:902:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L902"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L902"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:905:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L905"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L905"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:905:31: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L905"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L905"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:908:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L908"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L908"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:911:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L911"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L911"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:911:31: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L911"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L911"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:913:40: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L913"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L913"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:916:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L916"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L916"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:919:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L919"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L919"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:921:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L921"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L921"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:956:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L956"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L956"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:973:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L973"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L973"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:980:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L980"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L980"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:982:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L982"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L982"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:999:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/samtools.wdl/#L999"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L999"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:130:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L130"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L130"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:154:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L154"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L154"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:167:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L167"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L167"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:169:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L169"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L169"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:174:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L174"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L174"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:176:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L176"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L176"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:185:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L185"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L185"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:188:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L188"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L188"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:18:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L18"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L18"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:195:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L195"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L195"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:197:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L197"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L197"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:213:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L213"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L213"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:215:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L215"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L215"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:219:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L219"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L219"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:221:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L221"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L221"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:226:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L226"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L226"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:228:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L228"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L228"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:22:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:233:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L233"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L233"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:235:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L235"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L235"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:240:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L240"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L240"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:242:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L242"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L242"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:249:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L249"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L249"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:251:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L251"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L251"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:258:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L258"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L258"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:260:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L260"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L260"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:266:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L266"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L266"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:268:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L268"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L268"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:274:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L274"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L274"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:276:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L276"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L276"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:280:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L280"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L280"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:284:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L284"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L284"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:291:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L291"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L291"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:293:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L293"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L293"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:299:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L299"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L299"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:301:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L301"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L301"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:308:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L308"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L308"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:311:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L311"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:315:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L315"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L315"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:317:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L317"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L317"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:31:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L31"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L31"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:324:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L324"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:326:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L326"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L326"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:332:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L332"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L332"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:334:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L334"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L334"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:338:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L338"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L338"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:350:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L350"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L350"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:354:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L354"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L354"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:358:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L358"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L358"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:372:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L372"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L372"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:376:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L376"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L376"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:380:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L380"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L380"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:384:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L384"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L384"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:39:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:405:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L405"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L405"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:409:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L409"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L409"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:413:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L413"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L413"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:417:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L417"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L417"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:421:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L421"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L421"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:435:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L435"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L435"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:439:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L439"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L439"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:43:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L43"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L43"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:443:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L443"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L443"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:449:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L449"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L449"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:453:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L453"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L453"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:457:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L457"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L457"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:461:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L461"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L461"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:467:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L467"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L467"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:471:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L471"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L471"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:487:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L487"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L487"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:493:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L493"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L493"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:499:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L499"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L499"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:505:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L505"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L505"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:511:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L511"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L511"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:654:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L654"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L654"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:656:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L656"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L656"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:678:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L678"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L678"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:684:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L684"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L684"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:690:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L690"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L690"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:696:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L696"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L696"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:702:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L702"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L702"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:726:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L726"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L726"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:728:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L728"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L728"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:823:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/star.wdl/#L823"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L823"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:101:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L101"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L101"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:120:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L120"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L120"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:125:16: note[DisallowedInputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L125"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L125"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:142:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L142"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L142"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:161:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L161"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L161"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:242:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L242"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L242"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:279:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L279"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L279"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:324:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L324"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:366:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L366"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L366"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:384:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L384"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L384"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:392:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L392"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L392"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:425:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L425"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L425"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:45:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:61:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L61"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L61"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:65:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L65"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L65"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:686:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L686"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L686"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:764:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L764"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L764"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:780:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L780"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L780"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:825:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/tools/util.wdl/#L825"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L825"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:10:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L10"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L10"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:11:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:124:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L124"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L124"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:12:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L12"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:130:17: warning[UnusedCall]: unused call `validate_bam`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L130"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:21:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L21"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:76:20: warning[UnusedCall]: unused call `read_length`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L76"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:89:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:95:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L95"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L95"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:18:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L18"
+message = "dnaseq-core.wdl:17:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L17"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:22:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L22"
+message = "dnaseq-core.wdl:21:5: note[BlankLinesBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:31:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L31"
+message = "dnaseq-core.wdl:30:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:31:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L31"
+message = "dnaseq-core.wdl:30:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:36:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L36"
+message = "dnaseq-core.wdl:35:5: note[BlankLinesBetweenElements]: missing blank line"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L35"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:68:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L68"
+message = "dnaseq-core.wdl:67:17: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L67"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:80:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L80"
+message = "dnaseq-core.wdl:79:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L79"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
-message = "dnaseq-core.wdl:85:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-core.wdl/#L85"
+message = "dnaseq-core.wdl:84:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L84"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:116:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:116:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:14:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L14"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L14"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:151:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L151"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L151"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:18:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L18"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L18"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:30:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:30:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:36:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L36"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
+message = "dnaseq-standard-fastq.wdl:49:10: warning[UnusedCall]: unused call `parse_input`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L49"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:51:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L51"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L51"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:54:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L54"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L54"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:79:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L79"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L79"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:84:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L84"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L84"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:96:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L96"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L96"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:104:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L104"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L104"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:104:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L104"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L104"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:129:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L129"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L129"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:16:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L16"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L16"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:20:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:27:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L27"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L27"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:27:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L27"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L27"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:34:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/dnaseq/dnaseq-standard.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:15:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/alignment-post.wdl/#L15"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L15"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/alignment-post.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:29:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/alignment-post.wdl/#L29"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L29"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:58:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/alignment-post.wdl/#L58"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L58"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:6:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/alignment-post.wdl/#L6"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L6"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:70:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/alignment-post.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
 message = "bam-to-fastqs.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/bam-to-fastqs.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/bam-to-fastqs.wdl/#L11"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
+message = "bam-to-fastqs.wdl:28:19: warning[UnusedCall]: unused call `quickcheck`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/bam-to-fastqs.wdl/#L28"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
 message = "samtools-merge.wdl:15:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/samtools-merge.wdl/#L15"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/samtools-merge.wdl/#L15"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
 message = "samtools-merge.wdl:21:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/general/samtools-merge.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/samtools-merge.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/markdups-post.wdl"
 message = "markdups-post.wdl:25:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/markdups-post.wdl/#L25"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/markdups-post.wdl/#L25"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:161:15: warning[UnusedCall]: unused call `compression_integrity`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L161"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:181:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L181"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L181"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:185:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L185"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L185"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:187:36: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L187"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L187"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:189:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L189"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L189"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:34:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:39:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:451:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L451"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L451"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:463:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L463"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L463"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:467:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L467"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L467"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:47:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L47"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L47"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:556:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L556"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L556"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:57:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:67:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L67"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L67"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:74:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/qc/quality-check-standard.wdl/#L74"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L74"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/bwa-db-build.wdl"
 message = "bwa-db-build.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/bwa-db-build.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/bwa-db-build.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:17:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/gatk-reference.wdl/#L17"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L17"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:57:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/gatk-reference.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:70:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/gatk-reference.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:76:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/gatk-reference.wdl/#L76"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L76"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:83:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/gatk-reference.wdl/#L83"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L83"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:90:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/gatk-reference.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:137:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/make-qc-reference.wdl/#L137"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L137"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/make-qc-reference.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:34:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/make-qc-reference.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:40:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/make-qc-reference.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:48:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/make-qc-reference.wdl/#L48"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L48"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/star-db-build.wdl"
 message = "star-db-build.wdl:12:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/reference/star-db-build.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/star-db-build.wdl/#L12"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/ESTIMATE.wdl"
 message = "ESTIMATE.wdl:12:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/ESTIMATE.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/ESTIMATE.wdl/#L12"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:105:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L105"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L105"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:111:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L111"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L111"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:127:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L127"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L127"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:151:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L151"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L151"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:196:33: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L196"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L196"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:198:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L198"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L198"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:20:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:36:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:40:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:45:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:48:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L48"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L48"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:53:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:57:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:66:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L66"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L66"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:72:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L72"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L72"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:77:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L77"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L77"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:82:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L82"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L82"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:87:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L87"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:93:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L93"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L93"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:99:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-core.wdl/#L99"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L99"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:112:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L112"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L112"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:143:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L143"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L143"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:148:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L148"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L148"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:36:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:49:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L49"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L49"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:63:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L63"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L63"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:70:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:73:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L73"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L73"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:78:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L78"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L78"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:82:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L82"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L82"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:141:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L141"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L141"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:145:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L145"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L145"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:153:16: note[DisallowedInputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L153"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L153"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:182:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L182"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L182"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:20:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:33:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L33"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L33"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:36:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:41:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L41"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L41"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:45:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:73:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-standard.wdl/#L73"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L73"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "rnaseq-variant-calling.wdl:100:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L100"
+message = "rnaseq-variant-calling.wdl:106:9: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L106"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "rnaseq-variant-calling.wdl:107:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L107"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "rnaseq-variant-calling.wdl:116:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L116"
+message = "rnaseq-variant-calling.wdl:115:9: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L115"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:13:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L13"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L13"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:51:9: note[ExpressionSpacing]: prefix operators may not contain whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L51"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L51"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:54:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L54"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L54"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "rnaseq-variant-calling.wdl:64:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L64"
+message = "rnaseq-variant-calling.wdl:75:9: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L75"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "rnaseq-variant-calling.wdl:76:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L76"
+message = "rnaseq-variant-calling.wdl:82:9: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L82"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "rnaseq-variant-calling.wdl:83:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L83"
+message = "rnaseq-variant-calling.wdl:87:9: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
-message = "rnaseq-variant-calling.wdl:88:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/rnaseq/rnaseq-variant-calling.wdl/#L88"
+message = "rnaseq-variant-calling.wdl:99:13: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L99"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:18:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L18"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L18"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "10x-bam-to-fastqs.wdl:34:19: warning[UnusedCall]: unused call `quickcheck`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:64:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L64"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L64"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:69:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L69"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L69"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:93:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L93"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L93"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
 message = "scrnaseq-standard.wdl:32:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/scrnaseq/scrnaseq-standard.wdl/#L32"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L32"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
+message = "scrnaseq-standard.wdl:78:17: warning[UnusedCall]: unused call `validate_bam`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L78"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
 message = "scrnaseq-standard.wdl:91:14: note[DisallowedOutputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/scrnaseq/scrnaseq-standard.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L91"

--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -20,7 +20,7 @@ commit_hash = "4536dd2c6719b86f4c50348f0ce354818260cadb"
 
 [repositories."broadinstitute/palantir-workflows"]
 identifier = "broadinstitute/palantir-workflows"
-commit_hash = "56575fff0bfb76cf873f94f944d673f87734e237"
+commit_hash = "d15f556cca2626667fd163e1da775cf377982f70"
 
 [repositories."broadinstitute/warp"]
 identifier = "broadinstitute/warp"
@@ -44,17 +44,32 @@ commit_hash = "c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
-commit_hash = "8a709b25b8a0d0b850c4adb1ba915293d9d024d1"
+commit_hash = "a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a"
 filters = ["/template/task-templates.wdl"]
 
 [repositories."theiagen/public_health_bioinformatics"]
 identifier = "theiagen/public_health_bioinformatics"
-commit_hash = "c1b9b23c10f77abe031378400411f0250a355be6"
+commit_hash = "26c0dddb9fe7274dc93fbea5daf725a951e3b994"
 
 [[diagnostics]]
 document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
 message = "chip.wdl:1357:64: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
 permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/chip.wdl/#L1357"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
+message = "chip.wdl:1604:13: warning[UnusedDeclaration]: unused declaration `has_all_inputs_of_pool_ta_pr2`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/chip.wdl/#L1604"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
+message = "chip.wdl:176:17: warning[UnusedInput]: unused input `use_filt_pe_ta_for_xcor`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/chip.wdl/#L176"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
+message = "chip.wdl:2169:15: warning[UnusedInput]: unused input `ref_fa`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/chip.wdl/#L2169"
 
 [[diagnostics]]
 document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
@@ -67,9 +82,119 @@ message = "chip.wdl:2620:46: error: type mismatch: expected type `Array[Int]`, b
 permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/chip.wdl/#L2620"
 
 [[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_bam2ta.wdl"
+message = "test_bam2ta.wdl:79:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_bam2ta.wdl/#L79"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_bam_to_pbam.wdl"
+message = "test_bam_to_pbam.wdl:79:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_bam_to_pbam.wdl/#L79"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_bam_to_pbam.wdl"
+message = "test_bam_to_pbam.wdl:9:17: warning[UnusedInput]: unused input `no_dup_removal`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_bam_to_pbam.wdl/#L9"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_bowtie2.wdl"
+message = "test_bowtie2.wdl:111:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_bowtie2.wdl/#L111"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_bwa.wdl"
+message = "test_bwa.wdl:70:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_bwa.wdl/#L70"
+
+[[diagnostics]]
 document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_choose_ctl.wdl"
 message = "test_choose_ctl.wdl:196:24: error: type mismatch: expected type `Array[String]?`, but found type `Array[Int]`"
 permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_choose_ctl.wdl/#L196"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_choose_ctl.wdl"
+message = "test_choose_ctl.wdl:3:32: warning[UnusedImport]: unused import namespace `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_choose_ctl.wdl/#L3"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_count_signal_track.wdl"
+message = "test_count_signal_track.wdl:27:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_count_signal_track.wdl/#L27"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_filter.wdl"
+message = "test_filter.wdl:106:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_filter.wdl/#L106"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_filter.wdl"
+message = "test_filter.wdl:9:17: warning[UnusedInput]: unused input `no_dup_removal`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_filter.wdl/#L9"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_gc_bias.wdl"
+message = "test_gc_bias.wdl:33:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_gc_bias.wdl/#L33"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_idr.wdl"
+message = "test_idr.wdl:48:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_idr.wdl/#L48"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_jsd.wdl"
+message = "test_jsd.wdl:50:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_jsd.wdl/#L50"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_macs2.wdl"
+message = "test_macs2.wdl:55:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_macs2.wdl/#L55"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_macs2_signal_track.wdl"
+message = "test_macs2_signal_track.wdl:42:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_macs2_signal_track.wdl/#L42"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_overlap.wdl"
+message = "test_overlap.wdl:45:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_overlap.wdl/#L45"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_pool_ta.wdl"
+message = "test_pool_ta.wdl:24:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_pool_ta.wdl/#L24"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_reproducibility.wdl"
+message = "test_reproducibility.wdl:32:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_reproducibility.wdl/#L32"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_spp.wdl"
+message = "test_spp.wdl:54:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_spp.wdl/#L54"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_spr.wdl"
+message = "test_spr.wdl:61:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_spr.wdl/#L61"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_subsample_ctl.wdl"
+message = "test_subsample_ctl.wdl:64:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_subsample_ctl.wdl/#L64"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_trimmomatic.wdl"
+message = "test_trimmomatic.wdl:117:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_trimmomatic.wdl/#L117"
+
+[[diagnostics]]
+document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_xcor.wdl"
+message = "test_xcor.wdl:79:25: warning[UnusedCall]: unused call `compare_md5sum`"
+permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_xcor.wdl/#L79"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/cohort_analysis/cohort_analysis.wdl"
@@ -252,6 +377,46 @@ message = "backend_configuration.wdl:94:26: error: type mismatch: a type common 
 permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L94"
 
 [[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/main.wdl"
+message = "main.wdl:4:35: warning[UnusedImport]: unused import namespace `structs`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/main.wdl/#L4"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:286:11: warning[UnusedInput]: unused input `ref_alt`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L286"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:287:10: warning[UnusedInput]: unused input `ref_amb`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L287"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:288:10: warning[UnusedInput]: unused input `ref_ann`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L288"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:289:10: warning[UnusedInput]: unused input `ref_bwt`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L289"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:290:10: warning[UnusedInput]: unused input `ref_pac`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L290"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:291:10: warning[UnusedInput]: unused input `ref_sa`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L291"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:298:12: warning[UnusedInput]: unused input `gotc_path`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L298"
+
+[[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:574:40: error: function `sep` requires a minimum WDL version of WDL v1.1"
 permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L574"
@@ -267,6 +432,46 @@ message = "processing-for-variant-discovery-gatk4.wdl:576:43: error: function `s
 permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L576"
 
 [[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/main.wdl"
+message = "main.wdl:5:35: warning[UnusedImport]: unused import namespace `structs`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/main.wdl/#L5"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:286:11: warning[UnusedInput]: unused input `ref_alt`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L286"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:287:10: warning[UnusedInput]: unused input `ref_amb`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L287"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:288:10: warning[UnusedInput]: unused input `ref_ann`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L288"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:289:10: warning[UnusedInput]: unused input `ref_bwt`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L289"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:290:10: warning[UnusedInput]: unused input `ref_pac`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L290"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:291:10: warning[UnusedInput]: unused input `ref_sa`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L291"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:298:12: warning[UnusedInput]: unused input `gotc_path`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L298"
+
+[[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:572:40: error: function `sep` requires a minimum WDL version of WDL v1.1"
 permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L572"
@@ -280,6 +485,16 @@ permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:574:43: error: function `sep` requires a minimum WDL version of WDL v1.1"
 permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L574"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
+message = "processing-for-variant-discovery-gatk4.wdl:703:9: warning[UnusedInput]: unused input `compression_level`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L703"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
+message = "mutec2.wdl:100:13: warning[UnusedInput]: unused input `small_task_mem`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L100"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
@@ -320,6 +535,16 @@ permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:198:21: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
 permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L198"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
+message = "mutec2.wdl:99:13: warning[UnusedInput]: unused input `small_task_cpu`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L99"
+
+[[diagnostics]]
+document = "aws-samples/amazon-omics-tutorials:/example-workflows/other_WDL/workflows/HISAT-genotype/hla_from_fastq.wdl"
+message = "hla_from_fastq.wdl:59:16: warning[UnusedInput]: unused input `aws_region`"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/other_WDL/workflows/HISAT-genotype/hla_from_fastq.wdl/#L59"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
@@ -437,6 +662,11 @@ message = 'bcftools.wdl:114:75: error: unknown escape sequence `\_`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/bcftools.wdl/#L114"
 
 [[diagnostics]]
+document = "biowdl/tasks:/bcftools.wdl"
+message = "bcftools.wdl:49:13: warning[UnusedInput]: unused input `threads`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/bcftools.wdl/#L49"
+
+[[diagnostics]]
 document = "biowdl/tasks:/bedtools.wdl"
 message = 'bedtools.wdl:27:48: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/bedtools.wdl/#L27"
@@ -460,6 +690,11 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 document = "biowdl/tasks:/bowtie.wdl"
 message = 'bowtie.wdl:75:48: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/bowtie.wdl/#L75"
+
+[[diagnostics]]
+document = "biowdl/tasks:/ccs.wdl"
+message = "ccs.wdl:41:15: warning[UnusedInput]: unused input `subreadsIndexFile`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/ccs.wdl/#L41"
 
 [[diagnostics]]
 document = "biowdl/tasks:/centrifuge.wdl"
@@ -490,6 +725,11 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 document = "biowdl/tasks:/centrifuge.wdl"
 message = 'centrifuge.wdl:256:64: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/centrifuge.wdl/#L256"
+
+[[diagnostics]]
+document = "biowdl/tasks:/clever.wdl"
+message = "clever.wdl:28:14: warning[UnusedInput]: unused input `indexedFiteredBam`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/clever.wdl/#L28"
 
 [[diagnostics]]
 document = "biowdl/tasks:/common.wdl"
@@ -532,6 +772,21 @@ message = 'gatk.wdl:1597:41: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/gatk.wdl/#L1597"
 
 [[diagnostics]]
+document = "biowdl/tasks:/gridss.wdl"
+message = "gridss.wdl:32:14: warning[UnusedInput]: unused input `viralReferenceImg`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/gridss.wdl/#L32"
+
+[[diagnostics]]
+document = "biowdl/tasks:/gridss.wdl"
+message = "gridss.wdl:390:14: warning[UnusedInput]: unused input `ponBedpe`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/gridss.wdl/#L390"
+
+[[diagnostics]]
+document = "biowdl/tasks:/gridss.wdl"
+message = "gridss.wdl:447:14: warning[UnusedInput]: unused input `referenceImg`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/gridss.wdl/#L447"
+
+[[diagnostics]]
 document = "biowdl/tasks:/hisat2.wdl"
 message = 'hisat2.wdl:60:34: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hisat2.wdl/#L60"
@@ -542,9 +797,64 @@ message = 'hisat2.wdl:60:41: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hisat2.wdl/#L60"
 
 [[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:1077:14: warning[UnusedInput]: unused input `proteinFeaturesCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L1077"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:1078:14: warning[UnusedInput]: unused input `transExonDataCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L1078"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:1079:14: warning[UnusedInput]: unused input `transSpliceDataCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L1079"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:603:14: warning[UnusedInput]: unused input `proteinFeaturesCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L603"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:604:14: warning[UnusedInput]: unused input `transExonDataCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L604"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:605:14: warning[UnusedInput]: unused input `transSpliceDataCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L605"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:899:14: warning[UnusedInput]: unused input `proteinFeaturesCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L899"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:900:14: warning[UnusedInput]: unused input `transExonDataCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L900"
+
+[[diagnostics]]
+document = "biowdl/tasks:/hmftools.wdl"
+message = "hmftools.wdl:901:14: warning[UnusedInput]: unused input `transSpliceDataCsv`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/hmftools.wdl/#L901"
+
+[[diagnostics]]
 document = "biowdl/tasks:/multiqc.wdl"
 message = 'multiqc.wdl:133:45: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/multiqc.wdl/#L133"
+
+[[diagnostics]]
+document = "biowdl/tasks:/nanopack.wdl"
+message = "nanopack.wdl:35:16: warning[UnusedInput]: unused input `title`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/nanopack.wdl/#L35"
+
+[[diagnostics]]
+document = "biowdl/tasks:/ncbi.wdl"
+message = "ncbi.wdl:98:16: warning[UnusedInput]: unused input `seqTaxMapPath`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/ncbi.wdl/#L98"
 
 [[diagnostics]]
 document = "biowdl/tasks:/picard.wdl"
@@ -638,8 +948,28 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 
 [[diagnostics]]
 document = "biowdl/tasks:/samtools.wdl"
+message = "samtools.wdl:72:16: warning[UnusedInput]: unused input `javaXmx`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/samtools.wdl/#L72"
+
+[[diagnostics]]
+document = "biowdl/tasks:/samtools.wdl"
 message = 'samtools.wdl:80:42: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/samtools.wdl/#L80"
+
+[[diagnostics]]
+document = "biowdl/tasks:/spades.wdl"
+message = "spades.wdl:48:15: warning[UnusedInput]: unused input `tmpDir`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/spades.wdl/#L48"
+
+[[diagnostics]]
+document = "biowdl/tasks:/strelka.wdl"
+message = "strelka.wdl:114:15: warning[UnusedInput]: unused input `doNotDefineThis`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/strelka.wdl/#L114"
+
+[[diagnostics]]
+document = "biowdl/tasks:/strelka.wdl"
+message = "strelka.wdl:23:24: warning[UnusedImport]: unused import namespace `common`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/strelka.wdl/#L23"
 
 [[diagnostics]]
 document = "biowdl/tasks:/umi-tools.wdl"
@@ -655,6 +985,16 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 document = "biowdl/tasks:/umi.wdl"
 message = 'umi.wdl:39:60: error: unknown escape sequence `\.`'
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/umi.wdl/#L39"
+
+[[diagnostics]]
+document = "biowdl/tasks:/unicycler.wdl"
+message = "unicycler.wdl:32:14: warning[UnusedInput]: unused input `verbosity`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/unicycler.wdl/#L32"
+
+[[diagnostics]]
+document = "biowdl/tasks:/vardict.wdl"
+message = "vardict.wdl:23:8: warning[UnusedImport]: unused import namespace `common`"
+permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/vardict.wdl/#L23"
 
 [[diagnostics]]
 document = "biowdl/tasks:/whatshap.wdl"
@@ -1007,684 +1347,869 @@ message = "UnmarkDuplicatesAllArgs.wdl:267:6: error: conflicting task name `Unma
 permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/UnmarkDuplicatesAllArgs.wdl/#L267"
 
 [[diagnostics]]
+document = "broadinstitute/palantir-workflows:/BenchmarkPhasing/PhaseVCF.wdl"
+message = "PhaseVCF.wdl:38:17: warning[UnusedInput]: unused input `input_sample_name`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkPhasing/PhaseVCF.wdl/#L38"
+
+[[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:104:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L104"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:148:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L148"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L148"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:204:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L204"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L204"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:216:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L216"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L216"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:242:26: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L242"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L242"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:243:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:243:78: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:244:48: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:244:75: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
+message = "BenchmarkSVs.wdl:416:21: warning[UnusedInput]: unused input `bed_regions`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L416"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
+message = "BenchmarkSVs.wdl:417:23: warning[UnusedInput]: unused input `bed_labels`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L417"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
+message = "BenchmarkSVs.wdl:418:13: warning[UnusedInput]: unused input `breakpoint_padding`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L418"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:457:40: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:457:49: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:485:43: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:485:52: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:772:43: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:772:52: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:77:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:789:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:789:49: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:790:42: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:790:51: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:890:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:890:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:23:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/CleanSVs.wdl/#L23"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:33:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/CleanSVs.wdl/#L33"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:42:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/CleanSVs.wdl/#L42"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:51:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/CleanSVs.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/WittyerTasks.wdl"
 message = "WittyerTasks.wdl:74:14: error: conflicting output name `wittyer_config`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkSVs/WittyerTasks.wdl/#L74"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/WittyerTasks.wdl/#L74"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
+message = "BenchmarkAndCompareVCFs.wdl:23:21: warning[UnusedInput]: unused input `evaluation_intervals`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:75:32: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L75"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:76:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L76"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:77:22: error: type mismatch: expected type `Array[Int]`, but found type `Array[Int]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:178:37: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L178"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L178"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:179:38: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L179"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L179"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:180:37: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L180"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L180"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:189:18: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L189"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L189"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
+message = "BenchmarkVCFs.wdl:243:17: warning[UnusedInput]: unused input `experiment`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:613:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:613:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:621:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:621:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:626:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:626:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:631:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:631:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:91:54: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/BenchmarkVCFs.wdl/#L91"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/CompareBenchmarks.wdl"
 message = "CompareBenchmarks.wdl:31:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/CompareBenchmarks.wdl/#L31"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/CompareBenchmarks.wdl/#L31"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/CompareBenchmarks.wdl"
 message = "CompareBenchmarks.wdl:32:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/CompareBenchmarks.wdl/#L32"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/CompareBenchmarks.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:127:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L127"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L127"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:135:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L135"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L135"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:143:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L143"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:151:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L151"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L151"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Fingerprints/GetFingerprintMetrics.wdl"
 message = "GetFingerprintMetrics.wdl:45:11: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Fingerprints/GetFingerprintMetrics.wdl/#L45"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Fingerprints/GetFingerprintMetrics.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:119:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L119"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:120:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L120"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L120"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:125:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L125"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L125"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:166:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L166"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L166"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:167:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L167"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L167"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:170:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L170"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L170"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:195:42: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L195"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L195"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:196:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L196"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L196"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:199:76: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L199"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L199"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:224:42: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L224"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L224"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:225:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L225"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L225"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:228:76: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L228"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L228"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:236:57: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L236"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L236"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:283:30: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L283"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L283"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
+message = "FunctionalEquivalence.wdl:59:17: warning[UnusedInput]: unused input `signed_difference`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:65:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:65:32: error: type mismatch: expected type `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:69:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:69:32: error: type mismatch: expected type `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:92:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L92"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:93:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L93"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:98:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/FunctionalEquivalence.wdl/#L98"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/FEEvaluation.wdl"
 message = "FEEvaluation.wdl:11:69: error: type mismatch: string concatenation is not supported for type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L11"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/FEEvaluation.wdl"
 message = "FEEvaluation.wdl:124:35: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L124"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L124"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/PlotROC.wdl"
+message = "PlotROC.wdl:41:9: warning[UnusedDeclaration]: unused declaration `machine_mem_gb`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L41"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/PlotROC.wdl"
 message = "PlotROC.wdl:43:95: error: type mismatch: string concatenation is not supported for type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L43"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:48:21: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L48"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:49:28: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L49"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:55:46: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L55"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:56:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L56"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:61:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L61"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:62:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L62"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:63:61: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L63"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:64:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L64"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:65:29: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L65"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:74:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L74"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:75:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L75"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:76:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L76"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:77:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:60:38: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L60"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:62:50: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L62"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:63:31: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L63"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:67:31: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L67"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:68:26: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L68"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L68"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:69:65: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:70:30: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L70"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:71:33: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L71"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:91:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L91"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:92:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L92"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:93:42: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L93"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:94:36: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L94"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L94"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:95:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L95"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/HaplotypeMap/BuildHaplotypeMap.wdl"
 message = "BuildHaplotypeMap.wdl:17:1: error: a WDL document must start with a version statement"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/HaplotypeMap/BuildHaplotypeMap.wdl/#L17"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/HaplotypeMap/BuildHaplotypeMap.wdl/#L17"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/EndToEndPipeline.wdl"
+message = "EndToEndPipeline.wdl:6:25: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/EndToEndPipeline.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:1062:11: error: type mismatch: expected type `String` or type `Array[String]`, but found type `Int`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Imputation.wdl/#L1062"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L1062"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
+message = "Imputation.wdl:1081:7: warning[UnusedInput]: unused input `mem`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L1081"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:294:31: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Imputation.wdl/#L294"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L294"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
+message = "Imputation.wdl:373:12: warning[UnusedInput]: unused input `vcf_index`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L373"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:487:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Imputation.wdl/#L487"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L487"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:519:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Imputation.wdl/#L519"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L519"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:85:17: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Imputation.wdl/#L85"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L85"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCARE.wdl"
+message = "PCARE.wdl:3:8: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCARE.wdl/#L3"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCARE.wdl"
+message = "PCARE.wdl:44:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCARE.wdl/#L44"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
+message = "PCAREAndQC.wdl:48:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L48"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
+message = "PCAREAndQC.wdl:60:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L60"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
+message = "PCAREAndQC.wdl:61:35: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L61"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
+message = "PCAREAndQC.wdl:62:41: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
-message = "PRSWrapper.wdl:50:30: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/PRSWrapper.wdl/#L50"
+message = "PRSWrapper.wdl:48:30: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PRSWrapper.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
-message = "PRSWrapper.wdl:68:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/PRSWrapper.wdl/#L68"
+message = "PRSWrapper.wdl:4:8: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PRSWrapper.wdl/#L4"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
+message = "PRSWrapper.wdl:64:25: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PRSWrapper.wdl/#L64"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
+message = "PerformPopulationPCA.wdl:105:8: warning[UnusedCall]: unused call `CheckPCA`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PerformPopulationPCA.wdl/#L105"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
+message = "PerformPopulationPCA.wdl:134:6: warning[UnusedDeclaration]: unused declaration `disk_size`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PerformPopulationPCA.wdl/#L134"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
 message = "PerformPopulationPCA.wdl:407:41: error: type mismatch: a type common to both type `File` and type `Array[File]` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/PerformPopulationPCA.wdl/#L407"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PerformPopulationPCA.wdl/#L407"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoreBGE/ScoreBGE.wdl"
-message = "ScoreBGE.wdl:38:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/ScoreBGE/ScoreBGE.wdl/#L38"
+message = "ScoreBGE.wdl:34:32: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/ScoreBGE/ScoreBGE.wdl/#L34"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoringPart.wdl"
+message = "ScoringPart.wdl:23:6: warning[UnusedInput]: unused input `population_scoring_mem`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/ScoringPart.wdl/#L23"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoringPart.wdl"
+message = "ScoringPart.wdl:6:8: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/ScoringPart.wdl/#L6"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/TrainAncestryAdjustmentModel.wdl"
+message = "TrainAncestryAdjustmentModel.wdl:3:26: warning[UnusedImport]: unused import namespace `PCATasks`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L3"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/TrainAncestryAdjustmentModel.wdl"
+message = "TrainAncestryAdjustmentModel.wdl:5:8: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
 message = "FullImputationPRSValidation.wdl:52:18: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L52"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
+message = "FullImputationPRSValidation.wdl:5:8: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
 message = "SubsetWeightSet.wdl:27:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `SelfExclusiveSites`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L27"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
 message = "SubsetWeightSet.wdl:28:66: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[SelfExclusiveSites]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/ValidateImputation.wdl"
+message = "ValidateImputation.wdl:4:28: warning[UnusedImport]: unused import namespace `structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/ValidateImputation.wdl/#L4"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/ValidateScoring.wdl"
+message = "ValidateScoring.wdl:7:28: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/ValidateScoring.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/JointCalling/CreateSampleMap.wdl"
 message = "CreateSampleMap.wdl:57:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/JointCalling/CreateSampleMap.wdl/#L57"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/JointCalling/CreateSampleMap.wdl/#L57"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/Bambu.wdl"
+message = "Bambu.wdl:11:16: warning[UnusedInput]: unused input `dataType`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/Bambu.wdl/#L11"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/Flames.wdl"
+message = "Flames.wdl:10:16: warning[UnusedInput]: unused input `datasetName`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/Flames.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:143:24: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L143"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:147:13: error: conflicting scatter variable name `gtf`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L147"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L147"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:157:29: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L157"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L157"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:158:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L158"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L158"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:164:25: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L164"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:165:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L165"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:172:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L172"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L172"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
+message = "IsoformDiscoveryBenchmark.wdl:22:14: warning[UnusedInput]: unused input `excludedGTF`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl"
 message = "IsoformDiscoveryBenchmarkTasks.wdl:69:32: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl/#L69"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
+message = "ComputeIntervalBamStats.wdl:175:14: warning[UnusedInput]: unused input `interval_file`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L175"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:223:37: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:223:50: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:270:37: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:270:50: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
+message = "ComputeIntervalBamStats.wdl:77:14: warning[UnusedInput]: unused input `ref_fasta`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:51:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/CreateIGVSession.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:51:50: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/CreateIGVSession.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:52:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/CreateIGVSession.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:52:50: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/CreateIGVSession.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:53:46: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/CreateIGVSession.wdl/#L53"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:53:60: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/CreateIGVSession.wdl/#L53"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
 message = "DownsampleAndCollectCoverage.wdl:173:91: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L173"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L173"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
 message = "DownsampleAndCollectCoverage.wdl:196:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L196"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L196"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/IndexCramOrBam.wdl"
 message = "IndexCramOrBam.wdl:36:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/IndexCramOrBam.wdl/#L36"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/IndexCramOrBam.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
 message = "MatchFingerprints.wdl:67:33: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[String]]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/56575fff0bfb76cf873f94f944d673f87734e237/Utilities/WDLs/MatchFingerprints.wdl/#L67"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/MatchFingerprints.wdl/#L67"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
+message = "MatchFingerprints.wdl:88:17: warning[UnusedInput]: unused input `fail_on_mismatch`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/MatchFingerprints.wdl/#L88"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
+message = "TargetedSomaticSingleSample.wdl:18:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L18"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
+message = "TargetedSomaticSingleSample.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L23"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl"
+message = "BuildIndexHisat3n.9.wdl:9:15: warning[UnusedInput]: unused input `monitoring_script_path`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
+message = "AnnotationFiltration.wdl:104:12: warning[UnusedInput]: unused input `significant_variants_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
@@ -1692,9 +2217,29 @@ message = "AnnotationFiltration.wdl:77:54: error: type mismatch: a type common t
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L77"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
+message = "AnnotationFiltration.wdl:7:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L7"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
 message = "Imputation.wdl:262:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/imputation/Imputation.wdl/#L262"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
+message = "Imputation.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/imputation/Imputation.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
+message = "MultiSampleArrays.wdl:21:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L21"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
+message = "MultiSampleArrays.wdl:26:10: warning[UnusedInput]: unused input `ref_fasta`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
@@ -1717,6 +2262,41 @@ message = "MultiSampleArrays.wdl:57:21: error: type mismatch: expected type `Arr
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L57"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
+message = "Arrays.wdl:26:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/single_sample/Arrays.wdl/#L26"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
+message = "Arrays.wdl:322:28: warning[UnusedCall]: unused call `UpdateChipWellBarcodeIndex`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/single_sample/Arrays.wdl/#L322"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
+message = "ValidateChip.wdl:137:24: warning[UnusedCall]: unused call `ValidateVariants`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L137"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
+message = "ValidateChip.wdl:255:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L255"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
+message = "ValidateChip.wdl:259:10: warning[UnusedInput]: unused input `truth_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L259"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
+message = "ValidateChip.wdl:4:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L4"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
+message = "JointGenotyping.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L10"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:205:81: error: type mismatch: string concatenation is not supported for type `File?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L205"
@@ -1727,9 +2307,24 @@ message = "JointGenotyping.wdl:397:41: error: type mismatch: expected type `Arra
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L397"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
+message = "JointGenotyping.wdl:62:13: warning[UnusedInput]: unused input `rename_gvcf_samples`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L62"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
+message = "UltimaGenomicsJointGenotyping.wdl:14:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L14"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:269:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L269"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
+message = "UltimaGenomicsJointGenotyping.wdl:63:13: warning[UnusedInput]: unused input `cross_check_fingerprints`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
@@ -1737,9 +2332,99 @@ message = "JointGenotypingByChromosomePartOne.wdl:210:41: error: type mismatch: 
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L210"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
+message = "JointGenotypingByChromosomePartOne.wdl:47:23: warning[UnusedInput]: unused input `gnarly_workaround_annotations`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L47"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
+message = "JointGenotypingByChromosomePartOne.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L8"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:14:10: warning[UnusedInput]: unused input `ref_fasta`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L14"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:23:9: warning[UnusedInput]: unused input `large_disk`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L23"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:24:9: warning[UnusedInput]: unused input `huge_disk`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L24"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:58:11: warning[UnusedInput]: unused input `excess_het_threshold`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L58"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:61:9: warning[UnusedInput]: unused input `SNP_VQSR_downsampleFactor`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L61"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:75:15: warning[UnusedDeclaration]: unused declaration `fingerprinting_vcf_indices`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L75"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:78:7: warning[UnusedDeclaration]: unused declaration `num_gvcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L78"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
+message = "JointGenotypingByChromosomePartTwo.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L8"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:51:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L51"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
+message = "ReblockGVCF.wdl:57:28: warning[UnusedCall]: unused call `ValidateVCF`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L57"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
+message = "ReblockGVCF.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
+message = "ExomeGermlineSingleSample.wdl:42:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L42"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
+message = "ExomeGermlineSingleSample.wdl:48:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L48"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
+message = "ExomeGermlineSingleSample.wdl:73:10: warning[UnusedDeclaration]: unused declaration `gatk_docker`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L73"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
+message = "UltimaGenomicsWholeGenomeGermline.wdl:10:83: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineQC`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L10"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
+message = "UltimaGenomicsWholeGenomeGermline.wdl:11:92: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L11"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
+message = "UltimaGenomicsWholeGenomeGermline.wdl:53:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
@@ -1752,9 +2437,59 @@ message = "UltimaGenomicsWholeGenomeGermline.wdl:63:24: error: type mismatch: ex
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
+message = "UltimaGenomicsWholeGenomeGermline.wdl:7:104: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
+message = "UltimaGenomicsWholeGenomeGermline.wdl:83:7: warning[UnusedDeclaration]: unused declaration `hc_divisor`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L83"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
+message = "UltimaGenomicsWholeGenomeGermline.wdl:8:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L8"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
+message = "UltimaGenomicsWholeGenomeGermline.wdl:9:50: warning[UnusedImport]: unused import namespace `QC`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:109:37: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
+message = "WholeGenomeGermlineSingleSample.wdl:37:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L37"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
+message = "WholeGenomeGermlineSingleSample.wdl:43:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L43"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
+message = "VariantCalling.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L12"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
+message = "VariantCalling.wdl:209:26: warning[UnusedCall]: unused call `ValidateVCF`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L209"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "UltimaGenomicsWholeGenomeCramOnly.wdl:10:92: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L10"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "UltimaGenomicsWholeGenomeCramOnly.wdl:46:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
@@ -1765,6 +2500,26 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:59:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "UltimaGenomicsWholeGenomeCramOnly.wdl:5:72: warning[UnusedImport]: unused import namespace `VariantDiscoverTasks`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L5"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "UltimaGenomicsWholeGenomeCramOnly.wdl:87:30: warning[UnusedCall]: unused call `ValidateCram`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L87"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
+message = "GDCWholeGenomeSomaticSingleSample.wdl:391:9: warning[UnusedInput]: unused input `max_retries`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L391"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
+message = "GDCWholeGenomeSomaticSingleSample.wdl:626:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
@@ -1800,6 +2555,31 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:746:20: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L746"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
+message = "BroadInternalImputation.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
+message = "BroadInternalImputation.wdl:81:34: warning[UnusedCall]: unused call `TriggerPrsWithImputationTsv`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L81"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
+message = "BroadInternalArrays.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L12"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
+message = "BroadInternalArrays.wdl:80:24: warning[UnusedCall]: unused call `IngestOutputsToTDR`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L80"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
+message = "BroadInternalUltimaGenomics.wdl:4:95: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
@@ -1847,9 +2627,89 @@ message = "BroadInternalUltimaGenomics.wdl:97:44: error: type mismatch: argument
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
+message = "BroadInternalUltimaGenomics.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
+message = "BroadInternalRNAWithUMIs.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L10"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
 message = "BroadInternalRNAWithUMIs.wdl:160:45: error: type mismatch: expected type `String`, but found type `Float`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L160"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/qc/CheckFingerprint.wdl"
+message = "CheckFingerprint.wdl:27:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/qc/CheckFingerprint.wdl/#L27"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
+message = "CramToUnmappedBams.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L12"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
+message = "CramToUnmappedBams.wdl:20:12: warning[UnusedInput]: unused input `base_file_name`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L20"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
+message = "ExomeReprocessing.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L10"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
+message = "ExomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L5"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
+message = "ExternalExomeReprocessing.wdl:62:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L62"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
+message = "ExternalExomeReprocessing.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L8"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
+message = "ExternalWholeGenomeReprocessing.wdl:60:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L60"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
+message = "ExternalWholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
+message = "WholeGenomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L5"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
+message = "WholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl"
+message = "RNAWithUMIsPipeline.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl/#L23"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl"
+message = "BuildCembaReferences.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/cemba/cemba_methylcseq/CEMBA.wdl"
+message = "CEMBA.wdl:60:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/cemba/cemba_methylcseq/CEMBA.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
@@ -1863,6 +2723,16 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
+message = "atac.wdl:3:52: warning[UnusedImport]: unused import namespace `Merge`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L3"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
+message = "atac.wdl:49:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L49"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:507:10: error: conflicting input name `annotations_gtf`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L507"
 
@@ -1870,6 +2740,11 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:150:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/build_indices/BuildIndices.wdl/#L150"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
+message = "BuildIndices.wdl:160:12: warning[UnusedInput]: unused input `gtf_annotation_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/build_indices/BuildIndices.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
@@ -1922,6 +2797,21 @@ message = "Optimus.wdl:282:26: error: type mismatch: expected type `Int`, but fo
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L282"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
+message = "Optimus.wdl:78:14: warning[UnusedDeclaration]: unused declaration `indices`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L78"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
+message = "Optimus.wdl:91:10: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L91"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
+message = "PairedTag.wdl:5:49: warning[UnusedImport]: unused import namespace `H5adUtils`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
 message = "PairedTag.wdl:86:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
@@ -1933,8 +2823,23 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
+message = "SlideSeq.wdl:49:12: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/slideseq/SlideSeq.wdl/#L49"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
+message = "SlideSeq.wdl:7:51: warning[UnusedImport]: unused import namespace `OptimusInputChecks`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:98:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl"
+message = "MultiSampleSmartSeq2.wdl:71:28: warning[UnusedCall]: unused call `checkArrays`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
@@ -1943,13 +2848,68 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
+message = "MultiSampleSmartSeq2SingleNucleus.wdl:34:15: warning[UnusedInput]: unused input `batch_name`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L34"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
+message = "MultiSampleSmartSeq2SingleNucleus.wdl:35:22: warning[UnusedInput]: unused input `project_id`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L35"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
+message = "MultiSampleSmartSeq2SingleNucleus.wdl:36:22: warning[UnusedInput]: unused input `project_name`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L36"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
+message = "MultiSampleSmartSeq2SingleNucleus.wdl:37:22: warning[UnusedInput]: unused input `library`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L37"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
+message = "MultiSampleSmartSeq2SingleNucleus.wdl:38:22: warning[UnusedInput]: unused input `species`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L38"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
+message = "MultiSampleSmartSeq2SingleNucleus.wdl:39:22: warning[UnusedInput]: unused input `organ`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L39"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
+message = "MultiSampleSmartSeq2SingleNucleus.wdl:81:40: warning[UnusedCall]: unused call `checkArrays`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
+message = "snm3C.wdl:278:14: warning[UnusedInput]: unused input `chromosome_sizes`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/snm3C/snm3C.wdl/#L278"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
+message = "snm3C.wdl:47:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/snm3C/snm3C.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:131:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
+message = "CreateOptimusAdapterMetadata.wdl:217:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
+message = "CreateOptimusAdapterMetadata.wdl:45:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
@@ -1970,6 +2930,36 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:175:68: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
+message = "CreateSs2AdapterMetadata.wdl:231:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L231"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
+message = "CreateSs2AdapterMetadata.wdl:42:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L42"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
+message = "CreateSs2AdapterMetadata.wdl:90:10: warning[UnusedDeclaration]: unused declaration `project_name`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L90"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
+message = "AdapterTasks.wdl:580:13: warning[UnusedInput]: unused input `cache_invalidate`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/tasks/AdapterTasks.wdl/#L580"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
+message = "AdapterTasks.wdl:738:13: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/tasks/AdapterTasks.wdl/#L738"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/projects/tasks/CreateReferenceMetadata.wdl"
+message = "CreateReferenceMetadata.wdl:15:12: warning[UnusedInput]: unused input `input_type`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/tasks/CreateReferenceMetadata.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/scripts/BuildAFComparisonTable.wdl"
@@ -2038,6 +3028,16 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
+message = "GermlineVariantDiscovery.wdl:27:12: warning[UnusedInput]: unused input `contamination`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L27"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
+message = "GermlineVariantDiscovery.wdl:335:12: warning[UnusedInput]: unused input `vcf_basename`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L335"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:373:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L373"
 
@@ -2057,9 +3057,99 @@ message = "GermlineVariantDiscovery.wdl:74:10: error: type mismatch: expected ty
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L74"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
+message = "GermlineVariantDiscovery.wdl:92:12: warning[UnusedInput]: unused input `contamination`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L92"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
+message = "GermlineVariantDiscovery.wdl:98:13: warning[UnusedInput]: unused input `use_dragen_hard_filtering`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L98"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:109:11: warning[UnusedInput]: unused input `fingerprint_genotypes_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L109"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:214:10: warning[UnusedInput]: unused input `input_vcf`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L214"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:287:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L287"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:289:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L289"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:423:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L423"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:541:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L541"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:556:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L556"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:591:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L591"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:595:11: warning[UnusedInput]: unused input `truth_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L595"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:62:9: warning[UnusedInput]: unused input `disk_size`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L62"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:661:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L661"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
+message = "IlluminaGenotypingArrayTasks.wdl:698:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L698"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/ImputationTasks.wdl"
+message = "ImputationTasks.wdl:529:9: warning[UnusedInput]: unused input `nSamples`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/ImputationTasks.wdl/#L529"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
+message = "InternalArraysTasks.wdl:42:10: warning[UnusedInput]: unused input `upload_metrics_output`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalArraysTasks.wdl/#L42"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
+message = "InternalArraysTasks.wdl:85:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalArraysTasks.wdl/#L85"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/InternalImputationTasks.wdl"
+message = "InternalImputationTasks.wdl:129:25: warning[UnusedInput]: unused input `run_task`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalImputationTasks.wdl/#L129"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/InternalTasks.wdl"
+message = "InternalTasks.wdl:13:10: warning[UnusedDeclaration]: unused declaration `safe_name`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalTasks.wdl/#L13"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
@@ -2075,6 +3165,11 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:434:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L434"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
+message = "JointGenotypingTasks.wdl:49:13: warning[UnusedInput]: unused input `sample_names_unique_done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
@@ -2095,6 +3190,11 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:859:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L859"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
+message = "JointGenotypingTasks.wdl:87:10: warning[UnusedInput]: unused input `ref_fasta`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
@@ -2122,9 +3222,69 @@ message = "Qc.wdl:506:29: error: type mismatch: expected type `String`, but foun
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Qc.wdl/#L506"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/RNAWithUMIsTasks.wdl"
+message = "RNAWithUMIsTasks.wdl:935:12: warning[UnusedInput]: unused input `mem`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/RNAWithUMIsTasks.wdl/#L935"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
+message = "SplitLargeReadGroup.wdl:21:45: warning[UnusedImport]: unused import namespace `Utils`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/SplitLargeReadGroup.wdl/#L21"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
+message = "SplitLargeReadGroup.wdl:22:53: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/SplitLargeReadGroup.wdl/#L22"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl"
+message = "UltimaGenomicsGermlineFilteringThreshold.wdl:228:11: warning[UnusedInput]: unused input `interval_list`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl/#L228"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:14:11: warning[UnusedInput]: unused input `rsq_threshold`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L14"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:5:80: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L5"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:65:7: warning[UnusedDeclaration]: unused declaration `rounded_disk_size`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L65"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:1096:12: warning[UnusedInput]: unused input `annotation`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L1096"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:63:9: warning[UnusedInput]: unused input `preemptible`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L63"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:785:10: warning[UnusedInput]: unused input `read_length`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L785"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:786:11: warning[UnusedInput]: unused input `jar_override`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L786"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:814:27: error: expected string, but found integer"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
+message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:839:10: warning[UnusedInput]: unused input `read_length`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L839"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
@@ -2135,6 +3295,11 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:168:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UnmappedBamToAlignedBam.wdl/#L168"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
+message = "UnmappedBamToAlignedBam.wdl:25:53: warning[UnusedImport]: unused import namespace `Structs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
@@ -2152,6 +3317,11 @@ message = "Utilities.wdl:183:10: error: type mismatch: expected type `Int` or ty
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Utilities.wdl/#L183"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/tasks/skylab/FastqProcessing.wdl"
+message = "FastqProcessing.wdl:243:16: warning[UnusedInput]: unused input `barcode_orientation`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/FastqProcessing.wdl/#L243"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:119:10: error: conflicting output name `library_metrics`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L119"
@@ -2163,8 +3333,33 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
+message = "H5adUtils.wdl:237:12: warning[UnusedInput]: unused input `cpuPlatform`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L237"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:35:12: error: conflicting input name `counting_mode`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L35"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
+message = "H5adUtils.wdl:537:24: warning[UnusedInput]: unused input `input_names`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L537"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/skylab/LoomUtils.wdl"
+message = "LoomUtils.wdl:318:24: warning[UnusedInput]: unused input `input_names`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/LoomUtils.wdl/#L318"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/skylab/PairedTagUtils.wdl"
+message = "PairedTagUtils.wdl:206:16: warning[UnusedInput]: unused input `cpuPlatform`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/PairedTagUtils.wdl/#L206"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
+message = "StarAlign.wdl:459:12: warning[UnusedInput]: unused input `gex_nhash_id`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/StarAlign.wdl/#L459"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
@@ -2173,8 +3368,33 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
+message = "bwa-mk-index.wdl:24:16: warning[UnusedInput]: unused input `ref_name`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:48:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
+message = "dummyWorkflow.wdl:6:13: warning[UnusedInput]: unused input `dummy_int`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L6"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
+message = "dummyWorkflow.wdl:7:16: warning[UnusedInput]: unused input `dummy_string`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L7"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
+message = "dummyWorkflow.wdl:8:17: warning[UnusedInput]: unused input `dummy_boolean`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L8"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
+message = "dummyWorkflow.wdl:9:17: warning[UnusedInput]: unused input `dummy_option`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/cemba/pr/CheckCembaOutputs.wdl"
@@ -2182,14 +3402,189 @@ message = "CheckCembaOutputs.wdl:1:1: error: a WDL document must start with a ve
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/tests/skylab/scATAC/pr/test_scATAC_PR.wdl"
+message = "test_scATAC_PR.wdl:35:34: warning[UnusedCall]: unused call `checker`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/scATAC/pr/test_scATAC_PR.wdl/#L35"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
+message = "test_smartseq2_multisample_PR.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
 message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
+message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
+message = "VerifyArrays.wdl:46:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyArrays.wdl/#L46"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
+message = "VerifyArrays.wdl:49:38: warning[UnusedCall]: unused call `VerifyIlluminaGenotypingArray`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyArrays.wdl/#L49"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
+message = "VerifyArrays.wdl:66:40: warning[UnusedCall]: unused call `CompareParamsFiles`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyArrays.wdl/#L66"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
+message = "VerifyCheckFingerprint.wdl:31:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyCheckFingerprint.wdl/#L31"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
+message = "VerifyCheckFingerprint.wdl:42:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyCheckFingerprint.wdl/#L42"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyCramToUnmappedBamsUpdated.wdl"
+message = "VerifyCramToUnmappedBamsUpdated.wdl:9:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyCramToUnmappedBamsUpdated.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
+message = "VerifyExomeReprocessing.wdl:24:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyExomeReprocessing.wdl/#L24"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
+message = "VerifyExomeReprocessing.wdl:37:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyExomeReprocessing.wdl/#L37"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyExternalReprocessing.wdl"
+message = "VerifyExternalReprocessing.wdl:10:10: warning[UnusedCall]: unused call `AssertTrue`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyExternalReprocessing.wdl/#L10"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
+message = "VerifyGDCSomaticSingleSample.wdl:17:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGDCSomaticSingleSample.wdl/#L17"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
+message = "VerifyGDCSomaticSingleSample.wdl:26:20: warning[UnusedCall]: unused call `CompareBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGDCSomaticSingleSample.wdl/#L26"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
+message = "VerifyGermlineSingleSample.wdl:22:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L22"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
+message = "VerifyGermlineSingleSample.wdl:26:14: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L26"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
+message = "VerifyGermlineSingleSample.wdl:40:8: warning[UnusedCall]: unused call `CompareGvcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L40"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
+message = "VerifyGermlineSingleSample.wdl:46:14: warning[UnusedCall]: unused call `CompareCrais`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L46"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
+message = "VerifyGermlineSingleSample.wdl:52:14: warning[UnusedCall]: unused call `CompareCrams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L52"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
+message = "VerifyGvcf.wdl:13:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGvcf.wdl/#L13"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
+message = "VerifyGvcf.wdl:16:20: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGvcf.wdl/#L16"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
+message = "VerifyGvcf.wdl:24:20: warning[UnusedCall]: unused call `CompareVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGvcf.wdl/#L24"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
+message = "VerifyIlluminaGenotypingArray.wdl:102:24: warning[UnusedCall]: unused call `CompareGreenIdatMdf5Sum`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L102"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
+message = "VerifyIlluminaGenotypingArray.wdl:108:24: warning[UnusedCall]: unused call `CompareRedIdatMdf5Sum`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L108"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
+message = "VerifyIlluminaGenotypingArray.wdl:43:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L43"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
+message = "VerifyIlluminaGenotypingArray.wdl:83:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L83"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
+message = "VerifyIlluminaGenotypingArray.wdl:89:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L89"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
+message = "VerifyIlluminaGenotypingArray.wdl:95:14: warning[UnusedCall]: unused call `CompareGtcs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L95"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
+message = "VerifyImputation.wdl:43:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyImputation.wdl/#L43"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
+message = "VerifyImputation.wdl:56:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyImputation.wdl/#L56"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
+message = "VerifyImputation.wdl:72:8: warning[UnusedCall]: unused call `CrosscheckFingerprints`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyImputation.wdl/#L72"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
+message = "VerifyJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyJointGenotyping.wdl/#L25"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
+message = "VerifyJointGenotyping.wdl:48:28: warning[UnusedCall]: unused call `VerifyMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyJointGenotyping.wdl/#L48"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
+message = "VerifyJointGenotyping.wdl:54:40: warning[UnusedCall]: unused call `CompareIntervals`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyJointGenotyping.wdl/#L54"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
+message = "VerifyMetrics.wdl:73:11: warning[UnusedInput]: unused input `dependency_input`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMetrics.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
@@ -2200,6 +3595,71 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:87:89: error: a placeholder cannot have more than one option"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMetrics.wdl/#L87"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
+message = "VerifyMultiSampleArrays.wdl:25:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleArrays.wdl/#L25"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
+message = "VerifyMultiSampleArrays.wdl:28:14: warning[UnusedCall]: unused call `CompareVcfsAllowingQualityDifferences`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleArrays.wdl/#L28"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
+message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:12:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L12"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
+message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:24:43: warning[UnusedCall]: unused call `CompareH5adFiles`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L24"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:32:18: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L32"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L35"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L42"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L48"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L54"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L60"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L65"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L70"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
@@ -2213,8 +3673,43 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
+message = "VerifyNA12878.wdl:62:9: warning[UnusedDeclaration]: unused declaration `default_disk_space_gb`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyNA12878.wdl/#L62"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
 message = "VerifyNA12878.wdl:65:47: error: type mismatch: multiplication operator is not supported for type `Int?` and type `Int`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyNA12878.wdl/#L65"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
+message = "VerifyOptimus.wdl:23:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L23"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
+message = "VerifyOptimus.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L26"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
+message = "VerifyOptimus.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L33"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
+message = "VerifyOptimus.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L39"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
+message = "VerifyOptimus.wdl:45:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L45"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
+message = "VerifyOptimus.wdl:51:40: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
@@ -2228,6 +3723,51 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:32:18: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L32"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L35"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L42"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L48"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L54"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L60"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L65"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L70"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
+message = "VerifyPairedTag.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L75"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L77"
 
@@ -2235,6 +3775,101 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L78"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
+message = "VerifyRNAWithUMIs.wdl:103:50: warning[UnusedCall]: unused call `CompareGeneCounts`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L103"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
+message = "VerifyRNAWithUMIs.wdl:109:50: warning[UnusedCall]: unused call `CompareExonCounts`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L109"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
+message = "VerifyRNAWithUMIs.wdl:28:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L28"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
+message = "VerifyRNAWithUMIs.wdl:37:40: warning[UnusedCall]: unused call `CompareTextMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L37"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
+message = "VerifyRNAWithUMIs.wdl:43:35: warning[UnusedCall]: unused call `CompareOutputBam`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L43"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
+message = "VerifyRNAWithUMIs.wdl:97:50: warning[UnusedCall]: unused call `CompareGeneTpms`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L97"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyReprocessing.wdl"
+message = "VerifyReprocessing.wdl:33:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyReprocessing.wdl/#L33"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
+message = "VerifySlideSeq.wdl:23:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L23"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
+message = "VerifySlideSeq.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L26"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
+message = "VerifySlideSeq.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L33"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
+message = "VerifySlideSeq.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L39"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
+message = "VerifySlideSeq.wdl:45:50: warning[UnusedCall]: unused call `CompareUMIMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L45"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
+message = "VerifySlideSeq.wdl:51:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L51"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
+message = "VerifySomaticSingleSample.wdl:24:14: warning[UnusedCall]: unused call `CompareCrais`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySomaticSingleSample.wdl/#L24"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
+message = "VerifySomaticSingleSample.wdl:30:14: warning[UnusedCall]: unused call `CompareCrams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySomaticSingleSample.wdl/#L30"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
+message = "VerifyUltimaGenomicsJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L25"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
+message = "VerifyUltimaGenomicsJointGenotyping.wdl:36:28: warning[UnusedCall]: unused call `VerifyMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L36"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
+message = "VerifyUltimaGenomicsJointGenotyping.wdl:42:40: warning[UnusedCall]: unused call `CompareIntervals`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L42"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
+message = "VerifyUltimaGenomicsJointGenotyping.wdl:48:8: warning[UnusedCall]: unused call `CompareFingerprints`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
@@ -2247,6 +3882,41 @@ message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:102:87: error: a placehol
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:17:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L17"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:64:14: warning[UnusedCall]: unused call `CompareCrams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L64"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:72:14: warning[UnusedCall]: unused call `CompareCrais`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L72"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:89:11: warning[UnusedInput]: unused input `dependency_input`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L89"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:105:29: warning[UnusedCall]: unused call `CompareGvcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L105"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:112:22: warning[UnusedCall]: unused call `VerifyNA12878`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L112"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:161:11: warning[UnusedInput]: unused input `dependency_input`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L161"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:115: error: cannot coerce type `Array[String]` to `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
@@ -2255,6 +3925,81 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:87: error: a placeholder cannot have more than one option"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:30:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L30"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:77:14: warning[UnusedCall]: unused call `CompareCrams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L77"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:85:14: warning[UnusedCall]: unused call `CompareCrais`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L85"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:91:29: warning[UnusedCall]: unused call `CompareVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L91"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:98:29: warning[UnusedCall]: unused call `CompareFilteredVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L98"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
+message = "VerifyValidateChip.wdl:40:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L40"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
+message = "VerifyValidateChip.wdl:43:14: warning[UnusedCall]: unused call `CompareGtcs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L43"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
+message = "VerifyValidateChip.wdl:50:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L50"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
+message = "VerifyValidateChip.wdl:56:55: warning[UnusedCall]: unused call `CompareGenotypeConcordanceVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L56"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
+message = "VerifyValidateChip.wdl:62:55: warning[UnusedCall]: unused call `CompareIndelGenotypeConcordanceVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L62"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
+message = "VerifyscATAC.wdl:12:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyscATAC.wdl/#L12"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
+message = "VerifyscATAC.wdl:15:35: warning[UnusedCall]: unused call `CompareBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyscATAC.wdl/#L15"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
+message = "VerifyscATAC.wdl:22:43: warning[UnusedCall]: unused call `CompareSnapTextFiles`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyscATAC.wdl/#L22"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
+message = "Verifysnm3C.wdl:23:18: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/Verifysnm3C.wdl/#L23"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
+message = "Verifysnm3C.wdl:26:52: warning[UnusedCall]: unused call `CompareMappingSummaryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/Verifysnm3C.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
@@ -2275,6 +4020,21 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "TestBroadInternalUltimaGenomics.wdl:58:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/test-wdls/TestCheckFingerprint.wdl"
+message = "TestCheckFingerprint.wdl:33:15: warning[UnusedInput]: unused input `vault_token_path_arrays`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/test-wdls/TestExomeReprocessing.wdl"
+message = "TestExomeReprocessing.wdl:7:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestExomeReprocessing.wdl/#L7"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl"
+message = "TestExternalWholeGenomeReprocessing.wdl:6:45: warning[UnusedImport]: unused import namespace `Utilities`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
@@ -2378,8 +4138,18 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
+message = "TestOptimus.wdl:28:11: warning[UnusedInput]: unused input `mt_genes`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestOptimus.wdl/#L28"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:76:36: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestOptimus.wdl/#L76"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
+message = "TestPairedTag.wdl:57:15: warning[UnusedInput]: unused input `run_cellbender`"
+permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestPairedTag.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
@@ -2435,6 +4205,16 @@ permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68
 document = "broadinstitute/warp:/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl"
 message = "TestWholeGenomeGermlineSingleSample.wdl:54:45: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
 permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
+message = "run.wdl:135:10: warning[UnusedCall]: unused call `tsvToSam`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L135"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
+message = "run.wdl:142:10: warning[UnusedCall]: unused call `ZipOutputs`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L142"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -2548,8 +4328,18 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
+message = "run.wdl:561:14: warning[UnusedInput]: unused input `card_json`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L561"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
 message = "run.wdl:575:36: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L575"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
+message = "run.wdl:587:14: warning[UnusedInput]: unused input `card_json`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L587"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -2638,6 +4428,21 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:440:16: warning[UnusedInput]: unused input `prefix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L440"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:54:16: warning[UnusedInput]: unused input `vadr_options`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L54"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:55:14: warning[UnusedInput]: unused input `vadr_model`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L55"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
 message = "run.wdl:604:40: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L604"
 
@@ -2653,13 +4458,58 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:794:16: warning[UnusedInput]: unused input `prefix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L794"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:81:16: warning[UnusedInput]: unused input `s3_wd_uri`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L81"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:822:16: warning[UnusedInput]: unused input `prefix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L822"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:868:16: warning[UnusedInput]: unused input `prefix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L868"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:877:13: warning[UnusedInput]: unused input `threads`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L877"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
 message = "run.wdl:87:22: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L87"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
+message = "run.wdl:938:14: warning[UnusedInput]: unused input `ref_host`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L938"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/diamond/diamond.wdl"
+message = "diamond.wdl:12:10: warning[UnusedCall]: unused call `RunDiamond`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/diamond/diamond.wdl/#L12"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/index-generation/index-generation.wdl"
 message = "index-generation.wdl:1:9: error: unsupported WDL version `development`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/index-generation/index-generation.wdl/#L1"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/legacy-host-filter/legacy-host-filter.wdl"
+message = "legacy-host-filter.wdl:39:12: warning[UnusedInput]: unused input `s3_wd_uri`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/legacy-host-filter/legacy-host-filter.wdl/#L39"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/minimap2/minimap2.wdl"
+message = "minimap2.wdl:12:10: warning[UnusedCall]: unused call `RunMinimap2`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/minimap2/minimap2.wdl/#L12"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/phylotree-ng/run.wdl"
@@ -2670,6 +4520,116 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 document = "chanzuckerberg/czid-workflows:/workflows/phylotree-ng/run.wdl"
 message = "run.wdl:27:30: error: type mismatch: expected type `String`, but found type `Float`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/phylotree-ng/run.wdl/#L27"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/phylotree-ng/run.wdl"
+message = "run.wdl:31:16: warning[UnusedInput]: unused input `s3_wd_uri`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/phylotree-ng/run.wdl/#L31"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/experimental.wdl"
+message = "experimental.wdl:160:12: warning[UnusedInput]: unused input `file_ext`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/experimental.wdl/#L160"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/experimental.wdl"
+message = "experimental.wdl:161:12: warning[UnusedInput]: unused input `nt_db`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/experimental.wdl/#L161"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/experimental.wdl"
+message = "experimental.wdl:162:10: warning[UnusedInput]: unused input `nt_loc_db`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/experimental.wdl/#L162"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/experimental.wdl"
+message = "experimental.wdl:165:10: warning[UnusedInput]: unused input `resist_genome_db`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/experimental.wdl/#L165"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/experimental.wdl"
+message = "experimental.wdl:166:10: warning[UnusedInput]: unused input `resist_genome_bed`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/experimental.wdl/#L166"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/host_filter.wdl"
+message = "host_filter.wdl:12:12: warning[UnusedInput]: unused input `nucleotide_type`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/host_filter.wdl/#L12"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/host_filter.wdl"
+message = "host_filter.wdl:22:11: warning[UnusedInput]: unused input `gtf_gz`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/host_filter.wdl/#L22"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:62:38: warning[UnusedCall]: unused call `experimental`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/local_driver.wdl/#L62"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:128:16: warning[UnusedInput]: unused input `prefix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L128"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:175:16: warning[UnusedInput]: unused input `prefix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L175"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:179:16: warning[UnusedInput]: unused input `s3_wd_uri`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L179"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:231:16: warning[UnusedInput]: unused input `prefix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L231"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:235:16: warning[UnusedInput]: unused input `s3_wd_uri`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L235"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:292:12: warning[UnusedInput]: unused input `index_dir_suffix`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L292"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:295:13: warning[UnusedInput]: unused input `use_deuterostome_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L295"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:296:13: warning[UnusedInput]: unused input `use_taxon_whitelist`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L296"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:297:13: warning[UnusedInput]: unused input `alignment_scalability`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L297"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/non_host_alignment.wdl"
+message = "non_host_alignment.wdl:301:13: warning[UnusedInput]: unused input `local_gsnap_genome_name`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/non_host_alignment.wdl/#L301"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/postprocess.wdl"
+message = "postprocess.wdl:352:10: warning[UnusedInput]: unused input `assembly_gsnap_blast_top_m8`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/postprocess.wdl/#L352"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/postprocess.wdl"
+message = "postprocess.wdl:397:10: warning[UnusedInput]: unused input `assembly_gsnap_blast_top_m8`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/postprocess.wdl/#L397"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/postprocess.wdl"
+message = "postprocess.wdl:488:12: warning[UnusedInput]: unused input `index_version`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/short-read-mngs/postprocess.wdl/#L488"
 
 [[diagnostics]]
 document = "getwilds/ww-star-deseq2:/ww-star-deseq2.wdl"
@@ -2693,1645 +4653,1770 @@ permalink = "https://github.com/getwilds/ww-star-deseq2/blob/6d81ede0ad963115697
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:362:10: warning[UnusedInput]: unused input `dbSNP_vcf`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L362"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:427:11: warning[UnusedInput]: unused input `ref_alt`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L427"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:428:10: warning[UnusedInput]: unused input `ref_amb`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L428"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:429:10: warning[UnusedInput]: unused input `ref_ann`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L429"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:430:10: warning[UnusedInput]: unused input `ref_bwt`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L430"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:431:10: warning[UnusedInput]: unused input `ref_pac`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L431"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:432:10: warning[UnusedInput]: unused input `ref_sa`"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L432"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:451:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L451"
 
 [[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:140:53: warning[UnusedCall]: unused call `validate_include_if_any`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L140"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:143:53: warning[UnusedCall]: unused call `validate_include_if_all`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L143"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:146:53: warning[UnusedCall]: unused call `validate_exclude_if_any`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L146"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
+message = "flag_filter.wdl:149:53: warning[UnusedCall]: unused call `validate_exclude_if_all`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L149"
+
+[[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:110:45: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/stjudecloud/workflows/blob/8a709b25b8a0d0b850c4adb1ba915293d9d024d1/workflows/chipseq/chipseq-standard.wdl/#L110"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L110"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:130:17: warning[UnusedCall]: unused call `validate_bam`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L130"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
+message = "chipseq-standard.wdl:76:20: warning[UnusedCall]: unused call `read_length`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L76"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
+message = "dnaseq-standard-fastq.wdl:49:10: warning[UnusedCall]: unused call `parse_input`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L49"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
+message = "bam-to-fastqs.wdl:28:19: warning[UnusedCall]: unused call `quickcheck`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/bam-to-fastqs.wdl/#L28"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
+message = "quality-check-standard.wdl:161:15: warning[UnusedCall]: unused call `compression_integrity`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L161"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
+message = "10x-bam-to-fastqs.wdl:34:19: warning[UnusedCall]: unused call `quickcheck`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L34"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
+message = "scrnaseq-standard.wdl:78:17: warning[UnusedCall]: unused call `validate_bam`"
+permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L78"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:11:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/assembly/task_ivar_consensus.wdl/#L11"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_ivar_consensus.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:12:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/assembly/task_ivar_consensus.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_ivar_consensus.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:9:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/assembly/task_ivar_consensus.wdl/#L9"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_ivar_consensus.wdl/#L9"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_metaspades.wdl"
 message = "task_metaspades.wdl:39:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/assembly/task_metaspades.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_metaspades.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_shovill.wdl"
 message = "task_shovill.wdl:77:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/assembly/task_shovill.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_shovill.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:10:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:12:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:13:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:95:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl"
 message = "task_snippy_gene_query.wdl:69:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_variants.wdl"
 message = "task_snippy_variants.wdl:128:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L128"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/advanced_metrics/task_gambittools.wdl"
 message = "task_gambittools.wdl:67:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:44:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L44"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L44"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:45:19: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L45"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L45"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:46:23: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L46"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L46"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:47:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L47"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L47"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl"
 message = "task_cg_pipeline.wdl:102:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:46:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:47:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:48:29: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:49:24: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:50:40: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_quast.wdl"
 message = "task_quast.wdl:64:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_readlength.wdl"
 message = "task_readlength.wdl:26:33: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
+message = "task_screen.wdl:15:13: warning[UnusedInput]: unused input `organism`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/comparisons/task_screen.wdl/#L15"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
+message = "task_screen.wdl:185:13: warning[UnusedInput]: unused input `organism`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/comparisons/task_screen.wdl/#L185"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/species_typing/salmonella/task_genotyphi.wdl"
 message = "task_genotyphi.wdl:61:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:76:45: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/taxon_id/contamination/task_midas.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/taxon_id/contamination/task_midas.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:77:44: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/taxon_id/contamination/task_midas.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/taxon_id/contamination/task_midas.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/task_gambit.wdl"
 message = "task_gambit.wdl:164:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/taxon_id/task_gambit.wdl/#L164"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/taxon_id/task_gambit.wdl/#L164"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/data_handling/task_parse_mapping.wdl"
 message = "task_parse_mapping.wdl:133:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/tasks/utilities/submission/task_broad_ncbi_tools.wdl"
+message = "task_broad_ncbi_tools.wdl:11:12: warning[UnusedInput]: unused input `docker`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/utilities/submission/task_broad_ncbi_tools.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:120: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:40: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:120:126: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:120:42: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:124:108: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:124:36: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:131:114: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:131:38: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_plot.wdl"
 message = "wf_freyja_plot.wdl:18:25: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/freyja/wf_freyja_plot.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_plot.wdl/#L18"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_update.wdl"
+message = "wf_freyja_update.wdl:13:17: warning[UnusedCall]: unused call `transfer_files`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_update.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:153:80: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_augur.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_augur.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:62:21: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_augur.wdl/#L62"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_augur.wdl/#L62"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_core_gene_snp.wdl"
 message = "wf_core_gene_snp.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_mashtree_fasta.wdl"
 message = "wf_mashtree_fasta.wdl:37:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:33:58: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:34:53: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:35:51: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:36:52: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:37:57: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L101"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L101"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:106:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L106"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L106"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:107:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:108:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:119:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L119"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L119"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:120:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:121:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:122:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:123:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:132:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L132"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L132"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:150:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L150"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L150"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:71:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L71"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L71"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:72:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:73:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:74:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:84:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:85:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:86:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:87:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:27:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:32:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:33:19: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:34:17: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:35:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:36:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:37:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:38:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:39:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:40:23: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:37:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:38:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:39:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:42:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:69:45: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:71:40: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:72:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:73:52: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/standalone_modules/wf_snippy_variants.wdl/#L73"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_clearlabs.wdl"
 message = "wf_theiacov_clearlabs.wdl:148:26: error: type mismatch: expected type `String?`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
 message = "wf_theiacov_illumina_pe.wdl:233:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
+message = "wf_theiacov_illumina_pe.wdl:4:84: warning[UnusedImport]: unused import namespace `assembly_metrics`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L4"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:192:38: error: type mismatch: expected type `Float?`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:273:29: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L273"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L273"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:274:28: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L274"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L274"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:275:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:236:30: error: type mismatch: expected type `String?`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:119: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:84: error: type mismatch: a type common to both type `Float?` and type `String?` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:118:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:127:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:70:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
-message = "wf_theiameta_illumina_pe.wdl:255:31: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L255"
+message = "wf_theiameta_illumina_pe.wdl:258:31: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L258"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
-message = "wf_theiameta_illumina_pe.wdl:257:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L257"
+message = "wf_theiameta_illumina_pe.wdl:260:37: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L260"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
-message = "wf_theiameta_illumina_pe.wdl:266:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L266"
+message = "wf_theiameta_illumina_pe.wdl:269:38: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L269"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl"
 message = "wf_theiaprok_illumina_pe.wdl:115:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_se.wdl"
 message = "wf_theiaprok_illumina_se.wdl:110:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:103:28: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:84:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_create_terra_table.wdl"
+message = "wf_create_terra_table.wdl:17:46: warning[UnusedCall]: unused call `make_table`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_create_terra_table.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:17:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:18:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:19:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:20:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:21:23: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_terra_2_bq.wdl"
+message = "wf_terra_2_bq.wdl:14:26: warning[UnusedCall]: unused call `terra_to_bigquery`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_terra_2_bq.wdl/#L14"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:100:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L100"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L100"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L101"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L101"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:109:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:110:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:111:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L111"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L111"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:112:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:154: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:94: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:118:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:123:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L123"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L123"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:124:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:125:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L125"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L125"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:126:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L126"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L126"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:127:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L127"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:128:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L128"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:131:17: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:141:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L141"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L141"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:142:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L142"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L142"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:143:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L143"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L143"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:144:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L144"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L144"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:170:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L170"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L170"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:182:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L182"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L182"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:183:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L183"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L183"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:184:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L184"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L184"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:185:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L185"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L185"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:186:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L186"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L186"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:187:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L187"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L187"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:188:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L188"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L188"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:189:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L189"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L189"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:190:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L190"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L190"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:199:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L199"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L199"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:200:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L200"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L200"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:201:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L201"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L201"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:202:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L202"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L202"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:208:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L208"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L208"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:209:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L209"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L209"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:210:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L210"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L210"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:211:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L211"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L211"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:220:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L220"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L220"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:221:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L221"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L221"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:222:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L222"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L222"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:223:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L223"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L223"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:229:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L229"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L229"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:230:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L230"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L230"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:231:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L231"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L231"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:232:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L232"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L232"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:86:28: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L86"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:87:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L87"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:88:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L88"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L88"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:89:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:90:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:98:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L98"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L98"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:99:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_flu_track.wdl/#L99"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L99"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:102:16: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:103:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:104:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L104"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L104"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:105:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L105"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L105"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:106:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L106"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L106"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:112:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:113:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L113"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L113"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:114:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L114"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L114"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:115:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:29: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:104: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:28: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L154"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L154"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:56:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L56"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:57:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L57"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L57"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:58:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L58"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L58"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:59:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L59"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L59"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:67:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:68:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L68"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L68"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:69:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:70:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:76:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:77:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:78:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L78"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L78"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:79:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L79"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L79"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:90:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:91:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:92:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L92"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L92"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:93:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_ivar_consensus.wdl/#L93"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L93"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:228:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L228"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L228"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:229:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L229"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L229"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:230:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L230"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L230"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:231:23: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L231"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L231"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:232:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L232"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L232"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:241:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L241"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L241"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:253:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L253"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L253"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:259:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L259"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L259"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:260:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L260"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L260"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:261:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L261"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L261"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:262:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L262"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L262"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:263:18: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L263"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L263"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:264:25: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L264"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L264"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:265:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L265"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L265"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:274:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L274"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L274"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:281:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L281"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L281"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:290:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L290"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L290"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:304:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L304"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L304"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:305:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L305"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L305"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:317:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:326:18: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L326"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L326"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:327:19: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L327"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L327"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:328:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L328"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L328"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:336:30: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L336"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L336"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:337:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L337"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L337"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:338:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L338"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L338"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:339:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L339"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L339"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:340:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L340"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L340"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:349:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L349"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L349"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:357:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L357"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L357"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:367:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L367"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L367"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:377:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L377"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L377"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:378:24: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L378"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L378"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:379:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L379"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L379"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:380:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L380"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L380"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:381:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L381"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L381"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:382:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L382"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L382"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:383:34: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L383"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L383"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:384:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L384"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L384"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:392:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L392"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L392"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:400:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L400"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L400"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:408:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L408"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L408"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:409:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L409"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L409"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:410:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L410"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L410"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:421:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L421"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L421"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:432:32: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L432"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L432"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:433:20: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L433"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L433"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:434:25: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L434"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L434"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:435:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L435"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L435"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:436:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L436"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L436"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:437:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L437"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L437"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:439:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L439"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L439"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:455:32: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L455"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L455"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:456:36: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L456"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L456"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:457:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L457"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L457"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:467:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L467"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L467"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:475:21: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L475"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L475"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:476:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L476"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L476"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:482:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L482"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L482"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:488:23: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L488"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L488"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:489:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L489"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L489"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:499:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L499"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L499"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:506:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L506"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L506"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:507:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L507"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L507"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:508:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L508"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L508"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:515:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L515"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L515"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:516:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L516"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L516"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:517:20: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L517"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L517"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:518:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L518"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L518"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:519:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L519"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L519"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:520:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L520"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L520"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:521:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L521"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L521"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:522:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L522"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L522"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:523:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L523"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L523"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:524:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L524"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L524"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:525:26: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L525"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L525"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:526:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L526"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L526"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:527:37: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L527"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L527"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:528:31: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L528"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L528"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:529:39: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L529"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L529"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:530:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L530"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L530"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:539:14: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L539"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L539"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:540:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L540"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L540"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:541:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L541"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L541"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:542:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L542"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L542"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:543:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L543"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L543"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:544:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L544"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L544"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:545:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L545"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L545"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:546:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L546"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L546"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:547:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L547"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L547"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:548:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L548"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L548"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:549:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L549"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L549"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:557:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L557"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L557"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:566:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L566"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L566"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:581:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L581"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L581"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:590:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L590"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L590"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:601:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L601"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L601"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:602:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L602"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L602"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:603:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L603"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L603"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:604:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L604"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L604"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:605:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L605"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L605"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:606:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L606"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L606"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:607:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L607"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L607"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:608:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L608"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L608"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:609:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L609"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L609"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:610:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L610"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L610"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:611:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L611"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L611"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:612:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L612"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L612"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:623:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L623"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L623"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:627:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L627"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L627"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:635:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L635"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L635"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:674:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L674"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L674"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:678:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L678"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L678"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:686:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L686"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L686"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:700:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L700"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L700"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:704:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L704"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L704"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:712:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_merlin_magic.wdl/#L712"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L712"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:109:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:51:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:52:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:53:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:89:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:90:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:91:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:129:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:141:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:142:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:143:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:74:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:118:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:129:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:130:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:131:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:56:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/c1b9b23c10f77abe031378400411f0250a355be6/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"

--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -20,11 +20,11 @@ commit_hash = "4536dd2c6719b86f4c50348f0ce354818260cadb"
 
 [repositories."broadinstitute/palantir-workflows"]
 identifier = "broadinstitute/palantir-workflows"
-commit_hash = "d15f556cca2626667fd163e1da775cf377982f70"
+commit_hash = "f8833a0000cd441a3cc4be2718876a1433cb21ef"
 
 [repositories."broadinstitute/warp"]
 identifier = "broadinstitute/warp"
-commit_hash = "78f8c5c3160b06a81648c68f02307e235acdb3a1"
+commit_hash = "ec91e512235419b267e295583db3ec2594fcd717"
 
 [repositories."chanzuckerberg/czid-workflows"]
 identifier = "chanzuckerberg/czid-workflows"
@@ -49,7 +49,7 @@ filters = ["/template/task-templates.wdl"]
 
 [repositories."theiagen/public_health_bioinformatics"]
 identifier = "theiagen/public_health_bioinformatics"
-commit_hash = "26c0dddb9fe7274dc93fbea5daf725a951e3b994"
+commit_hash = "be24047e2b64d02a187824909b91d04bda6074d8"
 
 [[diagnostics]]
 document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
@@ -1349,2862 +1349,2872 @@ permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkPhasing/PhaseVCF.wdl"
 message = "PhaseVCF.wdl:38:17: warning[UnusedInput]: unused input `input_sample_name`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkPhasing/PhaseVCF.wdl/#L38"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkPhasing/PhaseVCF.wdl/#L38"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:104:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L104"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:148:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L148"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L148"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:204:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L204"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L204"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:216:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L216"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L216"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:242:26: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L242"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L242"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:243:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:243:78: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:244:48: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:244:75: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:416:21: warning[UnusedInput]: unused input `bed_regions`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L416"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L416"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:417:23: warning[UnusedInput]: unused input `bed_labels`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L417"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L417"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:418:13: warning[UnusedInput]: unused input `breakpoint_padding`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L418"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L418"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:457:40: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:457:49: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:485:43: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:485:52: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:772:43: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:772:52: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:77:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:789:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:789:49: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:790:42: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:790:51: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:890:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:890:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:23:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L23"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/CleanSVs.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:33:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L33"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/CleanSVs.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:42:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L42"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/CleanSVs.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:51:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/CleanSVs.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/CleanSVs.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/WittyerTasks.wdl"
 message = "WittyerTasks.wdl:74:14: error: conflicting output name `wittyer_config`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkSVs/WittyerTasks.wdl/#L74"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkSVs/WittyerTasks.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:23:21: warning[UnusedInput]: unused input `evaluation_intervals`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L23"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:75:32: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L75"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:76:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L76"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:77:22: error: type mismatch: expected type `Array[Int]`, but found type `Array[Int]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:178:37: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L178"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L178"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:179:38: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L179"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L179"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:180:37: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L180"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L180"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:189:18: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L189"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L189"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:243:17: warning[UnusedInput]: unused input `experiment`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:613:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:613:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:621:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:621:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:626:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:626:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:631:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:631:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:91:54: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/BenchmarkVCFs.wdl/#L91"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/BenchmarkVCFs.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/CompareBenchmarks.wdl"
 message = "CompareBenchmarks.wdl:31:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/CompareBenchmarks.wdl/#L31"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/CompareBenchmarks.wdl/#L31"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/CompareBenchmarks.wdl"
 message = "CompareBenchmarks.wdl:32:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/CompareBenchmarks.wdl/#L32"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/CompareBenchmarks.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:127:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L127"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L127"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:135:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L135"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L135"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:143:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L143"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:151:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L151"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L151"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Fingerprints/GetFingerprintMetrics.wdl"
 message = "GetFingerprintMetrics.wdl:45:11: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Fingerprints/GetFingerprintMetrics.wdl/#L45"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Fingerprints/GetFingerprintMetrics.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:119:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L119"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:120:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L120"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L120"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:125:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L125"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L125"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:166:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L166"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L166"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:167:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L167"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L167"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:170:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L170"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L170"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:195:42: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L195"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L195"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:196:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L196"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L196"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:199:76: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L199"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L199"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:224:42: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L224"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L224"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:225:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L225"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L225"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:228:76: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L228"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L228"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:236:57: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L236"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L236"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:283:30: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L283"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L283"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:59:17: warning[UnusedInput]: unused input `signed_difference`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L59"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:65:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:65:32: error: type mismatch: expected type `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:69:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:69:32: error: type mismatch: expected type `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:92:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L92"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:93:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L93"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:98:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/FunctionalEquivalence.wdl/#L98"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/FunctionalEquivalence.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/FEEvaluation.wdl"
 message = "FEEvaluation.wdl:11:69: error: type mismatch: string concatenation is not supported for type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L11"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/FEEvaluation.wdl"
 message = "FEEvaluation.wdl:124:35: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L124"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L124"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/PlotROC.wdl"
 message = "PlotROC.wdl:41:9: warning[UnusedDeclaration]: unused declaration `machine_mem_gb`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L41"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L41"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/PlotROC.wdl"
 message = "PlotROC.wdl:43:95: error: type mismatch: string concatenation is not supported for type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L43"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:48:21: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L48"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:49:28: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L49"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:55:46: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L55"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:56:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L56"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:61:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L61"
+message = "Glimpse2ImputationAndCheckQC.wdl:60:27: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:62:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L62"
+message = "Glimpse2ImputationAndCheckQC.wdl:61:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:63:61: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L63"
+message = "Glimpse2ImputationAndCheckQC.wdl:62:61: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:64:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L64"
+message = "Glimpse2ImputationAndCheckQC.wdl:63:26: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:65:29: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L65"
+message = "Glimpse2ImputationAndCheckQC.wdl:64:29: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:74:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L74"
+message = "Glimpse2ImputationAndCheckQC.wdl:70:39: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:75:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L75"
+message = "Glimpse2ImputationAndCheckQC.wdl:73:27: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:76:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L76"
+message = "Glimpse2ImputationAndCheckQC.wdl:74:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:77:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L77"
+message = "Glimpse2ImputationAndCheckQC.wdl:75:19: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L75"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
+message = "Glimpse2ImputationAndCheckQC.wdl:76:22: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L76"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
+message = "Glimpse2ImputationAndCheckQC.wdl:83:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:60:38: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L60"
+message = "Glimpse2ImputationInBatches.wdl:63:50: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:62:50: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L62"
+message = "Glimpse2ImputationInBatches.wdl:64:31: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:63:31: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L63"
+message = "Glimpse2ImputationInBatches.wdl:68:31: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L68"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:67:31: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L67"
+message = "Glimpse2ImputationInBatches.wdl:69:26: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:68:26: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L68"
+message = "Glimpse2ImputationInBatches.wdl:70:65: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:69:65: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L69"
+message = "Glimpse2ImputationInBatches.wdl:71:30: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:70:30: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L70"
+message = "Glimpse2ImputationInBatches.wdl:72:33: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:71:33: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L71"
+message = "Glimpse2ImputationInBatches.wdl:83:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:91:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L91"
+message = "Glimpse2ImputationInBatches.wdl:84:27: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:92:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L92"
+message = "Glimpse2ImputationInBatches.wdl:85:36: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:93:42: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L93"
+message = "Glimpse2ImputationInBatches.wdl:86:28: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:94:36: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L94"
+message = "Glimpse2ImputationInBatches.wdl:88:29: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L88"
 
 [[diagnostics]]
-document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
-message = "Glimpse2ImputationInBatches.wdl:95:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L95"
+document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl"
+message = "Glimpse2MergeBatches.wdl:157:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl/#L157"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/HaplotypeMap/BuildHaplotypeMap.wdl"
 message = "BuildHaplotypeMap.wdl:17:1: error: a WDL document must start with a version statement"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/HaplotypeMap/BuildHaplotypeMap.wdl/#L17"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/HaplotypeMap/BuildHaplotypeMap.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/EndToEndPipeline.wdl"
 message = "EndToEndPipeline.wdl:6:25: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/EndToEndPipeline.wdl/#L6"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/EndToEndPipeline.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:1062:11: error: type mismatch: expected type `String` or type `Array[String]`, but found type `Int`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L1062"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Imputation.wdl/#L1062"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:1081:7: warning[UnusedInput]: unused input `mem`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L1081"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Imputation.wdl/#L1081"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:294:31: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L294"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Imputation.wdl/#L294"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:373:12: warning[UnusedInput]: unused input `vcf_index`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L373"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Imputation.wdl/#L373"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:487:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L487"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Imputation.wdl/#L487"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:519:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L519"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Imputation.wdl/#L519"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:85:17: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Imputation.wdl/#L85"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Imputation.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCARE.wdl"
 message = "PCARE.wdl:3:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCARE.wdl/#L3"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PCARE.wdl/#L3"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCARE.wdl"
 message = "PCARE.wdl:44:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCARE.wdl/#L44"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PCARE.wdl/#L44"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:48:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L48"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PCAREAndQC.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:60:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L60"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PCAREAndQC.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:61:35: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L61"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PCAREAndQC.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:62:41: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PCAREAndQC.wdl/#L62"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PCAREAndQC.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
 message = "PRSWrapper.wdl:48:30: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PRSWrapper.wdl/#L48"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PRSWrapper.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
 message = "PRSWrapper.wdl:4:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PRSWrapper.wdl/#L4"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PRSWrapper.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
 message = "PRSWrapper.wdl:64:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PRSWrapper.wdl/#L64"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PRSWrapper.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
 message = "PerformPopulationPCA.wdl:105:8: warning[UnusedCall]: unused call `CheckPCA`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PerformPopulationPCA.wdl/#L105"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PerformPopulationPCA.wdl/#L105"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
 message = "PerformPopulationPCA.wdl:134:6: warning[UnusedDeclaration]: unused declaration `disk_size`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PerformPopulationPCA.wdl/#L134"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PerformPopulationPCA.wdl/#L134"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
 message = "PerformPopulationPCA.wdl:407:41: error: type mismatch: a type common to both type `File` and type `Array[File]` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/PerformPopulationPCA.wdl/#L407"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/PerformPopulationPCA.wdl/#L407"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoreBGE/ScoreBGE.wdl"
 message = "ScoreBGE.wdl:34:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/ScoreBGE/ScoreBGE.wdl/#L34"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/ScoreBGE/ScoreBGE.wdl/#L34"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoringPart.wdl"
 message = "ScoringPart.wdl:23:6: warning[UnusedInput]: unused input `population_scoring_mem`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/ScoringPart.wdl/#L23"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/ScoringPart.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoringPart.wdl"
 message = "ScoringPart.wdl:6:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/ScoringPart.wdl/#L6"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/ScoringPart.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/TrainAncestryAdjustmentModel.wdl"
 message = "TrainAncestryAdjustmentModel.wdl:3:26: warning[UnusedImport]: unused import namespace `PCATasks`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L3"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L3"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/TrainAncestryAdjustmentModel.wdl"
 message = "TrainAncestryAdjustmentModel.wdl:5:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L5"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
 message = "FullImputationPRSValidation.wdl:52:18: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
 message = "FullImputationPRSValidation.wdl:5:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L5"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
 message = "SubsetWeightSet.wdl:27:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `SelfExclusiveSites`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L27"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
 message = "SubsetWeightSet.wdl:28:66: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[SelfExclusiveSites]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/ValidateImputation.wdl"
 message = "ValidateImputation.wdl:4:28: warning[UnusedImport]: unused import namespace `structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/ValidateImputation.wdl/#L4"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Validation/ValidateImputation.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/ValidateScoring.wdl"
 message = "ValidateScoring.wdl:7:28: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/ImputationPipeline/Validation/ValidateScoring.wdl/#L7"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Validation/ValidateScoring.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/JointCalling/CreateSampleMap.wdl"
 message = "CreateSampleMap.wdl:57:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/JointCalling/CreateSampleMap.wdl/#L57"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/JointCalling/CreateSampleMap.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/Bambu.wdl"
 message = "Bambu.wdl:11:16: warning[UnusedInput]: unused input `dataType`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/Bambu.wdl/#L11"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/Bambu.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/Flames.wdl"
 message = "Flames.wdl:10:16: warning[UnusedInput]: unused input `datasetName`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/Flames.wdl/#L10"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/Flames.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:143:24: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L143"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:147:13: error: conflicting scatter variable name `gtf`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L147"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L147"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:157:29: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L157"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L157"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:158:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L158"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L158"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:164:25: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L164"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:165:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L165"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:172:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L172"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L172"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:22:14: warning[UnusedInput]: unused input `excludedGTF`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L22"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl"
 message = "IsoformDiscoveryBenchmarkTasks.wdl:69:32: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:175:14: warning[UnusedInput]: unused input `interval_file`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L175"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L175"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:223:37: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:223:50: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:270:37: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:270:50: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:77:14: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:51:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/CreateIGVSession.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:51:50: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/CreateIGVSession.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:52:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/CreateIGVSession.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:52:50: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/CreateIGVSession.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:53:46: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L53"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/CreateIGVSession.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:53:60: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/CreateIGVSession.wdl/#L53"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/CreateIGVSession.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
 message = "DownsampleAndCollectCoverage.wdl:173:91: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L173"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L173"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
 message = "DownsampleAndCollectCoverage.wdl:196:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L196"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L196"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/IndexCramOrBam.wdl"
 message = "IndexCramOrBam.wdl:36:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/IndexCramOrBam.wdl/#L36"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/IndexCramOrBam.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
 message = "MatchFingerprints.wdl:67:33: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[String]]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/MatchFingerprints.wdl/#L67"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/MatchFingerprints.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
 message = "MatchFingerprints.wdl:88:17: warning[UnusedInput]: unused input `fail_on_mismatch`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d15f556cca2626667fd163e1da775cf377982f70/Utilities/WDLs/MatchFingerprints.wdl/#L88"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/Utilities/WDLs/MatchFingerprints.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
 message = "TargetedSomaticSingleSample.wdl:18:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L18"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L18"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
 message = "TargetedSomaticSingleSample.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl"
 message = "BuildIndexHisat3n.9.wdl:9:15: warning[UnusedInput]: unused input `monitoring_script_path`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:104:12: warning[UnusedInput]: unused input `significant_variants_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L104"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:77:54: error: type mismatch: a type common to both type `File` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:7:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
 message = "Imputation.wdl:262:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/imputation/Imputation.wdl/#L262"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/imputation/Imputation.wdl/#L262"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
 message = "Imputation.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/imputation/Imputation.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/imputation/Imputation.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:21:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L21"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L21"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:26:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:47:16: error: type mismatch: expected type `Array[File]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L47"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:48:23: error: type mismatch: expected type `Array[File]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:56:14: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:57:21: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
 message = "Arrays.wdl:26:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/single_sample/Arrays.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/single_sample/Arrays.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
 message = "Arrays.wdl:322:28: warning[UnusedCall]: unused call `UpdateChipWellBarcodeIndex`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/single_sample/Arrays.wdl/#L322"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/single_sample/Arrays.wdl/#L322"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:137:24: warning[UnusedCall]: unused call `ValidateVariants`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L137"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L137"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:255:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L255"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L255"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:259:10: warning[UnusedInput]: unused input `truth_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L259"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L259"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:4:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L4"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:205:81: error: type mismatch: string concatenation is not supported for type `File?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L205"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L205"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:397:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L397"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L397"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:62:13: warning[UnusedInput]: unused input `rename_gvcf_samples`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:14:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:269:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L269"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L269"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:63:13: warning[UnusedInput]: unused input `cross_check_fingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:210:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L210"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L210"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:47:23: warning[UnusedInput]: unused input `gnarly_workaround_annotations`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L47"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:14:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:23:9: warning[UnusedInput]: unused input `large_disk`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:24:9: warning[UnusedInput]: unused input `huge_disk`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:58:11: warning[UnusedInput]: unused input `excess_het_threshold`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:61:9: warning[UnusedInput]: unused input `SNP_VQSR_downsampleFactor`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L61"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:75:15: warning[UnusedDeclaration]: unused declaration `fingerprinting_vcf_indices`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L75"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:78:7: warning[UnusedDeclaration]: unused declaration `num_gvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:51:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:57:28: warning[UnusedCall]: unused call `ValidateVCF`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:42:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:48:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:73:10: warning[UnusedDeclaration]: unused declaration `gatk_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:10:83: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineQC`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:11:92: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L11"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:53:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:62:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:63:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:7:104: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:83:7: warning[UnusedDeclaration]: unused declaration `hc_divisor`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L83"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:8:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:9:50: warning[UnusedImport]: unused import namespace `QC`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:109:37: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:37:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:43:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
 message = "VariantCalling.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
 message = "VariantCalling.wdl:209:26: warning[UnusedCall]: unused call `ValidateVCF`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L209"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L209"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:10:92: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:46:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:58:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:59:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:5:72: warning[UnusedImport]: unused import namespace `VariantDiscoverTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:87:30: warning[UnusedCall]: unused call `ValidateCram`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:391:9: warning[UnusedInput]: unused input `max_retries`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L391"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L391"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:626:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L626"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:666:40: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L666"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L666"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:672:14: error: conflicting scatter variable name `ubam`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L672"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L672"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:698:32: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L698"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L698"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:699:32: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L699"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L699"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:700:30: error: type mismatch: expected type `Array[Object]+`, but found type `Array[Object]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L700"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L700"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:724:30: error: type mismatch: expected type `Array[Object]+`, but found type `Array[Object]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L724"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L724"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:746:20: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L746"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L746"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
 message = "BroadInternalImputation.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
 message = "BroadInternalImputation.wdl:81:34: warning[UnusedCall]: unused call `TriggerPrsWithImputationTsv`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L81"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L81"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
 message = "BroadInternalArrays.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
 message = "BroadInternalArrays.wdl:80:24: warning[UnusedCall]: unused call `IngestOutputsToTDR`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L80"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L80"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:4:95: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:63:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:64:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L64"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:91:34: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:92:48: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L92"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:93:46: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L93"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:94:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L94"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L94"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:95:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L95"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:96:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L96"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L96"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:97:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
 message = "BroadInternalRNAWithUMIs.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
 message = "BroadInternalRNAWithUMIs.wdl:160:45: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L160"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/qc/CheckFingerprint.wdl"
 message = "CheckFingerprint.wdl:27:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/qc/CheckFingerprint.wdl/#L27"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/qc/CheckFingerprint.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
 message = "CramToUnmappedBams.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
 message = "CramToUnmappedBams.wdl:20:12: warning[UnusedInput]: unused input `base_file_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L20"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L20"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
 message = "ExomeReprocessing.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
 message = "ExomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
 message = "ExternalExomeReprocessing.wdl:62:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
 message = "ExternalExomeReprocessing.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
 message = "ExternalWholeGenomeReprocessing.wdl:60:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
 message = "ExternalWholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
 message = "WholeGenomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
 message = "WholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl"
 message = "RNAWithUMIsPipeline.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl"
 message = "BuildCembaReferences.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/cemba/cemba_methylcseq/CEMBA.wdl"
 message = "CEMBA.wdl:60:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/cemba/cemba_methylcseq/CEMBA.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/cemba/cemba_methylcseq/CEMBA.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:142:25: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L142"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/atac/atac.wdl/#L142"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:153:25: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L153"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/atac/atac.wdl/#L153"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:3:52: warning[UnusedImport]: unused import namespace `Merge`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L3"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/atac/atac.wdl/#L3"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:49:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/atac/atac.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:507:10: error: conflicting input name `annotations_gtf`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/atac/atac.wdl/#L507"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/atac/atac.wdl/#L507"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:150:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/build_indices/BuildIndices.wdl/#L150"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/build_indices/BuildIndices.wdl/#L150"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:160:12: warning[UnusedInput]: unused input `gtf_annotation_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/build_indices/BuildIndices.wdl/#L160"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/build_indices/BuildIndices.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:190:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/build_indices/BuildIndices.wdl/#L190"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/build_indices/BuildIndices.wdl/#L190"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:73:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/build_indices/BuildIndices.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/build_indices/BuildIndices.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/multiome/Multiome.wdl"
 message = "Multiome.wdl:105:13: error: duplicate call input `cloud_provider` in call statement"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/multiome/Multiome.wdl/#L105"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/multiome/Multiome.wdl/#L105"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/multiome/Multiome.wdl"
 message = "Multiome.wdl:90:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/multiome/Multiome.wdl/#L90"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/multiome/Multiome.wdl/#L90"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:163:18: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:226:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L226"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L226"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:227:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L227"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L227"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:245:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L245"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L245"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:276:24: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L276"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L276"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:282:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L282"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L282"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:78:14: warning[UnusedDeclaration]: unused declaration `indices`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:91:10: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/optimus/Optimus.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/optimus/Optimus.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
 message = "PairedTag.wdl:5:49: warning[UnusedImport]: unused import namespace `H5adUtils`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
 message = "PairedTag.wdl:86:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/scATAC/scATAC.wdl"
 message = "scATAC.wdl:203:9: error: duplicate key `cpu` in runtime section"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/scATAC/scATAC.wdl/#L203"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/scATAC/scATAC.wdl/#L203"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:49:12: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/slideseq/SlideSeq.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/slideseq/SlideSeq.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:7:51: warning[UnusedImport]: unused import namespace `OptimusInputChecks`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:98:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl"
 message = "MultiSampleSmartSeq2.wdl:71:28: warning[UnusedCall]: unused call `checkArrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:135:27: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L135"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L135"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:34:15: warning[UnusedInput]: unused input `batch_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L34"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L34"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:35:22: warning[UnusedInput]: unused input `project_id`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:36:22: warning[UnusedInput]: unused input `project_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L36"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:37:22: warning[UnusedInput]: unused input `library`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:38:22: warning[UnusedInput]: unused input `species`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L38"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L38"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:39:22: warning[UnusedInput]: unused input `organ`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:81:40: warning[UnusedCall]: unused call `checkArrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
 message = "snm3C.wdl:278:14: warning[UnusedInput]: unused input `chromosome_sizes`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/snm3C/snm3C.wdl/#L278"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/snm3C/snm3C.wdl/#L278"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
 message = "snm3C.wdl:47:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/pipelines/skylab/snm3C/snm3C.wdl/#L47"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/skylab/snm3C/snm3C.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:131:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:217:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:45:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:141:73: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L141"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L141"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:142:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L142"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L142"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:143:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L143"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:175:68: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:231:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L231"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L231"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:42:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:90:10: warning[UnusedDeclaration]: unused declaration `project_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L90"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L90"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
 message = "AdapterTasks.wdl:580:13: warning[UnusedInput]: unused input `cache_invalidate`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/tasks/AdapterTasks.wdl/#L580"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/tasks/AdapterTasks.wdl/#L580"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
 message = "AdapterTasks.wdl:738:13: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/tasks/AdapterTasks.wdl/#L738"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/tasks/AdapterTasks.wdl/#L738"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/CreateReferenceMetadata.wdl"
 message = "CreateReferenceMetadata.wdl:15:12: warning[UnusedInput]: unused input `input_type`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/projects/tasks/CreateReferenceMetadata.wdl/#L15"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/tasks/CreateReferenceMetadata.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/scripts/BuildAFComparisonTable.wdl"
 message = "BuildAFComparisonTable.wdl:88:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/scripts/BuildAFComparisonTable.wdl/#L88"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/scripts/BuildAFComparisonTable.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/AggregatedBamQC.wdl"
 message = "AggregatedBamQC.wdl:60:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/AggregatedBamQC.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/AggregatedBamQC.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Alignment.wdl"
 message = "Alignment.wdl:119:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Alignment.wdl/#L119"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Alignment.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/BamProcessing.wdl"
 message = "BamProcessing.wdl:53:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/BamProcessing.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/BamProcessing.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/CopyFilesFromCloudToCloud.wdl"
 message = "CopyFilesFromCloudToCloud.wdl:71:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/CopyFilesFromCloudToCloud.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/CopyFilesFromCloudToCloud.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:163:118: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Funcotator.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Funcotator.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:163:92: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Funcotator.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Funcotator.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:164:118: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Funcotator.wdl/#L164"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Funcotator.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:164:89: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Funcotator.wdl/#L164"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Funcotator.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:165:121: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Funcotator.wdl/#L165"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Funcotator.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:165:91: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Funcotator.wdl/#L165"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Funcotator.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:140:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:157:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L157"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L157"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:27:12: warning[UnusedInput]: unused input `contamination`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L27"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:335:12: warning[UnusedInput]: unused input `vcf_basename`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L335"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L335"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:373:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L373"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L373"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:429:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L429"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L429"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:67:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:74:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L74"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:92:12: warning[UnusedInput]: unused input `contamination`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L92"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:98:13: warning[UnusedInput]: unused input `use_dragen_hard_filtering`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/GermlineVariantDiscovery.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/GermlineVariantDiscovery.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:109:11: warning[UnusedInput]: unused input `fingerprint_genotypes_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:214:10: warning[UnusedInput]: unused input `input_vcf`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L214"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L214"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:287:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L287"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L287"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:289:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L289"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L289"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:423:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L423"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L423"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:541:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L541"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L541"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:556:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L556"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L556"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:591:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L591"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L591"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:595:11: warning[UnusedInput]: unused input `truth_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L595"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L595"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:62:9: warning[UnusedInput]: unused input `disk_size`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:661:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L661"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L661"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:698:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L698"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L698"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/ImputationTasks.wdl"
 message = "ImputationTasks.wdl:529:9: warning[UnusedInput]: unused input `nSamples`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/ImputationTasks.wdl/#L529"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/ImputationTasks.wdl/#L529"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
 message = "InternalArraysTasks.wdl:42:10: warning[UnusedInput]: unused input `upload_metrics_output`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalArraysTasks.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/InternalArraysTasks.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
 message = "InternalArraysTasks.wdl:85:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalArraysTasks.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/InternalArraysTasks.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalImputationTasks.wdl"
 message = "InternalImputationTasks.wdl:129:25: warning[UnusedInput]: unused input `run_task`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalImputationTasks.wdl/#L129"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/InternalImputationTasks.wdl/#L129"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalTasks.wdl"
 message = "InternalTasks.wdl:13:10: warning[UnusedDeclaration]: unused declaration `safe_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/InternalTasks.wdl/#L13"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/InternalTasks.wdl/#L13"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:304:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L304"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L304"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:366:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L366"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L366"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:434:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:49:13: warning[UnusedInput]: unused input `sample_names_unique_done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:581:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L581"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L581"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:641:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L641"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L641"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:688:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L688"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L688"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:859:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L859"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L859"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:87:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:900:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/JointGenotypingTasks.wdl/#L900"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/JointGenotypingTasks.wdl/#L900"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:434:31: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Qc.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Qc.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:434:46: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Qc.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Qc.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:436:46: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Qc.wdl/#L436"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Qc.wdl/#L436"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:506:29: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Qc.wdl/#L506"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Qc.wdl/#L506"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/RNAWithUMIsTasks.wdl"
 message = "RNAWithUMIsTasks.wdl:935:12: warning[UnusedInput]: unused input `mem`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/RNAWithUMIsTasks.wdl/#L935"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/RNAWithUMIsTasks.wdl/#L935"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
 message = "SplitLargeReadGroup.wdl:21:45: warning[UnusedImport]: unused import namespace `Utils`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/SplitLargeReadGroup.wdl/#L21"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/SplitLargeReadGroup.wdl/#L21"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
 message = "SplitLargeReadGroup.wdl:22:53: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/SplitLargeReadGroup.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/SplitLargeReadGroup.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl"
 message = "UltimaGenomicsGermlineFilteringThreshold.wdl:228:11: warning[UnusedInput]: unused input `interval_list`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl/#L228"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl/#L228"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:14:11: warning[UnusedInput]: unused input `rsq_threshold`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:5:80: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:65:7: warning[UnusedDeclaration]: unused declaration `rounded_disk_size`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:1096:12: warning[UnusedInput]: unused input `annotation`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L1096"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L1096"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:63:9: warning[UnusedInput]: unused input `preemptible`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:785:10: warning[UnusedInput]: unused input `read_length`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L785"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L785"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:786:11: warning[UnusedInput]: unused input `jar_override`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L786"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L786"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:814:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:839:10: warning[UnusedInput]: unused input `read_length`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L839"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L839"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:866:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:168:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UnmappedBamToAlignedBam.wdl/#L168"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UnmappedBamToAlignedBam.wdl/#L168"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:25:53: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:85:31: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/UnmappedBamToAlignedBam.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/UnmappedBamToAlignedBam.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Utilities.wdl"
 message = "Utilities.wdl:152:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Utilities.wdl/#L152"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Utilities.wdl/#L152"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Utilities.wdl"
 message = "Utilities.wdl:183:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/broad/Utilities.wdl/#L183"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/broad/Utilities.wdl/#L183"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/FastqProcessing.wdl"
 message = "FastqProcessing.wdl:243:16: warning[UnusedInput]: unused input `barcode_orientation`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/FastqProcessing.wdl/#L243"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/FastqProcessing.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:119:10: error: conflicting output name `library_metrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L119"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/H5adUtils.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:224:14: error: conflicting output name `library_metrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L224"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/H5adUtils.wdl/#L224"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:237:12: warning[UnusedInput]: unused input `cpuPlatform`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L237"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/H5adUtils.wdl/#L237"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:35:12: error: conflicting input name `counting_mode`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/H5adUtils.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:537:24: warning[UnusedInput]: unused input `input_names`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/H5adUtils.wdl/#L537"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/H5adUtils.wdl/#L537"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/LoomUtils.wdl"
 message = "LoomUtils.wdl:318:24: warning[UnusedInput]: unused input `input_names`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/LoomUtils.wdl/#L318"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/LoomUtils.wdl/#L318"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/PairedTagUtils.wdl"
 message = "PairedTagUtils.wdl:206:16: warning[UnusedInput]: unused input `cpuPlatform`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/PairedTagUtils.wdl/#L206"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/PairedTagUtils.wdl/#L206"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
 message = "StarAlign.wdl:459:12: warning[UnusedInput]: unused input `gex_nhash_id`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/StarAlign.wdl/#L459"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/StarAlign.wdl/#L459"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
 message = "StarAlign.wdl:784:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/StarAlign.wdl/#L784"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/StarAlign.wdl/#L784"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:24:16: warning[UnusedInput]: unused input `ref_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:48:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:6:13: warning[UnusedInput]: unused input `dummy_int`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L6"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:7:16: warning[UnusedInput]: unused input `dummy_string`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:8:17: warning[UnusedInput]: unused input `dummy_boolean`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:9:17: warning[UnusedInput]: unused input `dummy_option`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/cemba/pr/CheckCembaOutputs.wdl"
 message = "CheckCembaOutputs.wdl:1:1: error: a WDL document must start with a version statement"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/scATAC/pr/test_scATAC_PR.wdl"
 message = "test_scATAC_PR.wdl:35:34: warning[UnusedCall]: unused call `checker`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/scATAC/pr/test_scATAC_PR.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/skylab/scATAC/pr/test_scATAC_PR.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
 message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
 message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:46:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyArrays.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyArrays.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:49:38: warning[UnusedCall]: unused call `VerifyIlluminaGenotypingArray`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyArrays.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyArrays.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:66:40: warning[UnusedCall]: unused call `CompareParamsFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyArrays.wdl/#L66"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyArrays.wdl/#L66"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
 message = "VerifyCheckFingerprint.wdl:31:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyCheckFingerprint.wdl/#L31"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyCheckFingerprint.wdl/#L31"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
 message = "VerifyCheckFingerprint.wdl:42:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyCheckFingerprint.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyCheckFingerprint.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCramToUnmappedBamsUpdated.wdl"
 message = "VerifyCramToUnmappedBamsUpdated.wdl:9:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyCramToUnmappedBamsUpdated.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyCramToUnmappedBamsUpdated.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
 message = "VerifyExomeReprocessing.wdl:24:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyExomeReprocessing.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyExomeReprocessing.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
 message = "VerifyExomeReprocessing.wdl:37:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyExomeReprocessing.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyExomeReprocessing.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExternalReprocessing.wdl"
 message = "VerifyExternalReprocessing.wdl:10:10: warning[UnusedCall]: unused call `AssertTrue`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyExternalReprocessing.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyExternalReprocessing.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
 message = "VerifyGDCSomaticSingleSample.wdl:17:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGDCSomaticSingleSample.wdl/#L17"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGDCSomaticSingleSample.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
 message = "VerifyGDCSomaticSingleSample.wdl:26:20: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGDCSomaticSingleSample.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGDCSomaticSingleSample.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:22:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGermlineSingleSample.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:26:14: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGermlineSingleSample.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:40:8: warning[UnusedCall]: unused call `CompareGvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGermlineSingleSample.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:46:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGermlineSingleSample.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:52:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGermlineSingleSample.wdl/#L52"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGermlineSingleSample.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:13:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGvcf.wdl/#L13"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGvcf.wdl/#L13"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:16:20: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGvcf.wdl/#L16"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGvcf.wdl/#L16"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:24:20: warning[UnusedCall]: unused call `CompareVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyGvcf.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyGvcf.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:102:24: warning[UnusedCall]: unused call `CompareGreenIdatMdf5Sum`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyIlluminaGenotypingArray.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:108:24: warning[UnusedCall]: unused call `CompareRedIdatMdf5Sum`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L108"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyIlluminaGenotypingArray.wdl/#L108"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:43:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyIlluminaGenotypingArray.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:83:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L83"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyIlluminaGenotypingArray.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:89:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L89"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyIlluminaGenotypingArray.wdl/#L89"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:95:14: warning[UnusedCall]: unused call `CompareGtcs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyIlluminaGenotypingArray.wdl/#L95"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyIlluminaGenotypingArray.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:43:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyImputation.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyImputation.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:56:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyImputation.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyImputation.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:72:8: warning[UnusedCall]: unused call `CrosscheckFingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyImputation.wdl/#L72"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyImputation.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyJointGenotyping.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyJointGenotyping.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:48:28: warning[UnusedCall]: unused call `VerifyMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyJointGenotyping.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyJointGenotyping.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:54:40: warning[UnusedCall]: unused call `CompareIntervals`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyJointGenotyping.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyJointGenotyping.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:73:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMetrics.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMetrics.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:87:117: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMetrics.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMetrics.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:87:89: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMetrics.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMetrics.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
 message = "VerifyMultiSampleArrays.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleArrays.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiSampleArrays.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
 message = "VerifyMultiSampleArrays.wdl:28:14: warning[UnusedCall]: unused call `CompareVcfsAllowingQualityDifferences`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleArrays.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiSampleArrays.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:12:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:24:43: warning[UnusedCall]: unused call `CompareH5adFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:32:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L32"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L70"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L75"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyMultiome.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
 message = "VerifyNA12878.wdl:62:9: warning[UnusedDeclaration]: unused declaration `default_disk_space_gb`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyNA12878.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyNA12878.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
 message = "VerifyNA12878.wdl:65:47: error: type mismatch: multiplication operator is not supported for type `Int?` and type `Int`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyNA12878.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyNA12878.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:23:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:45:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:51:40: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:53:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:54:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyOptimus.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:32:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L32"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L70"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L75"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyPairedTag.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:103:50: warning[UnusedCall]: unused call `CompareGeneCounts`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L103"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyRNAWithUMIs.wdl/#L103"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:109:50: warning[UnusedCall]: unused call `CompareExonCounts`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyRNAWithUMIs.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:28:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyRNAWithUMIs.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:37:40: warning[UnusedCall]: unused call `CompareTextMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyRNAWithUMIs.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:43:35: warning[UnusedCall]: unused call `CompareOutputBam`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyRNAWithUMIs.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:97:50: warning[UnusedCall]: unused call `CompareGeneTpms`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyRNAWithUMIs.wdl/#L97"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyRNAWithUMIs.wdl/#L97"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyReprocessing.wdl"
 message = "VerifyReprocessing.wdl:33:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyReprocessing.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyReprocessing.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:23:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySlideSeq.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySlideSeq.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySlideSeq.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySlideSeq.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:45:50: warning[UnusedCall]: unused call `CompareUMIMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySlideSeq.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:51:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySlideSeq.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySlideSeq.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
 message = "VerifySomaticSingleSample.wdl:24:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySomaticSingleSample.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySomaticSingleSample.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
 message = "VerifySomaticSingleSample.wdl:30:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifySomaticSingleSample.wdl/#L30"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifySomaticSingleSample.wdl/#L30"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:36:28: warning[UnusedCall]: unused call `VerifyMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L36"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:42:40: warning[UnusedCall]: unused call `CompareIntervals`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:48:8: warning[UnusedCall]: unused call `CompareFingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:102:115: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:102:87: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:17:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L17"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:64:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L64"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:72:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L72"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:89:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L89"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L89"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:105:29: warning[UnusedCall]: unused call `CompareGvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L105"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L105"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:112:22: warning[UnusedCall]: unused call `VerifyNA12878`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L112"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L112"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:161:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L161"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L161"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:115: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:87: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:30:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L30"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L30"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:77:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:85:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:91:29: warning[UnusedCall]: unused call `CompareVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:98:29: warning[UnusedCall]: unused call `CompareFilteredVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:40:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyValidateChip.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:43:14: warning[UnusedCall]: unused call `CompareGtcs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyValidateChip.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:50:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L50"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyValidateChip.wdl/#L50"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:56:55: warning[UnusedCall]: unused call `CompareGenotypeConcordanceVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyValidateChip.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:62:55: warning[UnusedCall]: unused call `CompareIndelGenotypeConcordanceVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyValidateChip.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyValidateChip.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:12:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyscATAC.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyscATAC.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:15:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyscATAC.wdl/#L15"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyscATAC.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:22:43: warning[UnusedCall]: unused call `CompareSnapTextFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/VerifyscATAC.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyscATAC.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:23:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/Verifysnm3C.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/Verifysnm3C.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:26:52: warning[UnusedCall]: unused call `CompareMappingSummaryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/Verifysnm3C.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/Verifysnm3C.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:66:17: error: conflicting output name `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/Verifysnm3C.wdl/#L66"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/Verifysnm3C.wdl/#L66"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl"
 message = "TestBroadInternalRNAWithUMIs.wdl:106:54: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "TestBroadInternalUltimaGenomics.wdl:57:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "TestBroadInternalUltimaGenomics.wdl:58:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestCheckFingerprint.wdl"
 message = "TestCheckFingerprint.wdl:33:15: warning[UnusedInput]: unused input `vault_token_path_arrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestExomeReprocessing.wdl"
 message = "TestExomeReprocessing.wdl:7:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestExomeReprocessing.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestExomeReprocessing.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl"
 message = "TestExternalWholeGenomeReprocessing.wdl:6:45: warning[UnusedImport]: unused import namespace `Utilities`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
 message = "TestGDCWholeGenomeSomaticSingleSample.wdl:77:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:141:20: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestImputation.wdl/#L141"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestImputation.wdl/#L141"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:162:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestImputation.wdl/#L162"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestImputation.wdl/#L162"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:163:46: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestImputation.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestImputation.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:54:30: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestImputation.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestImputation.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:55:37: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestImputation.wdl/#L55"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestImputation.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:86:56: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestImputation.wdl/#L86"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestImputation.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:110:20: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestJointGenotyping.wdl/#L110"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestJointGenotyping.wdl/#L110"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:85:44: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestJointGenotyping.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestJointGenotyping.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:87:46: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestJointGenotyping.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestJointGenotyping.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:88:49: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestJointGenotyping.wdl/#L88"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestJointGenotyping.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:51:23: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:56:22: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:57:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:58:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:59:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L59"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:60:17: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiome.wdl"
 message = "TestMultiome.wdl:67:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestMultiome.wdl/#L67"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestMultiome.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:118:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestOptimus.wdl/#L118"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestOptimus.wdl/#L118"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:172:14: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestOptimus.wdl/#L172"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestOptimus.wdl/#L172"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:28:11: warning[UnusedInput]: unused input `mt_genes`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestOptimus.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestOptimus.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:76:36: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestOptimus.wdl/#L76"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestOptimus.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
 message = "TestPairedTag.wdl:57:15: warning[UnusedInput]: unused input `run_cellbender`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestPairedTag.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestPairedTag.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
 message = "TestPairedTag.wdl:71:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestPairedTag.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestPairedTag.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:100:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L100"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:110:52: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L110"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L110"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:84:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L84"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestReblockGVCF.wdl"
 message = "TestReblockGVCF.wdl:49:31: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestReblockGVCF.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestReblockGVCF.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestSlideSeq.wdl"
 message = "TestSlideSeq.wdl:40:20: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestSlideSeq.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestSlideSeq.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:39:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:40:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
 message = "TestUltimaGenomicsWholeGenomeGermline.wdl:43:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
 message = "TestUltimaGenomicsWholeGenomeGermline.wdl:44:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L44"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L44"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl"
 message = "TestWholeGenomeGermlineSingleSample.wdl:54:45: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/78f8c5c3160b06a81648c68f02307e235acdb3a1/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -4754,1669 +4764,1669 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:11:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_ivar_consensus.wdl/#L11"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_ivar_consensus.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:12:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_ivar_consensus.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_ivar_consensus.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:9:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_ivar_consensus.wdl/#L9"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_ivar_consensus.wdl/#L9"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_metaspades.wdl"
 message = "task_metaspades.wdl:39:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_metaspades.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_metaspades.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_shovill.wdl"
 message = "task_shovill.wdl:77:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/assembly/task_shovill.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_shovill.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:10:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:12:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:13:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:95:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl"
 message = "task_snippy_gene_query.wdl:69:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_variants.wdl"
 message = "task_snippy_variants.wdl:128:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L128"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/advanced_metrics/task_gambittools.wdl"
 message = "task_gambittools.wdl:67:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:44:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L44"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L44"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:45:19: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L45"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L45"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:46:23: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L46"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L46"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:47:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L47"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L47"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl"
 message = "task_cg_pipeline.wdl:102:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:46:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:47:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:48:29: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:49:24: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:50:40: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_quast.wdl"
 message = "task_quast.wdl:64:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_readlength.wdl"
 message = "task_readlength.wdl:26:33: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
 message = "task_screen.wdl:15:13: warning[UnusedInput]: unused input `organism`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/comparisons/task_screen.wdl/#L15"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/comparisons/task_screen.wdl/#L15"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
 message = "task_screen.wdl:185:13: warning[UnusedInput]: unused input `organism`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/quality_control/comparisons/task_screen.wdl/#L185"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/comparisons/task_screen.wdl/#L185"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/species_typing/salmonella/task_genotyphi.wdl"
 message = "task_genotyphi.wdl:61:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:76:45: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/taxon_id/contamination/task_midas.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/taxon_id/contamination/task_midas.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:77:44: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/taxon_id/contamination/task_midas.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/taxon_id/contamination/task_midas.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/task_gambit.wdl"
 message = "task_gambit.wdl:164:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/taxon_id/task_gambit.wdl/#L164"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/taxon_id/task_gambit.wdl/#L164"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/data_handling/task_parse_mapping.wdl"
 message = "task_parse_mapping.wdl:133:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/submission/task_broad_ncbi_tools.wdl"
 message = "task_broad_ncbi_tools.wdl:11:12: warning[UnusedInput]: unused input `docker`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/tasks/utilities/submission/task_broad_ncbi_tools.wdl/#L11"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/utilities/submission/task_broad_ncbi_tools.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:120: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:40: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:120:126: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:120:42: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:124:108: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:124:36: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:131:114: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:131:38: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_plot.wdl"
 message = "wf_freyja_plot.wdl:18:25: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_plot.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_plot.wdl/#L18"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_update.wdl"
 message = "wf_freyja_update.wdl:13:17: warning[UnusedCall]: unused call `transfer_files`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/freyja/wf_freyja_update.wdl/#L13"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_update.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:153:80: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_augur.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_augur.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:62:21: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_augur.wdl/#L62"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_augur.wdl/#L62"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_core_gene_snp.wdl"
 message = "wf_core_gene_snp.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_mashtree_fasta.wdl"
 message = "wf_mashtree_fasta.wdl:37:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:33:58: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:34:53: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:35:51: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:36:52: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:37:57: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L101"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L101"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:106:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L106"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L106"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:107:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:108:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:119:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L119"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L119"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:120:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:121:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:122:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:123:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:132:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L132"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L132"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:150:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L150"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L150"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:71:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L71"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L71"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:72:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:73:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:74:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:84:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:85:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:86:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:87:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:27:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:32:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:33:19: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:34:17: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:35:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:36:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:37:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:38:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:39:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:40:23: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:37:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:38:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:39:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:42:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:69:45: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:71:40: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:72:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:73:52: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/standalone_modules/wf_snippy_variants.wdl/#L73"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_clearlabs.wdl"
 message = "wf_theiacov_clearlabs.wdl:148:26: error: type mismatch: expected type `String?`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
 message = "wf_theiacov_illumina_pe.wdl:233:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
 message = "wf_theiacov_illumina_pe.wdl:4:84: warning[UnusedImport]: unused import namespace `assembly_metrics`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L4"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L4"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:192:38: error: type mismatch: expected type `Float?`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:273:29: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L273"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L273"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:274:28: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L274"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L274"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:275:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:236:30: error: type mismatch: expected type `String?`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:119: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:84: error: type mismatch: a type common to both type `Float?` and type `String?` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:118:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:127:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:70:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
 message = "wf_theiameta_illumina_pe.wdl:258:31: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L258"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L258"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
 message = "wf_theiameta_illumina_pe.wdl:260:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L260"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L260"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
 message = "wf_theiameta_illumina_pe.wdl:269:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L269"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L269"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl"
 message = "wf_theiaprok_illumina_pe.wdl:115:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_se.wdl"
 message = "wf_theiaprok_illumina_se.wdl:110:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:103:28: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:84:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_create_terra_table.wdl"
 message = "wf_create_terra_table.wdl:17:46: warning[UnusedCall]: unused call `make_table`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_create_terra_table.wdl/#L17"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_create_terra_table.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:17:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:18:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:19:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:20:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:21:23: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_terra_2_bq.wdl"
 message = "wf_terra_2_bq.wdl:14:26: warning[UnusedCall]: unused call `terra_to_bigquery`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/data_import/wf_terra_2_bq.wdl/#L14"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_terra_2_bq.wdl/#L14"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:100:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L100"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L100"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L101"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L101"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:109:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:110:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:111:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L111"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L111"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:112:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:154: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:94: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:118:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:123:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L123"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L123"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:124:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:125:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L125"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L125"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:126:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L126"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L126"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:127:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L127"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:128:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L128"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:131:17: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:141:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L141"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L141"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:142:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L142"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L142"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:143:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L143"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L143"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:144:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L144"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L144"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:170:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L170"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L170"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:182:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L182"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L182"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:183:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L183"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L183"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:184:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L184"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L184"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:185:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L185"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L185"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:186:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L186"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L186"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:187:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L187"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L187"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:188:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L188"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L188"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:189:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L189"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L189"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:190:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L190"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L190"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:199:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L199"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L199"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:200:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L200"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L200"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:201:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L201"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L201"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:202:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L202"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L202"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:208:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L208"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L208"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:209:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L209"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L209"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:210:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L210"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L210"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:211:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L211"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L211"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:220:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L220"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L220"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:221:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L221"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L221"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:222:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L222"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L222"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:223:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L223"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L223"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:229:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L229"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L229"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:230:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L230"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L230"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:231:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L231"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L231"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:232:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L232"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L232"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:86:28: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L86"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:87:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L87"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:88:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L88"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L88"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:89:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:90:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:98:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L98"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L98"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:99:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_flu_track.wdl/#L99"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L99"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:102:16: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:103:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:104:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L104"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L104"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:105:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L105"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L105"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:106:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L106"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L106"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:112:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:113:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L113"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L113"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:114:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L114"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L114"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:115:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:29: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:104: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:28: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L154"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L154"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:56:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L56"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:57:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L57"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L57"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:58:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L58"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L58"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:59:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L59"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L59"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:67:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:68:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L68"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L68"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:69:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:70:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:76:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:77:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:78:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L78"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L78"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:79:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L79"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L79"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:90:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:91:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:92:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L92"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L92"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:93:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_ivar_consensus.wdl/#L93"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L93"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:228:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L228"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L228"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:229:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L229"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L229"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:230:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L230"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L230"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:231:23: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L231"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L231"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:232:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L232"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L232"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:241:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L241"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L241"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:253:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L253"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L253"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:259:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L259"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L259"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:260:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L260"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L260"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:261:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L261"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L261"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:262:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L262"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L262"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:263:18: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L263"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L263"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:264:25: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L264"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L264"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:265:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L265"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L265"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:274:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L274"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L274"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:281:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L281"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L281"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:290:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L290"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L290"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:304:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L304"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L304"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:305:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L305"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L305"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:317:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:326:18: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L326"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L326"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:327:19: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L327"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L327"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:328:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L328"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L328"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:336:30: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L336"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L336"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:337:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L337"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L337"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:338:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L338"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L338"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:339:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L339"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L339"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:340:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L340"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L340"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:349:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L349"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L349"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:357:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L357"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L357"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:367:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L367"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L367"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:377:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L377"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L377"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:378:24: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L378"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L378"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:379:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L379"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L379"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:380:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L380"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L380"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:381:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L381"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L381"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:382:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L382"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L382"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:383:34: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L383"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L383"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:384:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L384"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L384"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:392:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L392"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L392"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:400:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L400"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L400"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:408:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L408"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L408"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:409:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L409"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L409"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:410:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L410"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L410"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:421:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L421"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L421"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:432:32: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L432"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L432"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:433:20: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L433"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L433"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:434:25: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L434"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L434"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:435:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L435"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L435"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:436:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L436"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L436"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:437:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L437"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L437"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:439:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L439"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L439"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:455:32: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L455"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L455"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:456:36: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L456"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L456"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:457:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L457"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L457"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:467:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L467"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L467"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:475:21: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L475"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L475"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:476:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L476"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L476"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:482:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L482"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L482"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:488:23: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L488"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L488"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:489:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L489"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L489"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:499:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L499"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L499"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:506:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L506"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L506"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:507:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L507"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L507"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:508:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L508"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L508"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:515:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L515"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L515"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:516:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L516"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L516"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:517:20: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L517"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L517"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:518:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L518"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L518"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:519:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L519"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L519"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:520:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L520"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L520"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:521:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L521"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L521"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:522:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L522"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L522"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:523:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L523"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L523"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:524:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L524"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L524"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:525:26: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L525"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L525"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:526:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L526"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L526"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:527:37: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L527"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L527"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:528:31: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L528"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L528"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:529:39: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L529"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L529"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:530:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L530"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L530"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:539:14: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L539"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L539"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:540:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L540"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L540"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:541:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L541"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L541"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:542:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L542"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L542"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:543:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L543"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L543"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:544:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L544"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L544"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:545:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L545"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L545"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:546:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L546"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L546"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:547:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L547"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L547"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:548:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L548"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L548"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:549:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L549"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L549"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:557:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L557"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L557"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:566:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L566"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L566"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:581:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L581"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L581"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:590:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L590"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L590"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:601:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L601"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L601"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:602:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L602"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L602"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:603:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L603"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L603"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:604:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L604"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L604"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:605:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L605"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L605"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:606:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L606"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L606"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:607:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L607"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L607"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:608:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L608"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L608"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:609:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L609"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L609"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:610:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L610"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L610"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:611:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L611"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L611"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:612:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L612"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L612"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:623:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L623"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L623"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:627:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L627"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L627"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:635:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L635"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L635"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:674:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L674"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L674"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:678:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L678"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L678"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:686:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L686"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L686"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:700:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L700"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L700"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:704:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L704"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L704"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:712:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_merlin_magic.wdl/#L712"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L712"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:109:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:51:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:52:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:53:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:89:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:90:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:91:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:129:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:141:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:142:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:143:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:74:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:118:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:129:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:130:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:131:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:56:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/26c0dddb9fe7274dc93fbea5daf725a951e3b994/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -168,6 +168,7 @@ pub async fn gauntlet(args: Args) -> Result<()> {
             .context("failed to write next section")?;
 
         let analyzer = Analyzer::new_with_validator(
+            Default::default(),
             move |_: (), _, _, _| async move {},
             move || {
                 let mut validator = if !args.arena {

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -168,7 +168,14 @@ pub async fn gauntlet(args: Args) -> Result<()> {
             .context("failed to write next section")?;
 
         let analyzer = Analyzer::new_with_validator(
-            Default::default(),
+            // Don't bother duplicating analysis warnings for arena mode
+            if args.arena {
+                wdl::analysis::Config {
+                    diagnostics: wdl::analysis::DiagnosticsConfig::except_all(),
+                }
+            } else {
+                Default::default()
+            },
             move |_: (), _, _, _| async move {},
             move || {
                 let mut validator = if !args.arena {

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -40,6 +40,7 @@ use report::Status;
 use report::UnmatchedStatus;
 pub use repository::Repository;
 use wdl::analysis::Analyzer;
+use wdl::analysis::rules;
 use wdl::ast::Diagnostic;
 use wdl::ast::SyntaxNode;
 use wdl::lint::LintVisitor;
@@ -169,13 +170,7 @@ pub async fn gauntlet(args: Args) -> Result<()> {
 
         let analyzer = Analyzer::new_with_validator(
             // Don't bother duplicating analysis warnings for arena mode
-            if args.arena {
-                wdl::analysis::Config {
-                    diagnostics: wdl::analysis::DiagnosticsConfig::except_all(),
-                }
-            } else {
-                Default::default()
-            },
+            if args.arena { Vec::new() } else { rules() },
             move |_: (), _, _, _| async move {},
             move || {
                 let mut validator = if !args.arena {

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Implemented `UnusedImport`, `UnusedInput`, `UnusedDeclaration`, and
+  `UnusedCall` analysis warnings ([#211](https://github.com/stjude-rust-labs/wdl/pull/211))
 * Implemented static analysis for workflows ([#199](https://github.com/stjude-rust-labs/wdl/pull/199)).
 
 ### Fixed

--- a/wdl-analysis/Cargo.toml
+++ b/wdl-analysis/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { workspace = true, features = ["v4"] }
 walkdir = { workspace = true }
 id-arena = { workspace = true }
 tracing = { workspace = true }
+convert_case = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/wdl-analysis/Cargo.toml
+++ b/wdl-analysis/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://docs.rs/wdl-analysis"
 
 [dependencies]
 wdl-ast = { path = "../wdl-ast", version = "0.7.1" }
-wdl-lint = { path = "../wdl-lint", version = "0.6.0", optional = true }
 anyhow = { workspace = true }
 rowan = { workspace = true }
 url = { workspace = true }

--- a/wdl-analysis/src/analyzer.rs
+++ b/wdl-analysis/src/analyzer.rs
@@ -34,10 +34,11 @@ use wdl_ast::SyntaxNode;
 use wdl_ast::SyntaxNodeExt;
 use wdl_ast::Validator;
 
-use crate::diagnostics::UNUSED_CALL_RULE_ID;
-use crate::diagnostics::UNUSED_DECL_RULE_ID;
-use crate::diagnostics::UNUSED_IMPORT_RULE_ID;
-use crate::diagnostics::UNUSED_INPUT_RULE_ID;
+use crate::Rule;
+use crate::UNUSED_CALL_RULE_ID;
+use crate::UNUSED_DECL_RULE_ID;
+use crate::UNUSED_IMPORT_RULE_ID;
+use crate::UNUSED_INPUT_RULE_ID;
 use crate::graph::DocumentGraphNode;
 use crate::graph::ParseState;
 use crate::queue::AddRequest;
@@ -169,96 +170,6 @@ impl From<&ParseState> for ParseResult {
             },
         }
     }
-}
-
-/// Configuration for analysis diagnostics.
-///
-/// Only the analysis diagnostics that aren't inherently treated as errors are
-/// represented here.
-///
-/// These diagnostics default to a warning severity.
-#[derive(Debug, Clone, Copy)]
-pub struct DiagnosticsConfig {
-    /// The severity for the "unused import" diagnostic.
-    ///
-    /// A value of `None` disables the diagnostic.
-    pub unused_import: Option<Severity>,
-    /// The severity for the "unused input" diagnostic.
-    ///
-    /// A value of `None` disables the diagnostic.
-    pub unused_input: Option<Severity>,
-    /// The severity for the "unused declaration" diagnostic.
-    ///
-    /// A value of `None` disables the diagnostic.
-    pub unused_declaration: Option<Severity>,
-    /// The severity for the "unused call" diagnostic.
-    ///
-    /// A value of `None` disables the diagnostic.
-    pub unused_call: Option<Severity>,
-}
-
-impl DiagnosticsConfig {
-    /// Creates a diagnostics config that treats all diagnostics as errors.
-    pub fn deny_all() -> Self {
-        Self {
-            unused_import: Some(Severity::Error),
-            unused_input: Some(Severity::Error),
-            unused_declaration: Some(Severity::Error),
-            unused_call: Some(Severity::Error),
-        }
-    }
-
-    /// Creates a diagnostics config that excepts all diagnostics.
-    pub fn except_all() -> Self {
-        Self {
-            unused_import: None,
-            unused_input: None,
-            unused_declaration: None,
-            unused_call: None,
-        }
-    }
-
-    /// Gets the excepted set of diagnostics based on any `#@ except` comments
-    /// that precede the given syntax node.
-    pub fn excepted_for_node(mut self, node: &SyntaxNode) -> Self {
-        let exceptions = node.rule_exceptions();
-
-        if exceptions.contains(UNUSED_IMPORT_RULE_ID) {
-            self.unused_import = None;
-        }
-
-        if exceptions.contains(UNUSED_INPUT_RULE_ID) {
-            self.unused_input = None;
-        }
-
-        if exceptions.contains(UNUSED_DECL_RULE_ID) {
-            self.unused_declaration = None;
-        }
-
-        if exceptions.contains(UNUSED_CALL_RULE_ID) {
-            self.unused_call = None;
-        }
-
-        self
-    }
-}
-
-impl Default for DiagnosticsConfig {
-    fn default() -> Self {
-        Self {
-            unused_import: Some(Severity::Warning),
-            unused_input: Some(Severity::Warning),
-            unused_declaration: Some(Severity::Warning),
-            unused_call: Some(Severity::Warning),
-        }
-    }
-}
-
-/// Configuration for analysis.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Config {
-    /// The configuration for analysis diagnostics.
-    pub diagnostics: DiagnosticsConfig,
 }
 
 /// Represents the result of an analysis.
@@ -455,6 +366,84 @@ pub struct IncrementalChange {
     pub edits: Vec<SourceEdit>,
 }
 
+/// Configuration for analysis diagnostics.
+///
+/// Only the analysis diagnostics that aren't inherently treated as errors are
+/// represented here.
+///
+/// These diagnostics default to a warning severity.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DiagnosticsConfig {
+    /// The severity for the "unused import" diagnostic.
+    ///
+    /// A value of `None` disables the diagnostic.
+    pub unused_import: Option<Severity>,
+    /// The severity for the "unused input" diagnostic.
+    ///
+    /// A value of `None` disables the diagnostic.
+    pub unused_input: Option<Severity>,
+    /// The severity for the "unused declaration" diagnostic.
+    ///
+    /// A value of `None` disables the diagnostic.
+    pub unused_declaration: Option<Severity>,
+    /// The severity for the "unused call" diagnostic.
+    ///
+    /// A value of `None` disables the diagnostic.
+    pub unused_call: Option<Severity>,
+}
+
+impl DiagnosticsConfig {
+    /// Creates a new diagnostics configuration from a rule set.
+    pub fn new<T: AsRef<dyn Rule>>(rules: impl Iterator<Item = T>) -> Self {
+        let mut unused_import = None;
+        let mut unused_input = None;
+        let mut unused_declaration = None;
+        let mut unused_call = None;
+
+        for rule in rules {
+            let rule = rule.as_ref();
+            match rule.id() {
+                UNUSED_IMPORT_RULE_ID => unused_import = Some(rule.severity()),
+                UNUSED_INPUT_RULE_ID => unused_input = Some(rule.severity()),
+                UNUSED_DECL_RULE_ID => unused_declaration = Some(rule.severity()),
+                UNUSED_CALL_RULE_ID => unused_call = Some(rule.severity()),
+                _ => {}
+            }
+        }
+
+        Self {
+            unused_import,
+            unused_input,
+            unused_declaration,
+            unused_call,
+        }
+    }
+
+    /// Gets the excepted set of diagnostics based on any `#@ except` comments
+    /// that precede the given syntax node.
+    pub fn excepted_for_node(mut self, node: &SyntaxNode) -> Self {
+        let exceptions = node.rule_exceptions();
+
+        if exceptions.contains(UNUSED_IMPORT_RULE_ID) {
+            self.unused_import = None;
+        }
+
+        if exceptions.contains(UNUSED_INPUT_RULE_ID) {
+            self.unused_input = None;
+        }
+
+        if exceptions.contains(UNUSED_DECL_RULE_ID) {
+            self.unused_declaration = None;
+        }
+
+        if exceptions.contains(UNUSED_CALL_RULE_ID) {
+            self.unused_call = None;
+        }
+
+        self
+    }
+}
+
 /// Represents a Workflow Description Language (WDL) document analyzer.
 ///
 /// By default, analysis parses documents, performs validation checks, resolves
@@ -480,22 +469,26 @@ impl<Context> Analyzer<Context>
 where
     Context: Send + Clone + 'static,
 {
-    /// Constructs a new analyzer.
+    /// Constructs a new analyzer with the given analysis rules.
     ///
     /// The provided progress callback will be invoked during analysis.
     ///
     /// The analyzer will use a default validator for validation.
     ///
     /// The analyzer must be constructed from the context of a Tokio runtime.
-    pub fn new<Progress, Return>(config: Config, progress: Progress) -> Self
+    pub fn new<T: AsRef<dyn Rule>, Progress, Return>(
+        rules: impl IntoIterator<Item = T>,
+        progress: Progress,
+    ) -> Self
     where
         Progress: Fn(Context, ProgressKind, usize, usize) -> Return + Send + 'static,
         Return: Future<Output = ()>,
     {
-        Self::new_with_validator(config, progress, Validator::default)
+        Self::new_with_validator(rules, progress, Validator::default)
     }
 
-    /// Constructs a new analyzer with the given validator function.
+    /// Constructs a new analyzer with the given analysis rules and validator
+    /// function.
     ///
     /// The provided progress callback will be invoked during analysis.
     ///
@@ -503,8 +496,8 @@ where
     /// initialize a thread-local validator.
     ///
     /// The analyzer must be constructed from the context of a Tokio runtime.
-    pub fn new_with_validator<Progress, Return, Validator>(
-        config: Config,
+    pub fn new_with_validator<T: AsRef<dyn Rule>, Progress, Return, Validator>(
+        rules: impl IntoIterator<Item = T>,
         progress: Progress,
         validator: Validator,
     ) -> Self
@@ -515,6 +508,7 @@ where
     {
         let (tx, rx) = mpsc::unbounded_channel();
         let tokio = Handle::current();
+        let config = DiagnosticsConfig::new(rules.into_iter());
         let handle = std::thread::spawn(move || {
             let queue = AnalysisQueue::new(config, tokio, progress, validator);
             queue.run(rx);
@@ -743,10 +737,11 @@ mod test {
     use wdl_ast::Severity;
 
     use super::*;
+    use crate::rules;
 
     #[tokio::test]
     async fn it_returns_empty_results() {
-        let analyzer = Analyzer::new(Default::default(), |_: (), _, _, _| async {});
+        let analyzer = Analyzer::new(rules(), |_: (), _, _, _| async {});
         let results = analyzer.analyze(()).await.unwrap();
         assert!(results.is_empty());
     }
@@ -770,7 +765,7 @@ workflow test {
         .expect("failed to create test file");
 
         // Analyze the file and check the resulting diagnostic
-        let analyzer = Analyzer::new(Default::default(), |_: (), _, _, _| async {});
+        let analyzer = Analyzer::new(rules(), |_: (), _, _, _| async {});
         analyzer
             .add_documents(vec![path])
             .await
@@ -819,7 +814,7 @@ workflow test {
         .expect("failed to create test file");
 
         // Analyze the file and check the resulting diagnostic
-        let analyzer = Analyzer::new(Default::default(), |_: (), _, _, _| async {});
+        let analyzer = Analyzer::new(rules(), |_: (), _, _, _| async {});
         analyzer
             .add_documents(vec![path.clone()])
             .await
@@ -888,7 +883,7 @@ workflow test {
         .expect("failed to create test file");
 
         // Analyze the file and check the resulting diagnostic
-        let analyzer = Analyzer::new(Default::default(), |_: (), _, _, _| async {});
+        let analyzer = Analyzer::new(rules(), |_: (), _, _, _| async {});
         analyzer
             .add_documents(vec![path.clone()])
             .await
@@ -961,7 +956,7 @@ workflow test {
         .expect("failed to create test file");
 
         // Add all three documents to the analyzer
-        let analyzer = Analyzer::new(Default::default(), |_: (), _, _, _| async {});
+        let analyzer = Analyzer::new(rules(), |_: (), _, _, _| async {});
         analyzer
             .add_documents(vec![dir.path().to_path_buf()])
             .await

--- a/wdl-analysis/src/analyzer.rs
+++ b/wdl-analysis/src/analyzer.rs
@@ -221,10 +221,7 @@ impl DiagnosticsConfig {
     /// Gets the excepted set of diagnostics based on any `#@ except` comments
     /// that precede the given syntax node.
     pub fn excepted_for_node(mut self, node: &SyntaxNode) -> Self {
-        let exceptions = node
-            .parent()
-            .expect("token should have parent")
-            .rule_exceptions();
+        let exceptions = node.rule_exceptions();
 
         if exceptions.contains(UNUSED_IMPORT_RULE_ID) {
             self.unused_import = None;

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -9,20 +9,12 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::Version;
 
+use crate::UNUSED_CALL_RULE_ID;
+use crate::UNUSED_DECL_RULE_ID;
+use crate::UNUSED_IMPORT_RULE_ID;
+use crate::UNUSED_INPUT_RULE_ID;
 use crate::types::Type;
 use crate::types::Types;
-
-/// The rule identifier for unused import warnings.
-pub const UNUSED_IMPORT_RULE_ID: &str = "UnusedImport";
-
-/// The rule identifier for unused input warnings.
-pub const UNUSED_INPUT_RULE_ID: &str = "UnusedInput";
-
-/// The rule identifier for unused declaration warnings.
-pub const UNUSED_DECL_RULE_ID: &str = "UnusedDeclaration";
-
-/// The rule identifier for unused call warnings.
-pub const UNUSED_CALL_RULE_ID: &str = "UnusedCall";
 
 /// Represents the context for diagnostic reporting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -12,6 +12,18 @@ use wdl_ast::Version;
 use crate::types::Type;
 use crate::types::Types;
 
+/// The rule identifier for unused import warnings.
+pub const UNUSED_IMPORT_RULE_ID: &str = "UnusedImport";
+
+/// The rule identifier for unused input warnings.
+pub const UNUSED_INPUT_RULE_ID: &str = "UnusedInput";
+
+/// The rule identifier for unused declaration warnings.
+pub const UNUSED_DECL_RULE_ID: &str = "UnusedDeclaration";
+
+/// The rule identifier for unused call warnings.
+pub const UNUSED_CALL_RULE_ID: &str = "UnusedCall";
+
 /// Represents the context for diagnostic reporting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Context {
@@ -788,4 +800,32 @@ pub fn missing_call_input(workflow: bool, target: &Ident, input: &str) -> Diagno
         target = target.as_str(),
     ))
     .with_highlight(target.span())
+}
+
+/// Creates an "unused import" diagnostic.
+pub fn unused_import(name: &str, span: Span) -> Diagnostic {
+    Diagnostic::warning(format!("unused import namespace `{name}`"))
+        .with_rule(UNUSED_IMPORT_RULE_ID)
+        .with_highlight(span)
+}
+
+/// Creates an "unused input" diagnostic.
+pub fn unused_input(name: &str, span: Span) -> Diagnostic {
+    Diagnostic::warning(format!("unused input `{name}`"))
+        .with_rule(UNUSED_INPUT_RULE_ID)
+        .with_highlight(span)
+}
+
+/// Creates an "unused declaration" diagnostic.
+pub fn unused_declaration(name: &str, span: Span) -> Diagnostic {
+    Diagnostic::warning(format!("unused declaration `{name}`"))
+        .with_rule(UNUSED_DECL_RULE_ID)
+        .with_highlight(span)
+}
+
+/// Creates an "unused call" diagnostic.
+pub fn unused_call(name: &str, span: Span) -> Diagnostic {
+    Diagnostic::warning(format!("unused call `{name}`"))
+        .with_rule(UNUSED_CALL_RULE_ID)
+        .with_highlight(span)
 }

--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -15,8 +15,10 @@ pub mod eval;
 mod graph;
 mod queue;
 mod rayon;
+mod rules;
 pub mod scope;
 pub mod stdlib;
 pub mod types;
 
 pub use analyzer::*;
+pub use rules::*;

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -1,7 +1,6 @@
 //! Implements the analysis queue.
 
 use std::cell::RefCell;
-use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::ops::Range;
 use std::sync::Arc;
@@ -27,6 +26,7 @@ use wdl_ast::Ast;
 use wdl_ast::AstToken;
 
 use crate::AnalysisResult;
+use crate::Config;
 use crate::IncrementalChange;
 use crate::ProgressKind;
 use crate::graph::Analysis;
@@ -109,6 +109,8 @@ enum Cancelable<T> {
 pub struct AnalysisQueue<Progress, Context, Return, Validator> {
     /// The document graph maintained by the analysis queue.
     graph: Arc<RwLock<DocumentGraph>>,
+    /// The analysis configuration to use.
+    config: Config,
     /// The handle to the tokio runtime for blocking on async tasks.
     tokio: Handle,
     /// The HTTP client to use for fetching documents.
@@ -129,9 +131,10 @@ where
     Validator: Fn() -> wdl_ast::Validator + Send + Sync + 'static,
 {
     /// Constructs a new analysis queue.
-    pub fn new(tokio: Handle, progress: Progress, validator: Validator) -> Self {
+    pub fn new(config: Config, tokio: Handle, progress: Progress, validator: Validator) -> Self {
         Self {
             graph: Default::default(),
+            config,
             tokio,
             progress: Arc::new(progress),
             marker: PhantomData,
@@ -374,7 +377,10 @@ where
                         }
 
                         let graph = self.graph.clone();
-                        Some(RayonHandle::spawn(move || Self::analyze_node(graph, index)))
+                        let config = self.config;
+                        Some(RayonHandle::spawn(move || {
+                            Self::analyze_node(config, graph, index)
+                        }))
                     })
                     .collect::<FuturesUnordered<_>>()
             };
@@ -589,17 +595,14 @@ where
     }
 
     /// Analyzes a node in the document graph.
-    fn analyze_node(graph: Arc<RwLock<DocumentGraph>>, index: NodeIndex) -> (NodeIndex, Analysis) {
+    fn analyze_node(
+        config: Config,
+        graph: Arc<RwLock<DocumentGraph>>,
+        index: NodeIndex,
+    ) -> (NodeIndex, Analysis) {
         let start = Instant::now();
         let graph = graph.read();
-        let (scope, mut diagnostics) = DocumentScope::new(&graph, index);
-
-        diagnostics.sort_by(|a, b| match (a.labels().next(), b.labels().next()) {
-            (None, None) => Ordering::Equal,
-            (None, Some(_)) => Ordering::Less,
-            (Some(_), None) => Ordering::Greater,
-            (Some(a), Some(b)) => a.span().start().cmp(&b.span().start()),
-        });
+        let (scope, diagnostics) = DocumentScope::new(config, &graph, index);
 
         info!(
             "analysis of `{uri}` completed in {elapsed:?}",

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -26,7 +26,7 @@ use wdl_ast::Ast;
 use wdl_ast::AstToken;
 
 use crate::AnalysisResult;
-use crate::Config;
+use crate::DiagnosticsConfig;
 use crate::IncrementalChange;
 use crate::ProgressKind;
 use crate::graph::Analysis;
@@ -109,8 +109,8 @@ enum Cancelable<T> {
 pub struct AnalysisQueue<Progress, Context, Return, Validator> {
     /// The document graph maintained by the analysis queue.
     graph: Arc<RwLock<DocumentGraph>>,
-    /// The analysis configuration to use.
-    config: Config,
+    /// The diagnostics configuration to use.
+    config: DiagnosticsConfig,
     /// The handle to the tokio runtime for blocking on async tasks.
     tokio: Handle,
     /// The HTTP client to use for fetching documents.
@@ -131,7 +131,12 @@ where
     Validator: Fn() -> wdl_ast::Validator + Send + Sync + 'static,
 {
     /// Constructs a new analysis queue.
-    pub fn new(config: Config, tokio: Handle, progress: Progress, validator: Validator) -> Self {
+    pub fn new(
+        config: DiagnosticsConfig,
+        tokio: Handle,
+        progress: Progress,
+        validator: Validator,
+    ) -> Self {
         Self {
             graph: Default::default(),
             config,
@@ -596,7 +601,7 @@ where
 
     /// Analyzes a node in the document graph.
     fn analyze_node(
-        config: Config,
+        config: DiagnosticsConfig,
         graph: Arc<RwLock<DocumentGraph>>,
         index: NodeIndex,
     ) -> (NodeIndex, Analysis) {

--- a/wdl-analysis/src/rules.rs
+++ b/wdl-analysis/src/rules.rs
@@ -1,0 +1,227 @@
+//! Implementation of analysis rule configuration.
+
+use wdl_ast::Severity;
+
+/// The rule identifier for unused import warnings.
+pub const UNUSED_IMPORT_RULE_ID: &str = "UnusedImport";
+
+/// The rule identifier for unused input warnings.
+pub const UNUSED_INPUT_RULE_ID: &str = "UnusedInput";
+
+/// The rule identifier for unused declaration warnings.
+pub const UNUSED_DECL_RULE_ID: &str = "UnusedDeclaration";
+
+/// The rule identifier for unused call warnings.
+pub const UNUSED_CALL_RULE_ID: &str = "UnusedCall";
+
+/// A trait implemented by analysis rules.
+pub trait Rule: Send + Sync {
+    /// The unique identifier for the rule.
+    ///
+    /// The identifier is required to be pascal case and it is the identifier by
+    /// which a rule is excepted or denied.
+    fn id(&self) -> &'static str;
+
+    /// A short, single sentence description of the rule.
+    fn description(&self) -> &'static str;
+
+    /// Get the long-form explanation of the rule.
+    fn explanation(&self) -> &'static str;
+
+    /// Denies the rule.
+    ///
+    /// Denying the rule treats any diagnostics it emits as an error.
+    fn deny(&mut self);
+
+    /// Gets the severity of the rule.
+    fn severity(&self) -> Severity;
+}
+
+/// Gets the list of all analysis rules.
+pub fn rules() -> Vec<Box<dyn Rule>> {
+    let rules: Vec<Box<dyn Rule>> = vec![
+        Box::<UnusedImportRule>::default(),
+        Box::<UnusedInputRule>::default(),
+        Box::<UnusedDeclarationRule>::default(),
+        Box::<UnusedCallRule>::default(),
+    ];
+
+    // Ensure all the rule ids are unique and pascal case
+    #[cfg(debug_assertions)]
+    {
+        use convert_case::Case;
+        use convert_case::Casing;
+        let mut set = std::collections::HashSet::new();
+        for r in rules.iter() {
+            if r.id().to_case(Case::Pascal) != r.id() {
+                panic!("analysis rule id `{id}` is not pascal case", id = r.id());
+            }
+
+            if !set.insert(r.id()) {
+                panic!("duplicate rule id `{id}`", id = r.id());
+            }
+        }
+    }
+
+    rules
+}
+
+/// Represents the unused import rule.
+#[derive(Debug, Clone, Copy)]
+pub struct UnusedImportRule(Severity);
+
+impl UnusedImportRule {
+    /// Creates a new unused import rule.
+    pub fn new() -> Self {
+        Self(Severity::Warning)
+    }
+}
+
+impl Default for UnusedImportRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for UnusedImportRule {
+    fn id(&self) -> &'static str {
+        UNUSED_IMPORT_RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that import namespaces are used in the importing document."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "Imported WDL documents should be used in the document that imports them. Unused imports \
+         impact parsing and evaluation performance."
+    }
+
+    fn deny(&mut self) {
+        self.0 = Severity::Error;
+    }
+
+    fn severity(&self) -> Severity {
+        self.0
+    }
+}
+
+/// Represents the unused input rule.
+#[derive(Debug, Clone, Copy)]
+pub struct UnusedInputRule(Severity);
+
+impl UnusedInputRule {
+    /// Creates a new unused input rule.
+    pub fn new() -> Self {
+        Self(Severity::Warning)
+    }
+}
+
+impl Default for UnusedInputRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for UnusedInputRule {
+    fn id(&self) -> &'static str {
+        UNUSED_INPUT_RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that task or workspace inputs are used within the declaring task or workspace."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "Unused inputs degrade evaluation performance and reduce the clarity of the code. Unused \
+         file inputs in tasks can also cause unnecessary file localizations."
+    }
+
+    fn deny(&mut self) {
+        self.0 = Severity::Error;
+    }
+
+    fn severity(&self) -> Severity {
+        self.0
+    }
+}
+
+/// Represents the unused declaration rule.
+#[derive(Debug, Clone, Copy)]
+pub struct UnusedDeclarationRule(Severity);
+
+impl UnusedDeclarationRule {
+    /// Creates a new unused declaration rule.
+    pub fn new() -> Self {
+        Self(Severity::Warning)
+    }
+}
+
+impl Default for UnusedDeclarationRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for UnusedDeclarationRule {
+    fn id(&self) -> &'static str {
+        UNUSED_DECL_RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that private declarations in tasks or workspaces are used within the declaring \
+         task or workspace."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "Unused private declarations degrade evaluation performance and reduce the clarity of the \
+         code."
+    }
+
+    fn deny(&mut self) {
+        self.0 = Severity::Error;
+    }
+
+    fn severity(&self) -> Severity {
+        self.0
+    }
+}
+
+/// Represents the unused call rule.
+#[derive(Debug, Clone, Copy)]
+pub struct UnusedCallRule(Severity);
+
+impl UnusedCallRule {
+    /// Creates a new unused call rule.
+    pub fn new() -> Self {
+        Self(Severity::Warning)
+    }
+}
+
+impl Default for UnusedCallRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for UnusedCallRule {
+    fn id(&self) -> &'static str {
+        UNUSED_CALL_RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Ensures that outputs of a call statement are used in the declaring workflow."
+    }
+
+    fn explanation(&self) -> &'static str {
+        "Unused calls may cause unnecessary consumption of compute resources."
+    }
+
+    fn deny(&mut self) {
+        self.0 = Severity::Error;
+    }
+
+    fn severity(&self) -> Severity {
+        self.0
+    }
+}

--- a/wdl-analysis/src/scope.rs
+++ b/wdl-analysis/src/scope.rs
@@ -1,5 +1,6 @@
 //! Representation of scopes for for WDL documents.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -8,6 +9,7 @@ use petgraph::graph::NodeIndex;
 use url::Url;
 use wdl_ast::Ast;
 use wdl_ast::AstNode;
+use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
 use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
@@ -16,6 +18,8 @@ use wdl_ast::ToSpan;
 use wdl_ast::WorkflowDescriptionLanguage;
 use wdl_ast::support::token;
 
+use crate::Config;
+use crate::diagnostics::unused_import;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
 use crate::types::Type;
@@ -74,9 +78,19 @@ pub struct Namespace {
     source: Arc<Url>,
     /// The namespace's document scope.
     scope: Arc<DocumentScope>,
+    /// Whether or not the namespace is used (i.e. referenced) in the document.
+    used: bool,
+    /// Whether or not the namespace is excepted from the "unused import"
+    /// diagnostic.
+    excepted: bool,
 }
 
 impl Namespace {
+    /// Gets the span of the import that introduced the namespace.
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
     /// Gets the URI of the imported document that introduced the namespace.
     pub fn source(&self) -> &Arc<Url> {
         &self.source
@@ -390,7 +404,11 @@ pub struct DocumentScope {
 
 impl DocumentScope {
     /// Creates a new document scope for a given document.
-    pub(crate) fn new(graph: &DocumentGraph, index: NodeIndex) -> (Self, Vec<Diagnostic>) {
+    pub(crate) fn new(
+        mut config: Config,
+        graph: &DocumentGraph,
+        index: NodeIndex,
+    ) -> (Self, Vec<Diagnostic>) {
         let node = graph.get(index);
 
         let mut diagnostics = match node.parse_state() {
@@ -402,7 +420,6 @@ impl DocumentScope {
         };
 
         let document = node.document().expect("node should have been parsed");
-
         let version = match document.version_statement() {
             Some(stmt) => stmt.version(),
             None => {
@@ -411,10 +428,26 @@ impl DocumentScope {
             }
         };
 
+        config.diagnostics = config
+            .diagnostics
+            .excepted_for_node(&version.syntax().parent().expect("token should have parent"));
+
         let mut scope = match document.ast() {
             Ast::Unsupported => Default::default(),
-            Ast::V1(ast) => v1::scope_from_ast(graph, index, &ast, &version, &mut diagnostics),
+            Ast::V1(ast) => {
+                v1::scope_from_ast(config, graph, index, &ast, &version, &mut diagnostics)
+            }
         };
+
+        // Check for unused imports
+        if let Some(severity) = config.diagnostics.unused_import {
+            for (name, ns) in scope
+                .namespaces()
+                .filter(|(_, ns)| !ns.used && !ns.excepted)
+            {
+                diagnostics.push(unused_import(name, ns.span()).with_severity(severity));
+            }
+        }
 
         // Sort the scopes by their start position so that we can do a binary search by
         // position; this works without having to remap a task's or workflow's scope
@@ -422,6 +455,14 @@ impl DocumentScope {
         scope
             .scopes
             .sort_by(|a, b| a.span.start().cmp(&b.span.start()));
+
+        // Sort the diagnostics by start
+        diagnostics.sort_by(|a, b| match (a.labels().next(), b.labels().next()) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (Some(a), Some(b)) => a.span().start().cmp(&b.span().start()),
+        });
 
         // Perform a type check
         (scope, diagnostics)

--- a/wdl-analysis/src/scope.rs
+++ b/wdl-analysis/src/scope.rs
@@ -18,7 +18,7 @@ use wdl_ast::ToSpan;
 use wdl_ast::WorkflowDescriptionLanguage;
 use wdl_ast::support::token;
 
-use crate::Config;
+use crate::DiagnosticsConfig;
 use crate::diagnostics::unused_import;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
@@ -405,7 +405,7 @@ pub struct DocumentScope {
 impl DocumentScope {
     /// Creates a new document scope for a given document.
     pub(crate) fn new(
-        mut config: Config,
+        config: DiagnosticsConfig,
         graph: &DocumentGraph,
         index: NodeIndex,
     ) -> (Self, Vec<Diagnostic>) {
@@ -428,9 +428,8 @@ impl DocumentScope {
             }
         };
 
-        config.diagnostics = config
-            .diagnostics
-            .excepted_for_node(&version.syntax().parent().expect("token should have parent"));
+        let config =
+            config.excepted_for_node(&version.syntax().parent().expect("token should have parent"));
 
         let mut scope = match document.ast() {
             Ast::Unsupported => Default::default(),
@@ -440,7 +439,7 @@ impl DocumentScope {
         };
 
         // Check for unused imports
-        if let Some(severity) = config.diagnostics.unused_import {
+        if let Some(severity) = config.unused_import {
             for (name, ns) in scope
                 .namespaces()
                 .filter(|(_, ns)| !ns.used && !ns.excepted)

--- a/wdl-analysis/src/scope/v1.rs
+++ b/wdl-analysis/src/scope/v1.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
+use petgraph::Direction;
 use petgraph::algo::has_path_connecting;
 use petgraph::algo::toposort;
 use petgraph::graph::NodeIndex;
@@ -18,6 +19,7 @@ use wdl_ast::Ident;
 use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxNode;
+use wdl_ast::SyntaxNodeExt;
 use wdl_ast::ToSpan;
 use wdl_ast::TokenStrHash;
 use wdl_ast::Version;
@@ -47,7 +49,12 @@ use super::Task;
 use super::Workflow;
 use super::braced_scope_span;
 use super::heredoc_scope_span;
+use crate::Config;
 use crate::diagnostics::Context;
+use crate::diagnostics::UNUSED_CALL_RULE_ID;
+use crate::diagnostics::UNUSED_DECL_RULE_ID;
+use crate::diagnostics::UNUSED_IMPORT_RULE_ID;
+use crate::diagnostics::UNUSED_INPUT_RULE_ID;
 use crate::diagnostics::call_input_type_mismatch;
 use crate::diagnostics::duplicate_workflow;
 use crate::diagnostics::if_conditional_mismatch;
@@ -71,9 +78,12 @@ use crate::diagnostics::unknown_io_name;
 use crate::diagnostics::unknown_namespace;
 use crate::diagnostics::unknown_task_or_workflow;
 use crate::diagnostics::unknown_type;
-use crate::eval::v1::TaskGraph;
+use crate::diagnostics::unused_call;
+use crate::diagnostics::unused_declaration;
+use crate::diagnostics::unused_input;
+use crate::eval::v1::TaskGraphBuilder;
 use crate::eval::v1::TaskGraphNode;
-use crate::eval::v1::WorkflowGraph;
+use crate::eval::v1::WorkflowGraphBuilder;
 use crate::eval::v1::WorkflowGraphNode;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
@@ -89,8 +99,59 @@ use crate::types::Types;
 use crate::types::v1::AstTypeConverter;
 use crate::types::v1::ExprTypeEvaluator;
 
+/// Determines if an input is used based off a name heuristic.
+///
+/// To localize related files, WDL tasks typically use additional `File` or
+/// `Array[File]` inputs which aren't referenced in the task itself.
+///
+/// As such, we don't want to generate an "unused input" warning for these
+/// inputs.
+///
+/// It is expected that the name of the input is suffixed with a particular
+/// string (this list is based on the heuristic applied by `miniwdl`):
+///
+/// * index
+/// * indexes
+/// * indices
+/// * idx
+/// * tbi
+/// * bai
+/// * crai
+/// * csi
+/// * fai
+/// * dict
+fn is_input_used(document: &DocumentScope, name: &str, ty: Type) -> bool {
+    /// The suffixes that cause the input to be "used"
+    const SUFFIXES: &[&str] = &[
+        "index", "indexes", "indices", "idx", "tbi", "bai", "crai", "csi", "fai", "dict",
+    ];
+
+    // Determine if the input is `File` or `Array[File]`
+    match ty {
+        Type::Primitive(ty) if ty.kind() == PrimitiveTypeKind::File => {}
+        Type::Compound(ty) => match document.types.type_definition(ty.definition()) {
+            CompoundTypeDef::Array(ty) => match ty.element_type() {
+                Type::Primitive(ty) if ty.kind() == PrimitiveTypeKind::File => {}
+                _ => return false,
+            },
+            _ => return false,
+        },
+        _ => return false,
+    }
+
+    let name = name.to_lowercase();
+    for suffix in SUFFIXES {
+        if name.ends_with(suffix) {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Creates a new document scope for a V1 AST.
 pub(crate) fn scope_from_ast(
+    config: Config,
     graph: &DocumentGraph,
     index: NodeIndex,
     ast: &Ast,
@@ -132,7 +193,7 @@ pub(crate) fn scope_from_ast(
     for item in ast.items() {
         match item {
             DocumentItem::Task(task) => {
-                add_task(&mut document, &task, diagnostics);
+                add_task(config, &mut document, &task, diagnostics);
             }
             DocumentItem::Workflow(workflow) => {
                 // Note that this doesn't populate the workflow scope; we delay that until after
@@ -148,7 +209,7 @@ pub(crate) fn scope_from_ast(
     }
 
     if let Some(definition) = definition {
-        populate_workflow_scope(&mut document, &definition, diagnostics);
+        populate_workflow_scope(config, &mut document, &definition, diagnostics);
     }
 
     document
@@ -190,6 +251,8 @@ fn add_namespace(
                     span,
                     source: uri.clone(),
                     scope: imported.clone(),
+                    used: false,
+                    excepted: import.syntax().is_rule_excepted(UNUSED_IMPORT_RULE_ID),
                 });
                 ns
             }
@@ -327,7 +390,7 @@ fn convert_ast_type(
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Type {
     let mut converter = AstTypeConverter::new(&mut document.types, |name, span| {
-        lookup_type(&document.structs, name, span)
+        lookup_type(&mut document.namespaces, &document.structs, name, span)
     });
 
     match converter.convert_type(ty) {
@@ -386,6 +449,7 @@ fn create_output_type_map(
 
 /// Adds a task to the document's scope.
 fn add_task(
+    config: Config,
     document: &mut DocumentScope,
     task: &TaskDefinition,
     diagnostics: &mut Vec<Diagnostic>,
@@ -444,30 +508,70 @@ fn add_task(
     );
 
     // Process the task in evaluation order
-    let graph = TaskGraph::new(document.version.unwrap(), task, diagnostics);
+    let graph = TaskGraphBuilder::default().build(document.version.unwrap(), task, diagnostics);
     let scope = document.add_scope(Scope::new(None, braced_scope_span(task)));
     let mut output_scope = None;
     let mut command_scope = None;
 
-    for node in graph.toposort() {
-        match node {
+    for index in toposort(&graph, None).expect("graph should be acyclic") {
+        match graph[index].clone() {
             TaskGraphNode::Input(decl) => {
-                add_decl(
+                if !add_decl(
                     document,
                     scope,
                     &decl,
                     |_, n, _, _| inputs[n].0,
                     diagnostics,
-                );
+                ) {
+                    continue;
+                }
+
+                // Check for unused input
+                if let Some(severity) = config.diagnostics.unused_input {
+                    let name = decl.name();
+                    if graph
+                        .edges_directed(index, Direction::Outgoing)
+                        .next()
+                        .is_none()
+                    {
+                        // Determine if the input is really used based on its name and type
+                        if is_input_used(document, name.as_str(), inputs[name.as_str()].0) {
+                            continue;
+                        }
+
+                        if !decl.syntax().is_rule_excepted(UNUSED_INPUT_RULE_ID) {
+                            diagnostics.push(
+                                unused_input(name.as_str(), name.span()).with_severity(severity),
+                            );
+                        }
+                    }
+                }
             }
             TaskGraphNode::Decl(decl) => {
-                add_decl(
+                if !add_decl(
                     document,
                     scope,
                     &decl,
                     |doc, _, decl, diag| convert_ast_type(doc, &decl.ty(), diag),
                     diagnostics,
-                );
+                ) {
+                    continue;
+                }
+
+                // Check for unused declaration
+                if let Some(severity) = config.diagnostics.unused_declaration {
+                    let name = decl.name();
+                    if graph
+                        .edges_directed(index, Direction::Outgoing)
+                        .next()
+                        .is_none()
+                        && !decl.syntax().is_rule_excepted(UNUSED_DECL_RULE_ID)
+                    {
+                        diagnostics.push(
+                            unused_declaration(name.as_str(), name.span()).with_severity(severity),
+                        );
+                    }
+                }
             }
             TaskGraphNode::Output(decl) => {
                 let scope = *output_scope.get_or_insert_with(|| {
@@ -496,7 +600,9 @@ fn add_task(
                     document.version.unwrap(),
                     &mut document.types,
                     diagnostics,
-                    |name, span| lookup_type(&document.structs, name, span),
+                    |name, span| {
+                        lookup_type(&mut document.namespaces, &document.structs, name, span)
+                    },
                 );
 
                 for part in section.parts() {
@@ -511,7 +617,9 @@ fn add_task(
                     document.version.unwrap(),
                     &mut document.types,
                     diagnostics,
-                    |name, span| lookup_type(&document.structs, name, span),
+                    |name, span| {
+                        lookup_type(&mut document.namespaces, &document.structs, name, span)
+                    },
                 );
 
                 let scope = ScopeRef::new(&document.scopes, scope);
@@ -525,7 +633,9 @@ fn add_task(
                     document.version.unwrap(),
                     &mut document.types,
                     diagnostics,
-                    |name, span| lookup_type(&document.structs, name, span),
+                    |name, span| {
+                        lookup_type(&mut document.namespaces, &document.structs, name, span)
+                    },
                 );
 
                 let scope = ScopeRef::new(&document.scopes, scope);
@@ -539,7 +649,9 @@ fn add_task(
                     document.version.unwrap(),
                     &mut document.types,
                     diagnostics,
-                    |name, span| lookup_type(&document.structs, name, span),
+                    |name, span| {
+                        lookup_type(&mut document.namespaces, &document.structs, name, span)
+                    },
                 );
 
                 // Create a special scope for evaluating the hints section which allows for the
@@ -574,11 +686,11 @@ fn add_decl(
     decl: &Decl,
     ty: impl FnOnce(&mut DocumentScope, &str, &Decl, &mut Vec<Diagnostic>) -> Type,
     diagnostics: &mut Vec<Diagnostic>,
-) {
+) -> bool {
     let (name, expr) = (decl.name(), decl.expr());
     if document.scope(scope).lookup(name.as_str()).is_some() {
         // The declaration is conflicting; don't add to the scope
-        return;
+        return false;
     }
 
     let ty = ty(document, name.as_str(), decl, diagnostics);
@@ -590,6 +702,8 @@ fn add_decl(
     if let Some(expr) = expr {
         type_check_expr(document, scope, &expr, ty, name.span(), diagnostics);
     }
+
+    true
 }
 
 /// Adds a workflow to the document scope.
@@ -683,6 +797,7 @@ fn is_nested_inputs_allowed(document: &DocumentScope, definition: &WorkflowDefin
 
 /// Finishes processing a workflow by populating its scope.
 fn populate_workflow_scope(
+    config: Config,
     document: &mut DocumentScope,
     definition: &WorkflowDefinition,
     diagnostics: &mut Vec<Diagnostic>,
@@ -716,30 +831,72 @@ fn populate_workflow_scope(
         .map(|w| w.scope)
         .expect("should have a workflow");
     let mut output_scope = None;
-    let graph = WorkflowGraph::new(definition, diagnostics);
-    for node in graph.toposort() {
-        match node {
+    let graph = WorkflowGraphBuilder::default().build(definition, diagnostics);
+
+    for index in toposort(&graph, None).expect("graph should be acyclic") {
+        match graph[index].clone() {
             WorkflowGraphNode::Input(decl) => {
-                add_decl(
+                if !add_decl(
                     document,
                     workflow_scope,
                     &decl,
                     |_, n, _, _| inputs[n].0,
                     diagnostics,
-                );
+                ) {
+                    continue;
+                }
+
+                // Check for unused input
+                if let Some(severity) = config.diagnostics.unused_input {
+                    let name = decl.name();
+                    if graph
+                        .edges_directed(index, Direction::Outgoing)
+                        .next()
+                        .is_none()
+                    {
+                        // Determine if the input is really used based on its name and type
+                        if is_input_used(document, name.as_str(), inputs[name.as_str()].0) {
+                            continue;
+                        }
+
+                        if !decl.syntax().is_rule_excepted(UNUSED_INPUT_RULE_ID) {
+                            diagnostics.push(
+                                unused_input(name.as_str(), name.span()).with_severity(severity),
+                            );
+                        }
+                    }
+                }
             }
             WorkflowGraphNode::Decl(decl) => {
                 let scope = scopes
                     .get(&decl.syntax().parent().expect("should have parent"))
                     .copied()
                     .unwrap_or(workflow_scope);
-                add_decl(
+
+                if !add_decl(
                     document,
                     scope,
                     &decl,
                     |doc, _, decl, diag| convert_ast_type(doc, &decl.ty(), diag),
                     diagnostics,
-                );
+                ) {
+                    continue;
+                }
+
+                // Check for unused declaration
+                if let Some(severity) = config.diagnostics.unused_declaration {
+                    let name = decl.name();
+                    if graph
+                        .edges_directed(index, Direction::Outgoing)
+                        .next()
+                        .is_none()
+                        && !decl.syntax().is_rule_excepted(UNUSED_DECL_RULE_ID)
+                    {
+                        diagnostics.push(
+                            unused_declaration(name.as_str(), name.span()).with_severity(severity),
+                        );
+                    }
+                }
             }
             WorkflowGraphNode::Output(decl) => {
                 let scope = *output_scope.get_or_insert_with(|| {
@@ -779,6 +936,30 @@ fn populate_workflow_scope(
                     nested_inputs_allowed,
                     diagnostics,
                 );
+
+                // Check for unused call
+                if let Some(severity) = config.diagnostics.unused_call {
+                    if graph
+                        .edges_directed(index, Direction::Outgoing)
+                        .next()
+                        .is_none()
+                        && !statement.syntax().is_rule_excepted(UNUSED_CALL_RULE_ID)
+                    {
+                        let target_name = statement
+                            .target()
+                            .names()
+                            .last()
+                            .expect("expected a last call target name");
+
+                        let name = statement
+                            .alias()
+                            .map(|a| a.name())
+                            .unwrap_or_else(|| target_name);
+
+                        diagnostics
+                            .push(unused_call(name.as_str(), name.span()).with_severity(severity));
+                    }
+                }
             }
             WorkflowGraphNode::ExitConditional(statement) => {
                 let scope = scopes
@@ -818,7 +999,7 @@ fn add_conditional_statement(
         document.version.unwrap(),
         &mut document.types,
         diagnostics,
-        |name, span| lookup_type(&document.structs, name, span),
+        |name, span| lookup_type(&mut document.namespaces, &document.structs, name, span),
     );
 
     // Evaluate the statement's expression; it is expected to be a boolean
@@ -847,7 +1028,7 @@ fn add_scatter_statement(
         document.version.unwrap(),
         &mut document.types,
         diagnostics,
-        |name, span| lookup_type(&document.structs, name, span),
+        |name, span| lookup_type(&mut document.namespaces, &document.structs, name, span),
     );
 
     // Evaluate the statement expression; it is expected to be an array
@@ -1021,8 +1202,11 @@ fn resolve_call_target(
             return None;
         }
 
-        match document.namespaces.get(target.as_str()) {
-            Some(ns) => namespace = Some(ns),
+        match document.namespaces.get_mut(target.as_str()) {
+            Some(ns) => {
+                ns.used = true;
+                namespace = Some(&document.namespaces[target.as_str()])
+            }
             None => {
                 diagnostics.push(unknown_namespace(&target));
                 return None;
@@ -1032,7 +1216,6 @@ fn resolve_call_target(
 
     let target = namespace.map(|ns| ns.scope.as_ref()).unwrap_or(document);
     let name = name.expect("should have name");
-
     if namespace.is_none() && name.as_str() == workflow_name {
         diagnostics.push(recursive_workflow_call(&name));
         return None;
@@ -1255,14 +1438,18 @@ fn set_struct_types(document: &mut DocumentScope, diagnostics: &mut Vec<Diagnost
             StructDefinition::cast(SyntaxNode::new_root(document.structs[index].node.clone()))
                 .expect("node should cast");
 
-        let structs = &document.structs;
         let mut converter = AstTypeConverter::new(&mut document.types, |name, span| {
-            if let Some(s) = structs.get(name) {
+            if let Some(s) = document.structs.get(name) {
+                // Mark the struct's namespace as used
+                if let Some(ns) = &s.namespace {
+                    document.namespaces[ns].used = true;
+                }
+
                 Ok(s.ty().unwrap_or(Type::Union))
             } else {
                 diagnostics.push(unknown_type(
                     name,
-                    Span::new(span.start() + structs[index].offset, span.len()),
+                    Span::new(span.start() + document.structs[index].offset, span.len()),
                 ));
                 Ok(Type::Union)
             }
@@ -1280,13 +1467,21 @@ fn set_struct_types(document: &mut DocumentScope, diagnostics: &mut Vec<Diagnost
 
 /// Looks up a struct type.
 fn lookup_type(
+    namespaces: &mut IndexMap<String, Namespace>,
     structs: &IndexMap<String, Struct>,
     name: &str,
     span: Span,
 ) -> Result<Type, Diagnostic> {
     structs
         .get(name)
-        .map(|s| s.ty().expect("struct should have type"))
+        .map(|s| {
+            // Mark the struct's namespace as used
+            if let Some(ns) = &s.namespace {
+                namespaces[ns].used = true;
+            }
+
+            s.ty().expect("struct should have type")
+        })
         .ok_or_else(|| unknown_type(name, span))
 }
 
@@ -1303,7 +1498,7 @@ fn type_check_expr(
         document.version.unwrap(),
         &mut document.types,
         diagnostics,
-        |name, span| lookup_type(&document.structs, name, span),
+        |name, span| lookup_type(&mut document.namespaces, &document.structs, name, span),
     );
 
     let actual = evaluator

--- a/wdl-analysis/src/scope/v1.rs
+++ b/wdl-analysis/src/scope/v1.rs
@@ -49,12 +49,12 @@ use super::Task;
 use super::Workflow;
 use super::braced_scope_span;
 use super::heredoc_scope_span;
-use crate::Config;
+use crate::DiagnosticsConfig;
+use crate::UNUSED_CALL_RULE_ID;
+use crate::UNUSED_DECL_RULE_ID;
+use crate::UNUSED_IMPORT_RULE_ID;
+use crate::UNUSED_INPUT_RULE_ID;
 use crate::diagnostics::Context;
-use crate::diagnostics::UNUSED_CALL_RULE_ID;
-use crate::diagnostics::UNUSED_DECL_RULE_ID;
-use crate::diagnostics::UNUSED_IMPORT_RULE_ID;
-use crate::diagnostics::UNUSED_INPUT_RULE_ID;
 use crate::diagnostics::call_input_type_mismatch;
 use crate::diagnostics::duplicate_workflow;
 use crate::diagnostics::if_conditional_mismatch;
@@ -151,7 +151,7 @@ fn is_input_used(document: &DocumentScope, name: &str, ty: Type) -> bool {
 
 /// Creates a new document scope for a V1 AST.
 pub(crate) fn scope_from_ast(
-    config: Config,
+    config: DiagnosticsConfig,
     graph: &DocumentGraph,
     index: NodeIndex,
     ast: &Ast,
@@ -449,7 +449,7 @@ fn create_output_type_map(
 
 /// Adds a task to the document's scope.
 fn add_task(
-    config: Config,
+    config: DiagnosticsConfig,
     document: &mut DocumentScope,
     task: &TaskDefinition,
     diagnostics: &mut Vec<Diagnostic>,
@@ -527,7 +527,7 @@ fn add_task(
                 }
 
                 // Check for unused input
-                if let Some(severity) = config.diagnostics.unused_input {
+                if let Some(severity) = config.unused_input {
                     let name = decl.name();
                     if graph
                         .edges_directed(index, Direction::Outgoing)
@@ -559,7 +559,7 @@ fn add_task(
                 }
 
                 // Check for unused declaration
-                if let Some(severity) = config.diagnostics.unused_declaration {
+                if let Some(severity) = config.unused_declaration {
                     let name = decl.name();
                     if graph
                         .edges_directed(index, Direction::Outgoing)
@@ -797,7 +797,7 @@ fn is_nested_inputs_allowed(document: &DocumentScope, definition: &WorkflowDefin
 
 /// Finishes processing a workflow by populating its scope.
 fn populate_workflow_scope(
-    config: Config,
+    config: DiagnosticsConfig,
     document: &mut DocumentScope,
     definition: &WorkflowDefinition,
     diagnostics: &mut Vec<Diagnostic>,
@@ -847,7 +847,7 @@ fn populate_workflow_scope(
                 }
 
                 // Check for unused input
-                if let Some(severity) = config.diagnostics.unused_input {
+                if let Some(severity) = config.unused_input {
                     let name = decl.name();
                     if graph
                         .edges_directed(index, Direction::Outgoing)
@@ -884,7 +884,7 @@ fn populate_workflow_scope(
                 }
 
                 // Check for unused declaration
-                if let Some(severity) = config.diagnostics.unused_declaration {
+                if let Some(severity) = config.unused_declaration {
                     let name = decl.name();
                     if graph
                         .edges_directed(index, Direction::Outgoing)
@@ -938,7 +938,7 @@ fn populate_workflow_scope(
                 );
 
                 // Check for unused call
-                if let Some(severity) = config.diagnostics.unused_call {
+                if let Some(severity) = config.unused_call {
                     if graph
                         .edges_directed(index, Direction::Outgoing)
                         .next()

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -308,7 +308,7 @@ pub struct ExprTypeEvaluator<'a, L> {
 
 impl<'a, L> ExprTypeEvaluator<'a, L>
 where
-    L: Fn(&str, Span) -> Result<Type, Diagnostic>,
+    L: FnMut(&str, Span) -> Result<Type, Diagnostic>,
 {
     /// Constructs a new AST expression type evaluator.
     ///

--- a/wdl-analysis/tests/analysis.rs
+++ b/wdl-analysis/tests/analysis.rs
@@ -34,6 +34,7 @@ use pretty_assertions::StrComparison;
 use wdl_analysis::AnalysisResult;
 use wdl_analysis::Analyzer;
 use wdl_analysis::path_to_uri;
+use wdl_analysis::rules;
 use wdl_ast::Diagnostic;
 use wdl_ast::SyntaxNode;
 
@@ -155,7 +156,7 @@ async fn main() {
     println!("\nrunning {} tests\n", tests.len());
 
     // Start with a single analysis pass over all the test files
-    let analyzer = Analyzer::new(Default::default(), |_, _, _, _| async {});
+    let analyzer = Analyzer::new(rules(), |_, _, _, _| async {});
     analyzer
         .add_documents(tests.clone())
         .await
@@ -200,7 +201,7 @@ async fn main() {
     // Some tests are sensitive to the order in which files are parsed (e.g.
     // detecting cycles) For those, use a new analyzer and analyze the
     // `source.wdl` directly
-    let analyzer = Analyzer::new(Default::default(), |_, _, _, _| async {});
+    let analyzer = Analyzer::new(rules(), |_, _, _, _| async {});
     for test_name in single_file {
         let test = Path::new("tests/analysis").join(test_name);
         let document = test.join("source.wdl");

--- a/wdl-analysis/tests/analysis.rs
+++ b/wdl-analysis/tests/analysis.rs
@@ -155,7 +155,7 @@ async fn main() {
     println!("\nrunning {} tests\n", tests.len());
 
     // Start with a single analysis pass over all the test files
-    let analyzer = Analyzer::new(|_, _, _, _| async {});
+    let analyzer = Analyzer::new(Default::default(), |_, _, _, _| async {});
     analyzer
         .add_documents(tests.clone())
         .await
@@ -200,7 +200,7 @@ async fn main() {
     // Some tests are sensitive to the order in which files are parsed (e.g.
     // detecting cycles) For those, use a new analyzer and analyze the
     // `source.wdl` directly
-    let analyzer = Analyzer::new(|_, _, _, _| async {});
+    let analyzer = Analyzer::new(Default::default(), |_, _, _, _| async {});
     for test_name in single_file {
         let test = Path::new("tests/analysis").join(test_name);
         let document = test.join("source.wdl");

--- a/wdl-analysis/tests/analysis/allow-nested-inputs-1.0/source.wdl
+++ b/wdl-analysis/tests/analysis/allow-nested-inputs-1.0/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedInput,UnusedCall
 ## This is a test of allowed nested inputs in 1.0.
 ## This should be accepted without diagnostics.
 

--- a/wdl-analysis/tests/analysis/allow-nested-inputs-1.1/source.wdl
+++ b/wdl-analysis/tests/analysis/allow-nested-inputs-1.1/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedInput,UnusedCall
 ## This is a test of allowed nested inputs in 1.1.
 ## This should be accepted without diagnostics.
 

--- a/wdl-analysis/tests/analysis/allow-nested-inputs-1.2/source.wdl
+++ b/wdl-analysis/tests/analysis/allow-nested-inputs-1.2/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedInput,UnusedCall
 ## This is a test of allowed nested inputs in 1.2.
 ## This should be accepted without diagnostics.
 

--- a/wdl-analysis/tests/analysis/argument-type-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/argument-type-mismatch/source.diagnostics
@@ -1,6 +1,6 @@
 error: type mismatch: argument to function `sub` expects type `String`, but found type `Int`
-  ┌─ tests/analysis/argument-type-mismatch/source.wdl:6:27
+  ┌─ tests/analysis/argument-type-mismatch/source.wdl:7:27
   │
-6 │     String x = sub("foo", 1, "bar")
+7 │     String x = sub("foo", 1, "bar")
   │                           ^ this is type `Int`
 

--- a/wdl-analysis/tests/analysis/argument-type-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/argument-type-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a simple test of an argument type mismatch.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/call-input-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/call-input-mismatch/source.diagnostics
@@ -1,28 +1,28 @@
 error: type mismatch: expected type `Int`, but found type `String`
-   ┌─ tests/analysis/call-input-mismatch/source.wdl:16:31
+   ┌─ tests/analysis/call-input-mismatch/source.wdl:17:31
    │
-16 │     call my_task { input: x = "1" }
+17 │     call my_task { input: x = "1" }
    │                           -   ^^^ this is type `String`
    │                           │    
    │                           this expects type `Int`
 
 error: type mismatch: expected type `Int`, but found type `String`
-   ┌─ tests/analysis/call-input-mismatch/source.wdl:17:36
+   ┌─ tests/analysis/call-input-mismatch/source.wdl:18:36
    │
-17 │     call my_task as my_task2 { x = x }
+18 │     call my_task as my_task2 { x = x }
    │                                -   ^ this is type `String`
    │                                │    
    │                                this expects type `Int`
 
 error: type mismatch: expected type `Int`, but found type `String`
-   ┌─ tests/analysis/call-input-mismatch/source.wdl:18:32
+   ┌─ tests/analysis/call-input-mismatch/source.wdl:19:32
    │
-18 │     call my_task as my_task3 { x }
+19 │     call my_task as my_task3 { x }
    │                                ^ input `x` is type `Int`, but name `x` is type `String`
 
 error: type mismatch: expected type `Int`, but found type `String`
-   ┌─ tests/analysis/call-input-mismatch/source.wdl:19:39
+   ┌─ tests/analysis/call-input-mismatch/source.wdl:20:39
    │
-19 │     call my_task as my_task4 { input: x }
+20 │     call my_task as my_task4 { input: x }
    │                                       ^ input `x` is type `Int`, but name `x` is type `String`
 

--- a/wdl-analysis/tests/analysis/call-input-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/call-input-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedInput,UnusedDeclaration,UnusedCall
 # This is a test of passing an incorrect type to a call input.
 
 version 1.2

--- a/wdl-analysis/tests/analysis/call-multiple-namespaces/source.diagnostics
+++ b/wdl-analysis/tests/analysis/call-multiple-namespaces/source.diagnostics
@@ -1,6 +1,6 @@
 error: only one namespace may be specified in a call statement
-  ┌─ tests/analysis/call-multiple-namespaces/source.wdl:8:14
+  ┌─ tests/analysis/call-multiple-namespaces/source.wdl:9:14
   │
-8 │     call foo.bar.baz
+9 │     call foo.bar.baz
   │              ^^^
 

--- a/wdl-analysis/tests/analysis/call-multiple-namespaces/source.wdl
+++ b/wdl-analysis/tests/analysis/call-multiple-namespaces/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedCall
 ## This is a test of having multiple namespaces in a call statement.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/call-unknown-input/source.diagnostics
+++ b/wdl-analysis/tests/analysis/call-unknown-input/source.diagnostics
@@ -1,24 +1,24 @@
 error: task `my_task` does not have an input named `x`
-   ┌─ tests/analysis/call-unknown-input/source.wdl:10:27
+   ┌─ tests/analysis/call-unknown-input/source.wdl:11:27
    │
-10 │     call my_task { input: x = 1 }
+11 │     call my_task { input: x = 1 }
    │                           ^
 
 error: task `my_task2` does not have an input named `x`
-   ┌─ tests/analysis/call-unknown-input/source.wdl:11:32
+   ┌─ tests/analysis/call-unknown-input/source.wdl:12:32
    │
-11 │     call my_task as my_task2 { x = 1 }
+12 │     call my_task as my_task2 { x = 1 }
    │                                ^
 
 error: task `my_task3` does not have an input named `x`
-   ┌─ tests/analysis/call-unknown-input/source.wdl:12:39
+   ┌─ tests/analysis/call-unknown-input/source.wdl:13:39
    │
-12 │     call my_task as my_task3 { input: x }
+13 │     call my_task as my_task3 { input: x }
    │                                       ^
 
 error: task `my_task4` does not have an input named `x`
-   ┌─ tests/analysis/call-unknown-input/source.wdl:13:32
+   ┌─ tests/analysis/call-unknown-input/source.wdl:14:32
    │
-13 │     call my_task as my_task4 { x }
+14 │     call my_task as my_task4 { x }
    │                                ^
 

--- a/wdl-analysis/tests/analysis/call-unknown-input/source.wdl
+++ b/wdl-analysis/tests/analysis/call-unknown-input/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedCall
 ## This is a test of having an unknown input in a call statement.
 
 version 1.2

--- a/wdl-analysis/tests/analysis/call-unknown-task/source.diagnostics
+++ b/wdl-analysis/tests/analysis/call-unknown-task/source.diagnostics
@@ -1,6 +1,6 @@
 error: unknown task or workflow `foo`
-  ┌─ tests/analysis/call-unknown-task/source.wdl:6:10
+  ┌─ tests/analysis/call-unknown-task/source.wdl:7:10
   │
-6 │     call foo
+7 │     call foo
   │          ^^^
 

--- a/wdl-analysis/tests/analysis/call-unknown-task/source.wdl
+++ b/wdl-analysis/tests/analysis/call-unknown-task/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedCall
 ## This is a test of calling an unknown task or workflow.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/cannot-coerce-string/source.diagnostics
+++ b/wdl-analysis/tests/analysis/cannot-coerce-string/source.diagnostics
@@ -1,6 +1,6 @@
 error: cannot coerce type `Array[String]` to `String`
-  ┌─ tests/analysis/cannot-coerce-string/source.wdl:9:23
-  │
-9 │     String x = "foo ${a}"
-  │                       ^ this is type `Array[String]`
+   ┌─ tests/analysis/cannot-coerce-string/source.wdl:10:23
+   │
+10 │     String x = "foo ${a}"
+   │                       ^ this is type `Array[String]`
 

--- a/wdl-analysis/tests/analysis/cannot-coerce-string/source.wdl
+++ b/wdl-analysis/tests/analysis/cannot-coerce-string/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of coercing the result of an expression in a string interpolation.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/common-types/source.wdl
+++ b/wdl-analysis/tests/analysis/common-types/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This tests calculations of common types.
 ## No diagnostics are expected from this test.
 

--- a/wdl-analysis/tests/analysis/comparison-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/comparison-mismatch/source.diagnostics
@@ -1,142 +1,142 @@
 error: type mismatch: operator `==` cannot compare type `Int` to type `String`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:13:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:14:18
    │
-13 │     Boolean e2 = a == c
+14 │     Boolean e2 = a == c
    │                  ^^^^^^
    │                  │    │
    │                  │    this is type `String`
    │                  this is type `Int`
 
 error: type mismatch: operator `==` cannot compare type `String` to type `Int`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:14:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:15:18
    │
-14 │     Boolean e3 = c == a
+15 │     Boolean e3 = c == a
    │                  ^^^^^^
    │                  │    │
    │                  │    this is type `Int`
    │                  this is type `String`
 
 error: type mismatch: operator `!=` cannot compare type `Int` to type `String`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:22:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:23:19
    │
-22 │     Boolean ne2 = a != c
+23 │     Boolean ne2 = a != c
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `String`
    │                   this is type `Int`
 
 error: type mismatch: operator `!=` cannot compare type `String` to type `Int`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:23:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:24:19
    │
-23 │     Boolean ne3 = c != a
+24 │     Boolean ne3 = c != a
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `Int`
    │                   this is type `String`
 
 error: type mismatch: operator `<` cannot compare type `Int` to type `String`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:31:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:32:18
    │
-31 │     Boolean l2 = a < c
+32 │     Boolean l2 = a < c
    │                  ^^^^^
    │                  │   │
    │                  │   this is type `String`
    │                  this is type `Int`
 
 error: type mismatch: operator `<` cannot compare type `String` to type `Int`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:32:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:33:18
    │
-32 │     Boolean l3 = c < a
+33 │     Boolean l3 = c < a
    │                  ^^^^^
    │                  │   │
    │                  │   this is type `Int`
    │                  this is type `String`
 
 error: type mismatch: operator `<` cannot compare type `File` to type `File`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:34:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:35:18
    │
-34 │     Boolean l5 = d < d
+35 │     Boolean l5 = d < d
    │                  ^^^^^
    │                  │   │
    │                  │   this is type `File`
    │                  this is type `File`
 
 error: type mismatch: operator `<=` cannot compare type `Int` to type `String`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:40:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:41:19
    │
-40 │     Boolean le2 = a <= c
+41 │     Boolean le2 = a <= c
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `String`
    │                   this is type `Int`
 
 error: type mismatch: operator `<=` cannot compare type `String` to type `Int`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:41:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:42:19
    │
-41 │     Boolean le3 = c <= a
+42 │     Boolean le3 = c <= a
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `Int`
    │                   this is type `String`
 
 error: type mismatch: operator `<=` cannot compare type `File` to type `File`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:43:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:44:19
    │
-43 │     Boolean le5 = d <= d
+44 │     Boolean le5 = d <= d
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `File`
    │                   this is type `File`
 
 error: type mismatch: operator `>` cannot compare type `Int` to type `String`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:49:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:50:18
    │
-49 │     Boolean g2 = a > c
+50 │     Boolean g2 = a > c
    │                  ^^^^^
    │                  │   │
    │                  │   this is type `String`
    │                  this is type `Int`
 
 error: type mismatch: operator `>` cannot compare type `String` to type `Int`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:50:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:51:18
    │
-50 │     Boolean g3 = c > a
+51 │     Boolean g3 = c > a
    │                  ^^^^^
    │                  │   │
    │                  │   this is type `Int`
    │                  this is type `String`
 
 error: type mismatch: operator `>` cannot compare type `File` to type `File`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:52:18
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:53:18
    │
-52 │     Boolean g5 = d > d
+53 │     Boolean g5 = d > d
    │                  ^^^^^
    │                  │   │
    │                  │   this is type `File`
    │                  this is type `File`
 
 error: type mismatch: operator `>=` cannot compare type `Int` to type `String`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:58:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:59:19
    │
-58 │     Boolean ge2 = a >= c
+59 │     Boolean ge2 = a >= c
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `String`
    │                   this is type `Int`
 
 error: type mismatch: operator `>=` cannot compare type `String` to type `Int`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:59:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:60:19
    │
-59 │     Boolean ge3 = c >= a
+60 │     Boolean ge3 = c >= a
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `Int`
    │                   this is type `String`
 
 error: type mismatch: operator `>=` cannot compare type `File` to type `File`
-   ┌─ tests/analysis/comparison-mismatch/source.wdl:61:19
+   ┌─ tests/analysis/comparison-mismatch/source.wdl:62:19
    │
-61 │     Boolean ge5 = d >= d
+62 │     Boolean ge5 = d >= d
    │                   ^^^^^^
    │                   │    │
    │                   │    this is type `File`

--- a/wdl-analysis/tests/analysis/comparison-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/comparison-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of type mismatches in comparison expressions.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/conflicting-call-names/source.diagnostics
+++ b/wdl-analysis/tests/analysis/conflicting-call-names/source.diagnostics
@@ -1,102 +1,102 @@
 error: conflicting call name `my_int`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:25:10
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:26:10
    │
-24 │     Int my_int = 0      # FIRST
+25 │     Int my_int = 0      # FIRST
    │         ------ the declaration with the conflicting name is here
-25 │     call my_int         # NOT OK
+26 │     call my_int         # NOT OK
    │          ^^^^^^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name
 
 error: conflicting call name `foo`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:28:10
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:29:10
    │
-27 │     call foo            # FIRST
+28 │     call foo            # FIRST
    │          --- the call with the conflicting name is here
-28 │     call foo            # NOT OK
+29 │     call foo            # NOT OK
    │          ^^^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name
 
 error: conflicting call name `bar`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:31:17
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:32:17
    │
-30 │     call foo as bar     # FIRST
+31 │     call foo as bar     # FIRST
    │                 --- the call with the conflicting name is here
-31 │     call foo as bar     # NOT OK
+32 │     call foo as bar     # NOT OK
    │                 ^^^ this call name conflicts with a previously used name
 
 error: conflicting call name `bar`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:33:10
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:34:10
    │
-30 │     call foo as bar     # FIRST
+31 │     call foo as bar     # FIRST
    │                 --- the call with the conflicting name is here
    ·
-33 │     call bar            # NOT OK
+34 │     call bar            # NOT OK
    │          ^^^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name
 
 error: conflicting call name `bar`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:35:14
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:36:14
    │
-30 │     call foo as bar     # FIRST
+31 │     call foo as bar     # FIRST
    │                 --- the call with the conflicting name is here
    ·
-35 │     call baz.bar        # NOT OK
+36 │     call baz.bar        # NOT OK
    │              ^^^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name
 
 error: conflicting call name `baz`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:38:17
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:39:17
    │
-36 │     call baz.baz        # FIRST
+37 │     call baz.baz        # FIRST
    │              --- the call with the conflicting name is here
-37 │ 
-38 │     call foo as baz     # NOT OK
+38 │ 
+39 │     call foo as baz     # NOT OK
    │                 ^^^ this call name conflicts with a previously used name
 
 error: conflicting call name `foo`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:41:14
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:42:14
    │
-27 │     call foo            # FIRST
+28 │     call foo            # FIRST
    │          --- the call with the conflicting name is here
    ·
-41 │         call foo        # NOT OK
+42 │         call foo        # NOT OK
    │              ^^^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name
 
 error: conflicting call name `x`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:42:14
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:43:14
    │
-40 │     scatter (x in []) {
+41 │     scatter (x in []) {
    │              - the scatter variable with the conflicting name is here
-41 │         call foo        # NOT OK
-42 │         call x          # NOT OK
+42 │         call foo        # NOT OK
+43 │         call x          # NOT OK
    │              ^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name
 
 error: conflicting call name `x`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:46:10
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:47:10
    │
-42 │         call x          # NOT OK
+43 │         call x          # NOT OK
    │              - the call with the conflicting name is here
    ·
-46 │     call x              # NOT OK
+47 │     call x              # NOT OK
    │          ^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name
 
 error: conflicting call name `ok`
-   ┌─ tests/analysis/conflicting-call-names/source.wdl:47:10
+   ┌─ tests/analysis/conflicting-call-names/source.wdl:48:10
    │
-43 │         call ok         # OK
+44 │         call ok         # OK
    │              -- the call with the conflicting name is here
    ·
-47 │     call ok             # NOT OK
+48 │     call ok             # NOT OK
    │          ^^ this call name conflicts with a previously used name
    │
    = fix: add an `as` clause to the call to specify a different name

--- a/wdl-analysis/tests/analysis/conflicting-call-names/source.wdl
+++ b/wdl-analysis/tests/analysis/conflicting-call-names/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration,UnusedCall,UnusedInput
 ## This is a test of conflicting call names.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/conflicting-decl-names/source.diagnostics
+++ b/wdl-analysis/tests/analysis/conflicting-decl-names/source.diagnostics
@@ -1,108 +1,108 @@
 error: conflicting output name `x`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:13:16
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:14:16
    │
- 7 │         Int x
+ 8 │         Int x
    │             - the input with the conflicting name is here
    ·
-13 │         String x = "x"
+14 │         String x = "x"
    │                ^ this output conflicts with a previously used name
 
 error: conflicting output name `y`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:14:16
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:15:16
    │
- 8 │         Int y = 0
+ 9 │         Int y = 0
    │             - the input with the conflicting name is here
    ·
-14 │         String y = "y"
+15 │         String y = "y"
    │                ^ this output conflicts with a previously used name
 
 error: conflicting declaration name `x`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:19:9
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:20:9
    │
- 7 │         Int x
+ 8 │         Int x
    │             - the input with the conflicting name is here
    ·
-19 │     Int x = y
+20 │     Int x = y
    │         ^ this declaration conflicts with a previously used name
 
 error: conflicting output name `x`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:32:16
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:33:16
    │
-26 │         Int x
+27 │         Int x
    │             - the input with the conflicting name is here
    ·
-32 │         String x = "x"
+33 │         String x = "x"
    │                ^ this output conflicts with a previously used name
 
 error: conflicting output name `y`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:33:16
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:34:16
    │
-27 │         Int y = 0
+28 │         Int y = 0
    │             - the input with the conflicting name is here
    ·
-33 │         String y = "y"
+34 │         String y = "y"
    │                ^ this output conflicts with a previously used name
 
 error: conflicting declaration name `x`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:38:9
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:39:9
    │
-26 │         Int x
+27 │         Int x
    │             - the input with the conflicting name is here
    ·
-38 │     Int x = y
+39 │     Int x = y
    │         ^ this declaration conflicts with a previously used name
 
 error: conflicting declaration name `b`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:45:17
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:46:17
    │
-28 │         String b
+29 │         String b
    │                - the input with the conflicting name is here
    ·
-45 │             Int b = 0
+46 │             Int b = 0
    │                 ^ this declaration conflicts with a previously used name
 
 error: conflicting declaration name `x2`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:46:17
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:47:17
    │
-41 │         Int x2 = 0
+42 │         Int x2 = 0
    │             -- the declaration with the conflicting name is here
    ·
-46 │             Int x2 = 0
+47 │             Int x2 = 0
    │                 ^^ this declaration conflicts with a previously used name
 
 error: conflicting scatter variable name `x`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:51:14
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:52:14
    │
-26 │         Int x
+27 │         Int x
    │             - the input with the conflicting name is here
    ·
-51 │     scatter (x in [1, 2, 3]) {
+52 │     scatter (x in [1, 2, 3]) {
    │              ^ this scatter variable conflicts with a previously used name
 
 error: conflicting declaration name `z`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:52:13
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:53:13
    │
-37 │     Int z = x
+38 │     Int z = x
    │         - the declaration with the conflicting name is here
    ·
-52 │         Int z = x
+53 │         Int z = x
    │             ^ this declaration conflicts with a previously used name
 
 error: conflicting declaration name `nested`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:57:21
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:58:21
    │
-55 │         scatter (nested in [1, 2, 3]) {
+56 │         scatter (nested in [1, 2, 3]) {
    │                  ------ the scatter variable with the conflicting name is here
-56 │             scatter (baz in [1, 2, 3]) {
-57 │                 Int nested = 0
+57 │             scatter (baz in [1, 2, 3]) {
+58 │                 Int nested = 0
    │                     ^^^^^^ this declaration conflicts with a previously used name
 
 error: conflicting declaration name `nested`
-   ┌─ tests/analysis/conflicting-decl-names/source.wdl:64:13
+   ┌─ tests/analysis/conflicting-decl-names/source.wdl:65:13
    │
-57 │                 Int nested = 0
+58 │                 Int nested = 0
    │                     ------ the declaration with the conflicting name is here
    ·
-64 │         Int nested = 0
+65 │         Int nested = 0
    │             ^^^^^^ this declaration conflicts with a previously used name
 

--- a/wdl-analysis/tests/analysis/conflicting-decl-names/source.wdl
+++ b/wdl-analysis/tests/analysis/conflicting-decl-names/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedInput,UnusedDeclaration
 ## This is a test of conflicting declaration names.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/conflicting-imports/source.diagnostics
+++ b/wdl-analysis/tests/analysis/conflicting-imports/source.diagnostics
@@ -1,78 +1,78 @@
 error: conflicting import namespace `foo`
-  ┌─ tests/analysis/conflicting-imports/source.wdl:6:8
+  ┌─ tests/analysis/conflicting-imports/source.wdl:7:8
   │
-5 │ import "foo.wdl"                                    # First
+6 │ import "foo.wdl"                                    # First
   │        --------- the conflicting import namespace was introduced here
-6 │ import "foo"                                        # Conflicts
+7 │ import "foo"                                        # Conflicts
   │        ^^^^^ this conflicts with another import namespace
   │
   = fix: add an `as` clause to the import to specify a namespace
 
 error: import namespace is not a valid WDL identifier
-  ┌─ tests/analysis/conflicting-imports/source.wdl:7:8
+  ┌─ tests/analysis/conflicting-imports/source.wdl:8:8
   │
-7 │ import "bad-file-name.wdl"                          # Bad name
+8 │ import "bad-file-name.wdl"                          # Bad name
   │        ^^^^^^^^^^^^^^^^^^^ a namespace cannot be derived from this import path
   │
   = fix: add an `as` clause to the import to specify a namespace
 
 error: conflicting import namespace `baz`
-   ┌─ tests/analysis/conflicting-imports/source.wdl:11:21
+   ┌─ tests/analysis/conflicting-imports/source.wdl:12:21
    │
-10 │ import "qux/baz.wdl"                                # First
+11 │ import "qux/baz.wdl"                                # First
    │        ------------- the conflicting import namespace was introduced here
-11 │ import "Baz.wdl" as baz                             # Conflicts
+12 │ import "Baz.wdl" as baz                             # Conflicts
    │                     ^^^ this conflicts with another import namespace
 
 error: conflicting import namespace `baz`
-   ┌─ tests/analysis/conflicting-imports/source.wdl:12:8
+   ┌─ tests/analysis/conflicting-imports/source.wdl:13:8
    │
-10 │ import "qux/baz.wdl"                                # First
+11 │ import "qux/baz.wdl"                                # First
    │        ------------- the conflicting import namespace was introduced here
-11 │ import "Baz.wdl" as baz                             # Conflicts
-12 │ import "../conflicting-imports/qux/baz.wdl"         # Conflicts
+12 │ import "Baz.wdl" as baz                             # Conflicts
+13 │ import "../conflicting-imports/qux/baz.wdl"         # Conflicts
    │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this conflicts with another import namespace
-   │
-   = fix: add an `as` clause to the import to specify a namespace
-
-error: conflicting import namespace `md5sum`
-   ┌─ tests/analysis/conflicting-imports/source.wdl:14:8
-   │
-13 │ import "md5sum.wdl"                                 # First
-   │        ------------ the conflicting import namespace was introduced here
-14 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/md5sum.wdl"            # Conflicts
-   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this conflicts with another import namespace
    │
    = fix: add an `as` clause to the import to specify a namespace
 
 error: conflicting import namespace `md5sum`
    ┌─ tests/analysis/conflicting-imports/source.wdl:15:8
    │
-13 │ import "md5sum.wdl"                                 # First
+14 │ import "md5sum.wdl"                                 # First
    │        ------------ the conflicting import namespace was introduced here
-14 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/md5sum.wdl"            # Conflicts
-15 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/md5sum.wdl#something"  # Conflicts
-   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this conflicts with another import namespace
+15 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/md5sum.wdl"            # Conflicts
+   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this conflicts with another import namespace
    │
    = fix: add an `as` clause to the import to specify a namespace
 
-error: conflicting import namespace `star`
-   ┌─ tests/analysis/conflicting-imports/source.wdl:17:8
+error: conflicting import namespace `md5sum`
+   ┌─ tests/analysis/conflicting-imports/source.wdl:16:8
    │
-16 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/star.wdl?query=foo" # First
-   │        --------------------------------------------------------------------------------------------------------------------------- the conflicting import namespace was introduced here
-17 │ import "star.wdl"                                   # Conflicts
-   │        ^^^^^^^^^^ this conflicts with another import namespace
+14 │ import "md5sum.wdl"                                 # First
+   │        ------------ the conflicting import namespace was introduced here
+15 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/md5sum.wdl"            # Conflicts
+16 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/md5sum.wdl#something"  # Conflicts
+   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this conflicts with another import namespace
    │
    = fix: add an `as` clause to the import to specify a namespace
 
 error: conflicting import namespace `star`
    ┌─ tests/analysis/conflicting-imports/source.wdl:18:8
    │
-16 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/star.wdl?query=foo" # First
+17 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/star.wdl?query=foo" # First
    │        --------------------------------------------------------------------------------------------------------------------------- the conflicting import namespace was introduced here
-17 │ import "star.wdl"                                   # Conflicts
-18 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/%73tar.wdl" # Conflicts
+18 │ import "star.wdl"                                   # Conflicts
+   │        ^^^^^^^^^^ this conflicts with another import namespace
+   │
+   = fix: add an `as` clause to the import to specify a namespace
+
+error: conflicting import namespace `star`
+   ┌─ tests/analysis/conflicting-imports/source.wdl:19:8
+   │
+17 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/star.wdl?query=foo" # First
+   │        --------------------------------------------------------------------------------------------------------------------------- the conflicting import namespace was introduced here
+18 │ import "star.wdl"                                   # Conflicts
+19 │ import "https://raw.githubusercontent.com/stjudecloud/workflows/efdca837bc35fe5647de6aa95989652a5a9648dc/tools/%73tar.wdl" # Conflicts
    │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this conflicts with another import namespace
    │
    = fix: add an `as` clause to the import to specify a namespace

--- a/wdl-analysis/tests/analysis/conflicting-imports/source.wdl
+++ b/wdl-analysis/tests/analysis/conflicting-imports/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 ## This is a test of conflicting imports.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/conflicting-struct-names/source.diagnostics
+++ b/wdl-analysis/tests/analysis/conflicting-struct-names/source.diagnostics
@@ -1,39 +1,39 @@
 error: conflicting struct name `Foo`
-   ┌─ tests/analysis/conflicting-struct-names/source.wdl:7:8
+   ┌─ tests/analysis/conflicting-struct-names/source.wdl:8:8
    │
- 7 │ struct Foo {
+ 8 │ struct Foo {
    │        ^^^ this name conflicts with an imported struct
    ·
-27 │ import "bar.wdl" alias Baz as Foo
+28 │ import "bar.wdl" alias Baz as Foo
    │                               --- the import that introduced the struct is here
    │
    = fix: either rename the struct or use an `alias` clause on the import with a different name
 
 error: conflicting struct name `Foo`
-   ┌─ tests/analysis/conflicting-struct-names/source.wdl:15:8
+   ┌─ tests/analysis/conflicting-struct-names/source.wdl:16:8
    │
- 7 │ struct Foo {
+ 8 │ struct Foo {
    │        --- the struct with the conflicting name is here
    ·
-15 │ struct Foo {
+16 │ struct Foo {
    │        ^^^ this struct conflicts with a previously used name
 
 error: conflicting struct name `Bar`
-   ┌─ tests/analysis/conflicting-struct-names/source.wdl:19:8
+   ┌─ tests/analysis/conflicting-struct-names/source.wdl:20:8
    │
-11 │ struct Bar {
+12 │ struct Bar {
    │        --- the struct with the conflicting name is here
    ·
-19 │ struct Bar {
+20 │ struct Bar {
    │        ^^^ this struct conflicts with a previously used name
 
 error: conflicting struct name `Baz`
-   ┌─ tests/analysis/conflicting-struct-names/source.wdl:23:8
+   ┌─ tests/analysis/conflicting-struct-names/source.wdl:24:8
    │
- 5 │ import "foo.wdl" alias Foo as Baz
+ 6 │ import "foo.wdl" alias Foo as Baz
    │                               --- the import that introduced the struct is here
    ·
-23 │ struct Baz {
+24 │ struct Baz {
    │        ^^^ this name conflicts with an imported struct
    │
    = fix: either rename the struct or use an `alias` clause on the import with a different name

--- a/wdl-analysis/tests/analysis/conflicting-struct-names/source.wdl
+++ b/wdl-analysis/tests/analysis/conflicting-struct-names/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 ## This is a test of having conflicting struct names.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/duplicate-task/source.diagnostics
+++ b/wdl-analysis/tests/analysis/duplicate-task/source.diagnostics
@@ -1,9 +1,9 @@
 error: conflicting task name `foo`
-   ┌─ tests/analysis/duplicate-task/source.wdl:14:6
+   ┌─ tests/analysis/duplicate-task/source.wdl:15:6
    │
- 6 │ task foo {
+ 7 │ task foo {
    │      --- the task with the conflicting name is here
    ·
-14 │ task foo {
+15 │ task foo {
    │      ^^^ this task conflicts with a previously used name
 

--- a/wdl-analysis/tests/analysis/duplicate-task/source.wdl
+++ b/wdl-analysis/tests/analysis/duplicate-task/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This checks to ensure that validation and analysis of duplicate tasks
 ## is effectively ignored beyond reporting the duplicate
 

--- a/wdl-analysis/tests/analysis/forward-reference/source.diagnostics
+++ b/wdl-analysis/tests/analysis/forward-reference/source.diagnostics
@@ -1,7 +1,7 @@
 error: type mismatch: expected type `Int`, but found type `String`
-   ┌─ tests/analysis/forward-reference/source.wdl:13:17
+   ┌─ tests/analysis/forward-reference/source.wdl:14:17
    │
-13 │         Int y = z
+14 │         Int y = z
    │             -   ^ this is type `String`
    │             │    
    │             this expects type `Int`

--- a/wdl-analysis/tests/analysis/forward-reference/source.wdl
+++ b/wdl-analysis/tests/analysis/forward-reference/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test for forward references in a WDL task.
 
 version 1.2

--- a/wdl-analysis/tests/analysis/hints-section/source.diagnostics
+++ b/wdl-analysis/tests/analysis/hints-section/source.diagnostics
@@ -1,107 +1,107 @@
 error: type mismatch: expected type `Int` or type `Float`, but found type `Boolean`
-    ┌─ tests/analysis/hints-section/source.wdl:114:18
+    ┌─ tests/analysis/hints-section/source.wdl:115:18
     │
-114 │         max_cpu: true
+115 │         max_cpu: true
     │         -------  ^^^^ this is type `Boolean`
     │         │         
     │         this expects type `Int` or type `Float`
 
 error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
-    ┌─ tests/analysis/hints-section/source.wdl:115:21
+    ┌─ tests/analysis/hints-section/source.wdl:116:21
     │
-115 │         max_memory: false
+116 │         max_memory: false
     │         ----------  ^^^^^ this is type `Boolean`
     │         │            
     │         this expects type `Int` or type `String`
 
 error: type mismatch: expected type `String` or type `Map[String, String]`, but found type `Boolean`
-    ┌─ tests/analysis/hints-section/source.wdl:116:16
+    ┌─ tests/analysis/hints-section/source.wdl:117:16
     │
-116 │         disks: true
+117 │         disks: true
     │         -----  ^^^^ this is type `Boolean`
     │         │       
     │         this expects type `String` or type `Map[String, String]`
 
 error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
-    ┌─ tests/analysis/hints-section/source.wdl:117:14
+    ┌─ tests/analysis/hints-section/source.wdl:118:14
     │
-117 │         gpu: false
+118 │         gpu: false
     │         ---  ^^^^^ this is type `Boolean`
     │         │     
     │         this expects type `Int` or type `String`
 
 error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
-    ┌─ tests/analysis/hints-section/source.wdl:118:15
+    ┌─ tests/analysis/hints-section/source.wdl:119:15
     │
-118 │         fpga: true
+119 │         fpga: true
     │         ----  ^^^^ this is type `Boolean`
     │         │      
     │         this expects type `Int` or type `String`
 
 error: type mismatch: expected type `Boolean`, but found type `String`
-    ┌─ tests/analysis/hints-section/source.wdl:119:21
+    ┌─ tests/analysis/hints-section/source.wdl:120:21
     │
-119 │         short_task: "false"
+120 │         short_task: "false"
     │         ----------  ^^^^^^^ this is type `String`
     │         │            
     │         this expects type `Boolean`
 
 error: type mismatch: expected type `Boolean`, but found type `String`
-    ┌─ tests/analysis/hints-section/source.wdl:120:32
+    ┌─ tests/analysis/hints-section/source.wdl:121:32
     │
-120 │         localization_optional: "true"
+121 │         localization_optional: "true"
     │         ---------------------  ^^^^^^ this is type `String`
     │         │                       
     │         this expects type `Boolean`
 
 error: task `baz` does not have an input named `wrong`
-    ┌─ tests/analysis/hints-section/source.wdl:122:13
+    ┌─ tests/analysis/hints-section/source.wdl:123:13
     │
-122 │             wrong: hints {
+123 │             wrong: hints {
     │             ^^^^^
 
 error: struct `Foo` does not have a member named `wrong`
-    ┌─ tests/analysis/hints-section/source.wdl:125:17
+    ┌─ tests/analysis/hints-section/source.wdl:126:17
     │
-125 │             baz.wrong: hints {
+126 │             baz.wrong: hints {
     │                 ^^^^^
 
 error: struct member `foo` is not a struct
-    ┌─ tests/analysis/hints-section/source.wdl:128:17
+    ┌─ tests/analysis/hints-section/source.wdl:129:17
     │
-128 │             baz.foo.wrong: hints {
+129 │             baz.foo.wrong: hints {
     │                 ^^^
 
 error: type mismatch: expected type `hints`, but found type `String`
-    ┌─ tests/analysis/hints-section/source.wdl:131:18
+    ┌─ tests/analysis/hints-section/source.wdl:132:18
     │
-131 │             foo: "wrong"
+132 │             foo: "wrong"
     │             ---  ^^^^^^^ this is type `String`
     │             │     
     │             this expects type `hints`
 
 error: task `baz` does not have an output named `wrong`
-    ┌─ tests/analysis/hints-section/source.wdl:134:13
+    ┌─ tests/analysis/hints-section/source.wdl:135:13
     │
-134 │             wrong: hints {
+135 │             wrong: hints {
     │             ^^^^^
 
 error: struct `Foo` does not have a member named `wrong`
-    ┌─ tests/analysis/hints-section/source.wdl:137:19
+    ┌─ tests/analysis/hints-section/source.wdl:138:19
     │
-137 │             corge.wrong: hints {
+138 │             corge.wrong: hints {
     │                   ^^^^^
 
 error: struct member `foo` is not a struct
-    ┌─ tests/analysis/hints-section/source.wdl:140:19
+    ┌─ tests/analysis/hints-section/source.wdl:141:19
     │
-140 │             corge.foo.wrong: hints {
+141 │             corge.foo.wrong: hints {
     │                   ^^^
 
 error: type mismatch: expected type `hints`, but found type `String`
-    ┌─ tests/analysis/hints-section/source.wdl:143:18
+    ┌─ tests/analysis/hints-section/source.wdl:144:18
     │
-143 │             qux: "wrong"
+144 │             qux: "wrong"
     │             ---  ^^^^^^^ this is type `String`
     │             │     
     │             this expects type `hints`

--- a/wdl-analysis/tests/analysis/hints-section/source.wdl
+++ b/wdl-analysis/tests/analysis/hints-section/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedInput,UnusedDeclaration,UnusedCall
 ## This is a test of type checking `requirements` keys. 
 
 version 1.2

--- a/wdl-analysis/tests/analysis/if-conditional-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/if-conditional-mismatch/source.diagnostics
@@ -1,6 +1,6 @@
 error: type mismatch: expected `if` conditional expression to be type `Boolean`, but found type `Int`
-  ┌─ tests/analysis/if-conditional-mismatch/source.wdl:8:19
+  ┌─ tests/analysis/if-conditional-mismatch/source.wdl:9:19
   │
-8 │     String b = if a then "foo" else "bar"
+9 │     String b = if a then "foo" else "bar"
   │                   ^ this is type `Int`
 

--- a/wdl-analysis/tests/analysis/if-conditional-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/if-conditional-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of a type mismatch in an if conditional.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/import-dependency-cycle/foo.wdl
+++ b/wdl-analysis/tests/analysis/import-dependency-cycle/foo.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 version 1.1
 
 import "bar.wdl"

--- a/wdl-analysis/tests/analysis/import-dependency-cycle/source.wdl
+++ b/wdl-analysis/tests/analysis/import-dependency-cycle/source.wdl
@@ -1,5 +1,5 @@
+#@ except: UnusedImport
 ## This is a test of detecting an import dependency cycle.
-
 version 1.1
 
 import "foo.wdl"

--- a/wdl-analysis/tests/analysis/import-relative/a/file.wdl
+++ b/wdl-analysis/tests/analysis/import-relative/a/file.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 version 1.1
 
 import "../b/file.wdl"

--- a/wdl-analysis/tests/analysis/import-relative/source.wdl
+++ b/wdl-analysis/tests/analysis/import-relative/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 ## This a test of importing by relative paths.
 ## There should be no diagnostics generated
 

--- a/wdl-analysis/tests/analysis/imported-struct-conflict/source.diagnostics
+++ b/wdl-analysis/tests/analysis/imported-struct-conflict/source.diagnostics
@@ -1,9 +1,9 @@
 error: conflicting struct name `X`
-  ┌─ tests/analysis/imported-struct-conflict/source.wdl:6:8
+  ┌─ tests/analysis/imported-struct-conflict/source.wdl:7:8
   │
-5 │ import "foo.wdl"
+6 │ import "foo.wdl"
   │        --------- the first definition was introduced by this import
-6 │ import "bar.wdl"
+7 │ import "bar.wdl"
   │        ^^^^^^^^^ this import introduces a conflicting definition
   │
   = fix: add an `alias` clause to the import to specify a different name

--- a/wdl-analysis/tests/analysis/imported-struct-conflict/source.wdl
+++ b/wdl-analysis/tests/analysis/imported-struct-conflict/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 # This is a test of importing conflicting struct definitions.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/index-not-integer/source.diagnostics
+++ b/wdl-analysis/tests/analysis/index-not-integer/source.diagnostics
@@ -1,12 +1,12 @@
 error: type mismatch: expected index to be type `Int`, but found type `String`
-  ┌─ tests/analysis/index-not-integer/source.wdl:8:18
+  ┌─ tests/analysis/index-not-integer/source.wdl:9:18
   │
-8 │     String x = a["foo"]
+9 │     String x = a["foo"]
   │                  ^^^^^ this is type `String`
 
 error: type mismatch: expected index to be type `String`, but found type `Int`
-  ┌─ tests/analysis/index-not-integer/source.wdl:9:18
-  │
-9 │     String y = b[0]
-  │                  ^ this is type `Int`
+   ┌─ tests/analysis/index-not-integer/source.wdl:10:18
+   │
+10 │     String y = b[0]
+   │                  ^ this is type `Int`
 

--- a/wdl-analysis/tests/analysis/index-not-integer/source.wdl
+++ b/wdl-analysis/tests/analysis/index-not-integer/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of using an invalid index for an array or map.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/index-target-not-array/source.diagnostics
+++ b/wdl-analysis/tests/analysis/index-target-not-array/source.diagnostics
@@ -1,6 +1,6 @@
 error: indexing is only allowed on `Array` and `Map` types
-  ┌─ tests/analysis/index-target-not-array/source.wdl:7:16
+  ┌─ tests/analysis/index-target-not-array/source.wdl:8:16
   │
-7 │     String x = a[0]
+8 │     String x = a[0]
   │                ^ this is type `String`
 

--- a/wdl-analysis/tests/analysis/index-target-not-array/source.wdl
+++ b/wdl-analysis/tests/analysis/index-target-not-array/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of an index target that is not an array.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/invalid-access/source.diagnostics
+++ b/wdl-analysis/tests/analysis/invalid-access/source.diagnostics
@@ -1,6 +1,6 @@
 error: cannot access type `String`
-  ┌─ tests/analysis/invalid-access/source.wdl:7:16
+  ┌─ tests/analysis/invalid-access/source.wdl:8:16
   │
-7 │     String x = a.bar
+8 │     String x = a.bar
   │                ^ this is type `String`
 

--- a/wdl-analysis/tests/analysis/invalid-access/source.wdl
+++ b/wdl-analysis/tests/analysis/invalid-access/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of an invalid access.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/logical-and-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/logical-and-mismatch/source.diagnostics
@@ -1,6 +1,6 @@
 error: type mismatch: expected `logical and` operand to be type `Boolean`, but found type `String`
-  ┌─ tests/analysis/logical-and-mismatch/source.wdl:9:22
-  │
-9 │     Boolean d = a && c && b
-  │                      ^ this is type `String`
+   ┌─ tests/analysis/logical-and-mismatch/source.wdl:10:22
+   │
+10 │     Boolean d = a && c && b
+   │                      ^ this is type `String`
 

--- a/wdl-analysis/tests/analysis/logical-and-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/logical-and-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of a type mismatch for the logical AND operator.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/logical-not-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/logical-not-mismatch/source.diagnostics
@@ -1,6 +1,6 @@
 error: type mismatch: expected `logical not` operand to be type `Boolean`, but found type `String`
-  ┌─ tests/analysis/logical-not-mismatch/source.wdl:9:18
-  │
-9 │     Boolean d = !c
-  │                  ^ this is type `String`
+   ┌─ tests/analysis/logical-not-mismatch/source.wdl:10:18
+   │
+10 │     Boolean d = !c
+   │                  ^ this is type `String`
 

--- a/wdl-analysis/tests/analysis/logical-not-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/logical-not-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of a type mismatch for the logical NOT operator.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/logical-or-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/logical-or-mismatch/source.diagnostics
@@ -1,6 +1,6 @@
 error: type mismatch: expected `logical or` operand to be type `Boolean`, but found type `String`
-  ┌─ tests/analysis/logical-or-mismatch/source.wdl:9:22
-  │
-9 │     Boolean d = a || c || b
-  │                      ^ this is type `String`
+   ┌─ tests/analysis/logical-or-mismatch/source.wdl:10:22
+   │
+10 │     Boolean d = a || c || b
+   │                      ^ this is type `String`
 

--- a/wdl-analysis/tests/analysis/logical-or-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/logical-or-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of a type mismatch for the logical OR operator.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/map-key-not-primitive/source.diagnostics
+++ b/wdl-analysis/tests/analysis/map-key-not-primitive/source.diagnostics
@@ -1,7 +1,7 @@
 error: expected map literal to use primitive type keys
-   ┌─ tests/analysis/map-key-not-primitive/source.wdl:11:28
+   ┌─ tests/analysis/map-key-not-primitive/source.wdl:12:28
    │
-11 │     Map[Int, String] a = { f: "foo" }
+12 │     Map[Int, String] a = { f: "foo" }
    │                            ^
    │                            │
    │                            this is type `Foo`

--- a/wdl-analysis/tests/analysis/map-key-not-primitive/source.wdl
+++ b/wdl-analysis/tests/analysis/map-key-not-primitive/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test for a non-primitive map key.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/missing-aliased-struct/foo.wdl
+++ b/wdl-analysis/tests/analysis/missing-aliased-struct/foo.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 version 1.1
 
 import "bar.wdl"

--- a/wdl-analysis/tests/analysis/missing-aliased-struct/source.diagnostics
+++ b/wdl-analysis/tests/analysis/missing-aliased-struct/source.diagnostics
@@ -1,6 +1,6 @@
 error: a struct named `Foo` does not exist in the imported document
-  ┌─ tests/analysis/missing-aliased-struct/source.wdl:5:24
+  ┌─ tests/analysis/missing-aliased-struct/source.wdl:6:24
   │
-5 │ import "foo.wdl" alias Foo as Bar alias Bar as Baz alias Qux as Qux2
+6 │ import "foo.wdl" alias Foo as Bar alias Bar as Baz alias Qux as Qux2
   │                        ^^^ this struct does not exist
 

--- a/wdl-analysis/tests/analysis/missing-aliased-struct/source.wdl
+++ b/wdl-analysis/tests/analysis/missing-aliased-struct/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedImport
 ## This is a test of aliasing a struct that does not exist in an import.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/missing-call-input/source.diagnostics
+++ b/wdl-analysis/tests/analysis/missing-call-input/source.diagnostics
@@ -1,6 +1,6 @@
 error: missing required call input `required` for task `my_task`
-   ┌─ tests/analysis/missing-call-input/source.wdl:20:10
+   ┌─ tests/analysis/missing-call-input/source.wdl:21:10
    │
-20 │     call my_task
+21 │     call my_task
    │          ^^^^^^^
 

--- a/wdl-analysis/tests/analysis/missing-call-input/source.wdl
+++ b/wdl-analysis/tests/analysis/missing-call-input/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedInput,UnusedDeclaration,UnusedCall
 ## This is a test of a missing required call inputs.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/missing-struct-member/source.diagnostics
+++ b/wdl-analysis/tests/analysis/missing-struct-member/source.diagnostics
@@ -1,30 +1,30 @@
 error: struct `Foo` requires a value for member `z`
-   ┌─ tests/analysis/missing-struct-member/source.wdl:16:13
+   ┌─ tests/analysis/missing-struct-member/source.wdl:17:13
    │
-16 │     Foo b = Foo { x: 1, a: 3 }
+17 │     Foo b = Foo { x: 1, a: 3 }
    │             ^^^
 
 error: struct `Foo` requires a value for member `a`
-   ┌─ tests/analysis/missing-struct-member/source.wdl:18:13
+   ┌─ tests/analysis/missing-struct-member/source.wdl:19:13
    │
-18 │     Foo c = Foo { x: 1, y: 2, z: 3 }
+19 │     Foo c = Foo { x: 1, y: 2, z: 3 }
    │             ^^^
 
 error: struct `Foo` requires a value for members `a` and `z`
-   ┌─ tests/analysis/missing-struct-member/source.wdl:20:13
+   ┌─ tests/analysis/missing-struct-member/source.wdl:21:13
    │
-20 │     Foo d = Foo { x: 1, y: 2 }
+21 │     Foo d = Foo { x: 1, y: 2 }
    │             ^^^
 
 error: struct `Foo` requires a value for members `a`, `x`, and `z`
-   ┌─ tests/analysis/missing-struct-member/source.wdl:22:13
+   ┌─ tests/analysis/missing-struct-member/source.wdl:23:13
    │
-22 │     Foo e = Foo { y: 2 }
+23 │     Foo e = Foo { y: 2 }
    │             ^^^
 
 error: struct `Foo` requires a value for members `a`, `x`, and `z`
-   ┌─ tests/analysis/missing-struct-member/source.wdl:24:13
+   ┌─ tests/analysis/missing-struct-member/source.wdl:25:13
    │
-24 │     Foo f = Foo { }
+25 │     Foo f = Foo { }
    │             ^^^
 

--- a/wdl-analysis/tests/analysis/missing-struct-member/source.wdl
+++ b/wdl-analysis/tests/analysis/missing-struct-member/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test for a missing required struct member in a struct literal.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/name-reference-cycle/source.diagnostics
+++ b/wdl-analysis/tests/analysis/name-reference-cycle/source.diagnostics
@@ -1,9 +1,9 @@
 error: a name reference cycle was detected
-  ┌─ tests/analysis/name-reference-cycle/source.wdl:6:13
+  ┌─ tests/analysis/name-reference-cycle/source.wdl:7:13
   │
-6 │     Int a = b
+7 │     Int a = b
   │             ^ ensure this expression does not directly or indirectly refer to `c`
-7 │     Int b = c
-8 │     Int c = a
+8 │     Int b = c
+9 │     Int c = a
   │             - a reference back to `a` is here
 

--- a/wdl-analysis/tests/analysis/name-reference-cycle/source.wdl
+++ b/wdl-analysis/tests/analysis/name-reference-cycle/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of a name reference cycle in a task.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/negation-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/negation-mismatch/source.diagnostics
@@ -1,6 +1,6 @@
 error: type mismatch: expected negation operand to be type `Int` or `Float`, but found type `String`
-  ┌─ tests/analysis/negation-mismatch/source.wdl:9:14
-  │
-9 │     Int d = -c
-  │              ^ this is type `String`
+   ┌─ tests/analysis/negation-mismatch/source.wdl:10:14
+   │
+10 │     Int d = -c
+   │              ^ this is type `String`
 

--- a/wdl-analysis/tests/analysis/negation-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/negation-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of a type mismatch for the negation operator.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/not-a-struct-member/source.diagnostics
+++ b/wdl-analysis/tests/analysis/not-a-struct-member/source.diagnostics
@@ -1,12 +1,12 @@
 error: struct `Foo` does not have a member named `y`
-   ┌─ tests/analysis/not-a-struct-member/source.wdl:10:25
+   ┌─ tests/analysis/not-a-struct-member/source.wdl:11:25
    │
-10 │     Foo a = Foo { x: 1, y: "2" }
+11 │     Foo a = Foo { x: 1, y: "2" }
    │                         ^
 
 error: struct `Foo` does not have a member named `y`
-   ┌─ tests/analysis/not-a-struct-member/source.wdl:11:18
+   ┌─ tests/analysis/not-a-struct-member/source.wdl:12:18
    │
-11 │     String b = a.y
+12 │     String b = a.y
    │                  ^
 

--- a/wdl-analysis/tests/analysis/not-a-struct-member/source.wdl
+++ b/wdl-analysis/tests/analysis/not-a-struct-member/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test for a name that doesn't refer to a struct member.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/numeric-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/numeric-mismatch/source.diagnostics
@@ -1,211 +1,211 @@
 error: type mismatch: addition operator is not supported for type `File` and type `File`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:20:15
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:21:15
    │
-20 │     File a5 = d + d     # NOT OK
+21 │     File a5 = d + d     # NOT OK
    │               ^^^^^
    │               │   │
    │               │   this is type `File`
    │               this is type `File`
 
 error: type mismatch: string concatenation is not supported for type `Int?`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:24:21
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:25:21
    │
-24 │     String a9 = c + f   # NOT OK
+25 │     String a9 = c + f   # NOT OK
    │                     ^ this is type `Int?`
 
 error: type mismatch: string concatenation is not supported for type `String?`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:25:22
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:26:22
    │
-25 │     String a10 = c + g  # NOT OK
+26 │     String a10 = c + g  # NOT OK
    │                      ^ this is type `String?`
 
 error: type mismatch: string concatenation is not supported for type `File?`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:26:22
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:27:22
    │
-26 │     String a11 = c + h  # NOT OK
+27 │     String a11 = c + h  # NOT OK
    │                      ^ this is type `File?`
 
 error: type mismatch: string concatenation is not supported for type `Float?`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:27:22
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:28:22
    │
-27 │     String a12 = c + i  # NOT OK
+28 │     String a12 = c + i  # NOT OK
    │                      ^ this is type `Float?`
 
 error: type mismatch: subtraction operator is not supported for type `Int` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:41:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:42:17
    │
-41 │     String s2 = a - c   # NOT OK
+42 │     String s2 = a - c   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `String`
    │                 this is type `Int`
 
 error: type mismatch: subtraction operator is not supported for type `String` and type `Int`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:42:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:43:17
    │
-42 │     String s3 = c - a   # NOT OK
+43 │     String s3 = c - a   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `Int`
    │                 this is type `String`
 
 error: type mismatch: subtraction operator is not supported for type `String` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:43:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:44:17
    │
-43 │     String s4 = c - c   # NOT OK
+44 │     String s4 = c - c   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `String`
    │                 this is type `String`
 
 error: type mismatch: subtraction operator is not supported for type `File` and type `File`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:44:15
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:45:15
    │
-44 │     File s5 = d - d     # NOT OK
+45 │     File s5 = d - d     # NOT OK
    │               ^^^^^
    │               │   │
    │               │   this is type `File`
    │               this is type `File`
 
 error: type mismatch: multiplication operator is not supported for type `Int` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:50:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:51:17
    │
-50 │     String m2 = a * c   # NOT OK
+51 │     String m2 = a * c   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `String`
    │                 this is type `Int`
 
 error: type mismatch: multiplication operator is not supported for type `String` and type `Int`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:51:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:52:17
    │
-51 │     String m3 = c * a   # NOT OK
+52 │     String m3 = c * a   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `Int`
    │                 this is type `String`
 
 error: type mismatch: multiplication operator is not supported for type `String` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:52:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:53:17
    │
-52 │     String m4 = c * c   # NOT OK
+53 │     String m4 = c * c   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `String`
    │                 this is type `String`
 
 error: type mismatch: multiplication operator is not supported for type `File` and type `File`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:53:15
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:54:15
    │
-53 │     File m5 = d * d     # NOT OK
+54 │     File m5 = d * d     # NOT OK
    │               ^^^^^
    │               │   │
    │               │   this is type `File`
    │               this is type `File`
 
 error: type mismatch: division operator is not supported for type `Int` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:59:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:60:17
    │
-59 │     String d2 = a / c   # NOT OK
+60 │     String d2 = a / c   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `String`
    │                 this is type `Int`
 
 error: type mismatch: division operator is not supported for type `String` and type `Int`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:60:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:61:17
    │
-60 │     String d3 = c / a   # NOT OK
+61 │     String d3 = c / a   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `Int`
    │                 this is type `String`
 
 error: type mismatch: division operator is not supported for type `String` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:61:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:62:17
    │
-61 │     String d4 = c / c   # NOT OK
+62 │     String d4 = c / c   # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `String`
    │                 this is type `String`
 
 error: type mismatch: division operator is not supported for type `File` and type `File`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:62:15
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:63:15
    │
-62 │     File d5 = d / d     # NOT OK
+63 │     File d5 = d / d     # NOT OK
    │               ^^^^^
    │               │   │
    │               │   this is type `File`
    │               this is type `File`
 
 error: type mismatch: remainder operator is not supported for type `Int` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:68:19
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:69:19
    │
-68 │     String mod2 = a % c   # NOT OK
+69 │     String mod2 = a % c   # NOT OK
    │                   ^^^^^
    │                   │   │
    │                   │   this is type `String`
    │                   this is type `Int`
 
 error: type mismatch: remainder operator is not supported for type `String` and type `Int`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:69:19
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:70:19
    │
-69 │     String mod3 = c % a   # NOT OK
+70 │     String mod3 = c % a   # NOT OK
    │                   ^^^^^
    │                   │   │
    │                   │   this is type `Int`
    │                   this is type `String`
 
 error: type mismatch: remainder operator is not supported for type `String` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:70:19
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:71:19
    │
-70 │     String mod4 = c % c   # NOT OK
+71 │     String mod4 = c % c   # NOT OK
    │                   ^^^^^
    │                   │   │
    │                   │   this is type `String`
    │                   this is type `String`
 
 error: type mismatch: remainder operator is not supported for type `File` and type `File`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:71:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:72:17
    │
-71 │     File mod5 = d % d     # NOT OK
+72 │     File mod5 = d % d     # NOT OK
    │                 ^^^^^
    │                 │   │
    │                 │   this is type `File`
    │                 this is type `File`
 
 error: type mismatch: exponentiation operator is not supported for type `Int` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:77:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:78:17
    │
-77 │     String e2 = a ** c   # NOT OK
+78 │     String e2 = a ** c   # NOT OK
    │                 ^^^^^^
    │                 │    │
    │                 │    this is type `String`
    │                 this is type `Int`
 
 error: type mismatch: exponentiation operator is not supported for type `String` and type `Int`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:78:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:79:17
    │
-78 │     String e3 = c ** a   # NOT OK
+79 │     String e3 = c ** a   # NOT OK
    │                 ^^^^^^
    │                 │    │
    │                 │    this is type `Int`
    │                 this is type `String`
 
 error: type mismatch: exponentiation operator is not supported for type `String` and type `String`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:79:17
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:80:17
    │
-79 │     String e4 = c ** c   # NOT OK
+80 │     String e4 = c ** c   # NOT OK
    │                 ^^^^^^
    │                 │    │
    │                 │    this is type `String`
    │                 this is type `String`
 
 error: type mismatch: exponentiation operator is not supported for type `File` and type `File`
-   ┌─ tests/analysis/numeric-mismatch/source.wdl:80:15
+   ┌─ tests/analysis/numeric-mismatch/source.wdl:81:15
    │
-80 │     File e5 = d ** d     # NOT OK
+81 │     File e5 = d ** d     # NOT OK
    │               ^^^^^^
    │               │    │
    │               │    this is type `File`

--- a/wdl-analysis/tests/analysis/numeric-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/numeric-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of type mismatches in numeric expressions.
 
 version 1.2

--- a/wdl-analysis/tests/analysis/pair-accessor/source.diagnostics
+++ b/wdl-analysis/tests/analysis/pair-accessor/source.diagnostics
@@ -1,8 +1,8 @@
 error: cannot access a pair with name `nope`
-  ┌─ tests/analysis/pair-accessor/source.wdl:9:15
-  │
-9 │     Int c = p.nope
-  │               ^^^^
-  │
-  = fix: use `left` or `right` to access a pair
+   ┌─ tests/analysis/pair-accessor/source.wdl:10:15
+   │
+10 │     Int c = p.nope
+   │               ^^^^
+   │
+   = fix: use `left` or `right` to access a pair
 

--- a/wdl-analysis/tests/analysis/pair-accessor/source.wdl
+++ b/wdl-analysis/tests/analysis/pair-accessor/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of accessing a pair.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/recursive-workflow-call/source.diagnostics
+++ b/wdl-analysis/tests/analysis/recursive-workflow-call/source.diagnostics
@@ -1,6 +1,6 @@
 error: cannot recursively call workflow `test`
-  ┌─ tests/analysis/recursive-workflow-call/source.wdl:6:10
+  ┌─ tests/analysis/recursive-workflow-call/source.wdl:7:10
   │
-6 │     call test
+7 │     call test
   │          ^^^^
 

--- a/wdl-analysis/tests/analysis/recursive-workflow-call/source.wdl
+++ b/wdl-analysis/tests/analysis/recursive-workflow-call/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedCall
 ## This is a test of a recursive workflow call
 
 version 1.1

--- a/wdl-analysis/tests/analysis/self-referential-name/source.diagnostics
+++ b/wdl-analysis/tests/analysis/self-referential-name/source.diagnostics
@@ -1,6 +1,6 @@
 error: declaration of `c` is self-referential
-  ┌─ tests/analysis/self-referential-name/source.wdl:8:21
+  ┌─ tests/analysis/self-referential-name/source.wdl:9:21
   │
-8 │     Int c = a + b + c
+9 │     Int c = a + b + c
   │         -           ^ self-reference is here
 

--- a/wdl-analysis/tests/analysis/self-referential-name/source.wdl
+++ b/wdl-analysis/tests/analysis/self-referential-name/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of a self-referential name in a task.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/too-few-arguments/source.diagnostics
+++ b/wdl-analysis/tests/analysis/too-few-arguments/source.diagnostics
@@ -1,6 +1,6 @@
 error: function `sub` requires at least 3 arguments but 1 was supplied
-  ┌─ tests/analysis/too-few-arguments/source.wdl:6:16
+  ┌─ tests/analysis/too-few-arguments/source.wdl:7:16
   │
-6 │     String x = sub("foo")
+7 │     String x = sub("foo")
   │                ^^^
 

--- a/wdl-analysis/tests/analysis/too-few-arguments/source.wdl
+++ b/wdl-analysis/tests/analysis/too-few-arguments/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of too few arguments to a function.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/too-many-arguments/source.diagnostics
+++ b/wdl-analysis/tests/analysis/too-many-arguments/source.diagnostics
@@ -1,7 +1,7 @@
 error: function `sub` requires no more than 3 arguments but 5 were supplied
-  ┌─ tests/analysis/too-many-arguments/source.wdl:6:16
+  ┌─ tests/analysis/too-many-arguments/source.wdl:7:16
   │
-6 │     String x = sub("foo", "bar", "baz", "qux", "jam")
+7 │     String x = sub("foo", "bar", "baz", "qux", "jam")
   │                ^^^                      -----  ----- this argument is unexpected
   │                                         │       
   │                                         this argument is unexpected

--- a/wdl-analysis/tests/analysis/too-many-arguments/source.wdl
+++ b/wdl-analysis/tests/analysis/too-many-arguments/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of too many function arguments.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
@@ -1,79 +1,79 @@
 error: type mismatch: expected type `Int`, but found type `String`
-   ┌─ tests/analysis/type-mismatch/source.wdl:10:13
+   ┌─ tests/analysis/type-mismatch/source.wdl:11:13
    │
-10 │     Int a = "hello"
+11 │     Int a = "hello"
    │         -   ^^^^^^^ this is type `String`
    │         │    
    │         this expects type `Int`
 
 error: type mismatch: expected type `String`, but found type `Int`
-   ┌─ tests/analysis/type-mismatch/source.wdl:11:16
+   ┌─ tests/analysis/type-mismatch/source.wdl:12:16
    │
-11 │     String b = 5
+12 │     String b = 5
    │            -   ^ this is type `Int`
    │            │    
    │            this expects type `String`
 
 error: type mismatch: expected type `Array[String]`, but found type `Map[Int, String]`
-   ┌─ tests/analysis/type-mismatch/source.wdl:12:23
+   ┌─ tests/analysis/type-mismatch/source.wdl:13:23
    │
-12 │     Array[String] c = { 1: "one", 2: "two" }
+13 │     Array[String] c = { 1: "one", 2: "two" }
    │                   -   ^^^^^^^^^^^^^^^^^^^^^^ this is type `Map[Int, String]`
    │                   │    
    │                   this expects type `Array[String]`
 
 error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`
-   ┌─ tests/analysis/type-mismatch/source.wdl:13:20
+   ┌─ tests/analysis/type-mismatch/source.wdl:14:20
    │
-13 │     Array[Int] d = ["a", "b", "c"]
+14 │     Array[Int] d = ["a", "b", "c"]
    │                -   ^^^^^^^^^^^^^^^ this is type `Array[String]`
    │                │    
    │                this expects type `Array[Int]`
 
 error: type mismatch: expected type `Map[Int, String]`, but found type `Map[String, Int]`
-   ┌─ tests/analysis/type-mismatch/source.wdl:14:26
+   ┌─ tests/analysis/type-mismatch/source.wdl:15:26
    │
-14 │     Map[Int, String] e = { "a": 1, "b": 2, "c": 3 }
+15 │     Map[Int, String] e = { "a": 1, "b": 2, "c": 3 }
    │                      -   ^^^^^^^^^^^^^^^^^^^^^^^^^^ this is type `Map[String, Int]`
    │                      │    
    │                      this expects type `Map[Int, String]`
 
 error: type mismatch: a type common to both type `Int` and type `String` does not exist
-   ┌─ tests/analysis/type-mismatch/source.wdl:15:24
+   ┌─ tests/analysis/type-mismatch/source.wdl:16:24
    │
-15 │     Array[Int] f = [1, "2", "3"]
+16 │     Array[Int] f = [1, "2", "3"]
    │                     -  ^^^ this is type `String`
    │                     │   
    │                     this is type `Int`
 
 error: type mismatch: a type common to both type `Int` and type `String` does not exist
-   ┌─ tests/analysis/type-mismatch/source.wdl:15:29
+   ┌─ tests/analysis/type-mismatch/source.wdl:16:29
    │
-15 │     Array[Int] f = [1, "2", "3"]
+16 │     Array[Int] f = [1, "2", "3"]
    │                     -       ^^^ this is type `String`
    │                     │        
    │                     this is type `Int`
 
 error: type mismatch: a type common to both type `String` and type `Int` does not exist
-   ┌─ tests/analysis/type-mismatch/source.wdl:16:46
+   ┌─ tests/analysis/type-mismatch/source.wdl:17:46
    │
-16 │     Map[String, String] g = { "a": "1", "b": 2, "c": "3" }
+17 │     Map[String, String] g = { "a": "1", "b": 2, "c": "3" }
    │                                    ---       ^ this is type `Int`
    │                                    │          
    │                                    this is type `String`
 
 error: type mismatch: expected type `Int`, but found type `Array[Int]`
-   ┌─ tests/analysis/type-mismatch/source.wdl:17:22
+   ┌─ tests/analysis/type-mismatch/source.wdl:18:22
    │
-17 │     Foo h = Foo { x: [1] }
+18 │     Foo h = Foo { x: [1] }
    │                   -  ^^^ this is type `Array[Int]`
    │                   │   
    │                   this expects type `Int`
 
 error: type mismatch: a type common to both type `String` and type `Int` does not exist
-   ┌─ tests/analysis/type-mismatch/source.wdl:18:41
+   ┌─ tests/analysis/type-mismatch/source.wdl:19:41
    │
-18 │     Map[String, String] i = { "a": "1", 0: "2", "c": "3" }
+19 │     Map[String, String] i = { "a": "1", 0: "2", "c": "3" }
    │                               ---       ^ this is type `Int`
    │                               │          
    │                               this is type `String`

--- a/wdl-analysis/tests/analysis/type-mismatch/source.wdl
+++ b/wdl-analysis/tests/analysis/type-mismatch/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of type mismatches in a task.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/unknown-call-output/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unknown-call-output/source.diagnostics
@@ -1,6 +1,6 @@
 error: task `my_task` does not have an output named `unknown`
-   ┌─ tests/analysis/unknown-call-output/source.wdl:11:24
+   ┌─ tests/analysis/unknown-call-output/source.wdl:12:24
    │
-11 │     String x = my_task.unknown
+12 │     String x = my_task.unknown
    │                        ^^^^^^^
 

--- a/wdl-analysis/tests/analysis/unknown-call-output/source.wdl
+++ b/wdl-analysis/tests/analysis/unknown-call-output/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration,UnusedCall
 ## This is a test of accessing an unknown call output.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/unknown-function/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unknown-function/source.diagnostics
@@ -1,6 +1,6 @@
 error: unknown function `unknown`
-  ┌─ tests/analysis/unknown-function/source.wdl:6:16
+  ┌─ tests/analysis/unknown-function/source.wdl:7:16
   │
-6 │     String x = unknown()
+7 │     String x = unknown()
   │                ^^^^^^^ the WDL standard library does not have a function with this name
 

--- a/wdl-analysis/tests/analysis/unknown-function/source.wdl
+++ b/wdl-analysis/tests/analysis/unknown-function/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of calling an unknown function.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/unknown-name/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unknown-name/source.diagnostics
@@ -1,6 +1,6 @@
 error: unknown name `c`
-  ┌─ tests/analysis/unknown-name/source.wdl:8:16
+  ┌─ tests/analysis/unknown-name/source.wdl:9:16
   │
-8 │     String d = c
+9 │     String d = c
   │                ^
 

--- a/wdl-analysis/tests/analysis/unknown-name/source.wdl
+++ b/wdl-analysis/tests/analysis/unknown-name/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedDeclaration
 ## This is a test of an unknown name in a task.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/unknown-namespace/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unknown-namespace/source.diagnostics
@@ -1,6 +1,6 @@
 error: unknown namespace `foo`
-  ┌─ tests/analysis/unknown-namespace/source.wdl:6:10
+  ┌─ tests/analysis/unknown-namespace/source.wdl:7:10
   │
-6 │     call foo.bar
+7 │     call foo.bar
   │          ^^^
 

--- a/wdl-analysis/tests/analysis/unknown-namespace/source.wdl
+++ b/wdl-analysis/tests/analysis/unknown-namespace/source.wdl
@@ -1,3 +1,4 @@
+#@ except: UnusedCall
 ## This is a test of calling into an unknown import namespace.
 
 version 1.1

--- a/wdl-analysis/tests/analysis/unsupported-function/source.wdl
+++ b/wdl-analysis/tests/analysis/unsupported-function/source.wdl
@@ -1,5 +1,5 @@
+#@ except: UnusedDeclaration
 ## This is a test of an unsupported function.
-
 version 1.1
 
 task test {

--- a/wdl-analysis/tests/analysis/unused-call/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unused-call/source.diagnostics
@@ -1,0 +1,6 @@
+warning[UnusedCall]: unused call `foo`
+   ┌─ tests/analysis/unused-call/source.wdl:15:10
+   │
+15 │     call foo
+   │          ^^^
+

--- a/wdl-analysis/tests/analysis/unused-call/source.wdl
+++ b/wdl-analysis/tests/analysis/unused-call/source.wdl
@@ -1,0 +1,20 @@
+## This is a test of an unused call
+
+version 1.1
+
+task foo {
+    command <<<>>>
+
+    output {
+        Int x = 0
+    }
+}
+
+workflow test {
+    # The call is never used
+    call foo
+
+    # This call is never used, but is excepted
+    #@ except: UnusedCall
+    call foo as bar
+}

--- a/wdl-analysis/tests/analysis/unused-decl/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unused-decl/source.diagnostics
@@ -1,0 +1,24 @@
+warning[UnusedInput]: unused input `unused_input`
+  ┌─ tests/analysis/unused-decl/source.wdl:8:13
+  │
+8 │         Int unused_input = 0
+  │             ^^^^^^^^^^^^
+
+warning[UnusedDeclaration]: unused declaration `unused_decl`
+   ┌─ tests/analysis/unused-decl/source.wdl:18:9
+   │
+18 │     Int unused_decl = 0
+   │         ^^^^^^^^^^^
+
+warning[UnusedInput]: unused input `unused_input`
+   ┌─ tests/analysis/unused-decl/source.wdl:37:13
+   │
+37 │         Int unused_input = 0
+   │             ^^^^^^^^^^^^
+
+warning[UnusedDeclaration]: unused declaration `unused_decl`
+   ┌─ tests/analysis/unused-decl/source.wdl:47:9
+   │
+47 │     Int unused_decl = 0
+   │         ^^^^^^^^^^^
+

--- a/wdl-analysis/tests/analysis/unused-decl/source.wdl
+++ b/wdl-analysis/tests/analysis/unused-decl/source.wdl
@@ -1,0 +1,59 @@
+## This is a test of unused inputs and declarations.
+
+version 1.1
+
+task foo {
+    input {
+        # Unused input
+        Int unused_input = 0
+        # Unused but excepted
+        #@ except: UnusedInput
+        Int unused_input2 = 0
+        Int used = 1
+        Int x = used + 5
+        String y = "~{x}"
+    }
+
+    # Unused private decl
+    Int unused_decl = 0
+    # Unused but excepted
+    #@ except: UnusedDeclaration
+    Int unused_decl2 = 0
+    Int used_decl = 1
+    Int x_decl = used_decl + 5
+    String y_decl = "~{x_decl}"
+
+    command <<<>>>
+
+    output {
+        String o1 = y
+        String o2 = y_decl
+    }
+}
+
+workflow test {
+    input {
+        # Unused input
+        Int unused_input = 0
+        # Unused but excepted
+        #@ except: UnusedInput
+        Int unused_input2 = 0
+        Int used = 1
+        Int x = used + 5
+        String y = "~{x}"
+    }
+
+    # Unused private decl
+    Int unused_decl = 0
+    # Unused but excepted
+    #@ except: UnusedDeclaration
+    Int unused_decl2 = 0
+    Int used_decl = 1
+    Int x_decl = used_decl + 5
+    String y_decl = "~{x_decl}"
+
+    output {
+        String o1 = y
+        String o2 = y_decl
+    }
+}

--- a/wdl-analysis/tests/analysis/unused-file-input/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unused-file-input/source.diagnostics
@@ -1,0 +1,12 @@
+warning[UnusedInput]: unused input `used`
+  ┌─ tests/analysis/unused-file-input/source.wdl:8:14
+  │
+8 │         File used
+  │              ^^^^
+
+warning[UnusedInput]: unused input `used`
+   ┌─ tests/analysis/unused-file-input/source.wdl:29:14
+   │
+29 │         File used
+   │              ^^^^
+

--- a/wdl-analysis/tests/analysis/unused-file-input/source.wdl
+++ b/wdl-analysis/tests/analysis/unused-file-input/source.wdl
@@ -1,0 +1,43 @@
+## This is a test of an unused file input in workflows and tasks.
+
+version 1.1
+
+task test {
+    input {
+        # This is actually unused because it doesn't have matching suffix
+        File used
+
+        # The remainder are "used" because they have a matching suffix
+        File used_index
+        File used_indexes
+        File used_indices
+        File used_idx
+        File used_tbi
+        File used_bai
+        File used_crai
+        File used_csi
+        File used_fai
+        File used_dict
+    }
+
+    command <<<>>>
+}
+
+workflow wf {
+    input {
+        # This is actually unused because it doesn't have matching suffix
+        File used
+
+        # The remainder are "used" because they have a matching suffix
+        File used_index
+        File used_indexes
+        File used_indices
+        File used_idx
+        File used_tbi
+        File used_bai
+        File used_crai
+        File used_csi
+        File used_fai
+        File used_dict
+    }
+}

--- a/wdl-analysis/tests/analysis/unused-import/bar.wdl
+++ b/wdl-analysis/tests/analysis/unused-import/bar.wdl
@@ -1,0 +1,5 @@
+version 1.1
+
+workflow test {
+
+}

--- a/wdl-analysis/tests/analysis/unused-import/baz.wdl
+++ b/wdl-analysis/tests/analysis/unused-import/baz.wdl
@@ -1,0 +1,7 @@
+version 1.1
+
+workflow test {
+    output {
+        Int x = 0
+    }
+}

--- a/wdl-analysis/tests/analysis/unused-import/foo.wdl
+++ b/wdl-analysis/tests/analysis/unused-import/foo.wdl
@@ -1,0 +1,5 @@
+version 1.1
+
+struct X {
+    Int x
+}

--- a/wdl-analysis/tests/analysis/unused-import/source.diagnostics
+++ b/wdl-analysis/tests/analysis/unused-import/source.diagnostics
@@ -1,0 +1,6 @@
+warning[UnusedImport]: unused import namespace `bar`
+  ┌─ tests/analysis/unused-import/source.wdl:8:8
+  │
+8 │ import "bar.wdl"
+  │        ^^^^^^^^^
+

--- a/wdl-analysis/tests/analysis/unused-import/source.wdl
+++ b/wdl-analysis/tests/analysis/unused-import/source.wdl
@@ -1,0 +1,28 @@
+## This is a test of an unused import
+
+version 1.1
+
+import "foo.wdl" alias X as Y
+
+# This import is unused
+import "bar.wdl"
+
+# This import is unused, but excepted
+#@ except: UnusedImport
+import "bar.wdl" as ok
+
+import "baz.wdl"
+
+struct X {
+    # This uses a type from `foo`
+    Y y
+}
+
+workflow test {
+    # This uses a workflow from `baz`
+    call baz.test
+
+    output {
+        Int x = test.x
+    }
+}

--- a/wdl-ast/src/lib.rs
+++ b/wdl-ast/src/lib.rs
@@ -36,6 +36,7 @@
 #![warn(clippy::missing_docs_in_private_items)]
 #![warn(rustdoc::broken_intra_doc_links)]
 
+use std::collections::HashSet;
 use std::fmt;
 
 pub use rowan::Direction;
@@ -93,6 +94,62 @@ pub trait AstNodeExt {
 impl<T: AstNode> AstNodeExt for T {
     fn span(&self) -> Span {
         self.syntax().text_range().to_span()
+    }
+}
+
+/// An extension trait for syntax nodes.
+pub trait SyntaxNodeExt {
+    /// Gets an iterator over the `@except` comments for a syntax node.
+    fn except_comments(&self) -> impl Iterator<Item = SyntaxToken> + '_;
+
+    /// Gets the AST node's rule exceptions set.
+    ///
+    /// The set is the comma-delimited list of rule identifiers that follows a
+    /// `#@ except:` comment.
+    fn rule_exceptions(&self) -> HashSet<String>;
+
+    /// Determines if a given rule id is excepted for the syntax node.
+    fn is_rule_excepted(&self, id: &str) -> bool;
+}
+
+impl SyntaxNodeExt for SyntaxNode {
+    fn except_comments(&self) -> impl Iterator<Item = SyntaxToken> + '_ {
+        self.siblings_with_tokens(Direction::Prev)
+            .skip(1)
+            .map_while(|s| {
+                if s.kind() == SyntaxKind::Whitespace || s.kind() == SyntaxKind::Comment {
+                    s.into_token()
+                } else {
+                    None
+                }
+            })
+            .filter(|t| t.kind() == SyntaxKind::Comment)
+    }
+
+    fn rule_exceptions(&self) -> HashSet<String> {
+        let mut set = HashSet::default();
+        for comment in self.except_comments() {
+            if let Some(ids) = comment.text().strip_prefix(EXCEPT_COMMENT_PREFIX) {
+                for id in ids.split(',') {
+                    let id = id.trim();
+                    set.insert(id.to_string());
+                }
+            }
+        }
+
+        set
+    }
+
+    fn is_rule_excepted(&self, id: &str) -> bool {
+        for comment in self.except_comments() {
+            if let Some(ids) = comment.text().strip_prefix(EXCEPT_COMMENT_PREFIX) {
+                if ids.split(',').any(|i| i.trim() == id) {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 }
 

--- a/wdl-grammar/src/diagnostic.rs
+++ b/wdl-grammar/src/diagnostic.rs
@@ -190,6 +190,12 @@ impl Diagnostic {
         self
     }
 
+    /// Sets the severity of the diagnostic.
+    pub fn with_severity(mut self, severity: Severity) -> Self {
+        self.severity = severity;
+        self
+    }
+
     /// Gets the optional rule associated with the diagnostic.
     pub fn rule(&self) -> Option<&str> {
         self.rule.as_deref()

--- a/wdl-grammar/src/lexer/v1.rs
+++ b/wdl-grammar/src/lexer/v1.rs
@@ -151,8 +151,8 @@ pub enum DQStringToken {
     End,
 }
 
-/// Represents a token in a heredoc command or multiline string (e.g. `<<< hello
-/// >>>`).
+/// Represents a token in a heredoc command or multiline string
+/// (e.g. `<<< hello >>>`).
 #[derive(Logos, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum HeredocToken {

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -42,6 +42,14 @@ pub use tags::*;
 pub use visitor::*;
 pub use wdl_ast as ast;
 
+/// The reserved rule names that are used by analysis.
+const RESERVED_RULE_NAMES: &[&str] = &[
+    "UnusedImport",
+    "UnusedInput",
+    "UnusedDeclaration",
+    "UnusedCall",
+];
+
 /// A trait implemented by lint rules.
 pub trait Rule: Visitor<State = Diagnostics> {
     /// The unique identifier for the lint rule.
@@ -129,6 +137,10 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
 
             if !set.insert(r.id()) {
                 panic!("duplicate rule id `{id}`", id = r.id());
+            }
+
+            if RESERVED_RULE_NAMES.contains(&r.id()) {
+                panic!("rule id `{id}` is reserved", id = r.id());
             }
         }
     }

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -42,8 +42,8 @@ pub use tags::*;
 pub use visitor::*;
 pub use wdl_ast as ast;
 
-/// The reserved rule names that are used by analysis.
-const RESERVED_RULE_NAMES: &[&str] = &[
+/// The reserved rule identifiers that are used by analysis.
+pub const RESERVED_RULE_IDS: &[&str] = &[
     "UnusedImport",
     "UnusedInput",
     "UnusedDeclaration",
@@ -139,7 +139,7 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
                 panic!("duplicate rule id `{id}`", id = r.id());
             }
 
-            if RESERVED_RULE_NAMES.contains(&r.id()) {
+            if RESERVED_RULE_IDS.contains(&r.id()) {
                 panic!("rule id `{id}` is reserved", id = r.id());
             }
         }

--- a/wdl-lint/src/rules/unknown_rule.rs
+++ b/wdl-lint/src/rules/unknown_rule.rs
@@ -12,6 +12,7 @@ use wdl_ast::SyntaxKind;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 
+use crate::RESERVED_RULE_NAMES;
 use crate::Rule;
 use crate::Tag;
 use crate::TagSet;
@@ -78,7 +79,7 @@ impl Visitor for UnknownRule {
                 offset += id.len() - trimmed.len();
 
                 // Check if the rule is known
-                if !RULE_MAP.contains_key(&trimmed) {
+                if !RESERVED_RULE_NAMES.contains(&trimmed) && !RULE_MAP.contains_key(&trimmed) {
                     // Since this rule can only be excepted in a document-wide fashion,
                     // if the rule is running we can directly add the diagnostic
                     // without checking for the exceptable nodes

--- a/wdl-lint/src/rules/unknown_rule.rs
+++ b/wdl-lint/src/rules/unknown_rule.rs
@@ -1,4 +1,4 @@
-//! A lint rule for flagging uknown rules in lint directives.
+//! A lint rule for flagging unknown rules in lint directives.
 
 use wdl_ast::AstToken;
 use wdl_ast::Comment;
@@ -12,7 +12,7 @@ use wdl_ast::SyntaxKind;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 
-use crate::RESERVED_RULE_NAMES;
+use crate::RESERVED_RULE_IDS;
 use crate::Rule;
 use crate::Tag;
 use crate::TagSet;
@@ -79,7 +79,7 @@ impl Visitor for UnknownRule {
                 offset += id.len() - trimmed.len();
 
                 // Check if the rule is known
-                if !RESERVED_RULE_NAMES.contains(&trimmed) && !RULE_MAP.contains_key(&trimmed) {
+                if !RESERVED_RULE_IDS.contains(&trimmed) && !RULE_MAP.contains_key(&trimmed) {
                     // Since this rule can only be excepted in a document-wide fashion,
                     // if the rule is running we can directly add the diagnostic
                     // without checking for the exceptable nodes

--- a/wdl-lint/src/visitor.rs
+++ b/wdl-lint/src/visitor.rs
@@ -8,6 +8,7 @@ use wdl_ast::Comment;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
 use wdl_ast::SupportedVersion;
+use wdl_ast::SyntaxNodeExt;
 use wdl_ast::VersionStatement;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
@@ -87,11 +88,10 @@ impl Visitor for LintVisitor {
         }
 
         self.document_exceptions.extend(
-            state.exceptions_for(
-                doc.version_statement()
-                    .expect("document should have version statement")
-                    .syntax(),
-            ),
+            doc.version_statement()
+                .expect("document should have version statement")
+                .syntax()
+                .rule_exceptions(),
         );
 
         self.each_enabled_rule(state, |state, rule| {

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -205,6 +205,7 @@ impl Server {
                 client,
                 options,
                 analyzer: Analyzer::<ProgressToken>::new_with_validator(
+                    Default::default(),
                     move |token, kind, current, total| {
                         let client = analyzer_client.clone();
                         async move {

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -26,6 +26,7 @@ use wdl_analysis::IncrementalChange;
 use wdl_analysis::SourceEdit;
 use wdl_analysis::SourcePosition;
 use wdl_analysis::SourcePositionEncoding;
+use wdl_analysis::rules;
 use wdl_ast::Validator;
 use wdl_lint::LintVisitor;
 
@@ -205,7 +206,7 @@ impl Server {
                 client,
                 options,
                 analyzer: Analyzer::<ProgressToken>::new_with_validator(
-                    Default::default(),
+                    rules(),
                     move |token, kind, current, total| {
                         let client = analyzer_client.clone();
                         async move {

--- a/wdl/src/lib.rs
+++ b/wdl/src/lib.rs
@@ -87,3 +87,29 @@ pub use wdl_lint as lint;
 #[cfg(feature = "lsp")]
 #[doc(inline)]
 pub use wdl_lsp as lsp;
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+
+    /// This is a test for checking that the reserved rules in `wdl-lint` match
+    /// those from `wdl-analysis`.
+    #[cfg(all(feature = "analysis", feature = "lint"))]
+    #[test]
+    fn reserved_rule_ids() {
+        let rules: HashSet<_> = wdl_analysis::rules().iter().map(|r| r.id()).collect();
+        let reserved: HashSet<_> = wdl_lint::RESERVED_RULE_IDS.iter().map(|id| *id).collect();
+
+        for id in &reserved {
+            if !rules.contains(id) {
+                panic!("analysis rule `{id}` is not in the reservation set");
+            }
+        }
+
+        for id in &rules {
+            if !reserved.contains(id) {
+                panic!("reserved rule `{id}` is not an analysis rule");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the first warnings for analysis itself:

* Unused import
* Unused task/workflow input
* Unused task/workflow private declaration
* Unused call in a workflow

The warnings can be excepted the same way a lint directive can: either by having the warning's rule identifier in a preamble `#@ except` comment (i.e. a global except) or by having such a comment immediately precede the import/input/decl/call.

Additionally, the warnings may be treated as errors with a `--deny <id>` option to the `wdl check` command or excepted with `--except <id>`.

Closes #200.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
