### PR TITLE
refactor: refactor the analysis API.

### DIFF
--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -20,11 +20,11 @@ commit_hash = "4536dd2c6719b86f4c50348f0ce354818260cadb"
 
 [repositories."broadinstitute/palantir-workflows"]
 identifier = "broadinstitute/palantir-workflows"
-commit_hash = "d2c4f2331d5875f70d7565feb3f9298fca519359"
+commit_hash = "58f72308bdf511a760dea92dbf2ac21eb2c7dc0e"
 
 [repositories."broadinstitute/warp"]
 identifier = "broadinstitute/warp"
-commit_hash = "27adc7f7518812746f80c6d83dcf1ab05c1e57fe"
+commit_hash = "548f6d2d94eb85cd18613f1729f0d3e8386cd3b5"
 
 [repositories."chanzuckerberg/czid-workflows"]
 identifier = "chanzuckerberg/czid-workflows"
@@ -49,7 +49,7 @@ filters = ["/template/task-templates.wdl"]
 
 [repositories."theiagen/public_health_bioinformatics"]
 identifier = "theiagen/public_health_bioinformatics"
-commit_hash = "be24047e2b64d02a187824909b91d04bda6074d8"
+commit_hash = "d659feebab0f383898b728bd9b27e390ec7bed7f"
 
 [[diagnostics]]
 document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
@@ -1339,2797 +1339,2802 @@ permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkPhasing/PhaseVCF.wdl"
 message = "PhaseVCF.wdl:38:17: warning[UnusedInput]: unused input `input_sample_name`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkPhasing/PhaseVCF.wdl/#L38"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkPhasing/PhaseVCF.wdl/#L38"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:104:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L104"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:148:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L148"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L148"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:204:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L204"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L204"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:216:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L216"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L216"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:242:26: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L242"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L242"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:243:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:243:78: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:244:48: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:244:75: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L244"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:416:21: warning[UnusedInput]: unused input `bed_regions`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L416"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L416"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:417:23: warning[UnusedInput]: unused input `bed_labels`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L417"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L417"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:418:13: warning[UnusedInput]: unused input `breakpoint_padding`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L418"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L418"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:457:40: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:457:49: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L457"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:485:43: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:485:52: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L485"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:772:43: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:772:52: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L772"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:77:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:789:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:789:49: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L789"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:790:42: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:790:51: error: cannot coerce type `Array[Int]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L790"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:890:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:890:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L890"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:23:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/CleanSVs.wdl/#L23"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/CleanSVs.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:33:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/CleanSVs.wdl/#L33"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/CleanSVs.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:42:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/CleanSVs.wdl/#L42"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/CleanSVs.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/CleanSVs.wdl"
 message = "CleanSVs.wdl:51:29: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/CleanSVs.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/CleanSVs.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/WittyerTasks.wdl"
 message = "WittyerTasks.wdl:74:14: error: conflicting output name `wittyer_config`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkSVs/WittyerTasks.wdl/#L74"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/WittyerTasks.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:23:21: warning[UnusedInput]: unused input `evaluation_intervals`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L23"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:75:32: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L75"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:76:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L76"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
 message = "BenchmarkAndCompareVCFs.wdl:77:22: error: type mismatch: expected type `Array[Int]`, but found type `Array[Int]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:178:37: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L178"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L178"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:179:38: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L179"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L179"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:180:37: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L180"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L180"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:189:18: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L189"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L189"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:243:17: warning[UnusedInput]: unused input `experiment`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L243"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:613:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:613:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L613"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:621:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:621:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L621"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:626:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:626:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:631:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:631:49: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L631"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:91:54: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/BenchmarkVCFs.wdl/#L91"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/CompareBenchmarks.wdl"
 message = "CompareBenchmarks.wdl:31:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/CompareBenchmarks.wdl/#L31"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/CompareBenchmarks.wdl/#L31"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/CompareBenchmarks.wdl"
 message = "CompareBenchmarks.wdl:32:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/CompareBenchmarks.wdl/#L32"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/CompareBenchmarks.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:127:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L127"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L127"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:135:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L135"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L135"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:143:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L143"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/FindSamplesAndBenchmark.wdl"
 message = "FindSamplesAndBenchmark.wdl:151:31: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L151"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/FindSamplesAndBenchmark.wdl/#L151"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Fingerprints/GetFingerprintMetrics.wdl"
 message = "GetFingerprintMetrics.wdl:45:11: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Fingerprints/GetFingerprintMetrics.wdl/#L45"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Fingerprints/GetFingerprintMetrics.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:119:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L119"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:120:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L120"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L120"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:125:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L125"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L125"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:166:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L166"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L166"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:167:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L167"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L167"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:170:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L170"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L170"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:195:42: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L195"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L195"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:196:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L196"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L196"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:199:76: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L199"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L199"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:224:42: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L224"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L224"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:225:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L225"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L225"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:228:76: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L228"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L228"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:236:57: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L236"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L236"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:283:30: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L283"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L283"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:59:17: warning[UnusedInput]: unused input `signed_difference`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L59"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:65:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:65:32: error: type mismatch: expected type `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:69:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:69:32: error: type mismatch: expected type `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:92:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L92"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:93:35: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L93"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:98:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/FunctionalEquivalence.wdl/#L98"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/FunctionalEquivalence.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/FEEvaluation.wdl"
 message = "FEEvaluation.wdl:11:69: error: type mismatch: string concatenation is not supported for type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L11"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/FEEvaluation.wdl"
 message = "FEEvaluation.wdl:124:35: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L124"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/subworkflows/FEEvaluation.wdl/#L124"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/PlotROC.wdl"
 message = "PlotROC.wdl:41:9: warning[UnusedDeclaration]: unused declaration `machine_mem_gb`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L41"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L41"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/subworkflows/PlotROC.wdl"
 message = "PlotROC.wdl:43:95: error: type mismatch: string concatenation is not supported for type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L43"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/FunctionalEquivalence/subworkflows/PlotROC.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:48:21: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L48"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:49:28: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L49"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:55:46: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L55"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:56:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L56"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:60:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L60"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:61:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L61"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:62:61: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L62"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:63:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L63"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:64:29: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L64"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:70:39: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L70"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:73:27: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L73"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:74:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L74"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:75:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L75"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:76:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L76"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:83:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L83"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:63:50: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L63"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:64:31: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L64"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:68:31: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L68"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L68"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:69:26: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:70:65: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L70"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:71:30: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L71"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:72:33: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L72"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:83:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L83"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:84:27: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L84"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:85:36: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L85"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:86:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L86"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl"
 message = "Glimpse2ImputationInBatches.wdl:88:29: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L88"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl"
 message = "Glimpse2MergeBatches.wdl:157:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl/#L157"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl/#L157"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/HaplotypeMap/BuildHaplotypeMap.wdl"
 message = "BuildHaplotypeMap.wdl:17:1: error: a WDL document must start with a version statement"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/HaplotypeMap/BuildHaplotypeMap.wdl/#L17"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/HaplotypeMap/BuildHaplotypeMap.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/EndToEndPipeline.wdl"
 message = "EndToEndPipeline.wdl:6:25: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/EndToEndPipeline.wdl/#L6"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/EndToEndPipeline.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:1062:11: error: type mismatch: expected type `String` or type `Array[String]`, but found type `Int`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Imputation.wdl/#L1062"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Imputation.wdl/#L1062"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:1081:7: warning[UnusedInput]: unused input `mem`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Imputation.wdl/#L1081"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Imputation.wdl/#L1081"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:294:31: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Imputation.wdl/#L294"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Imputation.wdl/#L294"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:373:12: warning[UnusedInput]: unused input `vcf_index`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Imputation.wdl/#L373"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Imputation.wdl/#L373"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:487:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Imputation.wdl/#L487"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Imputation.wdl/#L487"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:519:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Imputation.wdl/#L519"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Imputation.wdl/#L519"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Imputation.wdl"
 message = "Imputation.wdl:85:17: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Imputation.wdl/#L85"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Imputation.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCARE.wdl"
 message = "PCARE.wdl:3:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PCARE.wdl/#L3"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCARE.wdl/#L3"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCARE.wdl"
 message = "PCARE.wdl:44:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PCARE.wdl/#L44"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCARE.wdl/#L44"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:49:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PCAREAndQC.wdl/#L49"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCAREAndQC.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:61:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PCAREAndQC.wdl/#L61"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCAREAndQC.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:62:35: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PCAREAndQC.wdl/#L62"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCAREAndQC.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:63:41: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PCAREAndQC.wdl/#L63"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCAREAndQC.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
 message = "PRSWrapper.wdl:48:30: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PRSWrapper.wdl/#L48"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PRSWrapper.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
 message = "PRSWrapper.wdl:4:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PRSWrapper.wdl/#L4"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PRSWrapper.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PRSWrapper.wdl"
 message = "PRSWrapper.wdl:64:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PRSWrapper.wdl/#L64"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PRSWrapper.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
 message = "PerformPopulationPCA.wdl:105:8: warning[UnusedCall]: unused call `CheckPCA`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PerformPopulationPCA.wdl/#L105"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PerformPopulationPCA.wdl/#L105"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
 message = "PerformPopulationPCA.wdl:134:6: warning[UnusedDeclaration]: unused declaration `disk_size`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PerformPopulationPCA.wdl/#L134"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PerformPopulationPCA.wdl/#L134"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PerformPopulationPCA.wdl"
 message = "PerformPopulationPCA.wdl:407:41: error: type mismatch: a type common to both type `File` and type `Array[File]` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/PerformPopulationPCA.wdl/#L407"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PerformPopulationPCA.wdl/#L407"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoreBGE/ScoreBGE.wdl"
 message = "ScoreBGE.wdl:34:32: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/ScoreBGE/ScoreBGE.wdl/#L34"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/ScoreBGE/ScoreBGE.wdl/#L34"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoringPart.wdl"
 message = "ScoringPart.wdl:23:6: warning[UnusedInput]: unused input `population_scoring_mem`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/ScoringPart.wdl/#L23"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/ScoringPart.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/ScoringPart.wdl"
 message = "ScoringPart.wdl:6:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/ScoringPart.wdl/#L6"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/ScoringPart.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/TrainAncestryAdjustmentModel.wdl"
 message = "TrainAncestryAdjustmentModel.wdl:3:26: warning[UnusedImport]: unused import namespace `PCATasks`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L3"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L3"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/TrainAncestryAdjustmentModel.wdl"
 message = "TrainAncestryAdjustmentModel.wdl:5:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L5"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/TrainAncestryAdjustmentModel.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
 message = "FullImputationPRSValidation.wdl:52:18: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
 message = "FullImputationPRSValidation.wdl:5:8: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L5"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
 message = "SubsetWeightSet.wdl:27:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `SelfExclusiveSites`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L27"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
 message = "SubsetWeightSet.wdl:28:66: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[SelfExclusiveSites]+`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/ValidateImputation.wdl"
 message = "ValidateImputation.wdl:4:28: warning[UnusedImport]: unused import namespace `structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Validation/ValidateImputation.wdl/#L4"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/ValidateImputation.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/ValidateScoring.wdl"
 message = "ValidateScoring.wdl:7:28: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/ImputationPipeline/Validation/ValidateScoring.wdl/#L7"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/ValidateScoring.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/JointCalling/CreateSampleMap.wdl"
 message = "CreateSampleMap.wdl:57:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/JointCalling/CreateSampleMap.wdl/#L57"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/JointCalling/CreateSampleMap.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/Bambu.wdl"
 message = "Bambu.wdl:11:16: warning[UnusedInput]: unused input `dataType`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/LongReadRNABenchmark/Bambu.wdl/#L11"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/LongReadRNABenchmark/Bambu.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/Flames.wdl"
 message = "Flames.wdl:10:16: warning[UnusedInput]: unused input `datasetName`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/LongReadRNABenchmark/Flames.wdl/#L10"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/LongReadRNABenchmark/Flames.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:147:13: error: conflicting scatter variable name `gtf`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L147"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L147"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl"
 message = "IsoformDiscoveryBenchmark.wdl:22:14: warning[UnusedInput]: unused input `excludedGTF`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L22"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/LongReadRNABenchmark/IsoformDiscoveryBenchmark.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl"
 message = "IsoformDiscoveryBenchmarkTasks.wdl:69:32: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl/#L69"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/LongReadRNABenchmark/IsoformDiscoveryBenchmarkTasks.wdl/#L69"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:175:14: warning[UnusedInput]: unused input `interval_file`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L175"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L175"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:223:37: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:223:50: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L223"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:270:37: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:270:50: error: cannot coerce type `Array[File]` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L270"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl"
 message = "ComputeIntervalBamStats.wdl:77:14: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L77"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:51:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/CreateIGVSession.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/CreateIGVSession.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:51:50: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/CreateIGVSession.wdl/#L51"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/CreateIGVSession.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:52:36: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/CreateIGVSession.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/CreateIGVSession.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:52:50: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/CreateIGVSession.wdl/#L52"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/CreateIGVSession.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:53:46: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/CreateIGVSession.wdl/#L53"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/CreateIGVSession.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/CreateIGVSession.wdl"
 message = "CreateIGVSession.wdl:53:60: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/CreateIGVSession.wdl/#L53"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/CreateIGVSession.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
 message = "DownsampleAndCollectCoverage.wdl:173:91: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L173"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L173"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
 message = "DownsampleAndCollectCoverage.wdl:196:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L196"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L196"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/IndexCramOrBam.wdl"
 message = "IndexCramOrBam.wdl:36:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/IndexCramOrBam.wdl/#L36"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/IndexCramOrBam.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
 message = "MatchFingerprints.wdl:67:33: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[String]]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/MatchFingerprints.wdl/#L67"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/MatchFingerprints.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
 message = "MatchFingerprints.wdl:88:17: warning[UnusedInput]: unused input `fail_on_mismatch`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/d2c4f2331d5875f70d7565feb3f9298fca519359/Utilities/WDLs/MatchFingerprints.wdl/#L88"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/Utilities/WDLs/MatchFingerprints.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
 message = "TargetedSomaticSingleSample.wdl:18:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L18"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L18"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
 message = "TargetedSomaticSingleSample.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl"
 message = "BuildIndexHisat3n.9.wdl:9:15: warning[UnusedInput]: unused input `monitoring_script_path`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/beta-pipelines/skylab/slidetags/SlideTags.wdl"
+message = "SlideTags.wdl:10:16: warning[UnusedInput]: unused input `id`"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L10"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/beta-pipelines/skylab/slidetags/SlideTags.wdl"
+message = "SlideTags.wdl:26:32: warning[UnusedCall]: unused call `spatial_count`"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L26"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/beta-pipelines/skylab/slidetags/SlideTags.wdl"
+message = "SlideTags.wdl:7:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L7"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/deprecated/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl"
+message = "BuildCembaReferences.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/deprecated/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl/#L9"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/deprecated/pipelines/cemba/cemba_methylcseq/CEMBA.wdl"
+message = "CEMBA.wdl:60:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/deprecated/pipelines/cemba/cemba_methylcseq/CEMBA.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:104:12: warning[UnusedInput]: unused input `significant_variants_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L104"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:77:54: error: type mismatch: a type common to both type `File` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:7:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
 message = "Imputation.wdl:262:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/imputation/Imputation.wdl/#L262"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/imputation/Imputation.wdl/#L262"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
 message = "Imputation.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/imputation/Imputation.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/imputation/Imputation.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:21:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L21"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L21"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:26:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
 message = "Arrays.wdl:26:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/single_sample/Arrays.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/single_sample/Arrays.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
 message = "Arrays.wdl:322:28: warning[UnusedCall]: unused call `UpdateChipWellBarcodeIndex`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/single_sample/Arrays.wdl/#L322"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/single_sample/Arrays.wdl/#L322"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:137:24: warning[UnusedCall]: unused call `ValidateVariants`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L137"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L137"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:255:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L255"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L255"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:259:10: warning[UnusedInput]: unused input `truth_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L259"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L259"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:4:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L4"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:205:81: error: type mismatch: string concatenation is not supported for type `File?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L205"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L205"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:397:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L397"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L397"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:62:13: warning[UnusedInput]: unused input `rename_gvcf_samples`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:14:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:269:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L269"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L269"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:63:13: warning[UnusedInput]: unused input `cross_check_fingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:210:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L210"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L210"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:47:23: warning[UnusedInput]: unused input `gnarly_workaround_annotations`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L47"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:14:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:23:9: warning[UnusedInput]: unused input `large_disk`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:24:9: warning[UnusedInput]: unused input `huge_disk`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:58:11: warning[UnusedInput]: unused input `excess_het_threshold`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:61:9: warning[UnusedInput]: unused input `SNP_VQSR_downsampleFactor`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L61"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:75:15: warning[UnusedDeclaration]: unused declaration `fingerprinting_vcf_indices`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L75"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:78:7: warning[UnusedDeclaration]: unused declaration `num_gvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:51:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:57:28: warning[UnusedCall]: unused call `ValidateVCF`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:42:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:48:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:73:10: warning[UnusedDeclaration]: unused declaration `gatk_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:10:83: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineQC`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:11:92: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L11"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:53:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:62:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:63:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:7:104: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:83:7: warning[UnusedDeclaration]: unused declaration `hc_divisor`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L83"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:8:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:9:50: warning[UnusedImport]: unused import namespace `QC`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:109:37: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:37:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:43:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
 message = "VariantCalling.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
 message = "VariantCalling.wdl:209:26: warning[UnusedCall]: unused call `ValidateVCF`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L209"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L209"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:10:92: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:46:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:58:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:59:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:5:72: warning[UnusedImport]: unused import namespace `VariantDiscoverTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:87:30: warning[UnusedCall]: unused call `ValidateCram`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:391:9: warning[UnusedInput]: unused input `max_retries`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L391"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L391"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:626:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L626"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:666:40: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L666"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L666"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:672:14: error: conflicting scatter variable name `ubam`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L672"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L672"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
 message = "BroadInternalImputation.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
 message = "BroadInternalImputation.wdl:81:34: warning[UnusedCall]: unused call `TriggerPrsWithImputationTsv`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L81"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L81"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
 message = "BroadInternalArrays.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
 message = "BroadInternalArrays.wdl:80:24: warning[UnusedCall]: unused call `IngestOutputsToTDR`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L80"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L80"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:4:95: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:63:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:64:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L64"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:91:34: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:92:48: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L92"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:93:46: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L93"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:94:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L94"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L94"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:95:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L95"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:96:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L96"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L96"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:97:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
 message = "BroadInternalRNAWithUMIs.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
 message = "BroadInternalRNAWithUMIs.wdl:160:45: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L160"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/qc/CheckFingerprint.wdl"
 message = "CheckFingerprint.wdl:27:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/qc/CheckFingerprint.wdl/#L27"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/qc/CheckFingerprint.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
 message = "CramToUnmappedBams.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
 message = "CramToUnmappedBams.wdl:20:12: warning[UnusedInput]: unused input `base_file_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L20"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L20"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
 message = "ExomeReprocessing.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
 message = "ExomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
 message = "ExternalExomeReprocessing.wdl:62:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
 message = "ExternalExomeReprocessing.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
 message = "ExternalWholeGenomeReprocessing.wdl:60:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
 message = "ExternalWholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
 message = "WholeGenomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
 message = "WholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl"
 message = "RNAWithUMIsPipeline.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl/#L23"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl"
-message = "BuildCembaReferences.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl/#L9"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/cemba/cemba_methylcseq/CEMBA.wdl"
-message = "CEMBA.wdl:60:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/cemba/cemba_methylcseq/CEMBA.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:142:25: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/atac/atac.wdl/#L142"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L142"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:153:25: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/atac/atac.wdl/#L153"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L153"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:3:52: warning[UnusedImport]: unused import namespace `Merge`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/atac/atac.wdl/#L3"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L3"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:49:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/atac/atac.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:507:10: error: conflicting input name `annotations_gtf`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/atac/atac.wdl/#L507"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L507"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:150:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/build_indices/BuildIndices.wdl/#L150"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L150"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:160:12: warning[UnusedInput]: unused input `gtf_annotation_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/build_indices/BuildIndices.wdl/#L160"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:190:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/build_indices/BuildIndices.wdl/#L190"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L190"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:73:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/build_indices/BuildIndices.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/multiome/Multiome.wdl"
 message = "Multiome.wdl:105:13: error: duplicate call input `cloud_provider` in call statement"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/multiome/Multiome.wdl/#L105"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/multiome/Multiome.wdl/#L105"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/multiome/Multiome.wdl"
 message = "Multiome.wdl:90:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/multiome/Multiome.wdl/#L90"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/multiome/Multiome.wdl/#L90"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:163:18: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:226:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L226"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L226"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:227:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L227"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L227"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:245:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L245"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L245"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:276:24: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L276"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L276"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:282:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L282"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L282"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:78:14: warning[UnusedDeclaration]: unused declaration `indices`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:91:10: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/optimus/Optimus.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
 message = "PairedTag.wdl:5:49: warning[UnusedImport]: unused import namespace `H5adUtils`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
 message = "PairedTag.wdl:86:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/scATAC/scATAC.wdl"
 message = "scATAC.wdl:203:9: error: duplicate key `cpu` in runtime section"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/scATAC/scATAC.wdl/#L203"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/scATAC/scATAC.wdl/#L203"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:49:12: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/slideseq/SlideSeq.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/slideseq/SlideSeq.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:7:51: warning[UnusedImport]: unused import namespace `OptimusInputChecks`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:98:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl"
 message = "MultiSampleSmartSeq2.wdl:71:28: warning[UnusedCall]: unused call `checkArrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:135:27: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L135"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L135"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:34:15: warning[UnusedInput]: unused input `batch_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L34"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L34"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:35:22: warning[UnusedInput]: unused input `project_id`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:36:22: warning[UnusedInput]: unused input `project_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L36"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:37:22: warning[UnusedInput]: unused input `library`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:38:22: warning[UnusedInput]: unused input `species`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L38"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L38"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:39:22: warning[UnusedInput]: unused input `organ`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:81:40: warning[UnusedCall]: unused call `checkArrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
 message = "snm3C.wdl:278:14: warning[UnusedInput]: unused input `chromosome_sizes`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/snm3C/snm3C.wdl/#L278"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/snm3C/snm3C.wdl/#L278"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
 message = "snm3C.wdl:47:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/pipelines/skylab/snm3C/snm3C.wdl/#L47"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/snm3C/snm3C.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:131:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:217:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:45:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:141:73: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L141"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L141"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:142:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L142"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L142"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:143:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L143"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:175:68: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:231:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L231"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L231"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:42:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:90:10: warning[UnusedDeclaration]: unused declaration `project_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L90"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L90"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
 message = "AdapterTasks.wdl:580:13: warning[UnusedInput]: unused input `cache_invalidate`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/tasks/AdapterTasks.wdl/#L580"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/tasks/AdapterTasks.wdl/#L580"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
 message = "AdapterTasks.wdl:738:13: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/tasks/AdapterTasks.wdl/#L738"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/tasks/AdapterTasks.wdl/#L738"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/CreateReferenceMetadata.wdl"
 message = "CreateReferenceMetadata.wdl:15:12: warning[UnusedInput]: unused input `input_type`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/projects/tasks/CreateReferenceMetadata.wdl/#L15"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/tasks/CreateReferenceMetadata.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/scripts/BuildAFComparisonTable.wdl"
 message = "BuildAFComparisonTable.wdl:88:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/scripts/BuildAFComparisonTable.wdl/#L88"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/scripts/BuildAFComparisonTable.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/AggregatedBamQC.wdl"
 message = "AggregatedBamQC.wdl:60:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/AggregatedBamQC.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/AggregatedBamQC.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Alignment.wdl"
 message = "Alignment.wdl:119:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Alignment.wdl/#L119"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Alignment.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/BamProcessing.wdl"
 message = "BamProcessing.wdl:53:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/BamProcessing.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/BamProcessing.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/CopyFilesFromCloudToCloud.wdl"
 message = "CopyFilesFromCloudToCloud.wdl:71:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/CopyFilesFromCloudToCloud.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/CopyFilesFromCloudToCloud.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:163:118: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Funcotator.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:163:92: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Funcotator.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:164:118: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Funcotator.wdl/#L164"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:164:89: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Funcotator.wdl/#L164"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:165:121: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Funcotator.wdl/#L165"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:165:91: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Funcotator.wdl/#L165"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:140:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:157:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L157"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L157"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:27:12: warning[UnusedInput]: unused input `contamination`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L27"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:335:12: warning[UnusedInput]: unused input `vcf_basename`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L335"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L335"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:373:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L373"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L373"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:429:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L429"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L429"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:67:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:74:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L74"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:92:12: warning[UnusedInput]: unused input `contamination`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L92"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:98:13: warning[UnusedInput]: unused input `use_dragen_hard_filtering`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/GermlineVariantDiscovery.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:109:11: warning[UnusedInput]: unused input `fingerprint_genotypes_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:214:10: warning[UnusedInput]: unused input `input_vcf`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L214"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L214"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:287:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L287"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L287"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:289:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L289"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L289"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:423:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L423"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L423"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:541:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L541"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L541"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:556:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L556"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L556"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:591:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L591"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L591"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:595:11: warning[UnusedInput]: unused input `truth_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L595"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L595"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:62:9: warning[UnusedInput]: unused input `disk_size`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:661:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L661"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L661"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:698:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L698"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L698"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/ImputationTasks.wdl"
 message = "ImputationTasks.wdl:529:9: warning[UnusedInput]: unused input `nSamples`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/ImputationTasks.wdl/#L529"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/ImputationTasks.wdl/#L529"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
 message = "InternalArraysTasks.wdl:42:10: warning[UnusedInput]: unused input `upload_metrics_output`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/InternalArraysTasks.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalArraysTasks.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
 message = "InternalArraysTasks.wdl:85:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/InternalArraysTasks.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalArraysTasks.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalImputationTasks.wdl"
 message = "InternalImputationTasks.wdl:129:25: warning[UnusedInput]: unused input `run_task`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/InternalImputationTasks.wdl/#L129"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalImputationTasks.wdl/#L129"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalTasks.wdl"
 message = "InternalTasks.wdl:13:10: warning[UnusedDeclaration]: unused declaration `safe_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/InternalTasks.wdl/#L13"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalTasks.wdl/#L13"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:304:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L304"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L304"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:366:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L366"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L366"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:434:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:49:13: warning[UnusedInput]: unused input `sample_names_unique_done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:581:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L581"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L581"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:641:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L641"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L641"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:688:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L688"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L688"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:859:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L859"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L859"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:87:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:900:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/JointGenotypingTasks.wdl/#L900"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L900"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:434:31: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Qc.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:434:46: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Qc.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:436:46: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Qc.wdl/#L436"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L436"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:506:29: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Qc.wdl/#L506"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L506"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/RNAWithUMIsTasks.wdl"
 message = "RNAWithUMIsTasks.wdl:935:12: warning[UnusedInput]: unused input `mem`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/RNAWithUMIsTasks.wdl/#L935"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/RNAWithUMIsTasks.wdl/#L935"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
 message = "SplitLargeReadGroup.wdl:21:45: warning[UnusedImport]: unused import namespace `Utils`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/SplitLargeReadGroup.wdl/#L21"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/SplitLargeReadGroup.wdl/#L21"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
 message = "SplitLargeReadGroup.wdl:22:53: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/SplitLargeReadGroup.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/SplitLargeReadGroup.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl"
 message = "UltimaGenomicsGermlineFilteringThreshold.wdl:228:11: warning[UnusedInput]: unused input `interval_list`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl/#L228"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl/#L228"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:14:11: warning[UnusedInput]: unused input `rsq_threshold`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:5:80: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:65:7: warning[UnusedDeclaration]: unused declaration `rounded_disk_size`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:1096:12: warning[UnusedInput]: unused input `annotation`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L1096"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L1096"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:63:9: warning[UnusedInput]: unused input `preemptible`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:785:10: warning[UnusedInput]: unused input `read_length`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L785"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L785"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:786:11: warning[UnusedInput]: unused input `jar_override`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L786"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L786"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:814:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:839:10: warning[UnusedInput]: unused input `read_length`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L839"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L839"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:866:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:168:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UnmappedBamToAlignedBam.wdl/#L168"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UnmappedBamToAlignedBam.wdl/#L168"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:25:53: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:85:31: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/UnmappedBamToAlignedBam.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UnmappedBamToAlignedBam.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Utilities.wdl"
 message = "Utilities.wdl:152:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Utilities.wdl/#L152"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Utilities.wdl/#L152"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Utilities.wdl"
 message = "Utilities.wdl:183:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/broad/Utilities.wdl/#L183"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Utilities.wdl/#L183"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/FastqProcessing.wdl"
 message = "FastqProcessing.wdl:243:16: warning[UnusedInput]: unused input `barcode_orientation`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/FastqProcessing.wdl/#L243"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/FastqProcessing.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:119:10: error: conflicting output name `library_metrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/H5adUtils.wdl/#L119"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:224:14: error: conflicting output name `library_metrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/H5adUtils.wdl/#L224"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L224"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:237:12: warning[UnusedInput]: unused input `cpuPlatform`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/H5adUtils.wdl/#L237"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L237"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:35:12: error: conflicting input name `counting_mode`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/H5adUtils.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:537:24: warning[UnusedInput]: unused input `input_names`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/H5adUtils.wdl/#L537"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L537"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/LoomUtils.wdl"
 message = "LoomUtils.wdl:318:24: warning[UnusedInput]: unused input `input_names`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/LoomUtils.wdl/#L318"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/LoomUtils.wdl/#L318"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/PairedTagUtils.wdl"
 message = "PairedTagUtils.wdl:206:16: warning[UnusedInput]: unused input `cpuPlatform`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/PairedTagUtils.wdl/#L206"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/PairedTagUtils.wdl/#L206"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
 message = "StarAlign.wdl:459:12: warning[UnusedInput]: unused input `gex_nhash_id`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/StarAlign.wdl/#L459"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/StarAlign.wdl/#L459"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
 message = "StarAlign.wdl:784:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/StarAlign.wdl/#L784"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/StarAlign.wdl/#L784"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:24:16: warning[UnusedInput]: unused input `ref_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:48:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:6:13: warning[UnusedInput]: unused input `dummy_int`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L6"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:7:16: warning[UnusedInput]: unused input `dummy_string`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:8:17: warning[UnusedInput]: unused input `dummy_boolean`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:9:17: warning[UnusedInput]: unused input `dummy_option`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/cemba/pr/CheckCembaOutputs.wdl"
 message = "CheckCembaOutputs.wdl:1:1: error: a WDL document must start with a version statement"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/scATAC/pr/test_scATAC_PR.wdl"
 message = "test_scATAC_PR.wdl:35:34: warning[UnusedCall]: unused call `checker`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/skylab/scATAC/pr/test_scATAC_PR.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/scATAC/pr/test_scATAC_PR.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
 message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
 message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:46:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyArrays.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyArrays.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:49:38: warning[UnusedCall]: unused call `VerifyIlluminaGenotypingArray`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyArrays.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyArrays.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:66:40: warning[UnusedCall]: unused call `CompareParamsFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyArrays.wdl/#L66"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyArrays.wdl/#L66"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
 message = "VerifyCheckFingerprint.wdl:31:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyCheckFingerprint.wdl/#L31"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyCheckFingerprint.wdl/#L31"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
 message = "VerifyCheckFingerprint.wdl:42:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyCheckFingerprint.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyCheckFingerprint.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCramToUnmappedBamsUpdated.wdl"
 message = "VerifyCramToUnmappedBamsUpdated.wdl:9:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyCramToUnmappedBamsUpdated.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyCramToUnmappedBamsUpdated.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
 message = "VerifyExomeReprocessing.wdl:24:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyExomeReprocessing.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyExomeReprocessing.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
 message = "VerifyExomeReprocessing.wdl:37:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyExomeReprocessing.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyExomeReprocessing.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExternalReprocessing.wdl"
 message = "VerifyExternalReprocessing.wdl:10:10: warning[UnusedCall]: unused call `AssertTrue`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyExternalReprocessing.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyExternalReprocessing.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
 message = "VerifyGDCSomaticSingleSample.wdl:17:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGDCSomaticSingleSample.wdl/#L17"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGDCSomaticSingleSample.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
 message = "VerifyGDCSomaticSingleSample.wdl:26:20: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGDCSomaticSingleSample.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGDCSomaticSingleSample.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:22:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGermlineSingleSample.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:26:14: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGermlineSingleSample.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:40:8: warning[UnusedCall]: unused call `CompareGvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGermlineSingleSample.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:46:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGermlineSingleSample.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:52:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGermlineSingleSample.wdl/#L52"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:13:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGvcf.wdl/#L13"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGvcf.wdl/#L13"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:16:20: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGvcf.wdl/#L16"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGvcf.wdl/#L16"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:24:20: warning[UnusedCall]: unused call `CompareVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyGvcf.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGvcf.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:102:24: warning[UnusedCall]: unused call `CompareGreenIdatMdf5Sum`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyIlluminaGenotypingArray.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:108:24: warning[UnusedCall]: unused call `CompareRedIdatMdf5Sum`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyIlluminaGenotypingArray.wdl/#L108"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L108"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:43:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyIlluminaGenotypingArray.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:83:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyIlluminaGenotypingArray.wdl/#L83"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:89:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyIlluminaGenotypingArray.wdl/#L89"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L89"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:95:14: warning[UnusedCall]: unused call `CompareGtcs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyIlluminaGenotypingArray.wdl/#L95"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:43:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyImputation.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyImputation.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:56:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyImputation.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyImputation.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:72:8: warning[UnusedCall]: unused call `CrosscheckFingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyImputation.wdl/#L72"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyImputation.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyJointGenotyping.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyJointGenotyping.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:48:28: warning[UnusedCall]: unused call `VerifyMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyJointGenotyping.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyJointGenotyping.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:54:40: warning[UnusedCall]: unused call `CompareIntervals`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyJointGenotyping.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyJointGenotyping.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:73:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMetrics.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMetrics.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:87:117: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMetrics.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMetrics.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:87:89: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMetrics.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMetrics.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
 message = "VerifyMultiSampleArrays.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiSampleArrays.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleArrays.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
 message = "VerifyMultiSampleArrays.wdl:28:14: warning[UnusedCall]: unused call `CompareVcfsAllowingQualityDifferences`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiSampleArrays.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleArrays.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:12:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:24:43: warning[UnusedCall]: unused call `CompareH5adFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:32:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L32"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L70"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L75"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
 message = "VerifyMultiome.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyMultiome.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
 message = "VerifyNA12878.wdl:62:9: warning[UnusedDeclaration]: unused declaration `default_disk_space_gb`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyNA12878.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyNA12878.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
 message = "VerifyNA12878.wdl:65:47: error: type mismatch: multiplication operator is not supported for type `Int?` and type `Int`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyNA12878.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyNA12878.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:23:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:45:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:51:40: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:53:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:54:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyOptimus.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:32:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L32"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L70"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L75"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyPairedTag.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:103:50: warning[UnusedCall]: unused call `CompareGeneCounts`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyRNAWithUMIs.wdl/#L103"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L103"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:109:50: warning[UnusedCall]: unused call `CompareExonCounts`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyRNAWithUMIs.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:28:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyRNAWithUMIs.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:37:40: warning[UnusedCall]: unused call `CompareTextMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyRNAWithUMIs.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:43:35: warning[UnusedCall]: unused call `CompareOutputBam`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyRNAWithUMIs.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:97:50: warning[UnusedCall]: unused call `CompareGeneTpms`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyRNAWithUMIs.wdl/#L97"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L97"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyReprocessing.wdl"
 message = "VerifyReprocessing.wdl:33:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyReprocessing.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyReprocessing.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:23:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySlideSeq.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySlideSeq.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySlideSeq.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySlideSeq.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:45:50: warning[UnusedCall]: unused call `CompareUMIMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySlideSeq.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:51:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySlideSeq.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
 message = "VerifySomaticSingleSample.wdl:24:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySomaticSingleSample.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySomaticSingleSample.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
 message = "VerifySomaticSingleSample.wdl:30:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifySomaticSingleSample.wdl/#L30"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySomaticSingleSample.wdl/#L30"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:36:28: warning[UnusedCall]: unused call `VerifyMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L36"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:42:40: warning[UnusedCall]: unused call `CompareIntervals`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:48:8: warning[UnusedCall]: unused call `CompareFingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:102:115: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:102:87: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:17:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L17"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:64:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L64"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:72:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L72"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:89:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L89"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L89"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:105:29: warning[UnusedCall]: unused call `CompareGvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L105"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L105"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:112:22: warning[UnusedCall]: unused call `VerifyNA12878`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L112"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L112"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:161:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L161"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L161"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:115: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:87: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:30:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L30"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L30"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:77:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:85:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:91:29: warning[UnusedCall]: unused call `CompareVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:98:29: warning[UnusedCall]: unused call `CompareFilteredVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:40:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyValidateChip.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:43:14: warning[UnusedCall]: unused call `CompareGtcs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyValidateChip.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:50:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyValidateChip.wdl/#L50"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L50"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:56:55: warning[UnusedCall]: unused call `CompareGenotypeConcordanceVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyValidateChip.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:62:55: warning[UnusedCall]: unused call `CompareIndelGenotypeConcordanceVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyValidateChip.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:12:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyscATAC.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyscATAC.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:15:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyscATAC.wdl/#L15"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyscATAC.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:22:43: warning[UnusedCall]: unused call `CompareSnapTextFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/VerifyscATAC.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyscATAC.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:23:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/Verifysnm3C.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/Verifysnm3C.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:26:52: warning[UnusedCall]: unused call `CompareMappingSummaryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/Verifysnm3C.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/Verifysnm3C.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:66:17: error: conflicting output name `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/Verifysnm3C.wdl/#L66"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/Verifysnm3C.wdl/#L66"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl"
 message = "TestBroadInternalRNAWithUMIs.wdl:106:54: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "TestBroadInternalUltimaGenomics.wdl:57:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "TestBroadInternalUltimaGenomics.wdl:58:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestCheckFingerprint.wdl"
 message = "TestCheckFingerprint.wdl:33:15: warning[UnusedInput]: unused input `vault_token_path_arrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestExomeReprocessing.wdl"
 message = "TestExomeReprocessing.wdl:7:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestExomeReprocessing.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestExomeReprocessing.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl"
 message = "TestExternalWholeGenomeReprocessing.wdl:6:45: warning[UnusedImport]: unused import namespace `Utilities`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
 message = "TestGDCWholeGenomeSomaticSingleSample.wdl:77:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:141:20: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestImputation.wdl/#L141"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L141"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:162:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestImputation.wdl/#L162"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L162"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:163:46: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestImputation.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:54:30: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestImputation.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:55:37: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestImputation.wdl/#L55"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:86:56: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestImputation.wdl/#L86"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:110:20: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestJointGenotyping.wdl/#L110"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L110"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:85:44: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestJointGenotyping.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:87:46: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestJointGenotyping.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:88:49: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestJointGenotyping.wdl/#L88"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:51:23: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:56:22: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:57:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:58:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:59:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L59"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:60:17: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiome.wdl"
 message = "TestMultiome.wdl:67:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestMultiome.wdl/#L67"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiome.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:118:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestOptimus.wdl/#L118"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L118"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:172:14: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestOptimus.wdl/#L172"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L172"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:28:11: warning[UnusedInput]: unused input `mt_genes`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestOptimus.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:76:36: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestOptimus.wdl/#L76"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
 message = "TestPairedTag.wdl:57:15: warning[UnusedInput]: unused input `run_cellbender`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestPairedTag.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestPairedTag.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
 message = "TestPairedTag.wdl:71:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestPairedTag.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestPairedTag.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:100:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L100"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:110:52: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L110"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L110"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:84:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L84"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestReblockGVCF.wdl"
 message = "TestReblockGVCF.wdl:49:31: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestReblockGVCF.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestReblockGVCF.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestSlideSeq.wdl"
 message = "TestSlideSeq.wdl:40:20: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestSlideSeq.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestSlideSeq.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:39:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:40:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
 message = "TestUltimaGenomicsWholeGenomeGermline.wdl:43:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
 message = "TestUltimaGenomicsWholeGenomeGermline.wdl:44:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L44"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L44"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl"
 message = "TestWholeGenomeGermlineSingleSample.wdl:54:45: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/27adc7f7518812746f80c6d83dcf1ab05c1e57fe/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -4569,1669 +4574,1669 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:11:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_ivar_consensus.wdl/#L11"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_ivar_consensus.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:12:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_ivar_consensus.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_ivar_consensus.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:9:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_ivar_consensus.wdl/#L9"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_ivar_consensus.wdl/#L9"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_metaspades.wdl"
 message = "task_metaspades.wdl:39:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_metaspades.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_metaspades.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_shovill.wdl"
 message = "task_shovill.wdl:77:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/assembly/task_shovill.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_shovill.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:10:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:12:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:13:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:95:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl"
 message = "task_snippy_gene_query.wdl:69:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_variants.wdl"
 message = "task_snippy_variants.wdl:128:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L128"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/advanced_metrics/task_gambittools.wdl"
 message = "task_gambittools.wdl:67:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:44:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L44"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L44"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:45:19: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L45"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L45"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:46:23: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L46"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L46"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
 message = "task_assembly_metrics.wdl:47:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L47"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L47"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl"
 message = "task_cg_pipeline.wdl:102:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:46:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:47:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:48:29: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:49:24: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:50:40: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_quast.wdl"
 message = "task_quast.wdl:64:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_readlength.wdl"
 message = "task_readlength.wdl:26:33: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
 message = "task_screen.wdl:15:13: warning[UnusedInput]: unused input `organism`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/comparisons/task_screen.wdl/#L15"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/comparisons/task_screen.wdl/#L15"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
-message = "task_screen.wdl:185:13: warning[UnusedInput]: unused input `organism`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/quality_control/comparisons/task_screen.wdl/#L185"
+message = "task_screen.wdl:187:13: warning[UnusedInput]: unused input `organism`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/comparisons/task_screen.wdl/#L187"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/species_typing/salmonella/task_genotyphi.wdl"
 message = "task_genotyphi.wdl:61:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:76:45: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/taxon_id/contamination/task_midas.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/taxon_id/contamination/task_midas.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:77:44: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/taxon_id/contamination/task_midas.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/taxon_id/contamination/task_midas.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/task_gambit.wdl"
 message = "task_gambit.wdl:164:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/taxon_id/task_gambit.wdl/#L164"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/taxon_id/task_gambit.wdl/#L164"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/data_handling/task_parse_mapping.wdl"
 message = "task_parse_mapping.wdl:133:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/submission/task_broad_ncbi_tools.wdl"
 message = "task_broad_ncbi_tools.wdl:11:12: warning[UnusedInput]: unused input `docker`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/tasks/utilities/submission/task_broad_ncbi_tools.wdl/#L11"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/utilities/submission/task_broad_ncbi_tools.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:120: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:40: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:120:126: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:120:42: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:124:108: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:124:36: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:131:114: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:131:38: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_plot.wdl"
 message = "wf_freyja_plot.wdl:18:25: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_plot.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_plot.wdl/#L18"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_update.wdl"
 message = "wf_freyja_update.wdl:13:17: warning[UnusedCall]: unused call `transfer_files`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/freyja/wf_freyja_update.wdl/#L13"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_update.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:153:80: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_augur.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_augur.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:62:21: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_augur.wdl/#L62"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_augur.wdl/#L62"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_core_gene_snp.wdl"
 message = "wf_core_gene_snp.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_mashtree_fasta.wdl"
 message = "wf_mashtree_fasta.wdl:37:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:33:58: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:34:53: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:35:51: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:36:52: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:37:57: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L101"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L101"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:106:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L106"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L106"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:107:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:108:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:119:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L119"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L119"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:120:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:121:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:122:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:123:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:132:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L132"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L132"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:150:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L150"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L150"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:71:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L71"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L71"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:72:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:73:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:74:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:84:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:85:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:86:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
 message = "wf_snippy_tree.wdl:87:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:27:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:32:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:33:19: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:34:17: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:35:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:36:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:37:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:38:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:39:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:40:23: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:37:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:38:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:39:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:42:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:69:45: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:71:40: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:72:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:73:52: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/standalone_modules/wf_snippy_variants.wdl/#L73"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_clearlabs.wdl"
 message = "wf_theiacov_clearlabs.wdl:148:26: error: type mismatch: expected type `String?`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
 message = "wf_theiacov_illumina_pe.wdl:233:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
 message = "wf_theiacov_illumina_pe.wdl:4:84: warning[UnusedImport]: unused import namespace `assembly_metrics`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L4"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L4"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:192:38: error: type mismatch: expected type `Float?`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:273:29: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L273"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L273"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:274:28: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L274"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L274"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:275:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:236:30: error: type mismatch: expected type `String?`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:119: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:84: error: type mismatch: a type common to both type `Float?` and type `String?` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:118:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:127:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:70:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
 message = "wf_theiameta_illumina_pe.wdl:258:31: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L258"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L258"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
 message = "wf_theiameta_illumina_pe.wdl:260:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L260"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L260"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
 message = "wf_theiameta_illumina_pe.wdl:269:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L269"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L269"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl"
 message = "wf_theiaprok_illumina_pe.wdl:115:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_se.wdl"
 message = "wf_theiaprok_illumina_se.wdl:110:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:103:28: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:84:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_create_terra_table.wdl"
 message = "wf_create_terra_table.wdl:17:46: warning[UnusedCall]: unused call `make_table`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_create_terra_table.wdl/#L17"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_create_terra_table.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:17:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:18:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:19:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:20:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:21:23: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_terra_2_bq.wdl"
 message = "wf_terra_2_bq.wdl:14:26: warning[UnusedCall]: unused call `terra_to_bigquery`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/data_import/wf_terra_2_bq.wdl/#L14"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_terra_2_bq.wdl/#L14"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:100:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L100"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L100"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L101"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L101"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:109:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:110:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:111:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L111"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L111"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:112:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:154: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:94: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:118:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:123:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L123"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L123"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:124:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L124"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:125:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L125"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L125"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:126:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L126"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L126"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:127:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L127"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:128:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L128"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:131:17: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:141:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L141"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L141"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:142:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L142"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L142"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:143:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L143"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L143"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:144:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L144"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L144"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:170:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L170"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L170"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:182:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L182"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L182"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:183:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L183"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L183"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:184:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L184"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L184"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:185:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L185"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L185"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:186:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L186"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L186"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:187:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L187"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L187"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:188:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L188"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L188"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:189:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L189"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L189"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:190:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L190"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L190"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:199:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L199"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L199"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:200:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L200"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L200"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:201:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L201"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L201"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:202:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L202"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L202"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:208:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L208"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L208"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:209:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L209"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L209"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:210:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L210"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L210"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:211:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L211"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L211"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:220:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L220"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L220"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:221:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L221"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L221"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:222:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L222"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L222"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:223:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L223"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L223"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:229:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L229"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L229"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:230:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L230"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L230"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:231:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L231"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L231"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:232:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L232"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L232"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:86:28: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L86"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:87:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L87"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:88:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L88"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L88"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:89:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:90:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:98:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L98"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L98"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:99:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_flu_track.wdl/#L99"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L99"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:102:16: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:103:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:104:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L104"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L104"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:105:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L105"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L105"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:106:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L106"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L106"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:112:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:113:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L113"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L113"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:114:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L114"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L114"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:115:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:29: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:104: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:28: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L154"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L154"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:56:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L56"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:57:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L57"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L57"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:58:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L58"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L58"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:59:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L59"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L59"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:67:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:68:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L68"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L68"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:69:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:70:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:76:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:77:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:78:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L78"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L78"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:79:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L79"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L79"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:90:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:91:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:92:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L92"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L92"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:93:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_ivar_consensus.wdl/#L93"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L93"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:228:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L228"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L228"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:229:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L229"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L229"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:230:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L230"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L230"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:231:23: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L231"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L231"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:232:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L232"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L232"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:241:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L241"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L241"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:253:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L253"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L253"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:259:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L259"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L259"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:260:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L260"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L260"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:261:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L261"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L261"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:262:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L262"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L262"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:263:18: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L263"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L263"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:264:25: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L264"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L264"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:265:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L265"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L265"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:274:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L274"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L274"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:281:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L281"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L281"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:290:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L290"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L290"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:304:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L304"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L304"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:305:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L305"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L305"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:317:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:326:18: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L326"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L326"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:327:19: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L327"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L327"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:328:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L328"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L328"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:336:30: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L336"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L336"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:337:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L337"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L337"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:338:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L338"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L338"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:339:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L339"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L339"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:340:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L340"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L340"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:349:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L349"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L349"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:357:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L357"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L357"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:367:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L367"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L367"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:377:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L377"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L377"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:378:24: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L378"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L378"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:379:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L379"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L379"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:380:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L380"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L380"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:381:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L381"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L381"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:382:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L382"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L382"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:383:34: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L383"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L383"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:384:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L384"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L384"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:392:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L392"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L392"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:400:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L400"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L400"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:408:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L408"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L408"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:409:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L409"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L409"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:410:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L410"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L410"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:421:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L421"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L421"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:432:32: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L432"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L432"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:433:20: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L433"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L433"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:434:25: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L434"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L434"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:435:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L435"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L435"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:436:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L436"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L436"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:437:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L437"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L437"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:439:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L439"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L439"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:455:32: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L455"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L455"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:456:36: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L456"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L456"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:457:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L457"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L457"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:467:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L467"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L467"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:475:21: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L475"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L475"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:476:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L476"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L476"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:482:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L482"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L482"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:488:23: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L488"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L488"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:489:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L489"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L489"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:499:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L499"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L499"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:506:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L506"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L506"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:507:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L507"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L507"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:508:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L508"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L508"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:515:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L515"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L515"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:516:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L516"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L516"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:517:20: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L517"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L517"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:518:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L518"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L518"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:519:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L519"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L519"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:520:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L520"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L520"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:521:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L521"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L521"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:522:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L522"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L522"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:523:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L523"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L523"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:524:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L524"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L524"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:525:26: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L525"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L525"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:526:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L526"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L526"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:527:37: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L527"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L527"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:528:31: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L528"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L528"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:529:39: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L529"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L529"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:530:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L530"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L530"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:539:14: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L539"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L539"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:540:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L540"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L540"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:541:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L541"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L541"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:542:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L542"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L542"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:543:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L543"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L543"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:544:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L544"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L544"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:545:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L545"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L545"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:546:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L546"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L546"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:547:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L547"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L547"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:548:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L548"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L548"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:549:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L549"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L549"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:557:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L557"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L557"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:566:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L566"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L566"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:581:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L581"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L581"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:590:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L590"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L590"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:601:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L601"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L601"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:602:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L602"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L602"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:603:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L603"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L603"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:604:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L604"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L604"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:605:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L605"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L605"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:606:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L606"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L606"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:607:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L607"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L607"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:608:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L608"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L608"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:609:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L609"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L609"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:610:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L610"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L610"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:611:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L611"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L611"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:612:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L612"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L612"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:623:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L623"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L623"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:627:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L627"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L627"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:635:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L635"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L635"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:674:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L674"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L674"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:678:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L678"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L678"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:686:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L686"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L686"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:700:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L700"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L700"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:704:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L704"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L704"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
 message = "wf_merlin_magic.wdl:712:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_merlin_magic.wdl/#L712"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L712"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:109:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:51:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:52:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:53:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:89:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:90:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:91:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:129:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:141:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:142:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:143:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:74:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:118:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:129:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:130:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:131:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:56:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/be24047e2b64d02a187824909b91d04bda6074d8/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The `wdl` CLI tool currently supports the following subcommands:
   prints the linting diagnostics and exits with a status code of `1`.
 * `analyze` - Parses, validates, and analyzes a single WDL document or a
   directory containing WDL documents. Prints a debug representation of the
-  document scopes and exits with a status code of `0` if the documents are
+  analysis result and exits with a status code of `0` if the documents are
   valid; otherwise, prints the validation diagnostics and exits with a status
   code of `1`.
 * `format` - Parses, validates, and then formats a single WDL document, printing

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Refactored the `DocumentScope` API to simply `Document` and exposed more
+  information about tasks and workflows such as their inputs and outputs (#[232](https://github.com/stjude-rust-labs/wdl/pull/232)).
 * Switched to `rustls-tls` for TLS implementation rather than relying on
   OpenSSL for Linux builds (#[228](https://github.com/stjude-rust-labs/wdl/pull/228)).
 

--- a/wdl-analysis/src/analyzer.rs
+++ b/wdl-analysis/src/analyzer.rs
@@ -38,6 +38,7 @@ use crate::UNUSED_CALL_RULE_ID;
 use crate::UNUSED_DECL_RULE_ID;
 use crate::UNUSED_IMPORT_RULE_ID;
 use crate::UNUSED_INPUT_RULE_ID;
+use crate::document::Document;
 use crate::graph::DocumentGraphNode;
 use crate::graph::ParseState;
 use crate::queue::AddRequest;
@@ -48,7 +49,6 @@ use crate::queue::NotifyIncrementalChangeRequest;
 use crate::queue::RemoveRequest;
 use crate::queue::Request;
 use crate::rayon::RayonHandle;
-use crate::scope::DocumentScope;
 
 /// Represents the kind of analysis progress being reported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -186,8 +186,8 @@ pub struct AnalysisResult {
     parse_result: ParseResult,
     /// The diagnostics for the document.
     diagnostics: Arc<[Diagnostic]>,
-    /// The scope of the analyzed document.
-    scope: Arc<DocumentScope>,
+    /// The analyzed document.
+    document: Arc<Document>,
 }
 
 impl AnalysisResult {
@@ -200,7 +200,7 @@ impl AnalysisResult {
             uri: node.uri().clone(),
             parse_result: node.parse_state().into(),
             diagnostics: analysis.diagnostics().clone(),
-            scope: analysis.scope().clone(),
+            document: analysis.document().clone(),
         }
     }
 
@@ -226,9 +226,9 @@ impl AnalysisResult {
         &self.diagnostics
     }
 
-    /// Gets the scope of the analyzed document.
-    pub fn scope(&self) -> &Arc<DocumentScope> {
-        &self.scope
+    /// Gets the analyzed document.
+    pub fn document(&self) -> &Arc<Document> {
+        &self.document
     }
 }
 

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -266,8 +266,8 @@ pub fn invalid_relative_import(error: &url::ParseError, span: Span) -> Diagnosti
     Diagnostic::error(format!("{error:?}")).with_highlight(span)
 }
 
-/// Creates a "struct not in scope" diagnostic.
-pub fn struct_not_in_scope(name: &Ident) -> Diagnostic {
+/// Creates a "struct not in document" diagnostic.
+pub fn struct_not_in_document(name: &Ident) -> Diagnostic {
     Diagnostic::error(format!(
         "a struct named `{name}` does not exist in the imported document",
         name = name.as_str()

--- a/wdl-analysis/src/eval/v1.rs
+++ b/wdl-analysis/src/eval/v1.rs
@@ -42,7 +42,7 @@ use crate::diagnostics::self_referential;
 use crate::diagnostics::task_reference_cycle;
 use crate::diagnostics::unknown_name;
 use crate::diagnostics::workflow_reference_cycle;
-use crate::scope::TASK_VAR_NAME;
+use crate::document::TASK_VAR_NAME;
 
 /// Represents a node in an task evaluation graph.
 #[derive(Debug, Clone)]

--- a/wdl-analysis/src/graph.rs
+++ b/wdl-analysis/src/graph.rs
@@ -32,7 +32,7 @@ use wdl_ast::SyntaxNode;
 use wdl_ast::Validator;
 
 use crate::IncrementalChange;
-use crate::scope::DocumentScope;
+use crate::document::Document;
 
 /// Represents space for a DFS search of a document graph.
 pub type DfsSpace =
@@ -87,18 +87,18 @@ pub enum ParseState {
 pub struct Analysis {
     /// The unique identifier of the analysis.
     id: Arc<String>,
-    /// The document's scope.
-    scope: Arc<DocumentScope>,
+    /// The analyzed document.
+    document: Arc<Document>,
     /// The analysis diagnostics.
     diagnostics: Arc<[Diagnostic]>,
 }
 
 impl Analysis {
     /// Constructs a new analysis.
-    pub fn new(scope: DocumentScope, diagnostics: impl Into<Arc<[Diagnostic]>>) -> Self {
+    pub fn new(document: Document, diagnostics: impl Into<Arc<[Diagnostic]>>) -> Self {
         Self {
             id: Arc::new(Uuid::new_v4().to_string()),
-            scope: Arc::new(scope),
+            document: Arc::new(document),
             diagnostics: diagnostics.into(),
         }
     }
@@ -110,9 +110,9 @@ impl Analysis {
         &self.id
     }
 
-    /// Gets the document scope from the analysis.
-    pub fn scope(&self) -> &Arc<DocumentScope> {
-        &self.scope
+    /// Gets the analyzed document.
+    pub fn document(&self) -> &Arc<Document> {
+        &self.document
     }
 
     /// Gets the diagnostics from the analysis.

--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -11,12 +11,12 @@
 
 mod analyzer;
 pub(crate) mod diagnostics;
+pub mod document;
 pub mod eval;
 mod graph;
 mod queue;
 mod rayon;
 mod rules;
-pub mod scope;
 pub mod stdlib;
 pub mod types;
 

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -29,12 +29,12 @@ use crate::AnalysisResult;
 use crate::DiagnosticsConfig;
 use crate::IncrementalChange;
 use crate::ProgressKind;
+use crate::document::Document;
 use crate::graph::Analysis;
 use crate::graph::DfsSpace;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
 use crate::rayon::RayonHandle;
-use crate::scope::DocumentScope;
 
 /// The minimum number of milliseconds between analysis progress reports.
 const MINIMUM_PROGRESS_MILLIS: u128 = 50;
@@ -607,7 +607,7 @@ where
     ) -> (NodeIndex, Analysis) {
         let start = Instant::now();
         let graph = graph.read();
-        let (scope, diagnostics) = DocumentScope::new(config, &graph, index);
+        let (document, diagnostics) = Document::new(config, &graph, index);
 
         info!(
             "analysis of `{uri}` completed in {elapsed:?}",
@@ -615,6 +615,6 @@ where
             elapsed = start.elapsed()
         );
 
-        (index, Analysis::new(scope, diagnostics))
+        (index, Analysis::new(document, diagnostics))
     }
 }

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -9,6 +9,7 @@ use id_arena::DefaultArenaBehavior;
 use id_arena::Id;
 use indexmap::IndexMap;
 
+use crate::document::Output;
 use crate::stdlib::STDLIB;
 
 pub mod v1;
@@ -1000,14 +1001,14 @@ pub struct CallOutputType {
     /// The name of the task or workflow that was called.
     name: String,
     /// The outputs from the call.
-    outputs: HashMap<String, Type>,
+    outputs: HashMap<String, Output>,
     /// Whether or not the call was to a workflow (or a task).
     workflow: bool,
 }
 
 impl CallOutputType {
     /// Constructs a new call output type.
-    pub fn new(name: impl Into<String>, outputs: HashMap<String, Type>, workflow: bool) -> Self {
+    pub fn new(name: impl Into<String>, outputs: HashMap<String, Output>, workflow: bool) -> Self {
         Self {
             name: name.into(),
             outputs,
@@ -1021,12 +1022,12 @@ impl CallOutputType {
     }
 
     /// Gets the outputs from the call.
-    pub fn outputs(&self) -> &HashMap<String, Type> {
+    pub fn outputs(&self) -> &HashMap<String, Output> {
         &self.outputs
     }
 
     /// Gets the mutable outputs from the call.
-    pub(crate) fn outputs_mut(&mut self) -> &mut HashMap<String, Type> {
+    pub(crate) fn outputs_mut(&mut self) -> &mut HashMap<String, Output> {
         &mut self.outputs
     }
 
@@ -1040,7 +1041,7 @@ impl CallOutputType {
     /// Asserts that this type is valid.
     fn assert_valid(&self, types: &Types) {
         for v in self.outputs.values() {
-            v.assert_valid(types);
+            v.ty().assert_valid(types);
         }
     }
 }
@@ -1213,7 +1214,7 @@ impl Types {
                     let members = ty
                         .outputs
                         .iter()
-                        .map(|(k, v)| (k.clone(), self.import(types, *v)))
+                        .map(|(k, v)| (k.clone(), Output::new(self.import(types, v.ty()))))
                         .collect();
 
                     self.add_call_output(CallOutputType::new(

--- a/wdl-grammar/src/diagnostic.rs
+++ b/wdl-grammar/src/diagnostic.rs
@@ -43,6 +43,11 @@ impl Span {
     pub fn is_empty(&self) -> bool {
         self.start == self.end
     }
+
+    /// Determines if the span contains the given offset.
+    pub fn contains(&self, offset: usize) -> bool {
+        offset >= self.start && offset < self.end
+    }
 }
 
 impl fmt::Display for Span {

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -36,7 +36,7 @@ anyhow = { workspace = true }
 codespan-reporting = { workspace = true }
 
 [features]
-default = ["ast", "grammar", "lint", "engine"]
+default = ["ast", "grammar", "lint", "format", "engine"]
 analysis = ["dep:wdl-analysis"]
 ast = ["dep:wdl-ast"]
 format = ["dep:wdl-format"]
@@ -49,6 +49,7 @@ cli = [
     "analysis",
     "codespan",
     "lint",
+    "format",
     "dep:clap",
     "dep:tracing-subscriber",
     "dep:anyhow",


### PR DESCRIPTION
This PR refactors the analysis API to assist in future engine work.

Primarily it exposes `Task` and `Workflow` from analyzed documents so that a task or workflow's inputs and outputs can be easily determined.

Additionally, this renames `DocumentScope` to simply `Document` to represent an analyzed document.

Scopes are now kept internally to a `Task` or `Workflow`, which allows for a `scope` method directly on those types.

As a result of the rename, `scope.rs` has been renamed to `document.rs`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
