### PR TITLE
ci: makes relevant CI tests multi-platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# The default behavior.
+* text=auto
+
+# Ensure that WDL files always use LF line endings.
+*.wdl text eol=lf

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,17 +53,27 @@ jobs:
       - run: cargo doc
 
   gauntlet:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
+      - run: git config --global core.autocrlf false
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo run --release --bin gauntlet
 
   arena:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
+      - run: git config --global core.autocrlf false
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo run --release --bin gauntlet -- --arena

--- a/gauntlet/src/document/identifier.rs
+++ b/gauntlet/src/document/identifier.rs
@@ -1,5 +1,7 @@
 //! Identifiers for documents.
 
+use std::path::MAIN_SEPARATOR;
+
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -63,11 +65,16 @@ pub struct Identifier {
 impl Identifier {
     /// Creates a new [`Identifier`].
     pub fn new(repository: repository::Identifier, relative_path: impl AsRef<str>) -> Self {
-        let path = relative_path.as_ref();
+        // NOTE: the tests are stored using UNIX filepath conventions (namely,
+        // with `/` as the delimiter), so we need to replace the separators on
+        // Windows with this.
+        let path = relative_path.as_ref().replace(MAIN_SEPARATOR, "/");
+        let path = path.strip_prefix("/").unwrap_or(&path);
+
         Self {
             repository,
             // Ensure the path always starts with `/`
-            path: format!("/{path}", path = path.strip_prefix('/').unwrap_or(path)),
+            path: format!("/{path}"),
         }
     }
 

--- a/gauntlet/src/repository.rs
+++ b/gauntlet/src/repository.rs
@@ -145,6 +145,8 @@ impl Repository {
             .join(self.identifier.organization())
             .join(self.identifier.name());
 
+        std::fs::create_dir_all(&repo_root).expect("failed to create repository root directory");
+
         let git_repo = match git2::Repository::open(&repo_root) {
             Ok(repo) => {
                 info!("opening existing repository: {:?}", repo_root);
@@ -208,6 +210,8 @@ impl Repository {
         let repo_root = root
             .join(self.identifier.organization())
             .join(self.identifier.name());
+
+        std::fs::create_dir_all(&repo_root).expect("failed to create repository root directory");
 
         // Clone the repository.
         info!("cloning repository: {:?}", self.identifier);

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -63,9 +63,11 @@ impl LineWidthRule {
         {
             let current_offset = start + offset;
             let previous_offset = self.previous_newline_offset.unwrap_or_default();
+            let length = current_offset - previous_offset;
 
-            if !self.ignored_section && current_offset - previous_offset > self.max_width {
-                let span = Span::new(previous_offset, current_offset - previous_offset);
+            if !self.ignored_section && length > self.max_width {
+                let span = Span::new(previous_offset, length);
+
                 state.exceptable_add(
                     line_too_long(span, self.max_width),
                     element.clone(),


### PR DESCRIPTION
We should make sure `wdl` is always tested to work on all major platforms. To that end, I've updated the CI here to ensure that it always is. Some steps don't need to be run multi-platform, others clearly do, and then there are a few that are in-between (e.g., linting).

In both the "definitely needs to be run on all platforms" and the "in-between" ones, I ended up just enabling multi-platform tests to be safe. For example, for linting, some lints may only show up when certain platform-based configuration options are available. This is only going to become more relevant as we add more platform-specific things (like the encoding of newlines for UNIX/Windows).

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
