### PR TITLE
fix: normalize LSP request URIs.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust
@@ -18,7 +18,11 @@ jobs:
       - run: cargo fmt -- --check
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust
@@ -28,23 +32,20 @@ jobs:
       - run: cargo clippy --all-features -- --deny warnings
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo test --all-features
-
-  test-examples:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update Rust
-        run: rustup update stable && rustup default stable
+      - run: cargo test --all --all-features
       - run: cargo test --all-features --examples
 
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust
@@ -52,7 +53,7 @@ jobs:
       - run: cargo doc
 
   gauntlet:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust
@@ -60,7 +61,7 @@ jobs:
       - run: cargo run --release --bin gauntlet
 
   arena:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust
@@ -68,7 +69,7 @@ jobs:
       - run: cargo run --release --bin gauntlet -- --arena
 
   workspace-lints-enabled:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Update Rust

--- a/wdl-analysis/tests/analysis.rs
+++ b/wdl-analysis/tests/analysis.rs
@@ -70,14 +70,21 @@ fn find_tests() -> Vec<PathBuf> {
 fn normalize(s: &str, is_error: bool) -> String {
     if is_error {
         // Normalize paths in any error messages
-        return s.replace('\\', "/").replace("\r\n", "\n");
+        let s = s.replace('\\', "/").replace("\r\n", "\n");
+
+        // Handle any OS specific errors messages
+        let s = s.replace(
+            "The system cannot find the file specified. (os error 2)",
+            "No such file or directory (os error 2)",
+        );
+        return s;
     }
 
     // Otherwise, just normalize line endings
     s.replace("\r\n", "\n")
 }
 
-/// Comparse a single result.
+/// Compares a single result.
 fn compare_result(path: &Path, result: &str, is_error: bool) -> Result<()> {
     let result = normalize(result, is_error);
     if env::var_os("BLESS").is_some() {

--- a/wdl-format/tests/format.rs
+++ b/wdl-format/tests/format.rs
@@ -33,6 +33,12 @@ use wdl_ast::Node;
 use wdl_format::Formatter;
 use wdl_format::element::node::AstNodeFormatExt;
 
+/// Normalizes a result.
+fn normalize(s: &str) -> String {
+    // Just normalize line endings
+    s.replace("\r\n", "\n")
+}
+
 /// Find all the tests in the `tests/format` directory.
 fn find_tests() -> Vec<PathBuf> {
     // Check for filter arguments consisting of test names
@@ -80,6 +86,7 @@ fn format_diagnostics(diagnostics: &[Diagnostic], path: &Path, source: &str) -> 
 
 /// Compare the result of a test to the expected result.
 fn compare_result(path: &Path, result: &str) -> Result<(), String> {
+    let result = normalize(result);
     if env::var_os("BLESS").is_some() {
         fs::write(path, &result).map_err(|e| {
             format!(

--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed an issue on Windows where request URIs were not being normalized ([#231](https://github.com/stjude-rust-labs/wdl/pull/231)).
+
 ## 0.4.0 - 10-16-2024
 
 ### Fixed


### PR DESCRIPTION
This fixes LSP requests that contain percent encoded colons and
lowercase drive letters in request URIs.

This caused the analyzer to report an empty set of diagnostics on Windows because
the requested document was unknown to the analyzer (it uses both a colon
and an uppercase drive letter in the document graph).

The fix is to percent decode the path segments and normalize the drive
letter to uppercase in the LSP server.

Fixes https://github.com/stjude-rust-labs/wdl/issues/229.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
