### PR TITLE
fix: fix panic in `wdl-format` when formatting 1.2 multiline strings.

### DIFF
--- a/wdl-format/CHANGELOG.md
+++ b/wdl-format/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fix panic on multiline strings in WDL 1.2 ([#227](https://github.com/stjude-rust-labs/wdl/pull/227)).
+
 ## 0.2.1 - 10-16-2024
 
 ### Fixed

--- a/wdl-format/src/v1/expr.rs
+++ b/wdl-format/src/v1/expr.rs
@@ -136,7 +136,7 @@ pub fn format_literal_string(element: &FormatElement, stream: &mut TokenStream<P
                     "\"".to_owned(),
                 );
             }
-            SyntaxKind::DoubleQuote => {
+            SyntaxKind::OpenHeredoc | SyntaxKind::CloseHeredoc | SyntaxKind::DoubleQuote => {
                 (&child).write(stream);
             }
             SyntaxKind::LiteralStringText => {

--- a/wdl-format/tests/format/multiline-strings/source.formatted.wdl
+++ b/wdl-format/tests/format/multiline-strings/source.formatted.wdl
@@ -1,0 +1,9 @@
+## This is a format test for multiline strings.
+
+version 1.2
+
+workflow test {
+    String x = <<<
+    ~{"foobar"}
+    >>>
+}

--- a/wdl-format/tests/format/multiline-strings/source.wdl
+++ b/wdl-format/tests/format/multiline-strings/source.wdl
@@ -1,0 +1,9 @@
+## This is a format test for multiline strings.
+
+version 1.2
+
+workflow test {
+    String x = <<<
+    ${  "foobar"  }
+    >>>
+}


### PR DESCRIPTION
Adds the `OpenHeredoc` and `CloseHeredoc` tokens to acceptable child tokens of string literals.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
