### PR TITLE
chore: use rustls-tls for `reqwest` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ path-clean = "1.0.1"
 petgraph = "0.6.5"
 pretty_assertions = "1.4.0"
 rayon = "1.10.0"
-reqwest = "0.12.5"
+reqwest = { version = "0.12.5", default-features = false, features = ["rustls-tls", "http2", "charset"] }
 rowan = "0.15.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.120"

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -11,8 +11,9 @@ rust-version.workspace = true
 
 [dependencies]
 chrono = "0.4.38"
+tokio.workspace = true
 clap.workspace = true
-reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
+reqwest.workspace = true
 toml.workspace = true
 toml_edit = { version = "0.22.21", features = ["serde"] }
 

--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -190,7 +190,16 @@ async fn main() {
             for _ in 0..3 {
                 let mut retry = Vec::new();
                 for krate in all_crates {
-                    if !publish(&krate.borrow(), dry_run).await {
+                    let (name, version, manifest_path) = {
+                        let krate = krate.borrow();
+                        (
+                            krate.name.clone(),
+                            krate.version.clone(),
+                            krate.manifest_path.clone(),
+                        )
+                    };
+
+                    if !publish(&name, &version, &manifest_path, dry_run).await {
                         retry.push(krate);
                     }
                 }
@@ -328,8 +337,8 @@ fn bump(version: &str, patch_bump: bool) -> String {
 }
 
 /// Publishes a crate.
-async fn publish(krate: &Crate, dry_run: bool) -> bool {
-    if !SORTED_CRATES_TO_PUBLISH.iter().any(|s| *s == krate.name) {
+async fn publish(name: &str, version: &str, manifest_path: &Path, dry_run: bool) -> bool {
+    if !SORTED_CRATES_TO_PUBLISH.iter().any(|s| *s == name) {
         return true;
     }
 
@@ -337,22 +346,22 @@ async fn publish(krate: &Crate, dry_run: bool) -> bool {
     // binary may be re-run and there's no need to re-attempt previous work.
     let client = reqwest::Client::new();
     let req = client
-        .get(format!("https://crates.io/api/v1/crates/{}", krate.name))
+        .get(format!("https://crates.io/api/v1/crates/{}", name))
         .header("User-Agent", "curl/8.7.1"); // crates.io requires a user agent apparently
     let response = req.send().await.expect("failed to get crate info");
     if response.status().is_success() {
         let text = response.text().await.expect("failed to get response text");
-        if text.contains(&format!("\"newest_version\":\"{}\"", krate.version)) {
+        if text.contains(&format!("\"newest_version\":\"{}\"", version)) {
             println!(
                 "skip publish {} because {} is latest version",
-                krate.name, krate.version,
+                name, version,
             );
             return true;
         }
     } else {
         println!(
             "skip publish {} because failed to get crate info: {}",
-            krate.name,
+            name,
             response.status()
         );
         return false;
@@ -361,7 +370,7 @@ async fn publish(krate: &Crate, dry_run: bool) -> bool {
     let mut command = Command::new("cargo");
     let command = command
         .arg("publish")
-        .current_dir(krate.manifest_path.parent().unwrap());
+        .current_dir(manifest_path.parent().unwrap());
     let status = if dry_run {
         command.arg("--dry-run").status().unwrap()
     } else {
@@ -369,7 +378,7 @@ async fn publish(krate: &Crate, dry_run: bool) -> bool {
     };
 
     if !status.success() {
-        println!("FAIL: failed to publish `{}`: {}", krate.name, status);
+        println!("FAIL: failed to publish `{}`: {}", name, status);
         return false;
     }
 

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Switched to `rustls-tls` for TLS implementation rather than relying on
+  OpenSSL for Linux builds (#[228](https://github.com/stjude-rust-labs/wdl/pull/228)).
+
 ## 0.4.0 - 10-16-2024
 
 ### Added


### PR DESCRIPTION
This commit enables the `rustls-tls` feature for the `reqwest` feature of `wdl-analysis`.

This should eliminate the OpenSSL dependency for Linux builds.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
