### PR TITLE
fix: accept Array[T] to Array[T]+ coercions.

### DIFF
--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -108,7 +108,7 @@ permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540
 
 [[diagnostics]]
 document = "ENCODE-DCC/chip-seq-pipeline2:/dev/test/test_task/test_choose_ctl.wdl"
-message = "test_choose_ctl.wdl:196:24: error: type mismatch: expected type `Array[String]?`, but found type `Array[Int]`"
+message = "test_choose_ctl.wdl:196:24: error: type mismatch: expected type `Array[String]?`, but found type `Array[Int]+`"
 permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_choose_ctl.wdl/#L196"
 
 [[diagnostics]]
@@ -233,7 +233,7 @@ permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/tertiary_analysis/tertiary_analysis.wdl"
-message = "tertiary_analysis.wdl:46:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[IndexData]]`"
+message = "tertiary_analysis.wdl:46:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[IndexData]]+`"
 permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/tertiary_analysis/tertiary_analysis.wdl/#L46"
 
 [[diagnostics]]
@@ -520,16 +520,6 @@ permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:115:41: error: expected struct member name, but found string"
 permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L115"
-
-[[diagnostics]]
-document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
-message = "mutec2.wdl:182:28: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L182"
-
-[[diagnostics]]
-document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
-message = "mutec2.wdl:187:38: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L187"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
@@ -903,7 +893,7 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 
 [[diagnostics]]
 document = "biowdl/tasks:/sambamba.wdl"
-message = "sambamba.wdl:157:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
+message = "sambamba.wdl:157:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/sambamba.wdl/#L157"
 
 [[diagnostics]]
@@ -938,7 +928,7 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 
 [[diagnostics]]
 document = "biowdl/tasks:/samtools.wdl"
-message = "samtools.wdl:470:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
+message = "samtools.wdl:470:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/samtools.wdl/#L470"
 
 [[diagnostics]]
@@ -978,7 +968,7 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 
 [[diagnostics]]
 document = "biowdl/tasks:/umi.wdl"
-message = "umi.wdl:39:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
+message = "umi.wdl:39:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
 permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026452d5dbae2/umi.wdl/#L39"
 
 [[diagnostics]]
@@ -1743,7 +1733,7 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a000
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/FEEvaluation.wdl"
-message = "FEEvaluation.wdl:124:35: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
+message = "FEEvaluation.wdl:124:35: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L124"
 
 [[diagnostics]]
@@ -1803,7 +1793,7 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a000
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:70:39: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "Glimpse2ImputationAndCheckQC.wdl:70:39: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L70"
 
 [[diagnostics]]
@@ -1828,7 +1818,7 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a000
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:83:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "Glimpse2ImputationAndCheckQC.wdl:83:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L83"
 
 [[diagnostics]]
@@ -2043,7 +2033,7 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a000
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
-message = "SubsetWeightSet.wdl:28:66: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[SelfExclusiveSites]`"
+message = "SubsetWeightSet.wdl:28:66: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[SelfExclusiveSites]+`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
 
 [[diagnostics]]
@@ -2073,38 +2063,8 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a000
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
-message = "IsoformDiscoveryBenchmark.wdl:143:24: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L143"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:147:13: error: conflicting scatter variable name `gtf`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L147"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
-message = "IsoformDiscoveryBenchmark.wdl:157:29: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L157"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
-message = "IsoformDiscoveryBenchmark.wdl:158:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L158"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
-message = "IsoformDiscoveryBenchmark.wdl:164:25: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L164"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
-message = "IsoformDiscoveryBenchmark.wdl:165:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L165"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
-message = "IsoformDiscoveryBenchmark.wdl:172:25: error: type mismatch: expected type `Array[String]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L172"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
@@ -2113,7 +2073,7 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a000
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl"
-message = "IsoformDiscoveryBenchmarkTasks.wdl:69:32: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
+message = "IsoformDiscoveryBenchmarkTasks.wdl:69:32: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/f8833a0000cd441a3cc4be2718876a1433cb21ef/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl/#L69"
 
 [[diagnostics]]
@@ -2250,26 +2210,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:26:10: warning[UnusedInput]: unused input `ref_fasta`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
-message = "MultiSampleArrays.wdl:47:16: error: type mismatch: expected type `Array[File]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L47"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
-message = "MultiSampleArrays.wdl:48:23: error: type mismatch: expected type `Array[File]+`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L48"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
-message = "MultiSampleArrays.wdl:56:14: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L56"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
-message = "MultiSampleArrays.wdl:57:21: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
@@ -2542,31 +2482,6 @@ message = "GDCWholeGenomeSomaticSingleSample.wdl:672:14: error: conflicting scat
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L672"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
-message = "GDCWholeGenomeSomaticSingleSample.wdl:698:32: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L698"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
-message = "GDCWholeGenomeSomaticSingleSample.wdl:699:32: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L699"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
-message = "GDCWholeGenomeSomaticSingleSample.wdl:700:30: error: type mismatch: expected type `Array[Object]+`, but found type `Array[Object]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L700"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
-message = "GDCWholeGenomeSomaticSingleSample.wdl:724:30: error: type mismatch: expected type `Array[Object]+`, but found type `Array[Object]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L724"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
-message = "GDCWholeGenomeSomaticSingleSample.wdl:746:20: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L746"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
 message = "BroadInternalImputation.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
@@ -2603,37 +2518,37 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:91:34: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "BroadInternalUltimaGenomics.wdl:91:34: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:92:48: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "BroadInternalUltimaGenomics.wdl:92:48: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:93:46: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "BroadInternalUltimaGenomics.wdl:93:46: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:94:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "BroadInternalUltimaGenomics.wdl:94:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L94"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:95:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "BroadInternalUltimaGenomics.wdl:95:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:96:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "BroadInternalUltimaGenomics.wdl:96:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L96"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:97:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "BroadInternalUltimaGenomics.wdl:97:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
 
 [[diagnostics]]
@@ -2938,7 +2853,7 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
-message = "CreateSs2AdapterMetadata.wdl:175:68: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
+message = "CreateSs2AdapterMetadata.wdl:175:68: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
 
 [[diagnostics]]
@@ -3673,12 +3588,12 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "VerifyMultiome.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "VerifyMultiome.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyMultiome.wdl/#L78"
 
 [[diagnostics]]
@@ -3723,12 +3638,12 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
-message = "VerifyOptimus.wdl:53:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "VerifyOptimus.wdl:53:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
-message = "VerifyOptimus.wdl:54:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "VerifyOptimus.wdl:54:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyOptimus.wdl/#L54"
 
 [[diagnostics]]
@@ -3778,12 +3693,12 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
-message = "VerifyPairedTag.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "VerifyPairedTag.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
-message = "VerifyPairedTag.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "VerifyPairedTag.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/VerifyPairedTag.wdl/#L78"
 
 [[diagnostics]]
@@ -4018,7 +3933,7 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl"
-message = "TestBroadInternalRNAWithUMIs.wdl:106:54: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "TestBroadInternalRNAWithUMIs.wdl:106:54: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
 
 [[diagnostics]]
@@ -4048,7 +3963,7 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
-message = "TestGDCWholeGenomeSomaticSingleSample.wdl:77:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
+message = "TestGDCWholeGenomeSomaticSingleSample.wdl:77:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
 
 [[diagnostics]]
@@ -4078,7 +3993,7 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
-message = "TestImputation.wdl:86:56: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
+message = "TestImputation.wdl:86:56: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestImputation.wdl/#L86"
 
 [[diagnostics]]
@@ -4138,7 +4053,7 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
-message = "TestOptimus.wdl:118:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "TestOptimus.wdl:118:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestOptimus.wdl/#L118"
 
 [[diagnostics]]
@@ -4168,17 +4083,17 @@ permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e2955
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
-message = "TestRNAWithUMIsPipeline.wdl:100:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "TestRNAWithUMIsPipeline.wdl:100:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
-message = "TestRNAWithUMIsPipeline.wdl:110:52: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "TestRNAWithUMIsPipeline.wdl:110:52: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L110"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
-message = "TestRNAWithUMIsPipeline.wdl:84:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "TestRNAWithUMIsPipeline.wdl:84:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/broadinstitute/warp/blob/ec91e512235419b267e295583db3ec2594fcd717/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L84"
 
 [[diagnostics]]
@@ -4228,43 +4143,18 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:146:24: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L146"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:147:13: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "run.wdl:147:13: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L147"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:152:23: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L152"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:153:13: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "run.wdl:153:13: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L153"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:162:30: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L162"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:163:13: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "run.wdl:163:13: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L163"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:237:34: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L237"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:38:34: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L38"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -4318,33 +4208,8 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:48:44: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L48"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:517:41: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L517"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:549:40: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L549"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:55:32: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L55"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
 message = "run.wdl:561:14: warning[UnusedInput]: unused input `card_json`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L561"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:575:36: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L575"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -4352,13 +4217,8 @@ message = "run.wdl:587:14: warning[UnusedInput]: unused input `card_json`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L587"
 
 [[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
-message = "run.wdl:597:35: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/amr/run.wdl/#L597"
-
-[[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/benchmark/long-read-mngs-benchmark.wdl"
-message = "long-read-mngs-benchmark.wdl:88:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "long-read-mngs-benchmark.wdl:88:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/benchmark/long-read-mngs-benchmark.wdl/#L88"
 
 [[diagnostics]]
@@ -4383,7 +4243,7 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/benchmark/short-read-mngs-benchmark.wdl"
-message = "short-read-mngs-benchmark.wdl:89:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "short-read-mngs-benchmark.wdl:89:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/benchmark/short-read-mngs-benchmark.wdl/#L89"
 
 [[diagnostics]]
@@ -4393,48 +4253,8 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:129:26: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L129"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:137:30: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L137"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:146:73: error: type mismatch: a type common to both type `Array[File]+?` and type `Array[File]` does not exist"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L146"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:156:95: error: type mismatch: a type common to both type `Array[File]+?` and type `Array[File]` does not exist"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L156"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:203:26: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L203"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:218:91: error: type mismatch: a type common to both type `Array[File]+?` and type `Array[File]` does not exist"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L218"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:235:22: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L235"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
 message = "run.wdl:244:38: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L244"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:351:41: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L351"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
@@ -4450,16 +4270,6 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
 message = "run.wdl:55:14: warning[UnusedInput]: unused input `vadr_model`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L55"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:604:40: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L604"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:638:39: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L638"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
@@ -4490,11 +4300,6 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
 message = "run.wdl:877:13: warning[UnusedInput]: unused input `threads`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L877"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
-message = "run.wdl:87:22: error: type mismatch: expected type `Array[File]+`, but found type `Array[File]`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/consensus-genome/run.wdl/#L87"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/consensus-genome/run.wdl"
@@ -4723,7 +4528,7 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
-message = "chipseq-standard.wdl:110:45: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
+message = "chipseq-standard.wdl:110:45: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
 permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L110"
 
 [[diagnostics]]
@@ -4993,27 +4798,27 @@ permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be240
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
-message = "wf_nextclade_addToRefTree.wdl:33:58: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
+message = "wf_nextclade_addToRefTree.wdl:33:58: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
-message = "wf_nextclade_addToRefTree.wdl:34:53: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "wf_nextclade_addToRefTree.wdl:34:53: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
-message = "wf_nextclade_addToRefTree.wdl:35:51: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "wf_nextclade_addToRefTree.wdl:35:51: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
-message = "wf_nextclade_addToRefTree.wdl:36:52: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
+message = "wf_nextclade_addToRefTree.wdl:36:52: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
-message = "wf_nextclade_addToRefTree.wdl:37:57: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]`"
+message = "wf_nextclade_addToRefTree.wdl:37:57: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
 
 [[diagnostics]]
@@ -5258,12 +5063,12 @@ permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be240
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
-message = "wf_theiaeuk_illumina_pe.wdl:118:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
+message = "wf_theiaeuk_illumina_pe.wdl:118:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
-message = "wf_theiaeuk_illumina_pe.wdl:127:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]`"
+message = "wf_theiaeuk_illumina_pe.wdl:127:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
 
 [[diagnostics]]

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Allow coercion of `Array[T]` to `Array[T]+` unless from an empty array
+  literal ([#213](https://github.com/stjude-rust-labs/wdl/pull/213)).
 * Improved type calculations in function calls and when determining common
   types in certain expressions ([#209](https://github.com/stjude-rust-labs/wdl/pull/209)).
 * Treat a coercion to `T?` for a function argument of type `T` as a preference

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -358,7 +358,7 @@ pub fn type_mismatch(
 pub fn non_empty_array_assignment(expected_span: Span, actual_span: Span) -> Diagnostic {
     Diagnostic::error("cannot assign an empty array to a non-empty array type")
         .with_label("this is an empty array", actual_span)
-        .with_label("this expected a non-empty array", expected_span)
+        .with_label("this expects a non-empty array", expected_span)
 }
 
 /// Creates a "call input type mismatch" diagnostic.

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -354,6 +354,13 @@ pub fn type_mismatch(
     )
 }
 
+/// Creates a "non-empty array assignment" diagnostic.
+pub fn non_empty_array_assignment(expected_span: Span, actual_span: Span) -> Diagnostic {
+    Diagnostic::error("cannot assign an empty array to a non-empty array type")
+        .with_label("this is an empty array", actual_span)
+        .with_label("this expected a non-empty array", expected_span)
+}
+
 /// Creates a "call input type mismatch" diagnostic.
 pub fn call_input_type_mismatch(
     types: &Types,

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -716,7 +716,7 @@ pub struct ArrayType {
     ///
     /// This is `None` for literal arrays so that the array may coerce to both
     /// empty and non-empty types.
-    non_empty: Option<bool>,
+    non_empty: bool,
 }
 
 impl ArrayType {
@@ -724,7 +724,7 @@ impl ArrayType {
     pub fn new(element_type: impl Into<Type>) -> Self {
         Self {
             element_type: element_type.into(),
-            non_empty: Some(false),
+            non_empty: false,
         }
     }
 
@@ -732,7 +732,7 @@ impl ArrayType {
     pub fn non_empty(element_type: impl Into<Type>) -> Self {
         Self {
             element_type: element_type.into(),
-            non_empty: Some(true),
+            non_empty: true,
         }
     }
 
@@ -742,7 +742,7 @@ impl ArrayType {
     }
 
     /// Determines if the array type is non-empty.
-    pub fn is_non_empty(&self) -> Option<bool> {
+    pub fn is_non_empty(&self) -> bool {
         self.non_empty
     }
 
@@ -760,7 +760,7 @@ impl ArrayType {
                 self.ty.element_type.display(self.types).fmt(f)?;
                 write!(f, "]")?;
 
-                if self.ty.non_empty == Some(true) {
+                if self.ty.non_empty {
                     write!(f, "+")?;
                 }
 
@@ -779,10 +779,6 @@ impl ArrayType {
 
 impl Coercible for ArrayType {
     fn is_coercible_to(&self, types: &Types, target: &Self) -> bool {
-        if self.is_non_empty() == Some(false) && target.is_non_empty() == Some(true) {
-            return false;
-        }
-
         self.element_type
             .is_coercible_to(types, &target.element_type)
     }

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -559,12 +559,7 @@ where
                     }
                 }
 
-                self.types.add_array(ArrayType {
-                    element_type: expected,
-                    // A special value that allows for coercion to either empty or non-empty
-                    // This allows for an expression like `if (true) then [a, b, c] else []`.
-                    non_empty: None,
-                })
+                self.types.add_array(ArrayType::non_empty(expected))
             }
             // Treat empty array as `Array[Union]`
             None => self.types.add_array(ArrayType::new(Type::Union)),

--- a/wdl-analysis/tests/analysis/non-empty-array/source.diagnostics
+++ b/wdl-analysis/tests/analysis/non-empty-array/source.diagnostics
@@ -1,0 +1,16 @@
+error: cannot assign an empty array to a non-empty array type
+   ┌─ tests/analysis/non-empty-array/source.wdl:16:21
+   │
+16 │     Array[Int]+ x = []
+   │                 -   ^^ this is an empty array
+   │                 │    
+   │                 this expected a non-empty array
+
+error: cannot assign an empty array to a non-empty array type
+   ┌─ tests/analysis/non-empty-array/source.wdl:30:31
+   │
+30 │     call t as t4 { input: x = ((([]))) }
+   │                           -   ^^^^^^^^ this is an empty array
+   │                           │    
+   │                           this expected a non-empty array
+

--- a/wdl-analysis/tests/analysis/non-empty-array/source.diagnostics
+++ b/wdl-analysis/tests/analysis/non-empty-array/source.diagnostics
@@ -4,7 +4,7 @@ error: cannot assign an empty array to a non-empty array type
 16 │     Array[Int]+ x = []
    │                 -   ^^ this is an empty array
    │                 │    
-   │                 this expected a non-empty array
+   │                 this expects a non-empty array
 
 error: cannot assign an empty array to a non-empty array type
    ┌─ tests/analysis/non-empty-array/source.wdl:30:31
@@ -12,5 +12,5 @@ error: cannot assign an empty array to a non-empty array type
 30 │     call t as t4 { input: x = ((([]))) }
    │                           -   ^^^^^^^^ this is an empty array
    │                           │    
-   │                           this expected a non-empty array
+   │                           this expects a non-empty array
 

--- a/wdl-analysis/tests/analysis/non-empty-array/source.wdl
+++ b/wdl-analysis/tests/analysis/non-empty-array/source.wdl
@@ -1,0 +1,31 @@
+#@ except: UnusedDeclaration, UnusedInput, UnusedCall
+## This is a test of assigning an empty array to a non-empty array declaration.
+
+version 1.1
+
+task t {
+    input {
+        Array[Int]+ x
+    }
+
+    command <<<>>>
+}
+
+workflow test {
+    # This is an error (cannot assign empty array)
+    Array[Int]+ x = []
+
+    # This is OK
+    Array[Int] y = []
+
+    # This is OK (checked at runtime)
+    Array[Int]+ z = y
+
+    # These are OK
+    call t { input: x }
+    call t as t2 { input: x = x }
+    call t as t3 { input: x = y }
+
+    # This is not OK because it's an empty array literal
+    call t as t4 { input: x = ((([]))) }
+}

--- a/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
+++ b/wdl-analysis/tests/analysis/type-mismatch/source.diagnostics
@@ -22,11 +22,11 @@ error: type mismatch: expected type `Array[String]`, but found type `Map[Int, St
    │                   │    
    │                   this expects type `Array[String]`
 
-error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`
+error: type mismatch: expected type `Array[Int]`, but found type `Array[String]+`
    ┌─ tests/analysis/type-mismatch/source.wdl:14:20
    │
 14 │     Array[Int] d = ["a", "b", "c"]
-   │                -   ^^^^^^^^^^^^^^^ this is type `Array[String]`
+   │                -   ^^^^^^^^^^^^^^^ this is type `Array[String]+`
    │                │    
    │                this expects type `Array[Int]`
 
@@ -62,11 +62,11 @@ error: type mismatch: a type common to both type `String` and type `Int` does no
    │                                    │          
    │                                    this is type `String`
 
-error: type mismatch: expected type `Int`, but found type `Array[Int]`
+error: type mismatch: expected type `Int`, but found type `Array[Int]+`
    ┌─ tests/analysis/type-mismatch/source.wdl:18:22
    │
 18 │     Foo h = Foo { x: [1] }
-   │                   -  ^^^ this is type `Array[Int]`
+   │                   -  ^^^ this is type `Array[Int]+`
    │                   │   
    │                   this expects type `Int`
 

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -853,6 +853,16 @@ impl Expr {
             _ => panic!("not an access expression"),
         }
     }
+
+    /// Determines if the expression is an empty array literal or any number of
+    /// parenthesized expressions that terminate with an empty array literal.
+    pub fn is_empty_array_literal(&self) -> bool {
+        match self {
+            Self::Parenthesized(expr) => expr.inner().is_empty_array_literal(),
+            Self::Literal(LiteralExpr::Array(expr)) => expr.elements().next().is_none(),
+            _ => false,
+        }
+    }
 }
 
 impl AstNode for Expr {


### PR DESCRIPTION
This commit allows coercions of `Array[T]` to `Array[T]+` unless the assignment
is from an empty array literal, which can be easily statically checked.

Fixes #212.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
