### PR TITLE
feat: implement expression evaluation in `wdl-engine`.

### DIFF
--- a/Arena.toml
+++ b/Arena.toml
@@ -12,7 +12,7 @@ commit_hash = "c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
-commit_hash = "a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a"
+commit_hash = "092bb0ca9760bf301ae0f57aef431a990f45dba6"
 filters = ["/template/task-templates.wdl"]
 
 [[diagnostics]]
@@ -1738,2317 +1738,2322 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:119:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L119"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/flag_filter.wdl/#L119"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:155:6: note[BlankLinesBetweenElements]: extra blank line(s) found"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/flag_filter.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:107:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L107"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/read_group.wdl/#L107"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:159:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L159"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/read_group.wdl/#L159"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:192:47: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/read_group.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/read_group.wdl"
 message = "read_group.wdl:444:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/read_group.wdl/#L444"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/read_group.wdl/#L444"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:102:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L102"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L102"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:142:79: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L142"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L142"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:22:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:245:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L245"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L245"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:298:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L298"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L298"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:308:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L308"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L308"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:30:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:347:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L347"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L347"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:34:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:38:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L38"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L38"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:397:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L397"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L397"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:44:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L44"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L44"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:80:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L80"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L80"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:87:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L87"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:93:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L93"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L93"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"
 message = "arriba.wdl:97:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/arriba.wdl/#L97"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/arriba.wdl/#L97"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:105:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L105"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L105"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:109:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L109"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L109"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:115:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L115"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L115"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:119:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L119"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L119"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:123:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L123"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L123"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:171:46: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L171"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L171"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:171:57: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L171"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L171"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:190:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L190"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L190"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:210:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L210"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L210"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:214:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L214"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L214"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:218:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L218"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L218"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:264:55: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L264"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L264"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:264:73: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L264"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L264"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:268:46: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L268"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L268"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:268:57: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L268"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L268"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:27:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L27"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L27"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:286:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L286"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L286"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:303:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L303"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L303"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:337:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L337"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L337"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/bwa.wdl"
 message = "bwa.wdl:89:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/bwa.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/bwa.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:113:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L113"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L113"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:154:23: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L154"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L154"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:154:41: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L154"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L154"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:155:25: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:155:30: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:155:48: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L155"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L155"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:156:25: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:156:30: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:156:43: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:157:25: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L157"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L157"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:184:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L184"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L184"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:43:16: note[DisallowedInputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L43"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L43"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:5:1: note[PreambleFormatting]: lint directives must come before preamble comments"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L5"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L5"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/cellranger.wdl"
 message = "cellranger.wdl:95:14: note[DisallowedOutputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/cellranger.wdl/#L95"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/cellranger.wdl/#L95"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/deeptools.wdl"
 message = "deeptools.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/deeptools.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/deeptools.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/deeptools.wdl"
 message = "deeptools.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/deeptools.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/deeptools.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/deeptools.wdl"
 message = "deeptools.wdl:70:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/deeptools.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/deeptools.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/estimate.wdl"
 message = "estimate.wdl:39:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/estimate.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/estimate.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/estimate.wdl"
 message = "estimate.wdl:53:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/estimate.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/estimate.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:10:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L10"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fastqc.wdl/#L10"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fastqc.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fastqc.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fastqc.wdl"
 message = "fastqc.wdl:67:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fastqc.wdl/#L67"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fastqc.wdl/#L67"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:106:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L106"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L106"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:116:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L116"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L116"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:120:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L120"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L120"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:143:30: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L143"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L143"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:145:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L145"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L145"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:156:15: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L156"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L156"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:158:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L158"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L158"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:16:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L16"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L16"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:172:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L172"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L172"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:20:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:24:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L24"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L24"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:32:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L32"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L32"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:37:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L37"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L37"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:40:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:45:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:48:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L48"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L48"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:53:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/fq.wdl"
 message = "fq.wdl:96:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/fq.wdl/#L96"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/fq.wdl/#L96"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:12:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L12"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:150:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L150"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L150"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:161:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L161"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L161"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:162:10: note[BlankLinesBetweenElements]: extra blank line(s) found"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L162"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L162"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:214:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L214"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L214"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:225:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L225"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L225"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:234:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L234"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L234"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:244:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L244"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L244"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:300:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L300"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L300"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:311:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L311"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:324:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L324"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:328:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L328"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L328"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:373:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L373"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L373"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:385:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L385"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L385"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:397:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L397"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L397"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:400:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L400"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L400"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:409:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L409"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L409"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:417:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L417"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L417"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:423:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L423"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L423"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:486:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L486"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L486"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/gatk4.wdl"
 message = "gatk4.wdl:69:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/gatk4.wdl/#L69"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/gatk4.wdl/#L69"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:135:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L135"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L135"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:19:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L19"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L19"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
-message = "htseq.wdl:206:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L206"
+message = "htseq.wdl:210:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L210"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:22:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:28:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L28"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L28"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:32:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L32"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L32"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:37:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L37"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L37"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:40:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:45:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:49:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L49"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L49"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:53:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:57:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:61:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L61"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L61"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/htseq.wdl"
 message = "htseq.wdl:65:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/htseq.wdl/#L65"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L65"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/tools/htseq.wdl"
+message = "htseq.wdl:96:1: note[LineWidth]: line exceeds maximum width of 90"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/htseq.wdl/#L96"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:118:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L118"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L118"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:175:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L175"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L175"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:192:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:197:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L197"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L197"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:205:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L205"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L205"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:259:15: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L259"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L259"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:261:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L261"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L261"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:284:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L284"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L284"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:295:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L295"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L295"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:297:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L297"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L297"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:299:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L299"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L299"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:311:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L311"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:316:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L316"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L316"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:321:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L321"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L321"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:330:14: note[DisallowedInputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L330"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L330"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:351:24: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L351"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L351"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:353:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L353"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L353"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:398:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L398"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L398"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:44:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L44"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L44"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:60:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L60"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L60"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:72:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L72"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L72"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:85:32: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L85"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L85"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:85:45: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L85"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L85"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:89:28: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:89:41: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:90:18: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:90:33: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:90:40: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:13: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:18: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:33: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:91:40: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L91"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/kraken2.wdl"
 message = "kraken2.wdl:92:13: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/kraken2.wdl/#L92"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/kraken2.wdl/#L92"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/librarian.wdl"
 message = "librarian.wdl:20:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/librarian.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/librarian.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/librarian.wdl"
 message = "librarian.wdl:52:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/librarian.wdl/#L52"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/librarian.wdl/#L52"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/md5sum.wdl"
 message = "md5sum.wdl:39:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/md5sum.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/md5sum.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/mosdepth.wdl"
 message = "mosdepth.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/mosdepth.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/mosdepth.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/mosdepth.wdl"
 message = "mosdepth.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/mosdepth.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/mosdepth.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/mosdepth.wdl"
 message = "mosdepth.wdl:69:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/mosdepth.wdl/#L69"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/mosdepth.wdl/#L69"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/multiqc.wdl"
 message = "multiqc.wdl:21:21: note[DisallowedInputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/multiqc.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/multiqc.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/multiqc.wdl"
 message = "multiqc.wdl:68:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/multiqc.wdl/#L68"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/multiqc.wdl/#L68"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:106:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L106"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L106"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:140:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L140"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L140"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:159:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L159"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L159"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:163:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L163"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L163"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:204:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L204"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L204"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:21:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:223:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L223"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L223"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:25:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L25"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L25"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:281:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L281"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L281"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:29:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L29"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L29"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:303:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L303"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L303"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:307:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L307"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L307"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:311:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L311"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:315:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L315"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L315"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:33:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L33"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L33"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:369:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L369"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L369"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:387:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L387"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L387"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:391:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L391"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L391"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:395:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L395"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L395"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:399:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L399"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L399"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:403:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L403"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L403"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:407:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L407"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L407"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:427:21: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L427"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L427"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:427:33: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L427"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L427"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:429:7: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L429"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L429"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:429:7: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L429"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L429"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:451:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L451"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L451"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/ngsderive.wdl"
 message = "ngsderive.wdl:87:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/ngsderive.wdl/#L87"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/ngsderive.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:1037:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L1037"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L1037"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:125:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L125"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L125"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:145:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L145"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L145"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:14:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L14"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L14"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:153:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L153"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L153"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:159:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L159"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L159"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:163:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L163"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L163"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:167:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L167"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L167"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:190:28: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L190"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L190"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:192:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:194:29: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L194"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L194"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:196:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L196"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L196"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:247:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L247"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L247"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:259:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L259"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L259"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:270:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L270"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L270"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:272:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L272"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L272"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:280:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L280"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L280"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:29:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L29"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L29"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:330:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L330"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L330"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:342:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L342"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L342"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:355:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L355"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L355"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:357:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L357"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L357"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:364:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L364"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L364"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:38:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L38"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L38"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:417:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L417"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L417"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:429:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L429"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L429"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:441:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L441"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L441"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:46:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L46"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L46"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:485:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L485"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L485"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:497:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L497"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L497"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:511:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L511"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L511"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:52:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L52"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L52"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:548:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L548"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L548"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:560:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L560"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L560"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:562:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L562"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L562"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:574:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L574"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L574"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:610:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L610"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L610"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:622:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L622"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L622"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:626:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L626"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L626"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:628:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L628"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L628"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:641:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L641"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L641"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:681:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L681"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L681"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:693:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L693"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L693"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:695:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L695"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L695"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:707:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L707"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L707"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:743:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L743"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L743"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:754:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L754"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L754"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:766:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L766"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L766"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:802:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L802"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L802"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:819:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L819"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L819"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:842:49: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L842"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L842"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:842:56: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L842"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L842"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:847:36: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L847"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L847"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:858:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L858"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L858"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:869:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L869"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L869"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:897:14: note[DisallowedOutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L897"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L897"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:898:14: note[DisallowedOutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L898"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L898"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:904:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L904"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L904"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:915:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L915"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L915"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:923:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L923"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L923"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:926:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L926"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L926"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/picard.wdl"
 message = "picard.wdl:976:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/picard.wdl/#L976"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/picard.wdl/#L976"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/qualimap.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:157:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L157"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/qualimap.wdl/#L157"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:22:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/qualimap.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/qualimap.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/qualimap.wdl"
 message = "qualimap.wdl:89:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/qualimap.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/qualimap.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:117:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L117"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L117"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:135:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L135"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L135"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:172:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L172"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L172"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:17:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L17"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L17"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:183:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L183"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L183"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:192:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L192"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L192"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:21:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:228:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L228"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L228"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:246:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L246"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L246"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:250:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L250"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L250"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:285:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L285"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L285"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:57:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:75:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L75"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L75"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/sambamba.wdl"
 message = "sambamba.wdl:79:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/sambamba.wdl/#L79"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/sambamba.wdl/#L79"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1003:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1003"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1003"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1054:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1054"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1054"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1158:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1158"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1158"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1176:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1176"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1176"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1188:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1188"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1188"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1202:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1202"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1202"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1208:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1208"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1208"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1278:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1278"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1278"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:1324:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L1324"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L1324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:153:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L153"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L153"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:171:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L171"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L171"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:175:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L175"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L175"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:211:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L211"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L211"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:228:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L228"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L228"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:232:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L232"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L232"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:270:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L270"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L270"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:281:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L281"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L281"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:291:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L291"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L291"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:295:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L295"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L295"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:39:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:416:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L416"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L416"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:436:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L436"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L436"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:440:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L440"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L440"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:503:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L503"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L503"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:523:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L523"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L523"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:527:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L527"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L527"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:531:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L531"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L531"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:535:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L535"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L535"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:539:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L539"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L539"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:543:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L543"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L543"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:55:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L55"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L55"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:605:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L605"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L605"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:60:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L60"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L60"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:623:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L623"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L623"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:628:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L628"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L628"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:632:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L632"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L632"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:636:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L636"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L636"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:640:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L640"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L640"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:64:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L64"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L64"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:68:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L68"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L68"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:690:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L690"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L690"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:708:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L708"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L708"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:712:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L712"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L712"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:716:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L716"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L716"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:72:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L72"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L72"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:763:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L763"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L763"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:788:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L788"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L788"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:792:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L792"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L792"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:796:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L796"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L796"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:800:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L800"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L800"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:804:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L804"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L804"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:808:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L808"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L808"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:814:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L814"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L814"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:818:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L818"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L818"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:822:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L822"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L822"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:894:15: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L894"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L894"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:896:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L896"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L896"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:899:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L899"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L899"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:899:31: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L899"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L899"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:902:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L902"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L902"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:905:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L905"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L905"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:905:31: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L905"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L905"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:908:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L908"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L908"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:911:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L911"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L911"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:911:31: note[ExpressionSpacing]: multi-line if...then...else must have a preceding space"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L911"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L911"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:913:40: note[ExpressionSpacing]: operators must be surrounded by whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L913"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L913"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:916:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L916"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L916"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:919:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L919"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L919"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:921:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L921"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L921"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:956:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L956"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L956"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:973:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L973"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L973"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:980:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L980"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L980"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:982:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L982"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L982"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/samtools.wdl"
 message = "samtools.wdl:999:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/samtools.wdl/#L999"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/samtools.wdl/#L999"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:130:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L130"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L130"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:154:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L154"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L154"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:167:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L167"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L167"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:169:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L169"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L169"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:174:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L174"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L174"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:176:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L176"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L176"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:185:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L185"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L185"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:188:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L188"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L188"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:18:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L18"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L18"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:195:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L195"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L195"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:197:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L197"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L197"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:213:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L213"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L213"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:215:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L215"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L215"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:219:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L219"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L219"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:221:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L221"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L221"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:226:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L226"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L226"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:228:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L228"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L228"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:22:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L22"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L22"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:233:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L233"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L233"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:235:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L235"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L235"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:240:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L240"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L240"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:242:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L242"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L242"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:249:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L249"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L249"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:251:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L251"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L251"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:258:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L258"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L258"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:260:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L260"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L260"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:266:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L266"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L266"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:268:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L268"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L268"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:274:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L274"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L274"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:276:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L276"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L276"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:280:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L280"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L280"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:284:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L284"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L284"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:291:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L291"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L291"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:293:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L293"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L293"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:299:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L299"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L299"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:301:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L301"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L301"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:308:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L308"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L308"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:311:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L311"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L311"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:315:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L315"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L315"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:317:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L317"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L317"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:31:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L31"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L31"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:324:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L324"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:326:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L326"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L326"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:332:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L332"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L332"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:334:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L334"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L334"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:338:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L338"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L338"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:350:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L350"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L350"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:354:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L354"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L354"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:358:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L358"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L358"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:372:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L372"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L372"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:376:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L376"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L376"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:380:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L380"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L380"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:384:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L384"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L384"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:39:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:405:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L405"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L405"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:409:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L409"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L409"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:413:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L413"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L413"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:417:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L417"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L417"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:421:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L421"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L421"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:435:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L435"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L435"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:439:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L439"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L439"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:43:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L43"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L43"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:443:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L443"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L443"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:449:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L449"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L449"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:453:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L453"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L453"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:457:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L457"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L457"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:461:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L461"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L461"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:467:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L467"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L467"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:471:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L471"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L471"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:487:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L487"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L487"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:493:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L493"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L493"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:499:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L499"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L499"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:505:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L505"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L505"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:511:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L511"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L511"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "star.wdl:654:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L654"
+message = "star.wdl:648:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L648"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "star.wdl:656:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L656"
+message = "star.wdl:650:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L650"
+
+[[diagnostics]]
+document = "stjudecloud/workflows:/tools/star.wdl"
+message = "star.wdl:672:17: note[TrailingComma]: item missing trailing comma"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L672"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:678:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L678"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L678"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:684:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L684"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L684"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:690:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L690"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L690"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
 message = "star.wdl:696:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L696"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L696"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "star.wdl:702:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L702"
+message = "star.wdl:720:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L720"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "star.wdl:726:17: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L726"
+message = "star.wdl:722:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L722"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/star.wdl"
-message = "star.wdl:728:17: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L728"
-
-[[diagnostics]]
-document = "stjudecloud/workflows:/tools/star.wdl"
-message = "star.wdl:823:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/star.wdl/#L823"
+message = "star.wdl:817:20: note[ContainerValue]: container URI uses a mutable tag"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/star.wdl/#L817"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:101:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L101"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L101"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:120:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L120"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L120"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:125:16: note[DisallowedInputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L125"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L125"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:142:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L142"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L142"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:161:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L161"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L161"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:242:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L242"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L242"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:279:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L279"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L279"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:324:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L324"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L324"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:366:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L366"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L366"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:384:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L384"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L384"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:392:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L392"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L392"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:425:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L425"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L425"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:45:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:61:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L61"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L61"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:65:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L65"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L65"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:686:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L686"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L686"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:764:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L764"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L764"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:780:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L780"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L780"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/util.wdl"
 message = "util.wdl:825:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/tools/util.wdl/#L825"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/tools/util.wdl/#L825"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:10:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L10"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L10"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:11:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:124:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L124"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L124"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:12:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L12"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:21:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:89:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L89"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L89"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:95:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L95"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L95"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:17:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L17"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L17"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:21:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:30:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:30:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:35:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L35"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L35"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:67:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L67"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L67"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
@@ -4058,7 +4063,7 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:79:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L79"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L79"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
@@ -4068,147 +4073,147 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-core.wdl"
 message = "dnaseq-core.wdl:84:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-core.wdl/#L84"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-core.wdl/#L84"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:116:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:116:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:14:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L14"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L14"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:151:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L151"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L151"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:18:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L18"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L18"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:30:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:30:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L30"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:36:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:51:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L51"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L51"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:54:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L54"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L54"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:79:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L79"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L79"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:84:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L84"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L84"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:96:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L96"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L96"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:104:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L104"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L104"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:104:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L104"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L104"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:129:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L129"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L129"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:16:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L16"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L16"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:20:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:27:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L27"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L27"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:27:22: note[KeyValuePairs]: all items in an array or object should be on separate lines"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L27"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L27"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard.wdl"
 message = "dnaseq-standard.wdl:34:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:15:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L15"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/alignment-post.wdl/#L15"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:26:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L26"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/alignment-post.wdl/#L26"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:29:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L29"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/alignment-post.wdl/#L29"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:58:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L58"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/alignment-post.wdl/#L58"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:6:1: note[LineWidth]: line exceeds maximum width of 90"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L6"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/alignment-post.wdl/#L6"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/alignment-post.wdl"
 message = "alignment-post.wdl:70:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/alignment-post.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/alignment-post.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
 message = "bam-to-fastqs.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/bam-to-fastqs.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/bam-to-fastqs.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
@@ -4218,37 +4223,37 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
 message = "samtools-merge.wdl:15:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/samtools-merge.wdl/#L15"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/samtools-merge.wdl/#L15"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/samtools-merge.wdl"
 message = "samtools-merge.wdl:21:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/samtools-merge.wdl/#L21"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/samtools-merge.wdl/#L21"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/markdups-post.wdl"
 message = "markdups-post.wdl:25:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/markdups-post.wdl/#L25"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/markdups-post.wdl/#L25"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:181:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L181"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L181"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:185:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L185"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L185"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:187:36: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L187"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L187"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:189:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L189"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L189"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
@@ -4268,7 +4273,7 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:34:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
@@ -4278,322 +4283,322 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:39:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L39"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L39"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:451:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L451"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L451"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:463:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L463"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L463"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:467:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L467"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L467"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:47:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L47"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L47"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:556:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L556"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L556"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:57:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:67:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L67"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L67"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:74:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L74"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L74"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/bwa-db-build.wdl"
 message = "bwa-db-build.wdl:11:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/bwa-db-build.wdl/#L11"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/bwa-db-build.wdl/#L11"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:17:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L17"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/gatk-reference.wdl/#L17"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:57:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/gatk-reference.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:70:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/gatk-reference.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:76:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L76"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/gatk-reference.wdl/#L76"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:83:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L83"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/gatk-reference.wdl/#L83"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/gatk-reference.wdl"
 message = "gatk-reference.wdl:90:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/gatk-reference.wdl/#L90"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/gatk-reference.wdl/#L90"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:137:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L137"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/make-qc-reference.wdl/#L137"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:23:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L23"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/make-qc-reference.wdl/#L23"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:34:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/make-qc-reference.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:40:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/make-qc-reference.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/make-qc-reference.wdl"
 message = "make-qc-reference.wdl:48:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/make-qc-reference.wdl/#L48"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/make-qc-reference.wdl/#L48"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/reference/star-db-build.wdl"
 message = "star-db-build.wdl:12:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/reference/star-db-build.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/reference/star-db-build.wdl/#L12"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/ESTIMATE.wdl"
 message = "ESTIMATE.wdl:12:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/ESTIMATE.wdl/#L12"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/ESTIMATE.wdl/#L12"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:105:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L105"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L105"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:111:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L111"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L111"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:127:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L127"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L127"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:151:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L151"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L151"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:196:33: note[ExpressionSpacing]: multi-line if...then...else must have a preceding parenthesis and newline"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L196"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L196"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:198:9: note[ExpressionSpacing]: multi-line if...then...else must have a following newline and parenthesis"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L198"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L198"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:20:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:36:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:40:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L40"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L40"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:45:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:48:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L48"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L48"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:53:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L53"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L53"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:57:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L57"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L57"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:66:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L66"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L66"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:72:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L72"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L72"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:77:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L77"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L77"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:82:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L82"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L82"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:87:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L87"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:93:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L93"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L93"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-core.wdl"
 message = "rnaseq-core.wdl:99:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-core.wdl/#L99"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-core.wdl/#L99"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:112:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L112"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L112"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:143:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L143"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L143"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:148:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L148"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L148"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:36:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:49:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L49"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L49"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:63:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L63"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L63"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:70:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L70"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L70"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:73:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L73"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L73"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:78:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L78"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L78"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard-fastq.wdl"
 message = "rnaseq-standard-fastq.wdl:82:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L82"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard-fastq.wdl/#L82"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:141:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L141"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L141"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:145:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L145"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L145"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:153:16: note[DisallowedInputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L153"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L153"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:182:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L182"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L182"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:20:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L20"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L20"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:33:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L33"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L33"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:36:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L36"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L36"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:41:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L41"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L41"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:45:17: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L45"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L45"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-standard.wdl"
 message = "rnaseq-standard.wdl:73:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-standard.wdl/#L73"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-standard.wdl/#L73"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:106:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L106"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L106"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
@@ -4618,17 +4623,17 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:115:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L115"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L115"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:13:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L13"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L13"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:51:9: note[ExpressionSpacing]: prefix operators may not contain whitespace"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L51"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L51"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
@@ -4638,7 +4643,7 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:54:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L54"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L54"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
@@ -4683,7 +4688,7 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:75:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L75"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L75"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
@@ -4693,7 +4698,7 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:82:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L82"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L82"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
@@ -4703,7 +4708,7 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:87:9: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L87"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L87"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
@@ -4733,34 +4738,34 @@ permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/rnaseq/rnaseq-variant-calling.wdl"
 message = "rnaseq-variant-calling.wdl:99:13: note[TrailingComma]: item missing trailing comma"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/rnaseq/rnaseq-variant-calling.wdl/#L99"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/rnaseq/rnaseq-variant-calling.wdl/#L99"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:18:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L18"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L18"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:64:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L64"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L64"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:69:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L69"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L69"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:93:20: note[ContainerValue]: container URI uses a mutable tag"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L93"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L93"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
 message = "scrnaseq-standard.wdl:32:5: note[BlankLinesBetweenElements]: missing blank line"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L32"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/scrnaseq-standard.wdl/#L32"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
 message = "scrnaseq-standard.wdl:91:14: note[DisallowedOutputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L91"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/scrnaseq-standard.wdl/#L91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ rowan = "0.15.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.120"
 serde_with = "3.8.1"
-string-interner = "0.17.0"
 tempfile = "3.10.1"
 tokio = { version = "1.38.0", features = ["full"] }
 toml = "0.8.14"

--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -4,11 +4,11 @@ commit_hash = "26eeda81a0540dc793fc69b0c390d232ca7ca50a"
 
 [repositories."PacificBiosciences/HiFi-human-WGS-WDL"]
 identifier = "PacificBiosciences/HiFi-human-WGS-WDL"
-commit_hash = "1cf2b2e80024290d0ec1ea93b6a279ea2de519b0"
+commit_hash = "15e7f1ab7631adba924ce06cc3251556c19504e6"
 
 [repositories."aws-samples/amazon-omics-tutorials"]
 identifier = "aws-samples/amazon-omics-tutorials"
-commit_hash = "136ecf7e5aaee18619e14ee65a97acc6d6704bef"
+commit_hash = "74fc4a99034645db92fb9016cecea18f7f52d17b"
 
 [repositories."biowdl/tasks"]
 identifier = "biowdl/tasks"
@@ -16,7 +16,7 @@ commit_hash = "2bf875300d90a3c9c8d670b3d99026452d5dbae2"
 
 [repositories."broadinstitute/gatk-tool-wdls"]
 identifier = "broadinstitute/gatk-tool-wdls"
-commit_hash = "4536dd2c6719b86f4c50348f0ce354818260cadb"
+commit_hash = "980883d87ee81df7925cd60dd04140e9fd01e317"
 
 [repositories."broadinstitute/palantir-workflows"]
 identifier = "broadinstitute/palantir-workflows"
@@ -24,7 +24,7 @@ commit_hash = "58f72308bdf511a760dea92dbf2ac21eb2c7dc0e"
 
 [repositories."broadinstitute/warp"]
 identifier = "broadinstitute/warp"
-commit_hash = "548f6d2d94eb85cd18613f1729f0d3e8386cd3b5"
+commit_hash = "66a7e76462fd21b32ea29fb72914480ef82f246a"
 
 [repositories."chanzuckerberg/czid-workflows"]
 identifier = "chanzuckerberg/czid-workflows"
@@ -44,12 +44,12 @@ commit_hash = "c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
-commit_hash = "a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a"
+commit_hash = "092bb0ca9760bf301ae0f57aef431a990f45dba6"
 filters = ["/template/task-templates.wdl"]
 
 [repositories."theiagen/public_health_bioinformatics"]
 identifier = "theiagen/public_health_bioinformatics"
-commit_hash = "d659feebab0f383898b728bd9b27e390ec7bed7f"
+commit_hash = "2669f994a90dc2c6d6703eef14cf3c639a7bfc1c"
 
 [[diagnostics]]
 document = "ENCODE-DCC/chip-seq-pipeline2:/chip.wdl"
@@ -197,454 +197,384 @@ message = "test_xcor.wdl:79:25: warning[UnusedCall]: unused call `compare_md5sum
 permalink = "https://github.com/ENCODE-DCC/chip-seq-pipeline2/blob/26eeda81a0540dc793fc69b0c390d232ca7ca50a/dev/test/test_task/test_xcor.wdl/#L79"
 
 [[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/cohort_analysis/cohort_analysis.wdl"
-message = "cohort_analysis.wdl:48:14: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/cohort_analysis/cohort_analysis.wdl/#L48"
+document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/joint/joint.wdl"
+message = "joint.wdl:131:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/joint/joint.wdl/#L131"
 
 [[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/cohort_analysis/cohort_analysis.wdl"
-message = "cohort_analysis.wdl:72:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/cohort_analysis/cohort_analysis.wdl/#L72"
+document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/joint/joint.wdl"
+message = "joint.wdl:94:30: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/joint/joint.wdl/#L94"
 
 [[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/main.wdl"
-message = "main.wdl:40:25: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/main.wdl/#L40"
+document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/singleton.wdl"
+message = "singleton.wdl:3:8: warning[UnusedImport]: unused import namespace `humanwgs_structs`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/singleton.wdl/#L3"
 
 [[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/main.wdl"
-message = "main.wdl:51:25: error: type mismatch: expected type `DeepVariantModel`, but found type `DeepVariantModel?`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/main.wdl/#L51"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/main.wdl"
-message = "main.wdl:76:151: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[IndexData]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/main.wdl/#L76"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/sample_analysis/sample_analysis.wdl"
-message = "sample_analysis.wdl:346:35: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/sample_analysis/sample_analysis.wdl/#L346"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/sample_analysis/sample_analysis.wdl"
-message = "sample_analysis.wdl:59:24: error: type mismatch: expected type `DeepVariantModel`, but found type `DeepVariantModel?`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/sample_analysis/sample_analysis.wdl/#L59"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/tertiary_analysis/tertiary_analysis.wdl"
-message = "tertiary_analysis.wdl:46:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[IndexData]]+`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/tertiary_analysis/tertiary_analysis.wdl/#L46"
+document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/tertiary/tertiary.wdl"
+message = "tertiary.wdl:3:8: warning[UnusedImport]: unused import namespace `humanwgs_structs`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/tertiary/tertiary.wdl/#L3"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:22:51: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, Int]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L22"
+message = "backend_configuration.wdl:101:28: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L101"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:25:13: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L25"
+message = "backend_configuration.wdl:102:22: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L102"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:26:17: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L26"
+message = "backend_configuration.wdl:112:48: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, String]`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L112"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:27:26: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L27"
+message = "backend_configuration.wdl:114:28: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L114"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:30:56: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, Int]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L30"
+message = "backend_configuration.wdl:115:22: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L115"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:33:13: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L33"
+message = "backend_configuration.wdl:46:53: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, String]`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L46"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:34:17: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L34"
+message = "backend_configuration.wdl:48:28: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L48"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:35:26: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L35"
+message = "backend_configuration.wdl:49:22: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L49"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:44:53: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, Int]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L44"
+message = "backend_configuration.wdl:55:58: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, String]`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L55"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:47:13: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L47"
+message = "backend_configuration.wdl:57:28: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L57"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:48:17: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L48"
+message = "backend_configuration.wdl:58:22: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L58"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:49:26: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L49"
+message = "backend_configuration.wdl:70:55: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, String]`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L70"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:52:58: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, Int]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L52"
+message = "backend_configuration.wdl:72:28: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L72"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:55:13: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L55"
+message = "backend_configuration.wdl:73:22: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L73"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:56:17: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L56"
+message = "backend_configuration.wdl:79:60: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, String]`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L79"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:57:26: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L57"
+message = "backend_configuration.wdl:81:28: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L81"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:70:51: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, Int]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L70"
+message = "backend_configuration.wdl:82:22: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L82"
 
 [[diagnostics]]
 document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:73:13: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L73"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:74:17: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L74"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:75:26: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L75"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:78:56: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, Int]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L78"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:81:13: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L81"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:82:17: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L82"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:83:26: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L83"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:89:46: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, Int]`"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L89"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:92:13: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L92"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:93:17: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L93"
-
-[[diagnostics]]
-document = "PacificBiosciences/HiFi-human-WGS-WDL:/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl"
-message = "backend_configuration.wdl:94:26: error: type mismatch: a type common to both type `Int` and type `String` does not exist"
-permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/1cf2b2e80024290d0ec1ea93b6a279ea2de519b0/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L94"
+message = "backend_configuration.wdl:99:70: error: type mismatch: expected type `RuntimeAttributes`, but found type `Map[String, String]`"
+permalink = "https://github.com/PacificBiosciences/HiFi-human-WGS-WDL/blob/15e7f1ab7631adba924ce06cc3251556c19504e6/workflows/wdl-common/wdl/workflows/backend_configuration/backend_configuration.wdl/#L99"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/main.wdl"
 message = "main.wdl:4:35: warning[UnusedImport]: unused import namespace `structs`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/main.wdl/#L4"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/main.wdl/#L4"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:286:11: warning[UnusedInput]: unused input `ref_alt`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L286"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L286"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:287:10: warning[UnusedInput]: unused input `ref_amb`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L287"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L287"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:288:10: warning[UnusedInput]: unused input `ref_ann`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L288"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L288"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:289:10: warning[UnusedInput]: unused input `ref_bwt`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L289"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L289"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:290:10: warning[UnusedInput]: unused input `ref_pac`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L290"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L290"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:291:10: warning[UnusedInput]: unused input `ref_sa`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L291"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L291"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:298:12: warning[UnusedInput]: unused input `gotc_path`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L298"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L298"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:574:40: error: function `sep` requires a minimum WDL version of WDL v1.1"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L574"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L574"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:575:40: error: function `sep` requires a minimum WDL version of WDL v1.1"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L575"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L575"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:576:43: error: function `sep` requires a minimum WDL version of WDL v1.1"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L576"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L576"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/main.wdl"
 message = "main.wdl:5:35: warning[UnusedImport]: unused import namespace `structs`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/main.wdl/#L5"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/main.wdl/#L5"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:286:11: warning[UnusedInput]: unused input `ref_alt`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L286"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L286"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:287:10: warning[UnusedInput]: unused input `ref_amb`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L287"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L287"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:288:10: warning[UnusedInput]: unused input `ref_ann`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L288"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L288"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:289:10: warning[UnusedInput]: unused input `ref_bwt`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L289"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L289"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:290:10: warning[UnusedInput]: unused input `ref_pac`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L290"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L290"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:291:10: warning[UnusedInput]: unused input `ref_sa`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L291"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L291"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:298:12: warning[UnusedInput]: unused input `gotc_path`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L298"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L298"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:572:40: error: function `sep` requires a minimum WDL version of WDL v1.1"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L572"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L572"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:573:40: error: function `sep` requires a minimum WDL version of WDL v1.1"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L573"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L573"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:574:43: error: function `sep` requires a minimum WDL version of WDL v1.1"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L574"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L574"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl"
 message = "processing-for-variant-discovery-gatk4.wdl:703:9: warning[UnusedInput]: unused input `compression_level`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L703"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl/#L703"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:100:13: warning[UnusedInput]: unused input `small_task_mem`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L100"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L100"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:112:32: error: struct `Runtime` requires a value for members `gatk_docker`, `cpu`, `machine_mem`, and `command_mem`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L112"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L112"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:112:41: error: expected struct member name, but found string"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L112"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L112"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:113:41: error: expected struct member name, but found string"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L113"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L113"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:114:41: error: expected struct member name, but found string"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L114"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L114"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:115:41: error: expected struct member name, but found string"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L115"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L115"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:198:21: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L198"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L198"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl"
 message = "mutec2.wdl:99:13: warning[UnusedInput]: unused input `small_task_cpu`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L99"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl/#L99"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/other_WDL/workflows/HISAT-genotype/hla_from_fastq.wdl"
 message = "hla_from_fastq.wdl:59:16: warning[UnusedInput]: unused input `aws_region`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/other_WDL/workflows/HISAT-genotype/hla_from_fastq.wdl/#L59"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/other_WDL/workflows/HISAT-genotype/hla_from_fastq.wdl/#L59"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:110:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L110"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L110"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:111:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L111"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L111"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:142:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L142"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L142"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:143:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L143"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L143"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:174:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L174"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L174"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:175:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L175"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L175"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:210:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L210"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L210"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:211:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L211"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L211"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:244:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L244"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L244"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:245:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L245"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L245"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:284:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L284"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L284"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:285:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L285"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L285"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:323:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L323"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L323"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:324:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L324"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L324"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:325:28: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L325"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L325"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl"
 message = "alphafold-600.wdl:326:48: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L326"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/alphafold/alphafold-600.wdl/#L326"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl"
 message = "esmfold.wdl:58:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L58"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L58"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl"
 message = "esmfold.wdl:59:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L59"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L59"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl"
 message = "esmfold.wdl:83:29: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L83"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L83"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl"
 message = "esmfold.wdl:84:23: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L84"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L84"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl"
 message = "esmfold.wdl:85:28: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L85"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L85"
 
 [[diagnostics]]
 document = "aws-samples/amazon-omics-tutorials:/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl"
 message = "esmfold.wdl:86:48: error: expected runtime key, but found `,`"
-permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/136ecf7e5aaee18619e14ee65a97acc6d6704bef/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L86"
+permalink = "https://github.com/aws-samples/amazon-omics-tutorials/blob/74fc4a99034645db92fb9016cecea18f7f52d17b/example-workflows/protein-folding/workflows/esmfold/esmfold.wdl/#L86"
 
 [[diagnostics]]
 document = "biowdl/tasks:/bcftools.wdl"
@@ -999,342 +929,362 @@ permalink = "https://github.com/biowdl/tasks/blob/2bf875300d90a3c9c8d670b3d99026
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ApplyBQSR.wdl"
 message = "ApplyBQSR.wdl:104:6: error: conflicting task name `ApplyBQSR`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ApplyBQSR.wdl/#L104"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ApplyBQSR.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ApplyBQSR.wdl"
 message = "ApplyBQSR.wdl:51:8: error: cannot recursively call workflow `ApplyBQSR`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ApplyBQSR.wdl/#L51"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ApplyBQSR.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ApplyBQSRAllArgs.wdl"
 message = "ApplyBQSRAllArgs.wdl:144:8: error: cannot recursively call workflow `ApplyBQSR`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ApplyBQSRAllArgs.wdl/#L144"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ApplyBQSRAllArgs.wdl/#L144"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ApplyBQSRAllArgs.wdl"
 message = "ApplyBQSRAllArgs.wdl:291:6: error: conflicting task name `ApplyBQSR`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ApplyBQSRAllArgs.wdl/#L291"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ApplyBQSRAllArgs.wdl/#L291"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/BaseRecalibrator.wdl"
 message = "BaseRecalibrator.wdl:111:6: error: conflicting task name `BaseRecalibrator`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/BaseRecalibrator.wdl/#L111"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/BaseRecalibrator.wdl/#L111"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/BaseRecalibrator.wdl"
 message = "BaseRecalibrator.wdl:55:8: error: cannot recursively call workflow `BaseRecalibrator`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/BaseRecalibrator.wdl/#L55"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/BaseRecalibrator.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/BaseRecalibratorAllArgs.wdl"
 message = "BaseRecalibratorAllArgs.wdl:158:8: error: cannot recursively call workflow `BaseRecalibrator`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/BaseRecalibratorAllArgs.wdl/#L158"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/BaseRecalibratorAllArgs.wdl/#L158"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/BaseRecalibratorAllArgs.wdl"
 message = "BaseRecalibratorAllArgs.wdl:318:6: error: conflicting task name `BaseRecalibrator`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/BaseRecalibratorAllArgs.wdl/#L318"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/BaseRecalibratorAllArgs.wdl/#L318"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ClipReads.wdl"
 message = "ClipReads.wdl:100:6: error: conflicting task name `ClipReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ClipReads.wdl/#L100"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ClipReads.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ClipReads.wdl"
 message = "ClipReads.wdl:49:8: error: cannot recursively call workflow `ClipReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ClipReads.wdl/#L49"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ClipReads.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ClipReadsAllArgs.wdl"
 message = "ClipReadsAllArgs.wdl:150:8: error: cannot recursively call workflow `ClipReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ClipReadsAllArgs.wdl/#L150"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ClipReadsAllArgs.wdl/#L150"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ClipReadsAllArgs.wdl"
 message = "ClipReadsAllArgs.wdl:304:6: error: conflicting task name `ClipReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ClipReadsAllArgs.wdl/#L304"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ClipReadsAllArgs.wdl/#L304"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CollectReadCounts.wdl"
 message = "CollectReadCounts.wdl:49:8: error: cannot recursively call workflow `CollectReadCounts`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CollectReadCounts.wdl/#L49"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CollectReadCounts.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CollectReadCounts.wdl"
 message = "CollectReadCounts.wdl:99:6: error: conflicting task name `CollectReadCounts`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CollectReadCounts.wdl/#L99"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CollectReadCounts.wdl/#L99"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CollectReadCountsAllArgs.wdl"
 message = "CollectReadCountsAllArgs.wdl:132:8: error: cannot recursively call workflow `CollectReadCounts`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CollectReadCountsAllArgs.wdl/#L132"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CollectReadCountsAllArgs.wdl/#L132"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CollectReadCountsAllArgs.wdl"
 message = "CollectReadCountsAllArgs.wdl:266:6: error: conflicting task name `CollectReadCounts`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CollectReadCountsAllArgs.wdl/#L266"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CollectReadCountsAllArgs.wdl/#L266"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CombineGVCFs.wdl"
 message = "CombineGVCFs.wdl:112:6: error: conflicting task name `CombineGVCFs`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CombineGVCFs.wdl/#L112"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CombineGVCFs.wdl/#L112"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CombineGVCFs.wdl"
 message = "CombineGVCFs.wdl:55:8: error: cannot recursively call workflow `CombineGVCFs`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CombineGVCFs.wdl/#L55"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CombineGVCFs.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CombineGVCFsAllArgs.wdl"
 message = "CombineGVCFsAllArgs.wdl:160:8: error: cannot recursively call workflow `CombineGVCFs`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CombineGVCFsAllArgs.wdl/#L160"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CombineGVCFsAllArgs.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CombineGVCFsAllArgs.wdl"
 message = "CombineGVCFsAllArgs.wdl:323:6: error: conflicting task name `CombineGVCFs`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CombineGVCFsAllArgs.wdl/#L323"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CombineGVCFsAllArgs.wdl/#L323"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountBases.wdl"
 message = "CountBases.wdl:45:8: error: cannot recursively call workflow `CountBases`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountBases.wdl/#L45"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountBases.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountBases.wdl"
 message = "CountBases.wdl:91:6: error: conflicting task name `CountBases`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountBases.wdl/#L91"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountBases.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountBasesAllArgs.wdl"
 message = "CountBasesAllArgs.wdl:130:8: error: cannot recursively call workflow `CountBases`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountBasesAllArgs.wdl/#L130"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountBasesAllArgs.wdl/#L130"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountBasesAllArgs.wdl"
 message = "CountBasesAllArgs.wdl:262:6: error: conflicting task name `CountBases`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountBasesAllArgs.wdl/#L262"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountBasesAllArgs.wdl/#L262"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountReads.wdl"
 message = "CountReads.wdl:45:8: error: cannot recursively call workflow `CountReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountReads.wdl/#L45"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountReads.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountReads.wdl"
 message = "CountReads.wdl:91:6: error: conflicting task name `CountReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountReads.wdl/#L91"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountReads.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountReadsAllArgs.wdl"
 message = "CountReadsAllArgs.wdl:130:8: error: cannot recursively call workflow `CountReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountReadsAllArgs.wdl/#L130"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountReadsAllArgs.wdl/#L130"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/CountReadsAllArgs.wdl"
 message = "CountReadsAllArgs.wdl:262:6: error: conflicting task name `CountReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/CountReadsAllArgs.wdl/#L262"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/CountReadsAllArgs.wdl/#L262"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FixMisencodedBaseQualityReads.wdl"
 message = "FixMisencodedBaseQualityReads.wdl:100:6: error: conflicting task name `FixMisencodedBaseQualityReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FixMisencodedBaseQualityReads.wdl/#L100"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FixMisencodedBaseQualityReads.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FixMisencodedBaseQualityReads.wdl"
 message = "FixMisencodedBaseQualityReads.wdl:49:8: error: cannot recursively call workflow `FixMisencodedBaseQualityReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FixMisencodedBaseQualityReads.wdl/#L49"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FixMisencodedBaseQualityReads.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FixMisencodedBaseQualityReadsAllArgs.wdl"
 message = "FixMisencodedBaseQualityReadsAllArgs.wdl:132:8: error: cannot recursively call workflow `FixMisencodedBaseQualityReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FixMisencodedBaseQualityReadsAllArgs.wdl/#L132"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FixMisencodedBaseQualityReadsAllArgs.wdl/#L132"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FixMisencodedBaseQualityReadsAllArgs.wdl"
 message = "FixMisencodedBaseQualityReadsAllArgs.wdl:267:6: error: conflicting task name `FixMisencodedBaseQualityReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FixMisencodedBaseQualityReadsAllArgs.wdl/#L267"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FixMisencodedBaseQualityReadsAllArgs.wdl/#L267"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FlagStat.wdl"
 message = "FlagStat.wdl:45:8: error: cannot recursively call workflow `FlagStat`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FlagStat.wdl/#L45"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FlagStat.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FlagStat.wdl"
 message = "FlagStat.wdl:91:6: error: conflicting task name `FlagStat`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FlagStat.wdl/#L91"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FlagStat.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FlagStatAllArgs.wdl"
 message = "FlagStatAllArgs.wdl:130:8: error: cannot recursively call workflow `FlagStat`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FlagStatAllArgs.wdl/#L130"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FlagStatAllArgs.wdl/#L130"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/FlagStatAllArgs.wdl"
 message = "FlagStatAllArgs.wdl:262:6: error: conflicting task name `FlagStat`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/FlagStatAllArgs.wdl/#L262"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/FlagStatAllArgs.wdl/#L262"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/GatherTranches.wdl"
 message = "GatherTranches.wdl:47:8: error: cannot recursively call workflow `GatherTranches`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/GatherTranches.wdl/#L47"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GatherTranches.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/GatherTranches.wdl"
 message = "GatherTranches.wdl:95:6: error: conflicting task name `GatherTranches`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/GatherTranches.wdl/#L95"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GatherTranches.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/GatherTranchesAllArgs.wdl"
 message = "GatherTranchesAllArgs.wdl:146:6: error: conflicting task name `GatherTranches`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/GatherTranchesAllArgs.wdl/#L146"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GatherTranchesAllArgs.wdl/#L146"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/GatherTranchesAllArgs.wdl"
 message = "GatherTranchesAllArgs.wdl:72:8: error: cannot recursively call workflow `GatherTranches`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/GatherTranchesAllArgs.wdl/#L72"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GatherTranchesAllArgs.wdl/#L72"
+
+[[diagnostics]]
+document = "broadinstitute/gatk-tool-wdls:/wdls/GtfToBed.wdl"
+message = "GtfToBed.wdl:45:8: error: cannot recursively call workflow `GtfToBed`"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GtfToBed.wdl/#L45"
+
+[[diagnostics]]
+document = "broadinstitute/gatk-tool-wdls:/wdls/GtfToBed.wdl"
+message = "GtfToBed.wdl:91:6: error: conflicting task name `GtfToBed`"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GtfToBed.wdl/#L91"
+
+[[diagnostics]]
+document = "broadinstitute/gatk-tool-wdls:/wdls/GtfToBedAllArgs.wdl"
+message = "GtfToBedAllArgs.wdl:136:8: error: cannot recursively call workflow `GtfToBed`"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GtfToBedAllArgs.wdl/#L136"
+
+[[diagnostics]]
+document = "broadinstitute/gatk-tool-wdls:/wdls/GtfToBedAllArgs.wdl"
+message = "GtfToBedAllArgs.wdl:274:6: error: conflicting task name `GtfToBed`"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/GtfToBedAllArgs.wdl/#L274"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/LeftAlignIndels.wdl"
 message = "LeftAlignIndels.wdl:112:6: error: conflicting task name `LeftAlignIndels`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/LeftAlignIndels.wdl/#L112"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/LeftAlignIndels.wdl/#L112"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/LeftAlignIndels.wdl"
 message = "LeftAlignIndels.wdl:55:8: error: cannot recursively call workflow `LeftAlignIndels`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/LeftAlignIndels.wdl/#L55"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/LeftAlignIndels.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/LeftAlignIndelsAllArgs.wdl"
 message = "LeftAlignIndelsAllArgs.wdl:132:8: error: cannot recursively call workflow `LeftAlignIndels`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/LeftAlignIndelsAllArgs.wdl/#L132"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/LeftAlignIndelsAllArgs.wdl/#L132"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/LeftAlignIndelsAllArgs.wdl"
 message = "LeftAlignIndelsAllArgs.wdl:267:6: error: conflicting task name `LeftAlignIndels`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/LeftAlignIndelsAllArgs.wdl/#L267"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/LeftAlignIndelsAllArgs.wdl/#L267"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/PrintReads.wdl"
 message = "PrintReads.wdl:100:6: error: conflicting task name `PrintReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/PrintReads.wdl/#L100"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/PrintReads.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/PrintReads.wdl"
 message = "PrintReads.wdl:49:8: error: cannot recursively call workflow `PrintReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/PrintReads.wdl/#L49"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/PrintReads.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/PrintReadsAllArgs.wdl"
 message = "PrintReadsAllArgs.wdl:132:8: error: cannot recursively call workflow `PrintReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/PrintReadsAllArgs.wdl/#L132"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/PrintReadsAllArgs.wdl/#L132"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/PrintReadsAllArgs.wdl"
 message = "PrintReadsAllArgs.wdl:267:6: error: conflicting task name `PrintReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/PrintReadsAllArgs.wdl/#L267"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/PrintReadsAllArgs.wdl/#L267"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ReadAnonymizer.wdl"
 message = "ReadAnonymizer.wdl:112:6: error: conflicting task name `ReadAnonymizer`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ReadAnonymizer.wdl/#L112"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ReadAnonymizer.wdl/#L112"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ReadAnonymizer.wdl"
 message = "ReadAnonymizer.wdl:55:8: error: cannot recursively call workflow `ReadAnonymizer`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ReadAnonymizer.wdl/#L55"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ReadAnonymizer.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ReadAnonymizerAllArgs.wdl"
 message = "ReadAnonymizerAllArgs.wdl:136:8: error: cannot recursively call workflow `ReadAnonymizer`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ReadAnonymizerAllArgs.wdl/#L136"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ReadAnonymizerAllArgs.wdl/#L136"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/ReadAnonymizerAllArgs.wdl"
 message = "ReadAnonymizerAllArgs.wdl:275:6: error: conflicting task name `ReadAnonymizer`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/ReadAnonymizerAllArgs.wdl/#L275"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/ReadAnonymizerAllArgs.wdl/#L275"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/RevertBaseQualityScores.wdl"
 message = "RevertBaseQualityScores.wdl:100:6: error: conflicting task name `RevertBaseQualityScores`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/RevertBaseQualityScores.wdl/#L100"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/RevertBaseQualityScores.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/RevertBaseQualityScores.wdl"
 message = "RevertBaseQualityScores.wdl:49:8: error: cannot recursively call workflow `RevertBaseQualityScores`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/RevertBaseQualityScores.wdl/#L49"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/RevertBaseQualityScores.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/RevertBaseQualityScoresAllArgs.wdl"
 message = "RevertBaseQualityScoresAllArgs.wdl:132:8: error: cannot recursively call workflow `RevertBaseQualityScores`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/RevertBaseQualityScoresAllArgs.wdl/#L132"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/RevertBaseQualityScoresAllArgs.wdl/#L132"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/RevertBaseQualityScoresAllArgs.wdl"
 message = "RevertBaseQualityScoresAllArgs.wdl:267:6: error: conflicting task name `RevertBaseQualityScores`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/RevertBaseQualityScoresAllArgs.wdl/#L267"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/RevertBaseQualityScoresAllArgs.wdl/#L267"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitNCigarReads.wdl"
 message = "SplitNCigarReads.wdl:112:6: error: conflicting task name `SplitNCigarReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitNCigarReads.wdl/#L112"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitNCigarReads.wdl/#L112"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitNCigarReads.wdl"
 message = "SplitNCigarReads.wdl:55:8: error: cannot recursively call workflow `SplitNCigarReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitNCigarReads.wdl/#L55"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitNCigarReads.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitNCigarReadsAllArgs.wdl"
 message = "SplitNCigarReadsAllArgs.wdl:144:8: error: cannot recursively call workflow `SplitNCigarReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitNCigarReadsAllArgs.wdl/#L144"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitNCigarReadsAllArgs.wdl/#L144"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitNCigarReadsAllArgs.wdl"
 message = "SplitNCigarReadsAllArgs.wdl:291:6: error: conflicting task name `SplitNCigarReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitNCigarReadsAllArgs.wdl/#L291"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitNCigarReadsAllArgs.wdl/#L291"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitReads.wdl"
 message = "SplitReads.wdl:47:8: error: cannot recursively call workflow `SplitReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitReads.wdl/#L47"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitReads.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitReads.wdl"
 message = "SplitReads.wdl:95:6: error: conflicting task name `SplitReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitReads.wdl/#L95"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitReads.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitReadsAllArgs.wdl"
 message = "SplitReadsAllArgs.wdl:136:8: error: cannot recursively call workflow `SplitReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitReadsAllArgs.wdl/#L136"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitReadsAllArgs.wdl/#L136"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/SplitReadsAllArgs.wdl"
 message = "SplitReadsAllArgs.wdl:274:6: error: conflicting task name `SplitReads`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/SplitReadsAllArgs.wdl/#L274"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/SplitReadsAllArgs.wdl/#L274"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/UnmarkDuplicates.wdl"
 message = "UnmarkDuplicates.wdl:100:6: error: conflicting task name `UnmarkDuplicates`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/UnmarkDuplicates.wdl/#L100"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/UnmarkDuplicates.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/UnmarkDuplicates.wdl"
 message = "UnmarkDuplicates.wdl:49:8: error: cannot recursively call workflow `UnmarkDuplicates`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/UnmarkDuplicates.wdl/#L49"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/UnmarkDuplicates.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/UnmarkDuplicatesAllArgs.wdl"
 message = "UnmarkDuplicatesAllArgs.wdl:132:8: error: cannot recursively call workflow `UnmarkDuplicates`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/UnmarkDuplicatesAllArgs.wdl/#L132"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/UnmarkDuplicatesAllArgs.wdl/#L132"
 
 [[diagnostics]]
 document = "broadinstitute/gatk-tool-wdls:/wdls/UnmarkDuplicatesAllArgs.wdl"
 message = "UnmarkDuplicatesAllArgs.wdl:267:6: error: conflicting task name `UnmarkDuplicates`"
-permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/4536dd2c6719b86f4c50348f0ce354818260cadb/wdls/UnmarkDuplicatesAllArgs.wdl/#L267"
+permalink = "https://github.com/broadinstitute/gatk-tool-wdls/blob/980883d87ee81df7925cd60dd04140e9fd01e317/wdls/UnmarkDuplicatesAllArgs.wdl/#L267"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkPhasing/PhaseVCF.wdl"
@@ -2154,1987 +2104,1967 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308b
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
 message = "TargetedSomaticSingleSample.wdl:18:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L18"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L18"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl"
 message = "TargetedSomaticSingleSample.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/beta-pipelines/broad/somatic/single_sample/targeted/TargetedSomaticSingleSample.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl"
 message = "BuildIndexHisat3n.9.wdl:9:15: warning[UnusedInput]: unused input `monitoring_script_path`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/beta-pipelines/skylab/BuildIndexHisat/BuildIndexHisat3n.9.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/skylab/slidetags/SlideTags.wdl"
-message = "SlideTags.wdl:10:16: warning[UnusedInput]: unused input `id`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L10"
+message = "SlideTags.wdl:11:16: warning[UnusedInput]: unused input `id`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/skylab/slidetags/SlideTags.wdl"
-message = "SlideTags.wdl:26:32: warning[UnusedCall]: unused call `spatial_count`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L26"
+message = "SlideTags.wdl:15:16: warning[UnusedInput]: unused input `sb_path`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/beta-pipelines/skylab/slidetags/SlideTags.wdl"
-message = "SlideTags.wdl:7:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L7"
+message = "SlideTags.wdl:32:46: warning[UnusedCall]: unused call `positioning`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L32"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/beta-pipelines/skylab/slidetags/SlideTags.wdl"
+message = "SlideTags.wdl:8:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/beta-pipelines/skylab/slidetags/SlideTags.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/deprecated/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl"
 message = "BuildCembaReferences.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/deprecated/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/deprecated/pipelines/cemba/build_cemba_references/BuildCembaReferences.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/deprecated/pipelines/cemba/cemba_methylcseq/CEMBA.wdl"
 message = "CEMBA.wdl:60:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/deprecated/pipelines/cemba/cemba_methylcseq/CEMBA.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/deprecated/pipelines/cemba/cemba_methylcseq/CEMBA.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:104:12: warning[UnusedInput]: unused input `significant_variants_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L104"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L104"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:77:54: error: type mismatch: a type common to both type `File` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl"
 message = "AnnotationFiltration.wdl:7:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/annotation_filtration/AnnotationFiltration.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
 message = "Imputation.wdl:262:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/imputation/Imputation.wdl/#L262"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/imputation/Imputation.wdl/#L262"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/imputation/Imputation.wdl"
 message = "Imputation.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/imputation/Imputation.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/imputation/Imputation.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:21:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L21"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L21"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl"
 message = "MultiSampleArrays.wdl:26:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/multi_sample/MultiSampleArrays.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
 message = "Arrays.wdl:26:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/single_sample/Arrays.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/single_sample/Arrays.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/single_sample/Arrays.wdl"
 message = "Arrays.wdl:322:28: warning[UnusedCall]: unused call `UpdateChipWellBarcodeIndex`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/single_sample/Arrays.wdl/#L322"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/single_sample/Arrays.wdl/#L322"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:137:24: warning[UnusedCall]: unused call `ValidateVariants`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L137"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L137"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:255:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L255"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L255"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:259:10: warning[UnusedInput]: unused input `truth_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L259"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L259"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/arrays/validate_chip/ValidateChip.wdl"
 message = "ValidateChip.wdl:4:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L4"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/arrays/validate_chip/ValidateChip.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:205:81: error: type mismatch: string concatenation is not supported for type `File?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L205"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L205"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:397:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L397"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L397"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
 message = "JointGenotyping.wdl:62:13: warning[UnusedInput]: unused input `rename_gvcf_samples`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:14:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:269:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L269"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L269"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl"
 message = "UltimaGenomicsJointGenotyping.wdl:63:13: warning[UnusedInput]: unused input `cross_check_fingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/UltimaGenomics/UltimaGenomicsJointGenotyping.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:210:41: error: type mismatch: expected type `Array[Int]`, but found type `Array[String]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L210"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L210"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:47:23: warning[UnusedInput]: unused input `gnarly_workaround_annotations`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L47"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl"
 message = "JointGenotypingByChromosomePartOne.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartOne.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:14:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:23:9: warning[UnusedInput]: unused input `large_disk`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:24:9: warning[UnusedInput]: unused input `huge_disk`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:58:11: warning[UnusedInput]: unused input `excess_het_threshold`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:61:9: warning[UnusedInput]: unused input `SNP_VQSR_downsampleFactor`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L61"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L61"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:75:15: warning[UnusedDeclaration]: unused declaration `fingerprinting_vcf_indices`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L75"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:78:7: warning[UnusedDeclaration]: unused declaration `num_gvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl"
 message = "JointGenotypingByChromosomePartTwo.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/by_chromosome/JointGenotypingByChromosomePartTwo.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:51:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:57:28: warning[UnusedCall]: unused call `ValidateVCF`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl"
 message = "ReblockGVCF.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/joint_genotyping/reblocking/ReblockGVCF.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:42:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:48:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl"
 message = "ExomeGermlineSingleSample.wdl:73:10: warning[UnusedDeclaration]: unused declaration `gatk_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/exome/ExomeGermlineSingleSample.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:10:83: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineQC`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:11:92: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L11"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L11"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:53:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:62:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:63:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:7:104: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:83:7: warning[UnusedDeclaration]: unused declaration `hc_divisor`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L83"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:8:61: warning[UnusedImport]: unused import namespace `InternalTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:9:50: warning[UnusedImport]: unused import namespace `QC`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:109:37: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:37:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
 message = "WholeGenomeGermlineSingleSample.wdl:43:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
 message = "VariantCalling.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl"
 message = "VariantCalling.wdl:209:26: warning[UnusedCall]: unused call `ValidateVCF`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L209"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/germline/variant_calling/VariantCalling.wdl/#L209"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:10:92: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:46:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:58:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:59:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:5:72: warning[UnusedImport]: unused import namespace `VariantDiscoverTasks`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:87:30: warning[UnusedCall]: unused call `ValidateCram`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:391:9: warning[UnusedInput]: unused input `max_retries`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L391"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L391"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:626:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L626"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L626"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:666:40: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L666"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L666"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl"
 message = "GDCWholeGenomeSomaticSingleSample.wdl:672:14: error: conflicting scatter variable name `ubam`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L672"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/dna_seq/somatic/single_sample/wgs/gdc_genome/GDCWholeGenomeSomaticSingleSample.wdl/#L672"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
 message = "BroadInternalImputation.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl"
 message = "BroadInternalImputation.wdl:81:34: warning[UnusedCall]: unused call `TriggerPrsWithImputationTsv`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L81"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/arrays/imputation/BroadInternalImputation.wdl/#L81"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
 message = "BroadInternalArrays.wdl:12:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl"
 message = "BroadInternalArrays.wdl:80:24: warning[UnusedCall]: unused call `IngestOutputsToTDR`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L80"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/arrays/single_sample/BroadInternalArrays.wdl/#L80"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:4:95: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:63:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:64:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L64"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:91:34: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:92:48: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L92"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:93:46: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L93"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:94:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L94"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L94"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:95:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L95"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:96:38: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L96"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L96"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:97:44: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L97"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
 message = "BroadInternalRNAWithUMIs.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl"
 message = "BroadInternalRNAWithUMIs.wdl:160:45: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L160"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/internal/rna_seq/BroadInternalRNAWithUMIs.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/qc/CheckFingerprint.wdl"
 message = "CheckFingerprint.wdl:27:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/qc/CheckFingerprint.wdl/#L27"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/qc/CheckFingerprint.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
 message = "CramToUnmappedBams.wdl:12:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl"
 message = "CramToUnmappedBams.wdl:20:12: warning[UnusedInput]: unused input `base_file_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L20"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/cram_to_unmapped_bams/CramToUnmappedBams.wdl/#L20"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
 message = "ExomeReprocessing.wdl:10:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl"
 message = "ExomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/exome/ExomeReprocessing.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
 message = "ExternalExomeReprocessing.wdl:62:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl"
 message = "ExternalExomeReprocessing.wdl:8:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/external/exome/ExternalExomeReprocessing.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
 message = "ExternalWholeGenomeReprocessing.wdl:60:13: warning[UnusedCall]: unused call `CopyFilesFromCloudToCloud`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl"
 message = "ExternalWholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/external/wgs/ExternalWholeGenomeReprocessing.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
 message = "WholeGenomeReprocessing.wdl:5:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl"
 message = "WholeGenomeReprocessing.wdl:9:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/reprocessing/wgs/WholeGenomeReprocessing.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl"
 message = "RNAWithUMIsPipeline.wdl:23:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/broad/rna_seq/RNAWithUMIsPipeline.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
-message = "atac.wdl:142:25: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L142"
+message = "atac.wdl:145:25: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/atac/atac.wdl/#L145"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
-message = "atac.wdl:153:25: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L153"
+message = "atac.wdl:158:25: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/atac/atac.wdl/#L158"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
 message = "atac.wdl:3:52: warning[UnusedImport]: unused import namespace `Merge`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L3"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/atac/atac.wdl/#L3"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
-message = "atac.wdl:49:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L49"
+message = "atac.wdl:514:10: error: conflicting input name `annotations_gtf`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/atac/atac.wdl/#L514"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/atac/atac.wdl"
-message = "atac.wdl:507:10: error: conflicting input name `annotations_gtf`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/atac/atac.wdl/#L507"
+message = "atac.wdl:52:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/atac/atac.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:150:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L150"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/build_indices/BuildIndices.wdl/#L150"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:160:12: warning[UnusedInput]: unused input `gtf_annotation_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L160"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/build_indices/BuildIndices.wdl/#L160"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:190:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L190"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/build_indices/BuildIndices.wdl/#L190"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:73:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/build_indices/BuildIndices.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/build_indices/BuildIndices.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/multiome/Multiome.wdl"
 message = "Multiome.wdl:105:13: error: duplicate call input `cloud_provider` in call statement"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/multiome/Multiome.wdl/#L105"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/multiome/Multiome.wdl/#L105"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/multiome/Multiome.wdl"
 message = "Multiome.wdl:90:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/multiome/Multiome.wdl/#L90"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/multiome/Multiome.wdl/#L90"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:163:18: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L163"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
-message = "Optimus.wdl:226:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L226"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/optimus/Optimus.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:227:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L227"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
-message = "Optimus.wdl:245:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L245"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/optimus/Optimus.wdl/#L227"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:276:24: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L276"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
-message = "Optimus.wdl:282:26: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L282"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/optimus/Optimus.wdl/#L276"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:78:14: warning[UnusedDeclaration]: unused declaration `indices`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L78"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/optimus/Optimus.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:91:10: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/optimus/Optimus.wdl/#L91"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/optimus/Optimus.wdl/#L91"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
 message = "PairedTag.wdl:5:49: warning[UnusedImport]: unused import namespace `H5adUtils`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
 message = "PairedTag.wdl:86:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/scATAC/scATAC.wdl"
 message = "scATAC.wdl:203:9: error: duplicate key `cpu` in runtime section"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/scATAC/scATAC.wdl/#L203"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/scATAC/scATAC.wdl/#L203"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:49:12: warning[UnusedDeclaration]: unused declaration `pytools_docker`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/slideseq/SlideSeq.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/slideseq/SlideSeq.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:7:51: warning[UnusedImport]: unused import namespace `OptimusInputChecks`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
 message = "SlideSeq.wdl:98:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl"
 message = "MultiSampleSmartSeq2.wdl:71:28: warning[UnusedCall]: unused call `checkArrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:135:27: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L135"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L135"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:34:15: warning[UnusedInput]: unused input `batch_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L34"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L34"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:35:22: warning[UnusedInput]: unused input `project_id`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:36:22: warning[UnusedInput]: unused input `project_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L36"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:37:22: warning[UnusedInput]: unused input `library`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:38:22: warning[UnusedInput]: unused input `species`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L38"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L38"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:39:22: warning[UnusedInput]: unused input `organ`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:81:40: warning[UnusedCall]: unused call `checkArrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
 message = "MultiSampleSmartSeq2SingleNucleus.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
 message = "snm3C.wdl:278:14: warning[UnusedInput]: unused input `chromosome_sizes`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/snm3C/snm3C.wdl/#L278"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/snm3C/snm3C.wdl/#L278"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
 message = "snm3C.wdl:47:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/pipelines/skylab/snm3C/snm3C.wdl/#L47"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/pipelines/skylab/snm3C/snm3C.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:131:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:217:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:45:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:141:73: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L141"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L141"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:142:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L142"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L142"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:143:72: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L143"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L143"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:175:68: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:231:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L231"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L231"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:42:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
 message = "CreateSs2AdapterMetadata.wdl:90:10: warning[UnusedDeclaration]: unused declaration `project_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L90"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L90"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
 message = "AdapterTasks.wdl:580:13: warning[UnusedInput]: unused input `cache_invalidate`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/tasks/AdapterTasks.wdl/#L580"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/tasks/AdapterTasks.wdl/#L580"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/AdapterTasks.wdl"
 message = "AdapterTasks.wdl:738:13: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/tasks/AdapterTasks.wdl/#L738"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/tasks/AdapterTasks.wdl/#L738"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/tasks/CreateReferenceMetadata.wdl"
 message = "CreateReferenceMetadata.wdl:15:12: warning[UnusedInput]: unused input `input_type`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/projects/tasks/CreateReferenceMetadata.wdl/#L15"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/projects/tasks/CreateReferenceMetadata.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/scripts/BuildAFComparisonTable.wdl"
 message = "BuildAFComparisonTable.wdl:88:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/scripts/BuildAFComparisonTable.wdl/#L88"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/scripts/BuildAFComparisonTable.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/AggregatedBamQC.wdl"
 message = "AggregatedBamQC.wdl:60:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/AggregatedBamQC.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/AggregatedBamQC.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Alignment.wdl"
 message = "Alignment.wdl:119:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Alignment.wdl/#L119"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Alignment.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/BamProcessing.wdl"
 message = "BamProcessing.wdl:53:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/BamProcessing.wdl/#L53"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/BamProcessing.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/CopyFilesFromCloudToCloud.wdl"
 message = "CopyFilesFromCloudToCloud.wdl:71:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/CopyFilesFromCloudToCloud.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/CopyFilesFromCloudToCloud.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:163:118: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Funcotator.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:163:92: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Funcotator.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:164:118: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L164"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Funcotator.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:164:89: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L164"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Funcotator.wdl/#L164"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:165:121: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L165"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Funcotator.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Funcotator.wdl"
 message = "Funcotator.wdl:165:91: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Funcotator.wdl/#L165"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Funcotator.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:140:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L140"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:157:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L157"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L157"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:27:12: warning[UnusedInput]: unused input `contamination`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L27"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L27"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:335:12: warning[UnusedInput]: unused input `vcf_basename`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L335"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L335"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:373:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L373"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L373"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:429:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L429"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L429"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:67:32: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:74:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L74"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:92:12: warning[UnusedInput]: unused input `contamination`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L92"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L92"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:98:13: warning[UnusedInput]: unused input `use_dragen_hard_filtering`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/GermlineVariantDiscovery.wdl/#L98"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/GermlineVariantDiscovery.wdl/#L98"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:109:11: warning[UnusedInput]: unused input `fingerprint_genotypes_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:214:10: warning[UnusedInput]: unused input `input_vcf`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L214"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L214"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:287:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L287"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L287"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:289:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L289"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L289"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:423:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L423"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L423"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:541:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L541"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L541"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:556:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L556"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L556"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:591:10: warning[UnusedInput]: unused input `call_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L591"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L591"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:595:11: warning[UnusedInput]: unused input `truth_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L595"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L595"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:62:9: warning[UnusedInput]: unused input `disk_size`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:661:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L661"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L661"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:698:10: warning[UnusedInput]: unused input `dbSNP_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L698"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/IlluminaGenotypingArrayTasks.wdl/#L698"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/ImputationTasks.wdl"
 message = "ImputationTasks.wdl:529:9: warning[UnusedInput]: unused input `nSamples`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/ImputationTasks.wdl/#L529"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/ImputationTasks.wdl/#L529"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
 message = "InternalArraysTasks.wdl:42:10: warning[UnusedInput]: unused input `upload_metrics_output`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalArraysTasks.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/InternalArraysTasks.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalArraysTasks.wdl"
 message = "InternalArraysTasks.wdl:85:10: warning[UnusedInput]: unused input `input_vcf_index_file`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalArraysTasks.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/InternalArraysTasks.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalImputationTasks.wdl"
 message = "InternalImputationTasks.wdl:129:25: warning[UnusedInput]: unused input `run_task`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalImputationTasks.wdl/#L129"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/InternalImputationTasks.wdl/#L129"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/InternalTasks.wdl"
 message = "InternalTasks.wdl:13:10: warning[UnusedDeclaration]: unused declaration `safe_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/InternalTasks.wdl/#L13"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/InternalTasks.wdl/#L13"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:304:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L304"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L304"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:366:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L366"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L366"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:434:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:49:13: warning[UnusedInput]: unused input `sample_names_unique_done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:581:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L581"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L581"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:641:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L641"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L641"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:688:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L688"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L688"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:859:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L859"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L859"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:87:10: warning[UnusedInput]: unused input `ref_fasta`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:900:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/JointGenotypingTasks.wdl/#L900"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/JointGenotypingTasks.wdl/#L900"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:434:31: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Qc.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:434:46: error: cannot coerce type `Array[String]?` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L434"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Qc.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:436:46: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L436"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Qc.wdl/#L436"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Qc.wdl"
 message = "Qc.wdl:506:29: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Qc.wdl/#L506"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Qc.wdl/#L506"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/RNAWithUMIsTasks.wdl"
 message = "RNAWithUMIsTasks.wdl:935:12: warning[UnusedInput]: unused input `mem`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/RNAWithUMIsTasks.wdl/#L935"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/RNAWithUMIsTasks.wdl/#L935"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
 message = "SplitLargeReadGroup.wdl:21:45: warning[UnusedImport]: unused import namespace `Utils`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/SplitLargeReadGroup.wdl/#L21"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/SplitLargeReadGroup.wdl/#L21"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/SplitLargeReadGroup.wdl"
 message = "SplitLargeReadGroup.wdl:22:53: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/SplitLargeReadGroup.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/SplitLargeReadGroup.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl"
 message = "UltimaGenomicsGermlineFilteringThreshold.wdl:228:11: warning[UnusedInput]: unused input `interval_list`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl/#L228"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsGermlineFilteringThreshold.wdl/#L228"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:14:11: warning[UnusedInput]: unused input `rsq_threshold`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L14"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L14"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:5:80: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L5"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L5"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl:65:7: warning[UnusedDeclaration]: unused declaration `rounded_disk_size`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:1096:12: warning[UnusedInput]: unused input `annotation`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L1096"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L1096"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:63:9: warning[UnusedInput]: unused input `preemptible`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L63"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:785:10: warning[UnusedInput]: unused input `read_length`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L785"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L785"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:786:11: warning[UnusedInput]: unused input `jar_override`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L786"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L786"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:814:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L814"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:839:10: warning[UnusedInput]: unused input `read_length`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L839"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L839"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl"
 message = "UltimaGenomicsWholeGenomeGermlineTasks.wdl:866:27: error: expected string, but found integer"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UltimaGenomicsWholeGenomeGermlineTasks.wdl/#L866"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:168:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UnmappedBamToAlignedBam.wdl/#L168"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UnmappedBamToAlignedBam.wdl/#L168"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:25:53: warning[UnusedImport]: unused import namespace `Structs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
 message = "UnmappedBamToAlignedBam.wdl:85:31: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/UnmappedBamToAlignedBam.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/UnmappedBamToAlignedBam.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Utilities.wdl"
 message = "Utilities.wdl:152:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Utilities.wdl/#L152"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Utilities.wdl/#L152"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Utilities.wdl"
 message = "Utilities.wdl:183:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/broad/Utilities.wdl/#L183"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/broad/Utilities.wdl/#L183"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/FastqProcessing.wdl"
 message = "FastqProcessing.wdl:243:16: warning[UnusedInput]: unused input `barcode_orientation`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/FastqProcessing.wdl/#L243"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/FastqProcessing.wdl/#L243"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:119:10: error: conflicting output name `library_metrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L119"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/H5adUtils.wdl/#L119"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:224:14: error: conflicting output name `library_metrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L224"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/H5adUtils.wdl/#L224"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:237:12: warning[UnusedInput]: unused input `cpuPlatform`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L237"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/H5adUtils.wdl/#L237"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
 message = "H5adUtils.wdl:35:12: error: conflicting input name `counting_mode`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/H5adUtils.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/H5adUtils.wdl"
-message = "H5adUtils.wdl:537:24: warning[UnusedInput]: unused input `input_names`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/H5adUtils.wdl/#L537"
+message = "H5adUtils.wdl:548:24: warning[UnusedInput]: unused input `input_names`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/H5adUtils.wdl/#L548"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/LoomUtils.wdl"
 message = "LoomUtils.wdl:318:24: warning[UnusedInput]: unused input `input_names`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/LoomUtils.wdl/#L318"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/LoomUtils.wdl/#L318"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/PairedTagUtils.wdl"
 message = "PairedTagUtils.wdl:206:16: warning[UnusedInput]: unused input `cpuPlatform`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/PairedTagUtils.wdl/#L206"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/PairedTagUtils.wdl/#L206"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
 message = "StarAlign.wdl:459:12: warning[UnusedInput]: unused input `gex_nhash_id`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/StarAlign.wdl/#L459"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/StarAlign.wdl/#L459"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/StarAlign.wdl"
 message = "StarAlign.wdl:784:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/StarAlign.wdl/#L784"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/StarAlign.wdl/#L784"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:24:16: warning[UnusedInput]: unused input `ref_name`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:48:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tasks/skylab/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:6:13: warning[UnusedInput]: unused input `dummy_int`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L6"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:7:16: warning[UnusedInput]: unused input `dummy_string`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:8:17: warning[UnusedInput]: unused input `dummy_boolean`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L8"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L8"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl"
 message = "dummyWorkflow.wdl:9:17: warning[UnusedInput]: unused input `dummy_option`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/broad/scala_test/src/main/resources/dummy/dummyWorkflow.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/cemba/pr/CheckCembaOutputs.wdl"
 message = "CheckCembaOutputs.wdl:1:1: error: a WDL document must start with a version statement"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/cemba/pr/CheckCembaOutputs.wdl/#L1"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/scATAC/pr/test_scATAC_PR.wdl"
 message = "test_scATAC_PR.wdl:35:34: warning[UnusedCall]: unused call `checker`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/scATAC/pr/test_scATAC_PR.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/skylab/scATAC/pr/test_scATAC_PR.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
 message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
 message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:46:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyArrays.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyArrays.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:49:38: warning[UnusedCall]: unused call `VerifyIlluminaGenotypingArray`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyArrays.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyArrays.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:66:40: warning[UnusedCall]: unused call `CompareParamsFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyArrays.wdl/#L66"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyArrays.wdl/#L66"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
 message = "VerifyCheckFingerprint.wdl:31:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyCheckFingerprint.wdl/#L31"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyCheckFingerprint.wdl/#L31"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCheckFingerprint.wdl"
 message = "VerifyCheckFingerprint.wdl:42:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyCheckFingerprint.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyCheckFingerprint.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyCramToUnmappedBamsUpdated.wdl"
 message = "VerifyCramToUnmappedBamsUpdated.wdl:9:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyCramToUnmappedBamsUpdated.wdl/#L9"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyCramToUnmappedBamsUpdated.wdl/#L9"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
 message = "VerifyExomeReprocessing.wdl:24:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyExomeReprocessing.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyExomeReprocessing.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExomeReprocessing.wdl"
 message = "VerifyExomeReprocessing.wdl:37:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyExomeReprocessing.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyExomeReprocessing.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyExternalReprocessing.wdl"
 message = "VerifyExternalReprocessing.wdl:10:10: warning[UnusedCall]: unused call `AssertTrue`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyExternalReprocessing.wdl/#L10"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyExternalReprocessing.wdl/#L10"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
 message = "VerifyGDCSomaticSingleSample.wdl:17:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGDCSomaticSingleSample.wdl/#L17"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGDCSomaticSingleSample.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGDCSomaticSingleSample.wdl"
 message = "VerifyGDCSomaticSingleSample.wdl:26:20: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGDCSomaticSingleSample.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGDCSomaticSingleSample.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:22:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGermlineSingleSample.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:26:14: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGermlineSingleSample.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:40:8: warning[UnusedCall]: unused call `CompareGvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGermlineSingleSample.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:46:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L46"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGermlineSingleSample.wdl/#L46"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGermlineSingleSample.wdl"
 message = "VerifyGermlineSingleSample.wdl:52:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGermlineSingleSample.wdl/#L52"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGermlineSingleSample.wdl/#L52"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:13:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGvcf.wdl/#L13"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGvcf.wdl/#L13"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:16:20: warning[UnusedCall]: unused call `CompareVCFsVerbosely`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGvcf.wdl/#L16"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGvcf.wdl/#L16"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyGvcf.wdl"
 message = "VerifyGvcf.wdl:24:20: warning[UnusedCall]: unused call `CompareVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyGvcf.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyGvcf.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:102:24: warning[UnusedCall]: unused call `CompareGreenIdatMdf5Sum`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyIlluminaGenotypingArray.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:108:24: warning[UnusedCall]: unused call `CompareRedIdatMdf5Sum`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L108"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyIlluminaGenotypingArray.wdl/#L108"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:43:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyIlluminaGenotypingArray.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:83:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L83"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyIlluminaGenotypingArray.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:89:55: warning[UnusedCall]: unused call `CompareOutputFingerprintVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L89"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyIlluminaGenotypingArray.wdl/#L89"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyIlluminaGenotypingArray.wdl"
 message = "VerifyIlluminaGenotypingArray.wdl:95:14: warning[UnusedCall]: unused call `CompareGtcs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyIlluminaGenotypingArray.wdl/#L95"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyIlluminaGenotypingArray.wdl/#L95"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:43:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyImputation.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyImputation.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:56:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyImputation.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyImputation.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyImputation.wdl"
 message = "VerifyImputation.wdl:72:8: warning[UnusedCall]: unused call `CrosscheckFingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyImputation.wdl/#L72"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyImputation.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyJointGenotyping.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyJointGenotyping.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:48:28: warning[UnusedCall]: unused call `VerifyMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyJointGenotyping.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyJointGenotyping.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyJointGenotyping.wdl"
 message = "VerifyJointGenotyping.wdl:54:40: warning[UnusedCall]: unused call `CompareIntervals`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyJointGenotyping.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyJointGenotyping.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:73:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMetrics.wdl/#L73"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMetrics.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:87:117: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMetrics.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMetrics.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMetrics.wdl"
 message = "VerifyMetrics.wdl:87:89: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMetrics.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMetrics.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
 message = "VerifyMultiSampleArrays.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleArrays.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiSampleArrays.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleArrays.wdl"
 message = "VerifyMultiSampleArrays.wdl:28:14: warning[UnusedCall]: unused call `CompareVcfsAllowingQualityDifferences`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleArrays.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiSampleArrays.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:12:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "VerifyMultiSampleSmartSeq2SingleNucleus.wdl:24:43: warning[UnusedCall]: unused call `CompareH5adFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiSampleSmartSeq2SingleNucleus.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:32:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L32"
+message = "VerifyMultiome.wdl:35:18: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L35"
+message = "VerifyMultiome.wdl:38:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L38"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L42"
+message = "VerifyMultiome.wdl:45:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L48"
+message = "VerifyMultiome.wdl:51:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L54"
+message = "VerifyMultiome.wdl:57:37: warning[UnusedCall]: unused call `CompareAtacBams`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L60"
+message = "VerifyMultiome.wdl:63:38: warning[UnusedCall]: unused call `CompareFragment`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L63"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L65"
+message = "VerifyMultiome.wdl:68:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L68"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L70"
+message = "VerifyMultiome.wdl:73:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L73"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L75"
+message = "VerifyMultiome.wdl:78:45: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L77"
+message = "VerifyMultiome.wdl:83:42: warning[UnusedCall]: unused call `CompareAtacLibraryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L83"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
-message = "VerifyMultiome.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyMultiome.wdl/#L78"
+message = "VerifyMultiome.wdl:85:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L85"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyMultiome.wdl"
+message = "VerifyMultiome.wdl:86:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyMultiome.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
 message = "VerifyNA12878.wdl:62:9: warning[UnusedDeclaration]: unused declaration `default_disk_space_gb`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyNA12878.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyNA12878.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyNA12878.wdl"
 message = "VerifyNA12878.wdl:65:47: error: type mismatch: multiplication operator is not supported for type `Int?` and type `Int`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyNA12878.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyNA12878.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:23:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyOptimus.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyOptimus.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyOptimus.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyOptimus.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
 message = "VerifyOptimus.wdl:45:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyOptimus.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
-message = "VerifyOptimus.wdl:51:40: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L51"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
-message = "VerifyOptimus.wdl:53:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L53"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/VerifyOptimus.wdl"
-message = "VerifyOptimus.wdl:54:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyOptimus.wdl/#L54"
+message = "VerifyOptimus.wdl:51:43: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyOptimus.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:32:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L32"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:35:37: warning[UnusedCall]: unused call `CompareOptimusBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L35"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L35"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:42:52: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L42"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L42"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:48:52: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L48"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:54:37: warning[UnusedCall]: unused call `CompareAtacBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:60:38: warning[UnusedCall]: unused call `CompareFragment`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:65:46: warning[UnusedCall]: unused call `CompareH5adFilesATAC`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L65"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L65"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
 message = "VerifyPairedTag.wdl:70:45: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L70"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L70"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
-message = "VerifyPairedTag.wdl:75:42: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L75"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
-message = "VerifyPairedTag.wdl:77:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L77"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/VerifyPairedTag.wdl"
-message = "VerifyPairedTag.wdl:78:43: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyPairedTag.wdl/#L78"
+message = "VerifyPairedTag.wdl:75:45: warning[UnusedCall]: unused call `CompareLibraryMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyPairedTag.wdl/#L75"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:103:50: warning[UnusedCall]: unused call `CompareGeneCounts`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L103"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyRNAWithUMIs.wdl/#L103"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:109:50: warning[UnusedCall]: unused call `CompareExonCounts`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L109"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyRNAWithUMIs.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:28:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyRNAWithUMIs.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:37:40: warning[UnusedCall]: unused call `CompareTextMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L37"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyRNAWithUMIs.wdl/#L37"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:43:35: warning[UnusedCall]: unused call `CompareOutputBam`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyRNAWithUMIs.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyRNAWithUMIs.wdl"
 message = "VerifyRNAWithUMIs.wdl:97:50: warning[UnusedCall]: unused call `CompareGeneTpms`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyRNAWithUMIs.wdl/#L97"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyRNAWithUMIs.wdl/#L97"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyReprocessing.wdl"
 message = "VerifyReprocessing.wdl:33:35: warning[UnusedCall]: unused call `VerifyGermlineSingleSample`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyReprocessing.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyReprocessing.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:23:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySlideSeq.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:26:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySlideSeq.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:33:50: warning[UnusedCall]: unused call `CompareGeneMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySlideSeq.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:39:50: warning[UnusedCall]: unused call `CompareCellMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySlideSeq.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:45:50: warning[UnusedCall]: unused call `CompareUMIMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L45"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySlideSeq.wdl/#L45"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySlideSeq.wdl"
 message = "VerifySlideSeq.wdl:51:43: warning[UnusedCall]: unused call `CompareH5adFilesOptimus`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySlideSeq.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySlideSeq.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
 message = "VerifySomaticSingleSample.wdl:24:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySomaticSingleSample.wdl/#L24"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySomaticSingleSample.wdl/#L24"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifySomaticSingleSample.wdl"
 message = "VerifySomaticSingleSample.wdl:30:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifySomaticSingleSample.wdl/#L30"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifySomaticSingleSample.wdl/#L30"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
 message = "VerifyUltimaGenomicsJointGenotyping.wdl:25:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L25"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L25"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
-message = "VerifyUltimaGenomicsJointGenotyping.wdl:36:28: warning[UnusedCall]: unused call `VerifyMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L36"
+message = "VerifyUltimaGenomicsJointGenotyping.wdl:47:28: warning[UnusedCall]: unused call `VerifyMetrics`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L47"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
-message = "VerifyUltimaGenomicsJointGenotyping.wdl:42:40: warning[UnusedCall]: unused call `CompareIntervals`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L42"
+message = "VerifyUltimaGenomicsJointGenotyping.wdl:53:40: warning[UnusedCall]: unused call `CompareIntervals`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L53"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsJointGenotyping.wdl"
-message = "VerifyUltimaGenomicsJointGenotyping.wdl:48:8: warning[UnusedCall]: unused call `CompareFingerprints`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L48"
+message = "VerifyUltimaGenomicsJointGenotyping.wdl:59:8: warning[UnusedCall]: unused call `CompareFingerprints`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsJointGenotyping.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:102:115: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:102:87: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L102"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:17:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L17"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L17"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:64:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L64"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:72:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L72"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L72"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "VerifyUltimaGenomicsWholeGenomeCramOnly.wdl:89:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L89"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeCramOnly.wdl/#L89"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:105:29: warning[UnusedCall]: unused call `CompareGvcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L105"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:100:29: warning[UnusedCall]: unused call `CompareFilteredVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:112:22: warning[UnusedCall]: unused call `VerifyNA12878`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L112"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:107:29: warning[UnusedCall]: unused call `CompareGvcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L107"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:161:11: warning[UnusedInput]: unused input `dependency_input`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L161"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:114:38: warning[UnusedCall]: unused call `CompareGVcfsVerbosely`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L114"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:115: error: cannot coerce type `Array[String]` to `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:125:22: warning[UnusedCall]: unused call `VerifyNA12878`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L125"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:87: error: a placeholder cannot have more than one option"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:174:11: warning[UnusedInput]: unused input `dependency_input`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L174"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:30:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L30"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:187:115: error: cannot coerce type `Array[String]` to `String`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L187"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:77:14: warning[UnusedCall]: unused call `CompareCrams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L77"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:187:87: error: a placeholder cannot have more than one option"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L187"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:85:14: warning[UnusedCall]: unused call `CompareCrais`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L85"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:32:14: warning[UnusedInput]: unused input `done`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L32"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:91:29: warning[UnusedCall]: unused call `CompareVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L91"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:79:14: warning[UnusedCall]: unused call `CompareCrams`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L79"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
-message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:98:29: warning[UnusedCall]: unused call `CompareFilteredVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L98"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:87:14: warning[UnusedCall]: unused call `CompareCrais`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L87"
+
+[[diagnostics]]
+document = "broadinstitute/warp:/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl"
+message = "VerifyUltimaGenomicsWholeGenomeGermline.wdl:93:29: warning[UnusedCall]: unused call `CompareVcfs`"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyUltimaGenomicsWholeGenomeGermline.wdl/#L93"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:40:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyValidateChip.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:43:14: warning[UnusedCall]: unused call `CompareGtcs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyValidateChip.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:50:55: warning[UnusedCall]: unused call `CompareOutputVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L50"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyValidateChip.wdl/#L50"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:56:55: warning[UnusedCall]: unused call `CompareGenotypeConcordanceVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyValidateChip.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyValidateChip.wdl"
 message = "VerifyValidateChip.wdl:62:55: warning[UnusedCall]: unused call `CompareIndelGenotypeConcordanceVcfs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyValidateChip.wdl/#L62"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyValidateChip.wdl/#L62"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:12:14: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyscATAC.wdl/#L12"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyscATAC.wdl/#L12"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:15:35: warning[UnusedCall]: unused call `CompareBams`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyscATAC.wdl/#L15"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyscATAC.wdl/#L15"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyscATAC.wdl"
 message = "VerifyscATAC.wdl:22:43: warning[UnusedCall]: unused call `CompareSnapTextFiles`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/VerifyscATAC.wdl/#L22"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/VerifyscATAC.wdl/#L22"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:23:18: warning[UnusedInput]: unused input `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/Verifysnm3C.wdl/#L23"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/Verifysnm3C.wdl/#L23"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:26:52: warning[UnusedCall]: unused call `CompareMappingSummaryMetrics`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/Verifysnm3C.wdl/#L26"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/Verifysnm3C.wdl/#L26"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/Verifysnm3C.wdl"
 message = "Verifysnm3C.wdl:66:17: error: conflicting output name `done`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/Verifysnm3C.wdl/#L66"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/Verifysnm3C.wdl/#L66"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl"
 message = "TestBroadInternalRNAWithUMIs.wdl:106:54: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "TestBroadInternalUltimaGenomics.wdl:57:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
 message = "TestBroadInternalUltimaGenomics.wdl:58:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestCheckFingerprint.wdl"
 message = "TestCheckFingerprint.wdl:33:15: warning[UnusedInput]: unused input `vault_token_path_arrays`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestExomeReprocessing.wdl"
 message = "TestExomeReprocessing.wdl:7:8: warning[UnusedImport]: unused import namespace `DNASeqStructs`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestExomeReprocessing.wdl/#L7"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestExomeReprocessing.wdl/#L7"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl"
 message = "TestExternalWholeGenomeReprocessing.wdl:6:45: warning[UnusedImport]: unused import namespace `Utilities`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
 message = "TestGDCWholeGenomeSomaticSingleSample.wdl:77:46: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:141:20: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L141"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestImputation.wdl/#L141"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:162:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L162"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestImputation.wdl/#L162"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:163:46: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L163"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestImputation.wdl/#L163"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:54:30: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestImputation.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:55:37: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L55"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestImputation.wdl/#L55"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
 message = "TestImputation.wdl:86:56: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestImputation.wdl/#L86"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestImputation.wdl/#L86"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:110:20: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L110"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestJointGenotyping.wdl/#L110"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:85:44: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L85"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestJointGenotyping.wdl/#L85"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:87:46: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L87"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestJointGenotyping.wdl/#L87"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:88:49: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestJointGenotyping.wdl/#L88"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestJointGenotyping.wdl/#L88"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:51:23: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L51"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L51"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:56:22: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L56"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L56"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:57:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:58:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L58"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L58"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:59:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L59"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
 message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:60:17: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L60"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L60"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestMultiome.wdl"
 message = "TestMultiome.wdl:67:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestMultiome.wdl/#L67"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestMultiome.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:118:42: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L118"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestOptimus.wdl/#L118"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:172:14: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L172"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestOptimus.wdl/#L172"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:28:11: warning[UnusedInput]: unused input `mt_genes`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L28"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestOptimus.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
 message = "TestOptimus.wdl:76:36: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestOptimus.wdl/#L76"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestOptimus.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
 message = "TestPairedTag.wdl:57:15: warning[UnusedInput]: unused input `run_cellbender`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestPairedTag.wdl/#L57"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestPairedTag.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
 message = "TestPairedTag.wdl:71:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestPairedTag.wdl/#L71"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestPairedTag.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:100:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L100"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L100"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:110:52: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L110"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L110"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
 message = "TestRNAWithUMIsPipeline.wdl:84:47: error: type mismatch: argument to function `select_all` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L84"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestRNAWithUMIsPipeline.wdl/#L84"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestReblockGVCF.wdl"
 message = "TestReblockGVCF.wdl:49:31: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestReblockGVCF.wdl/#L49"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestReblockGVCF.wdl/#L49"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestSlideSeq.wdl"
 message = "TestSlideSeq.wdl:40:20: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestSlideSeq.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestSlideSeq.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:39:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L39"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L39"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:40:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L40"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L40"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
 message = "TestUltimaGenomicsWholeGenomeGermline.wdl:43:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L43"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L43"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
 message = "TestUltimaGenomicsWholeGenomeGermline.wdl:44:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L44"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L44"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl"
 message = "TestWholeGenomeGermlineSingleSample.wdl:54:45: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/548f6d2d94eb85cd18613f1729f0d3e8386cd3b5/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
+permalink = "https://github.com/broadinstitute/warp/blob/66a7e76462fd21b32ea29fb72914480ef82f246a/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -4514,1729 +4444,1794 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:140:53: warning[UnusedCall]: unused call `validate_include_if_any`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L140"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/flag_filter.wdl/#L140"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:143:53: warning[UnusedCall]: unused call `validate_include_if_all`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L143"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/flag_filter.wdl/#L143"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:146:53: warning[UnusedCall]: unused call `validate_exclude_if_any`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L146"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/flag_filter.wdl/#L146"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"
 message = "flag_filter.wdl:149:53: warning[UnusedCall]: unused call `validate_exclude_if_all`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/data_structures/flag_filter.wdl/#L149"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/data_structures/flag_filter.wdl/#L149"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:110:45: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Array[File]]+`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L110"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L110"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:130:17: warning[UnusedCall]: unused call `validate_bam`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L130"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L130"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/chipseq/chipseq-standard.wdl"
 message = "chipseq-standard.wdl:76:20: warning[UnusedCall]: unused call `read_length`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/chipseq/chipseq-standard.wdl/#L76"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/chipseq/chipseq-standard.wdl/#L76"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/dnaseq/dnaseq-standard-fastq.wdl"
 message = "dnaseq-standard-fastq.wdl:49:10: warning[UnusedCall]: unused call `parse_input`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L49"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/dnaseq/dnaseq-standard-fastq.wdl/#L49"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/general/bam-to-fastqs.wdl"
 message = "bam-to-fastqs.wdl:28:19: warning[UnusedCall]: unused call `quickcheck`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/general/bam-to-fastqs.wdl/#L28"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/general/bam-to-fastqs.wdl/#L28"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/qc/quality-check-standard.wdl"
 message = "quality-check-standard.wdl:161:15: warning[UnusedCall]: unused call `compression_integrity`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/qc/quality-check-standard.wdl/#L161"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/qc/quality-check-standard.wdl/#L161"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/10x-bam-to-fastqs.wdl"
 message = "10x-bam-to-fastqs.wdl:34:19: warning[UnusedCall]: unused call `quickcheck`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L34"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/10x-bam-to-fastqs.wdl/#L34"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/workflows/scrnaseq/scrnaseq-standard.wdl"
 message = "scrnaseq-standard.wdl:78:17: warning[UnusedCall]: unused call `validate_bam`"
-permalink = "https://github.com/stjudecloud/workflows/blob/a56ad9b8c7de5c9b13350f465c1543d0cb0b6b1a/workflows/scrnaseq/scrnaseq-standard.wdl/#L78"
+permalink = "https://github.com/stjudecloud/workflows/blob/092bb0ca9760bf301ae0f57aef431a990f45dba6/workflows/scrnaseq/scrnaseq-standard.wdl/#L78"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:11:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_ivar_consensus.wdl/#L11"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/assembly/task_ivar_consensus.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:12:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_ivar_consensus.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/assembly/task_ivar_consensus.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:9:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_ivar_consensus.wdl/#L9"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/assembly/task_ivar_consensus.wdl/#L9"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_metaspades.wdl"
 message = "task_metaspades.wdl:39:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_metaspades.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/assembly/task_metaspades.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_shovill.wdl"
 message = "task_shovill.wdl:77:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/assembly/task_shovill.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/assembly/task_shovill.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:10:21: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L10"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:12:18: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L12"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:13:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl"
 message = "task_ivar_variant_call.wdl:95:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L95"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl"
 message = "task_snippy_gene_query.wdl:69:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_variants.wdl"
-message = "task_snippy_variants.wdl:128:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L128"
+message = "task_snippy_variants.wdl:162:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L162"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/advanced_metrics/task_gambittools.wdl"
 message = "task_gambittools.wdl:67:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
-message = "task_assembly_metrics.wdl:44:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L44"
+message = "task_assembly_metrics.wdl:72:22: error: type mismatch: expected type `Float`, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
-message = "task_assembly_metrics.wdl:45:19: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L45"
+message = "task_assembly_metrics.wdl:73:19: error: type mismatch: expected type `Float`, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
-message = "task_assembly_metrics.wdl:46:23: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L46"
+message = "task_assembly_metrics.wdl:74:23: error: type mismatch: expected type `Float`, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
-message = "task_assembly_metrics.wdl:47:22: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L47"
+message = "task_assembly_metrics.wdl:75:22: error: type mismatch: expected type `Float`, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L75"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
+message = "task_assembly_metrics.wdl:76:37: error: type mismatch: expected type `Float`, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl"
 message = "task_cg_pipeline.wdl:102:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:46:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:47:23: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L47"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:48:29: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L48"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:49:24: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L49"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:50:40: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_quast.wdl"
 message = "task_quast.wdl:64:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_readlength.wdl"
 message = "task_readlength.wdl:26:33: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/basic_statistics/task_readlength.wdl/#L26"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
 message = "task_screen.wdl:15:13: warning[UnusedInput]: unused input `organism`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/comparisons/task_screen.wdl/#L15"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/comparisons/task_screen.wdl/#L15"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/comparisons/task_screen.wdl"
 message = "task_screen.wdl:187:13: warning[UnusedInput]: unused input `organism`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/quality_control/comparisons/task_screen.wdl/#L187"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/quality_control/comparisons/task_screen.wdl/#L187"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/species_typing/salmonella/task_genotyphi.wdl"
 message = "task_genotyphi.wdl:61:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/species_typing/salmonella/task_genotyphi.wdl/#L61"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:76:45: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/taxon_id/contamination/task_midas.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/taxon_id/contamination/task_midas.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:77:44: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/taxon_id/contamination/task_midas.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/taxon_id/contamination/task_midas.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/task_gambit.wdl"
 message = "task_gambit.wdl:164:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/taxon_id/task_gambit.wdl/#L164"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/taxon_id/task_gambit.wdl/#L164"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/data_handling/task_parse_mapping.wdl"
 message = "task_parse_mapping.wdl:133:20: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/utilities/data_handling/task_parse_mapping.wdl/#L133"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/submission/task_broad_ncbi_tools.wdl"
 message = "task_broad_ncbi_tools.wdl:11:12: warning[UnusedInput]: unused input `docker`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/tasks/utilities/submission/task_broad_ncbi_tools.wdl/#L11"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/tasks/utilities/submission/task_broad_ncbi_tools.wdl/#L11"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:120: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
 message = "wf_freyja_fastq.wdl:116:40: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
-message = "wf_freyja_fastq.wdl:120:126: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+message = "wf_freyja_fastq.wdl:122:126: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L122"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
-message = "wf_freyja_fastq.wdl:120:42: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L120"
+message = "wf_freyja_fastq.wdl:122:42: error: type mismatch: expected type `String`, but found type `Int`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L122"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
-message = "wf_freyja_fastq.wdl:124:108: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+message = "wf_freyja_fastq.wdl:128:108: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
-message = "wf_freyja_fastq.wdl:124:36: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L124"
+message = "wf_freyja_fastq.wdl:128:36: error: type mismatch: expected type `String`, but found type `Int`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
-message = "wf_freyja_fastq.wdl:131:114: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+message = "wf_freyja_fastq.wdl:135:114: error: type mismatch: a type common to both type `Int?` and type `String` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L135"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_fastq.wdl"
-message = "wf_freyja_fastq.wdl:131:38: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_fastq.wdl/#L131"
+message = "wf_freyja_fastq.wdl:135:38: error: type mismatch: expected type `String`, but found type `Int`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_fastq.wdl/#L135"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_plot.wdl"
 message = "wf_freyja_plot.wdl:18:25: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_plot.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_plot.wdl/#L18"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_update.wdl"
 message = "wf_freyja_update.wdl:13:17: warning[UnusedCall]: unused call `transfer_files`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/freyja/wf_freyja_update.wdl/#L13"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/freyja/wf_freyja_update.wdl/#L13"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:153:80: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `File`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_augur.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_augur.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:62:21: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_augur.wdl/#L62"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_augur.wdl/#L62"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_core_gene_snp.wdl"
 message = "wf_core_gene_snp.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_mashtree_fasta.wdl"
 message = "wf_mashtree_fasta.wdl:37:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:33:58: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:34:53: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:35:51: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:36:52: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[File]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"
 message = "wf_nextclade_addToRefTree.wdl:37:57: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[String]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L101"
+message = "wf_snippy_tree.wdl:102:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:106:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L106"
+message = "wf_snippy_tree.wdl:107:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:107:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L107"
+message = "wf_snippy_tree.wdl:108:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:108:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L108"
+message = "wf_snippy_tree.wdl:109:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:119:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L119"
+message = "wf_snippy_tree.wdl:120:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:120:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L120"
+message = "wf_snippy_tree.wdl:121:16: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:121:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L121"
+message = "wf_snippy_tree.wdl:122:13: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:122:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L122"
+message = "wf_snippy_tree.wdl:123:16: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:123:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L123"
+message = "wf_snippy_tree.wdl:124:19: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L124"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:132:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L132"
+message = "wf_snippy_tree.wdl:133:16: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L133"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:150:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L150"
+message = "wf_snippy_tree.wdl:151:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L151"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:71:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L71"
+message = "wf_snippy_tree.wdl:72:16: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:72:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L72"
+message = "wf_snippy_tree.wdl:73:13: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:73:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L73"
+message = "wf_snippy_tree.wdl:74:19: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:74:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L74"
+message = "wf_snippy_tree.wdl:75:16: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L75"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:84:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L84"
+message = "wf_snippy_tree.wdl:85:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:85:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L85"
+message = "wf_snippy_tree.wdl:86:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:86:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L86"
+message = "wf_snippy_tree.wdl:87:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_snippy_tree.wdl"
-message = "wf_snippy_tree.wdl:87:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/phylogenetics/wf_snippy_tree.wdl/#L87"
+message = "wf_snippy_tree.wdl:88:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/phylogenetics/wf_snippy_tree.wdl/#L88"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:27:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L27"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:32:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L32"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:33:19: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L33"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:34:17: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L34"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:35:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L35"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:36:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L36"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:37:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:38:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:39:20: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_nullarbor.wdl"
 message = "wf_nullarbor.wdl:40:23: error: type mismatch: expected type `File`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_nullarbor.wdl/#L40"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:37:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:38:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L38"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:39:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L39"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:42:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L42"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:69:45: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:71:40: error: type mismatch: expected type `Int`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L71"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
 message = "wf_snippy_variants.wdl:72:50: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L72"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/standalone_modules/wf_snippy_variants.wdl"
-message = "wf_snippy_variants.wdl:73:52: error: type mismatch: expected type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/standalone_modules/wf_snippy_variants.wdl/#L73"
+message = "wf_snippy_variants.wdl:74:52: error: type mismatch: expected type `Float`, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/standalone_modules/wf_snippy_variants.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_clearlabs.wdl"
 message = "wf_theiacov_clearlabs.wdl:148:26: error: type mismatch: expected type `String?`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_clearlabs.wdl/#L148"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
 message = "wf_theiacov_illumina_pe.wdl:233:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L233"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_pe.wdl"
 message = "wf_theiacov_illumina_pe.wdl:4:84: warning[UnusedImport]: unused import namespace `assembly_metrics`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L4"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_illumina_pe.wdl/#L4"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
 message = "wf_theiacov_illumina_se.wdl:192:38: error: type mismatch: expected type `Float?`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L192"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
-message = "wf_theiacov_illumina_se.wdl:273:29: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L273"
+message = "wf_theiacov_illumina_se.wdl:275:29: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
-message = "wf_theiacov_illumina_se.wdl:274:28: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L274"
+message = "wf_theiacov_illumina_se.wdl:276:28: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L276"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_illumina_se.wdl"
-message = "wf_theiacov_illumina_se.wdl:275:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L275"
+message = "wf_theiacov_illumina_se.wdl:277:37: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_illumina_se.wdl/#L277"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:236:30: error: type mismatch: expected type `String?`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_ont.wdl/#L236"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:119: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
 message = "wf_theiacov_ont.wdl:317:84: error: type mismatch: a type common to both type `Float?` and type `String?` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_ont.wdl/#L317"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
+message = "wf_theiacov_ont.wdl:431:145: error: type mismatch: a type common to both type `Float?` and type `String?` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_ont.wdl/#L431"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
+message = "wf_theiacov_ont.wdl:431:180: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_ont.wdl/#L431"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/theiacov/wf_theiacov_ont.wdl"
+message = "wf_theiacov_ont.wdl:431:38: error: type mismatch: expected type `String`, but found type `Float`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiacov/wf_theiacov_ont.wdl/#L431"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:118:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:127:40: error: type mismatch: argument to function `select_first` expects type `Array[X]` where `X`: any optional type, but found type `Array[Int]+`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl"
 message = "wf_theiaeuk_illumina_pe.wdl:70:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiaeuk/wf_theiaeuk_illumina_pe.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
-message = "wf_theiameta_illumina_pe.wdl:258:31: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L258"
+message = "wf_theiameta_illumina_pe.wdl:262:31: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L262"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
-message = "wf_theiameta_illumina_pe.wdl:260:37: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L260"
+message = "wf_theiameta_illumina_pe.wdl:264:37: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L264"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiameta/wf_theiameta_illumina_pe.wdl"
-message = "wf_theiameta_illumina_pe.wdl:269:38: error: type mismatch: expected type `Float?`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L269"
+message = "wf_theiameta_illumina_pe.wdl:273:38: error: type mismatch: expected type `Float?`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiameta/wf_theiameta_illumina_pe.wdl/#L273"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl"
 message = "wf_theiaprok_illumina_pe.wdl:115:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiaprok/wf_theiaprok_illumina_pe.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_illumina_se.wdl"
 message = "wf_theiaprok_illumina_se.wdl:110:27: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiaprok/wf_theiaprok_illumina_se.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:103:28: error: type mismatch: expected type `String?`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiaprok/wf_theiaprok_ont.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/theiaprok/wf_theiaprok_ont.wdl"
 message = "wf_theiaprok_ont.wdl:84:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/theiaprok/wf_theiaprok_ont.wdl/#L84"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_create_terra_table.wdl"
 message = "wf_create_terra_table.wdl:17:46: warning[UnusedCall]: unused call `make_table`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_create_terra_table.wdl/#L17"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/data_import/wf_create_terra_table.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:17:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/data_import/wf_sra_fetch.wdl/#L17"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:18:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/data_import/wf_sra_fetch.wdl/#L18"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:19:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/data_import/wf_sra_fetch.wdl/#L19"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:20:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/data_import/wf_sra_fetch.wdl/#L20"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_sra_fetch.wdl"
 message = "wf_sra_fetch.wdl:21:23: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/data_import/wf_sra_fetch.wdl/#L21"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/data_import/wf_terra_2_bq.wdl"
 message = "wf_terra_2_bq.wdl:14:26: warning[UnusedCall]: unused call `terra_to_bigquery`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/data_import/wf_terra_2_bq.wdl/#L14"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/data_import/wf_terra_2_bq.wdl/#L14"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:100:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L100"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L100"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:101:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L101"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L101"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:109:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:110:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L110"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L110"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:111:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L111"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L111"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:112:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:154: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:116:94: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L116"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L116"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:118:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L118"
+message = "wf_flu_track.wdl:119:111: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L119"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:123:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L123"
+message = "wf_flu_track.wdl:119:189: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L119"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:124:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L124"
+message = "wf_flu_track.wdl:122:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L122"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:125:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L125"
+message = "wf_flu_track.wdl:127:17: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L127"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:126:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L126"
+message = "wf_flu_track.wdl:128:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L128"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:127:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L127"
+message = "wf_flu_track.wdl:129:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:128:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L128"
+message = "wf_flu_track.wdl:130:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L130"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:131:17: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L131"
+message = "wf_flu_track.wdl:131:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:141:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L141"
+message = "wf_flu_track.wdl:132:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L132"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:142:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L142"
+message = "wf_flu_track.wdl:135:17: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `String`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L135"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:143:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L143"
+message = "wf_flu_track.wdl:145:17: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L145"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:144:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L144"
+message = "wf_flu_track.wdl:146:23: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L146"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:170:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L170"
+message = "wf_flu_track.wdl:147:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L147"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:182:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L182"
+message = "wf_flu_track.wdl:148:20: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L148"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:183:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L183"
+message = "wf_flu_track.wdl:174:15: error: type mismatch: argument to function `defined` expects type `X` where `X`: any optional type, but found type `Array[File]`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L174"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:184:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L184"
+message = "wf_flu_track.wdl:186:25: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L186"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:185:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L185"
+message = "wf_flu_track.wdl:187:25: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L187"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:186:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L186"
+message = "wf_flu_track.wdl:188:25: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L188"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:187:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L187"
+message = "wf_flu_track.wdl:189:25: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L189"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:188:23: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L188"
+message = "wf_flu_track.wdl:190:22: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L190"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:189:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L189"
+message = "wf_flu_track.wdl:191:23: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L191"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:190:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L190"
+message = "wf_flu_track.wdl:192:23: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L192"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:199:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L199"
+message = "wf_flu_track.wdl:193:27: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L193"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:200:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L200"
+message = "wf_flu_track.wdl:194:27: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L194"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:201:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L201"
+message = "wf_flu_track.wdl:203:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L203"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:202:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L202"
+message = "wf_flu_track.wdl:204:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L204"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:208:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L208"
+message = "wf_flu_track.wdl:205:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L205"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:209:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L209"
+message = "wf_flu_track.wdl:206:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L206"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:210:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L210"
+message = "wf_flu_track.wdl:212:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L212"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:211:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L211"
+message = "wf_flu_track.wdl:213:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L213"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:220:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L220"
+message = "wf_flu_track.wdl:214:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L214"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:221:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L221"
+message = "wf_flu_track.wdl:215:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L215"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:222:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L222"
+message = "wf_flu_track.wdl:224:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L224"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:223:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L223"
+message = "wf_flu_track.wdl:225:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L225"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:229:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L229"
+message = "wf_flu_track.wdl:226:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L226"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:230:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L230"
+message = "wf_flu_track.wdl:227:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L227"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:231:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L231"
+message = "wf_flu_track.wdl:233:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L233"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
-message = "wf_flu_track.wdl:232:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L232"
+message = "wf_flu_track.wdl:234:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L234"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
+message = "wf_flu_track.wdl:235:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L235"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
+message = "wf_flu_track.wdl:236:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L236"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:86:28: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L86"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L86"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:87:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L87"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L87"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:88:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L88"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L88"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:89:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:90:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:98:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L98"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L98"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_flu_track.wdl"
 message = "wf_flu_track.wdl:99:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_flu_track.wdl/#L99"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_flu_track.wdl/#L99"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:102:16: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L102"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L102"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:103:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L103"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L103"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:104:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L104"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L104"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:105:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L105"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L105"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:106:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L106"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L106"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:112:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L112"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L112"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:113:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L113"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L113"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:114:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L114"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L114"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:115:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L115"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L115"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:152:29: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L152"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L152"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:104: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:153:28: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L153"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L153"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:107: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L154"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:154:37: error: type mismatch: expected type `String`, but found type `Float`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L154"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
+message = "wf_ivar_consensus.wdl:158:144: error: type mismatch: a type common to both type `Float?` and type `String` does not exist"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L158"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
+message = "wf_ivar_consensus.wdl:158:38: error: type mismatch: expected type `String`, but found type `Float`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L158"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:56:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L56"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:57:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L57"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L57"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:58:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L58"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L58"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:59:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L59"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L59"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:67:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L67"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:68:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L68"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L68"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:69:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L69"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L69"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:70:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L70"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L70"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:76:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L76"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L76"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:77:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L77"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L77"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:78:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L78"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L78"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:79:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L79"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L79"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:90:13: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:91:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:92:19: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L92"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L92"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_ivar_consensus.wdl"
 message = "wf_ivar_consensus.wdl:93:16: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_ivar_consensus.wdl/#L93"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_ivar_consensus.wdl/#L93"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:228:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L228"
+message = "wf_merlin_magic.wdl:236:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L236"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:229:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L229"
+message = "wf_merlin_magic.wdl:237:24: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L237"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:230:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L230"
+message = "wf_merlin_magic.wdl:238:24: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L238"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:231:23: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L231"
+message = "wf_merlin_magic.wdl:239:23: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L239"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:232:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L232"
+message = "wf_merlin_magic.wdl:240:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L240"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:241:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L241"
+message = "wf_merlin_magic.wdl:249:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L249"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:253:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L253"
+message = "wf_merlin_magic.wdl:258:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L258"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:259:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L259"
+message = "wf_merlin_magic.wdl:259:23: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L259"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:260:16: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L260"
+message = "wf_merlin_magic.wdl:260:17: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L260"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:261:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L261"
+message = "wf_merlin_magic.wdl:261:20: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L261"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:262:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L262"
+message = "wf_merlin_magic.wdl:262:30: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L262"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:263:18: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L263"
+message = "wf_merlin_magic.wdl:274:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L274"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:264:25: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L264"
+message = "wf_merlin_magic.wdl:280:16: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L280"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:265:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L265"
+message = "wf_merlin_magic.wdl:281:16: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L281"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:274:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L274"
+message = "wf_merlin_magic.wdl:282:17: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L282"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:281:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L281"
+message = "wf_merlin_magic.wdl:283:17: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L283"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:290:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L290"
+message = "wf_merlin_magic.wdl:284:18: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L284"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:304:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L304"
+message = "wf_merlin_magic.wdl:285:25: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L285"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:305:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L305"
+message = "wf_merlin_magic.wdl:286:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L286"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:317:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L317"
+message = "wf_merlin_magic.wdl:295:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L295"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:326:18: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L326"
+message = "wf_merlin_magic.wdl:302:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L302"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:327:19: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L327"
+message = "wf_merlin_magic.wdl:311:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L311"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:328:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L328"
+message = "wf_merlin_magic.wdl:325:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L325"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:336:30: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L336"
+message = "wf_merlin_magic.wdl:326:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L326"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:337:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L337"
+message = "wf_merlin_magic.wdl:338:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L338"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:338:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L338"
+message = "wf_merlin_magic.wdl:347:18: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L347"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:339:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L339"
+message = "wf_merlin_magic.wdl:348:19: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L348"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:340:21: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L340"
+message = "wf_merlin_magic.wdl:349:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L349"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:349:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L349"
+message = "wf_merlin_magic.wdl:357:30: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L357"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:357:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L357"
+message = "wf_merlin_magic.wdl:358:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L358"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:367:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L367"
+message = "wf_merlin_magic.wdl:359:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L359"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:377:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L377"
+message = "wf_merlin_magic.wdl:360:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L360"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:378:24: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L378"
+message = "wf_merlin_magic.wdl:361:21: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L361"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:379:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L379"
+message = "wf_merlin_magic.wdl:370:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L370"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:380:24: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L380"
+message = "wf_merlin_magic.wdl:378:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L378"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:381:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L381"
+message = "wf_merlin_magic.wdl:388:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L388"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:382:33: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L382"
+message = "wf_merlin_magic.wdl:398:27: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L398"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:383:34: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L383"
+message = "wf_merlin_magic.wdl:399:24: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L399"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:384:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L384"
+message = "wf_merlin_magic.wdl:400:24: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L400"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:392:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L392"
+message = "wf_merlin_magic.wdl:401:24: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L401"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:400:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L400"
+message = "wf_merlin_magic.wdl:402:33: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L402"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:408:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L408"
+message = "wf_merlin_magic.wdl:403:33: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L403"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:409:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L409"
+message = "wf_merlin_magic.wdl:404:34: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L404"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:410:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L410"
+message = "wf_merlin_magic.wdl:405:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L405"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:421:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L421"
+message = "wf_merlin_magic.wdl:413:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L413"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:432:32: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L432"
+message = "wf_merlin_magic.wdl:421:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L421"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:433:20: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L433"
+message = "wf_merlin_magic.wdl:429:22: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L429"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:434:25: error: type mismatch: expected type `Float`, but found type `Float?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L434"
+message = "wf_merlin_magic.wdl:430:24: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L430"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:435:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L435"
+message = "wf_merlin_magic.wdl:431:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L431"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:436:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L436"
+message = "wf_merlin_magic.wdl:442:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L442"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:437:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L437"
+message = "wf_merlin_magic.wdl:453:32: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L453"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:439:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L439"
+message = "wf_merlin_magic.wdl:454:20: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L454"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:455:32: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L455"
+message = "wf_merlin_magic.wdl:455:25: error: type mismatch: expected type `Float`, but found type `Float?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L455"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:456:36: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L456"
+message = "wf_merlin_magic.wdl:456:23: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L456"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:457:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L457"
+message = "wf_merlin_magic.wdl:457:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L457"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:467:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L467"
+message = "wf_merlin_magic.wdl:458:28: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L458"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:475:21: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L475"
+message = "wf_merlin_magic.wdl:460:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L460"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:476:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L476"
+message = "wf_merlin_magic.wdl:476:32: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L476"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:482:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L482"
+message = "wf_merlin_magic.wdl:477:36: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L477"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:488:23: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L488"
+message = "wf_merlin_magic.wdl:478:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L478"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:489:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L489"
+message = "wf_merlin_magic.wdl:488:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L488"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:499:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L499"
+message = "wf_merlin_magic.wdl:496:21: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L496"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:506:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L506"
+message = "wf_merlin_magic.wdl:497:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L497"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:507:24: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L507"
+message = "wf_merlin_magic.wdl:503:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L503"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:508:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L508"
+message = "wf_merlin_magic.wdl:509:23: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L509"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:515:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L515"
+message = "wf_merlin_magic.wdl:510:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L510"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:516:27: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L516"
+message = "wf_merlin_magic.wdl:520:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L520"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:517:20: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L517"
+message = "wf_merlin_magic.wdl:527:22: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L527"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:518:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L518"
+message = "wf_merlin_magic.wdl:528:24: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L528"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:519:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L519"
+message = "wf_merlin_magic.wdl:529:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L529"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:520:32: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L520"
+message = "wf_merlin_magic.wdl:536:27: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L536"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:521:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L521"
+message = "wf_merlin_magic.wdl:537:27: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L537"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:522:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L522"
+message = "wf_merlin_magic.wdl:538:20: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L538"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:523:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L523"
+message = "wf_merlin_magic.wdl:539:22: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L539"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:524:25: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L524"
+message = "wf_merlin_magic.wdl:540:32: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L540"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:525:26: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L525"
+message = "wf_merlin_magic.wdl:541:32: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L541"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:526:30: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L526"
+message = "wf_merlin_magic.wdl:542:25: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L542"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:527:37: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L527"
+message = "wf_merlin_magic.wdl:543:30: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L543"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:528:31: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L528"
+message = "wf_merlin_magic.wdl:544:25: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L544"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:529:39: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L529"
+message = "wf_merlin_magic.wdl:545:25: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L545"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:530:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L530"
+message = "wf_merlin_magic.wdl:546:26: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L546"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:539:14: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L539"
+message = "wf_merlin_magic.wdl:547:30: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L547"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:540:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L540"
+message = "wf_merlin_magic.wdl:548:37: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L548"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:541:18: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L541"
+message = "wf_merlin_magic.wdl:549:31: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L549"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:542:25: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L542"
+message = "wf_merlin_magic.wdl:550:39: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L550"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:543:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L543"
+message = "wf_merlin_magic.wdl:551:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L551"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:544:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L544"
+message = "wf_merlin_magic.wdl:560:14: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L560"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:545:15: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L545"
+message = "wf_merlin_magic.wdl:561:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L561"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:546:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L546"
+message = "wf_merlin_magic.wdl:562:18: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L562"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:547:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L547"
+message = "wf_merlin_magic.wdl:563:25: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L563"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:548:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L548"
+message = "wf_merlin_magic.wdl:564:20: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L564"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:549:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L549"
+message = "wf_merlin_magic.wdl:565:22: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L565"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:557:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L557"
+message = "wf_merlin_magic.wdl:566:15: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L566"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:566:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L566"
+message = "wf_merlin_magic.wdl:567:23: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L567"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:581:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L581"
+message = "wf_merlin_magic.wdl:568:20: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L568"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:590:18: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L590"
+message = "wf_merlin_magic.wdl:569:20: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L569"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:601:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L601"
+message = "wf_merlin_magic.wdl:570:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L570"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:602:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L602"
+message = "wf_merlin_magic.wdl:578:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L578"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:603:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L603"
+message = "wf_merlin_magic.wdl:587:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L587"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:604:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L604"
+message = "wf_merlin_magic.wdl:602:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L602"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:605:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L605"
+message = "wf_merlin_magic.wdl:611:18: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L611"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:606:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L606"
+message = "wf_merlin_magic.wdl:622:23: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L622"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:607:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L607"
+message = "wf_merlin_magic.wdl:623:24: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L623"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:608:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L608"
+message = "wf_merlin_magic.wdl:624:34: error: type mismatch: expected type `String`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L624"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:609:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L609"
+message = "wf_merlin_magic.wdl:625:24: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L625"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:610:24: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L610"
+message = "wf_merlin_magic.wdl:626:34: error: type mismatch: expected type `String`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L626"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:611:34: error: type mismatch: expected type `String`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L611"
+message = "wf_merlin_magic.wdl:627:24: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L627"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:612:20: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L612"
+message = "wf_merlin_magic.wdl:628:34: error: type mismatch: expected type `String`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L628"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:623:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L623"
+message = "wf_merlin_magic.wdl:629:24: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L629"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:627:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L627"
+message = "wf_merlin_magic.wdl:630:34: error: type mismatch: expected type `String`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L630"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:635:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L635"
+message = "wf_merlin_magic.wdl:631:24: error: type mismatch: expected type `File`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L631"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:674:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L674"
+message = "wf_merlin_magic.wdl:632:34: error: type mismatch: expected type `String`, but found type `File?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L632"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:678:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L678"
+message = "wf_merlin_magic.wdl:633:20: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L633"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:686:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L686"
+message = "wf_merlin_magic.wdl:644:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L644"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:700:28: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L700"
+message = "wf_merlin_magic.wdl:648:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L648"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:704:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L704"
+message = "wf_merlin_magic.wdl:656:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L656"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
-message = "wf_merlin_magic.wdl:712:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_merlin_magic.wdl/#L712"
+message = "wf_merlin_magic.wdl:695:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L695"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
+message = "wf_merlin_magic.wdl:699:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L699"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
+message = "wf_merlin_magic.wdl:707:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L707"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
+message = "wf_merlin_magic.wdl:721:28: error: type mismatch: expected type `Int`, but found type `Int?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L721"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
+message = "wf_merlin_magic.wdl:725:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L725"
+
+[[diagnostics]]
+document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_merlin_magic.wdl"
+message = "wf_merlin_magic.wdl:733:22: error: type mismatch: expected type `String`, but found type `String?`"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_merlin_magic.wdl/#L733"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:109:25: error: type mismatch: expected type `String`, but found type `Int`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_ont.wdl/#L109"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:51:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_ont.wdl/#L51"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:52:22: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_ont.wdl/#L52"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:53:22: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_ont.wdl/#L53"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:89:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_ont.wdl/#L89"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:90:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_ont.wdl/#L90"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_ont.wdl"
 message = "wf_read_QC_trim_ont.wdl:91:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_ont.wdl/#L91"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:129:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_pe.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:141:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_pe.wdl/#L141"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:142:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_pe.wdl/#L142"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:143:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_pe.wdl/#L143"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_pe.wdl"
 message = "wf_read_QC_trim_pe.wdl:74:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_pe.wdl/#L74"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:118:22: error: type mismatch: expected type `File`, but found type `File?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_se.wdl/#L118"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:129:23: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_se.wdl/#L129"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:130:20: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_se.wdl/#L130"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:131:17: error: type mismatch: expected type `Int`, but found type `Int?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_se.wdl/#L131"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/utilities/wf_read_QC_trim_se.wdl"
 message = "wf_read_QC_trim_se.wdl:56:28: error: type mismatch: expected type `String`, but found type `String?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/d659feebab0f383898b728bd9b27e390ec7bed7f/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"
+permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2669f994a90dc2c6d6703eef14cf3c639a7bfc1c/workflows/utilities/wf_read_QC_trim_se.wdl/#L56"

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -249,15 +249,17 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .unwrap_or_default();
                     // The `+1` here is because line_index() is 0-based.
                     let line_no = file.line_index((), byte_start).unwrap_or_default() + 1;
-                    assert!(
-                        actual.insert((
-                            std::str::from_utf8(buffer.as_slice())
-                                .context("diagnostic should be UTF-8")?
-                                .trim()
-                                .to_string(),
-                            line_no,
-                        ))
-                    );
+                    let message = std::str::from_utf8(buffer.as_slice())
+                        .context("diagnostic should be UTF-8")?
+                        .trim()
+                        .to_string();
+
+                    if !actual.insert((message.clone(), line_no)) {
+                        panic!(
+                            "duplicate diagnostic: `{message}` at {path}:{line_no}",
+                            path = document_identifier.path()
+                        );
+                    }
                 }
             }
 

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Exposed information about workflow calls from an analyzed document ([#239](https://github.com/stjude-rust-labs/wdl/pull/239)).
 * Added formatting to the analyzer ([#247](https://github.com/stjude-rust-labs/wdl/pull/247)).
 
+### Changed
+
+* Made diagnostic creation functions public ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
+* Refactored expression type evaluator to provide context via a trait ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
+* Removed `PartialEq`, `Eq`, and `Hash` from WDL-type-related types ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
+
 ## 0.5.0 - 10-22-2024
 
 ### Changed

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -18,6 +18,8 @@ use crate::types::CallType;
 use crate::types::Type;
 use crate::types::Types;
 use crate::types::display_types;
+use crate::types::v1::ComparisonOperator;
+use crate::types::v1::NumericOperator;
 
 /// Utility type to represent an input or an output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -506,17 +508,12 @@ pub fn missing_struct_members(name: &Ident, count: usize, members: &str) -> Diag
 }
 
 /// Creates a "map key not primitive" diagnostic.
-pub fn map_key_not_primitive(
-    types: &Types,
-    span: Span,
-    actual: Type,
-    actual_span: Span,
-) -> Diagnostic {
+pub fn map_key_not_primitive(types: &Types, span: Span, actual: Type) -> Diagnostic {
     Diagnostic::error("expected map literal to use primitive type keys")
         .with_highlight(span)
         .with_label(
             format!("this is type `{actual}`", actual = actual.display(types)),
-            actual_span,
+            span,
         )
 }
 
@@ -588,7 +585,7 @@ pub fn logical_and_mismatch(types: &Types, actual: Type, actual_span: Span) -> D
 /// Creates a "comparison mismatch" diagnostic.
 pub fn comparison_mismatch(
     types: &Types,
-    op: &impl fmt::Display,
+    op: ComparisonOperator,
     span: Span,
     lhs: Type,
     lhs_span: Span,
@@ -614,7 +611,7 @@ pub fn comparison_mismatch(
 /// Creates a "numeric mismatch" diagnostic.
 pub fn numeric_mismatch(
     types: &Types,
-    op: &impl fmt::Display,
+    op: NumericOperator,
     span: Span,
     lhs: Type,
     lhs_span: Span,

--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(rustdoc::broken_intra_doc_links)]
 
 mod analyzer;
-pub(crate) mod diagnostics;
+pub mod diagnostics;
 pub mod document;
 pub mod eval;
 mod graph;

--- a/wdl-analysis/src/stdlib.rs
+++ b/wdl-analysis/src/stdlib.rs
@@ -33,13 +33,23 @@ pub use constraints::*;
 ///
 /// Accessing `STDLIB` will panic if a signature is defined that exceeds this
 /// number.
-const MAX_TYPE_PARAMETERS: usize = 4;
+pub const MAX_TYPE_PARAMETERS: usize = 4;
 
 #[allow(clippy::missing_docs_in_private_items)]
 const _: () = assert!(
     MAX_TYPE_PARAMETERS < usize::BITS as usize,
     "the maximum number of type parameters cannot exceed the number of bits in usize"
 );
+
+/// The maximum number of parameters to any standard library function.
+///
+/// A function cannot be defined with more than this number of parameters and
+/// accessing `STDLIB` will panic if a signature is defined that exceeds this
+/// number.
+///
+/// As new standard library functions are implemented, the maximum will be
+/// increased.
+pub const MAX_PARAMETERS: usize = 4;
 
 /// A helper function for writing uninferred type parameter constraints to a
 /// given writer.
@@ -864,7 +874,7 @@ impl TypeParameter {
 }
 
 /// Represents a successful binding of arguments to a function.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy)]
 enum Binding {
     /// The binding was an equivalence binding, meaning all of the provided
     /// arguments had type equivalence with corresponding concrete parameters.
@@ -1063,7 +1073,7 @@ impl FunctionSignature {
                         });
                     }
                 }
-                None if *argument == Type::Union => {
+                None if argument.is_union() => {
                     // If the type is `Union`, accept it as indeterminate
                     continue;
                 }
@@ -1181,6 +1191,11 @@ impl FunctionSignatureBuilder {
         assert!(
             sig.type_parameters.len() <= MAX_TYPE_PARAMETERS,
             "too many type parameters"
+        );
+
+        assert!(
+            sig.parameters.len() <= MAX_PARAMETERS,
+            "too many parameters"
         );
 
         // Ensure any generic type parameters indexes are in range for the parameters

--- a/wdl-analysis/src/stdlib/constraints.rs
+++ b/wdl-analysis/src/stdlib/constraints.rs
@@ -32,7 +32,7 @@ impl Constraint for OptionalTypeConstraint {
 
     fn satisfied(&self, _: &Types, ty: Type) -> bool {
         // For the purpose of the constraint, treat `Union` as optional
-        ty == Type::Union || ty.is_optional()
+        ty.is_union() || ty.is_optional()
     }
 }
 

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Implemented WDL expression evaluation ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
+* Refactored API to remove reliance on the engine for creating values ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
+* Split value representation into primitive and compound values ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
 * Added `InputFiles` type for parsing WDL input JSON files (#[241](https://github.com/stjude-rust-labs/wdl/pull/241)).
 * Added the `wdl-engine` crate that will eventually implement a WDL execution
   engine (#[225](https://github.com/stjude-rust-labs/wdl/pull/225)).

--- a/wdl-engine/Cargo.toml
+++ b/wdl-engine/Cargo.toml
@@ -14,19 +14,19 @@ documentation = "https://docs.rs/wdl-engine"
 wdl-ast = { version = "0.9.0", path = "../wdl-ast" }
 wdl-analysis = { version = "0.5.0", path = "../wdl-analysis" }
 anyhow = { workspace = true }
-id-arena = { workspace = true }
 ordered-float = { workspace = true }
-string-interner = { workspace = true }
 indexmap = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+wdl-grammar = { version = "0.10.0", path = "../wdl-grammar" }
 tokio = { workspace = true }
 pretty_assertions = { workspace = true }
 codespan-reporting = { workspace = true }
 path-clean = { workspace = true }
 colored = { workspace = true }
 tempfile = { workspace = true }
+approx = { workspace = true }
 
 [lints]
 workspace = true

--- a/wdl-engine/src/diagnostics.rs
+++ b/wdl-engine/src/diagnostics.rs
@@ -1,0 +1,150 @@
+//! Module for evaluation diagnostics.
+
+use wdl_analysis::types::Type;
+use wdl_analysis::types::Types;
+use wdl_ast::AstToken;
+use wdl_ast::Diagnostic;
+use wdl_ast::Ident;
+use wdl_ast::Span;
+
+/// Creates an "integer not in range" diagnostic.
+pub fn integer_not_in_range(span: Span) -> Diagnostic {
+    Diagnostic::error(format!(
+        "literal integer exceeds the range for a 64-bit signed integer ({min}..={max})",
+        min = i64::MIN,
+        max = i64::MAX,
+    ))
+    .with_label("this literal integer is not in range", span)
+}
+
+/// Creates an "integer negation not in range" diagnostic.
+pub fn integer_negation_not_in_range(value: i64, span: Span) -> Diagnostic {
+    Diagnostic::error(format!(
+        "negation of integer value {value} exceeds the range for a 64-bit signed integer \
+         ({min}..={max})",
+        min = i64::MIN,
+        max = i64::MAX,
+    ))
+    .with_highlight(span)
+}
+
+/// Creates a "float not in range" diagnostic.
+pub fn float_not_in_range(span: Span) -> Diagnostic {
+    Diagnostic::error(format!(
+        "literal float exceeds the range for a 64-bit float ({min:+e}..={max:+e})",
+        min = f64::MIN,
+        max = f64::MAX,
+    ))
+    .with_label("this literal float is not in range", span)
+}
+
+/// Creates a "numeric overflow" diagnostic.
+pub fn numeric_overflow(span: Span) -> Diagnostic {
+    Diagnostic::error("evaluation of arithmetic expression resulted in overflow")
+        .with_highlight(span)
+}
+
+/// Creates a "division by zero" diagnostic.
+pub fn division_by_zero(span: Span, divisor_span: Span) -> Diagnostic {
+    Diagnostic::error("attempt to divide by zero")
+        .with_highlight(span)
+        .with_label("this expression evaluated to zero", divisor_span)
+}
+
+/// Creates a "exponent not in range" diagnostic.
+pub fn exponent_not_in_range(span: Span) -> Diagnostic {
+    Diagnostic::error(format!(
+        "exponent exceeds acceptable range ({min}..={max})",
+        min = u32::MIN,
+        max = u32::MAX,
+    ))
+    .with_label("this value exceeds the range for an exponent", span)
+}
+
+/// Creates a "cannot call" diagnostic.
+pub fn cannot_call(target: &Ident) -> Diagnostic {
+    Diagnostic::error(format!(
+        "function `{target}` can only be called from task outputs",
+        target = target.as_str()
+    ))
+    .with_highlight(target.span())
+}
+
+/// Creates a "call failed" diagnostic.
+pub fn call_failed(target: &Ident, error: &anyhow::Error) -> Diagnostic {
+    Diagnostic::error(format!(
+        "function `{target}` failed: {error:#}",
+        target = target.as_str()
+    ))
+    .with_highlight(target.span())
+}
+
+/// Creates a "struct member coercion failed" diagnostic.
+pub fn struct_member_coercion_failed(
+    types: &Types,
+    e: &anyhow::Error,
+    expected: Type,
+    expected_span: Span,
+    actual: Type,
+    actual_span: Span,
+) -> Diagnostic {
+    Diagnostic::error(format!("type mismatch: {e:?}"))
+        .with_label(
+            format!("this is type `{actual}`", actual = actual.display(types)),
+            actual_span,
+        )
+        .with_label(
+            format!(
+                "this expects type `{expected}`",
+                expected = expected.display(types)
+            ),
+            expected_span,
+        )
+}
+
+/// Creates an "array index out of range" diagnostic.
+pub fn array_index_out_of_range(
+    index: i64,
+    count: usize,
+    span: Span,
+    target_span: Span,
+) -> Diagnostic {
+    Diagnostic::error(format!("array index {index} is out of range"))
+        .with_label(
+            format!("expected an index value between 0 and {count}"),
+            span,
+        )
+        .with_label(
+            format!(
+                "this array has {count} element{s}",
+                s = if count == 1 { "" } else { "s" }
+            ),
+            target_span,
+        )
+}
+
+/// Creates a "map key not found" diagnostic.
+pub fn map_key_not_found(span: Span) -> Diagnostic {
+    Diagnostic::error("the map does not contain an entry for the specified key")
+        .with_highlight(span)
+}
+
+/// Creates a "not an object member" diagnostic.
+pub fn not_an_object_member(member: &Ident) -> Diagnostic {
+    Diagnostic::error(format!(
+        "object does not have a member named `{member}`",
+        member = member.as_str()
+    ))
+    .with_highlight(member.span())
+}
+
+/// Creates an "exponentiation requirement" diagnostic.
+pub fn exponentiation_requirement(span: Span) -> Diagnostic {
+    Diagnostic::error("use of the exponentiation operator requires WDL version 1.2")
+        .with_highlight(span)
+}
+
+/// Creates a "multi-line string requirement" diagnostic.
+pub fn multiline_string_requirement(span: Span) -> Diagnostic {
+    Diagnostic::error("use of multi-line strings requires WDL version 1.2").with_highlight(span)
+}

--- a/wdl-engine/src/engine.rs
+++ b/wdl-engine/src/engine.rs
@@ -1,41 +1,20 @@
 //! Implementation of the WDL evaluation engine.
 
-use std::sync::Arc;
-
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use id_arena::Arena;
-use id_arena::ArenaBehavior;
-use id_arena::DefaultArenaBehavior;
-use string_interner::DefaultStringInterner;
 use wdl_analysis::document::Document;
-use wdl_analysis::types::CompoundTypeDef;
-use wdl_analysis::types::Type;
 use wdl_analysis::types::Types;
 
-use crate::Array;
-use crate::Coercible;
-use crate::CompoundValue;
-use crate::CompoundValueId;
-use crate::Map;
-use crate::Object;
 use crate::Outputs;
-use crate::Pair;
-use crate::Struct;
 use crate::TaskInputs;
-use crate::Value;
 use crate::WorkflowInputs;
 
 /// Represents a WDL evaluation engine.
 #[derive(Debug, Default)]
 pub struct Engine {
     /// The engine's type collection.
-    types: Types,
-    /// The storage arena for compound values.
-    values: Arena<CompoundValue>,
-    /// The string interner used to intern string/file/directory values.
-    interner: DefaultStringInterner,
+    pub(crate) types: Types,
 }
 
 impl Engine {
@@ -65,12 +44,15 @@ impl Engine {
         let workflow = document
             .workflow()
             .ok_or_else(|| anyhow!("document does not contain a workflow"))?;
-        inputs.validate(self, document, workflow).with_context(|| {
-            format!(
-                "failed to validate the inputs to workflow `{workflow}`",
-                workflow = workflow.name()
-            )
-        })?;
+        inputs
+            .validate(&mut self.types, document, workflow)
+            .with_context(|| {
+                format!(
+                    "failed to validate the inputs to workflow `{workflow}`",
+                    workflow = workflow.name()
+                )
+            })?;
+
         todo!("not yet implemented")
     }
 
@@ -86,278 +68,15 @@ impl Engine {
         let task = document
             .task_by_name(name)
             .ok_or_else(|| anyhow!("document does not contain a task named `{name}`"))?;
-        inputs.validate(self, document, task).with_context(|| {
-            format!(
-                "failed to validate the inputs to task `{task}`",
-                task = task.name()
-            )
-        })?;
+        inputs
+            .validate(&mut self.types, document, task)
+            .with_context(|| {
+                format!(
+                    "failed to validate the inputs to task `{task}`",
+                    task = task.name()
+                )
+            })?;
+
         todo!("not yet implemented")
-    }
-
-    /// Creates a new `String` value.
-    pub fn new_string(&mut self, s: impl AsRef<str>) -> Value {
-        Value::String(self.interner.get_or_intern(s))
-    }
-
-    /// Creates a new `File` value.
-    pub fn new_file(&mut self, s: impl AsRef<str>) -> Value {
-        Value::File(self.interner.get_or_intern(s))
-    }
-
-    /// Creates a new `Directory` value.
-    pub fn new_directory(&mut self, s: impl AsRef<str>) -> Value {
-        Value::Directory(self.interner.get_or_intern(s))
-    }
-
-    /// Creates a new `Pair` value.
-    ///
-    /// Returns an error if either the `left` value or the `right` value did not
-    /// coerce to the pair's `left` type or `right`` type, respectively.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the given type is not a pair type from this engine's types
-    /// collection or if any of the values are not from this engine.
-    pub fn new_pair(
-        &mut self,
-        ty: Type,
-        left: impl Into<Value>,
-        right: impl Into<Value>,
-    ) -> Result<Value> {
-        if let Type::Compound(compound_ty) = ty {
-            if let CompoundTypeDef::Pair(pair_ty) =
-                self.types.type_definition(compound_ty.definition())
-            {
-                let left_ty = pair_ty.left_type();
-                let right_ty = pair_ty.right_type();
-
-                let left = left
-                    .into()
-                    .coerce(self, left_ty)
-                    .context("failed to coerce pair's left value")?;
-                left.assert_valid(self);
-                let right = right
-                    .into()
-                    .coerce(self, right_ty)
-                    .context("failed to coerce pair's right value")?;
-                right.assert_valid(self);
-
-                let id = self
-                    .values
-                    .alloc(CompoundValue::Pair(Pair::new(ty, left, right)));
-                return Ok(Value::Compound(id));
-            }
-        }
-
-        panic!(
-            "type `{ty}` is not a pair type",
-            ty = ty.display(&self.types)
-        );
-    }
-
-    /// Creates a new `Array` value for the given array type.
-    ///
-    /// Returns an error if an element did not coerce to the array's element
-    /// type.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the given type is not an array type from this engine's types
-    /// collection or if any of the values are not from this engine.
-    pub fn new_array<V>(&mut self, ty: Type, elements: impl IntoIterator<Item = V>) -> Result<Value>
-    where
-        V: Into<Value>,
-    {
-        if let Type::Compound(compound_ty) = ty {
-            if let CompoundTypeDef::Array(array_ty) =
-                self.types.type_definition(compound_ty.definition())
-            {
-                let element_type = array_ty.element_type();
-                let elements = elements
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, v)| {
-                        let v = v.into();
-                        v.assert_valid(self);
-                        v.coerce(self, element_type)
-                            .with_context(|| format!("failed to coerce array element at index {i}"))
-                    })
-                    .collect::<Result<_>>()?;
-                let id = self
-                    .values
-                    .alloc(CompoundValue::Array(Array::new(ty, elements)));
-                return Ok(Value::Compound(id));
-            }
-        }
-
-        panic!(
-            "type `{ty}` is not an array type",
-            ty = ty.display(&self.types)
-        );
-    }
-
-    /// Creates a new `Map` value.
-    ///
-    /// Returns an error if an key or value did not coerce to the map's key or
-    /// value type, respectively.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the given type is not a map type from this engine's types
-    /// collection or if any of the values are not from this engine.
-    pub fn new_map<K, V>(
-        &mut self,
-        ty: Type,
-        elements: impl IntoIterator<Item = (K, V)>,
-    ) -> Result<Value>
-    where
-        K: Into<Value>,
-        V: Into<Value>,
-    {
-        if let Type::Compound(compound_ty) = ty {
-            if let CompoundTypeDef::Map(map_ty) =
-                self.types.type_definition(compound_ty.definition())
-            {
-                let key_type = map_ty.key_type();
-                let value_type = map_ty.value_type();
-
-                let elements = elements
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, (k, v))| {
-                        let k = k.into();
-                        k.assert_valid(self);
-                        let v = v.into();
-                        v.assert_valid(self);
-                        Ok((
-                            k.coerce(self, key_type).with_context(|| {
-                                format!("failed to coerce map key for element at index {i}")
-                            })?,
-                            v.coerce(self, value_type).with_context(|| {
-                                format!("failed to coerce map value for element at index {i}")
-                            })?,
-                        ))
-                    })
-                    .collect::<Result<_>>()?;
-                let id = self
-                    .values
-                    .alloc(CompoundValue::Map(Map::new(ty, Arc::new(elements))));
-                return Ok(Value::Compound(id));
-            }
-        }
-
-        panic!(
-            "type `{ty}` is not a map type",
-            ty = ty.display(&self.types)
-        );
-    }
-
-    /// Creates a new `Object` value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the values are not from this engine.
-    pub fn new_object<S, V>(&mut self, items: impl IntoIterator<Item = (S, V)>) -> Value
-    where
-        S: Into<String>,
-        V: Into<Value>,
-    {
-        let id = self
-            .values
-            .alloc(CompoundValue::Object(Object::new(Arc::new(
-                items
-                    .into_iter()
-                    .map(|(n, v)| {
-                        let n = n.into();
-                        let v = v.into();
-                        v.assert_valid(self);
-                        (n, v)
-                    })
-                    .collect(),
-            ))));
-        Value::Compound(id)
-    }
-
-    /// Creates a new struct value.
-    ///
-    /// Returns an error if the struct type does not contain a member of a given
-    /// name or if a value does not coerce to the corresponding member's type.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the given type is not a struct type from this engine's types
-    /// collection or if any of the values are not from this engine.
-    pub fn new_struct<S, V>(
-        &mut self,
-        ty: Type,
-        members: impl IntoIterator<Item = (S, V)>,
-    ) -> Result<Value>
-    where
-        S: Into<String>,
-        V: Into<Value>,
-    {
-        if let Type::Compound(compound_ty) = ty {
-            if let CompoundTypeDef::Struct(_) = self.types.type_definition(compound_ty.definition())
-            {
-                let members = members
-                    .into_iter()
-                    .map(|(n, v)| {
-                        let n = n.into();
-                        let v = v.into();
-                        v.assert_valid(self);
-                        let v = v
-                            .coerce(
-                                self,
-                                *self
-                                    .types
-                                    .type_definition(compound_ty.definition())
-                                    .as_struct()
-                                    .expect("should be a struct")
-                                    .members()
-                                    .get(&n)
-                                    .ok_or_else(|| {
-                                        anyhow!("struct does not contain a member named `{n}`")
-                                    })?,
-                            )
-                            .with_context(|| format!("failed to coerce struct member `{n}`"))?;
-                        Ok((n, v))
-                    })
-                    .collect::<Result<_>>()?;
-                let id = self
-                    .values
-                    .alloc(CompoundValue::Struct(Struct::new(ty, Arc::new(members))));
-                return Ok(Value::Compound(id));
-            }
-        }
-
-        panic!(
-            "type `{ty}` is not a struct type",
-            ty = ty.display(&self.types)
-        );
-    }
-
-    /// Gets a compound value given its identifier.
-    pub fn value(&self, id: CompoundValueId) -> &CompoundValue {
-        &self.values[id]
-    }
-
-    /// Allocates a new compound value in the engine.
-    pub(crate) fn alloc(&mut self, value: CompoundValue) -> CompoundValueId {
-        self.values.alloc(value)
-    }
-
-    /// Gets the string interner of the engine.
-    pub(crate) fn interner(&self) -> &DefaultStringInterner {
-        &self.interner
-    }
-
-    /// Asserts that the given id comes from this engine's values arena.
-    pub(crate) fn assert_same_arena(&self, id: CompoundValueId) {
-        assert!(
-            DefaultArenaBehavior::arena_id(id)
-                == DefaultArenaBehavior::arena_id(self.values.next_id()),
-            "id comes from a different values arena"
-        );
     }
 }

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -1,0 +1,110 @@
+//! Module for expression evaluation.
+
+use indexmap::IndexMap;
+
+use crate::Value;
+
+pub mod v1;
+
+/// Represents an index of a scope in a collection of scopes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ScopeIndex(usize);
+
+impl From<usize> for ScopeIndex {
+    fn from(index: usize) -> Self {
+        Self(index)
+    }
+}
+
+impl From<ScopeIndex> for usize {
+    fn from(index: ScopeIndex) -> Self {
+        index.0
+    }
+}
+
+/// Represents an evaluation scope in a WDL document.
+#[derive(Debug)]
+pub struct Scope {
+    /// The index of the parent scope.
+    ///
+    /// This is `None` for task and workflow scopes.
+    parent: Option<ScopeIndex>,
+    /// The map of names in scope to their values.
+    names: IndexMap<String, Value>,
+}
+
+impl Scope {
+    /// Creates a new scope given the parent scope.
+    pub fn new(parent: Option<ScopeIndex>) -> Self {
+        Self {
+            parent,
+            names: Default::default(),
+        }
+    }
+
+    /// Inserts a name into the scope.
+    pub fn insert(&mut self, name: impl Into<String>, value: impl Into<Value>) {
+        self.names.insert(name.into(), value.into());
+    }
+}
+
+/// Represents a reference to a scope.
+#[derive(Debug, Clone, Copy)]
+pub struct ScopeRef<'a> {
+    /// The reference to the scopes collection.
+    scopes: &'a [Scope],
+    /// The index of the scope in the collection.
+    index: ScopeIndex,
+}
+
+impl<'a> ScopeRef<'a> {
+    /// Creates a new scope reference given the scope index.
+    pub fn new(scopes: &'a [Scope], index: impl Into<ScopeIndex>) -> Self {
+        Self {
+            scopes,
+            index: index.into(),
+        }
+    }
+
+    /// Gets the parent scope.
+    ///
+    /// Returns `None` if there is no parent scope.
+    pub fn parent(&self) -> Option<Self> {
+        self.scopes[self.index.0].parent.map(|p| Self {
+            scopes: self.scopes,
+            index: p,
+        })
+    }
+
+    /// Gets all of the name and values available at this scope.
+    pub fn names(&self) -> impl Iterator<Item = (&str, &Value)> + use<'_> {
+        self.scopes[self.index.0]
+            .names
+            .iter()
+            .map(|(n, name)| (n.as_str(), name))
+    }
+
+    /// Gets the value of a name local to this scope.
+    ///
+    /// Returns `None` if a name local to this scope was not found.
+    pub fn local(&self, name: &str) -> Option<&Value> {
+        self.scopes[self.index.0].names.get(name)
+    }
+
+    /// Lookups a name in the scope.
+    ///
+    /// Returns `None` if the name is not available in the scope.
+    pub fn lookup(&self, name: &str) -> Option<&Value> {
+        let mut current = Some(self.index);
+
+        while let Some(index) = current {
+            if let Some(name) = self.scopes[index.0].names.get(name) {
+                return Some(name);
+            }
+
+            current = self.scopes[index.0].parent;
+        }
+
+        None
+    }
+}

--- a/wdl-engine/src/eval/v1.rs
+++ b/wdl-engine/src/eval/v1.rs
@@ -1,0 +1,2984 @@
+//! Implementation of an expression evaluator for 1.x WDL documents.
+
+use std::cmp::Ordering;
+use std::fmt::Write;
+use std::iter::once;
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use ordered_float::Pow;
+use wdl_analysis::diagnostics::ambiguous_argument;
+use wdl_analysis::diagnostics::argument_type_mismatch;
+use wdl_analysis::diagnostics::cannot_access;
+use wdl_analysis::diagnostics::cannot_coerce_to_string;
+use wdl_analysis::diagnostics::cannot_index;
+use wdl_analysis::diagnostics::comparison_mismatch;
+use wdl_analysis::diagnostics::if_conditional_mismatch;
+use wdl_analysis::diagnostics::index_type_mismatch;
+use wdl_analysis::diagnostics::logical_and_mismatch;
+use wdl_analysis::diagnostics::logical_not_mismatch;
+use wdl_analysis::diagnostics::logical_or_mismatch;
+use wdl_analysis::diagnostics::map_key_not_primitive;
+use wdl_analysis::diagnostics::missing_struct_members;
+use wdl_analysis::diagnostics::no_common_type;
+use wdl_analysis::diagnostics::not_a_pair_accessor;
+use wdl_analysis::diagnostics::not_a_struct_member;
+use wdl_analysis::diagnostics::numeric_mismatch;
+use wdl_analysis::diagnostics::too_few_arguments;
+use wdl_analysis::diagnostics::too_many_arguments;
+use wdl_analysis::diagnostics::type_mismatch_custom;
+use wdl_analysis::diagnostics::unknown_function;
+use wdl_analysis::diagnostics::unsupported_function;
+use wdl_analysis::stdlib::FunctionBindError;
+use wdl_analysis::stdlib::MAX_PARAMETERS;
+use wdl_analysis::stdlib::STDLIB;
+use wdl_analysis::types::ArrayType;
+use wdl_analysis::types::Coercible as _;
+use wdl_analysis::types::CompoundTypeDef;
+use wdl_analysis::types::MapType;
+use wdl_analysis::types::Optional;
+use wdl_analysis::types::PairType;
+use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::Type;
+use wdl_analysis::types::TypeEq;
+use wdl_analysis::types::Types;
+use wdl_analysis::types::v1::ComparisonOperator;
+use wdl_analysis::types::v1::ExprTypeEvaluator;
+use wdl_analysis::types::v1::NumericOperator;
+use wdl_ast::AstNode;
+use wdl_ast::AstNodeExt;
+use wdl_ast::AstToken;
+use wdl_ast::Diagnostic;
+use wdl_ast::Ident;
+use wdl_ast::Span;
+use wdl_ast::SupportedVersion;
+use wdl_ast::SyntaxKind;
+use wdl_ast::v1::AccessExpr;
+use wdl_ast::v1::CallExpr;
+use wdl_ast::v1::Expr;
+use wdl_ast::v1::IfExpr;
+use wdl_ast::v1::IndexExpr;
+use wdl_ast::v1::LiteralArray;
+use wdl_ast::v1::LiteralExpr;
+use wdl_ast::v1::LiteralMap;
+use wdl_ast::v1::LiteralObject;
+use wdl_ast::v1::LiteralPair;
+use wdl_ast::v1::LiteralString;
+use wdl_ast::v1::LiteralStringKind;
+use wdl_ast::v1::LiteralStruct;
+use wdl_ast::v1::LogicalAndExpr;
+use wdl_ast::v1::LogicalNotExpr;
+use wdl_ast::v1::LogicalOrExpr;
+use wdl_ast::v1::NegationExpr;
+use wdl_ast::v1::Placeholder;
+use wdl_ast::v1::PlaceholderOption;
+use wdl_ast::v1::StringPart;
+use wdl_ast::v1::StrippedStringPart;
+use wdl_ast::version::V1;
+
+use crate::Array;
+use crate::Coercible;
+use crate::CompoundValue;
+use crate::Map;
+use crate::Object;
+use crate::Pair;
+use crate::PrimitiveValue;
+use crate::Struct;
+use crate::Value;
+use crate::diagnostics::array_index_out_of_range;
+use crate::diagnostics::division_by_zero;
+use crate::diagnostics::exponent_not_in_range;
+use crate::diagnostics::exponentiation_requirement;
+use crate::diagnostics::float_not_in_range;
+use crate::diagnostics::integer_negation_not_in_range;
+use crate::diagnostics::integer_not_in_range;
+use crate::diagnostics::map_key_not_found;
+use crate::diagnostics::multiline_string_requirement;
+use crate::diagnostics::not_an_object_member;
+use crate::diagnostics::numeric_overflow;
+use crate::diagnostics::struct_member_coercion_failed;
+
+/// Represents context to an expression evaluator.
+pub trait EvaluationContext {
+    /// Gets the supported version of the document being evaluated.
+    fn version(&self) -> SupportedVersion;
+
+    /// Gets the types collection associated with the evaluation.
+    fn types(&self) -> &Types;
+
+    /// Gets the mutable types collection associated with the evaluation.
+    fn types_mut(&mut self) -> &mut Types;
+
+    /// Gets the value of the given name in scope.
+    fn resolve_name(&self, name: &Ident) -> Result<Value, Diagnostic>;
+
+    /// Resolves a type name to a type.
+    fn resolve_type_name(&self, name: &Ident) -> Result<Type, Diagnostic>;
+
+    /// Gets the value to return for a call to the `stdout` function.
+    ///
+    /// This is `Some` only when evaluating task outputs.
+    fn stdout(&self) -> Option<Value>;
+
+    /// Gets the value to return for a call to the `stderr` function.
+    ///
+    /// This is `Some` only when evaluating task outputs.
+    fn stderr(&self) -> Option<Value>;
+}
+
+/// Represents a WDL expression evaluator.
+#[derive(Debug)]
+pub struct ExprEvaluator<'a, C> {
+    /// The expression evaluation context.
+    context: &'a mut C,
+    /// The nested count of placeholder evaluation.
+    ///
+    /// This is incremented immediately before a placeholder expression is
+    /// evaluated and decremented immediately after.
+    ///
+    /// If the count is non-zero, special evaluation behavior is enabled for
+    /// string interpolation.
+    placeholders: usize,
+    /// Tracks whether or not a `None`-resulting expression was evaluated during
+    /// a placeholder evaluation.
+    evaluated_none: bool,
+}
+
+impl<'a, C: EvaluationContext> ExprEvaluator<'a, C> {
+    /// Creates a new expression evaluator.
+    pub fn new(context: &'a mut C) -> Self {
+        Self {
+            context,
+            placeholders: 0,
+            evaluated_none: false,
+        }
+    }
+
+    /// Evaluates the given expression.
+    pub fn evaluate_expr(&mut self, expr: &Expr) -> Result<Value, Diagnostic> {
+        let value = match expr {
+            Expr::Literal(expr) => self.evaluate_literal_expr(expr),
+            Expr::Name(r) => self.context.resolve_name(&r.name()),
+            Expr::Parenthesized(expr) => self.evaluate_expr(&expr.inner()),
+            Expr::If(expr) => self.evaluate_if_expr(expr),
+            Expr::LogicalNot(expr) => self.evaluate_logical_not_expr(expr),
+            Expr::Negation(expr) => self.evaluate_negation_expr(expr),
+            Expr::LogicalOr(expr) => self.evaluate_logical_or_expr(expr),
+            Expr::LogicalAnd(expr) => self.evaluate_logical_and_expr(expr),
+            Expr::Equality(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_comparison_expr(ComparisonOperator::Equality, &lhs, &rhs, expr.span())
+            }
+            Expr::Inequality(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_comparison_expr(
+                    ComparisonOperator::Inequality,
+                    &lhs,
+                    &rhs,
+                    expr.span(),
+                )
+            }
+            Expr::Less(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_comparison_expr(ComparisonOperator::Less, &lhs, &rhs, expr.span())
+            }
+            Expr::LessEqual(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_comparison_expr(
+                    ComparisonOperator::LessEqual,
+                    &lhs,
+                    &rhs,
+                    expr.span(),
+                )
+            }
+            Expr::Greater(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_comparison_expr(ComparisonOperator::Greater, &lhs, &rhs, expr.span())
+            }
+            Expr::GreaterEqual(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_comparison_expr(
+                    ComparisonOperator::GreaterEqual,
+                    &lhs,
+                    &rhs,
+                    expr.span(),
+                )
+            }
+            Expr::Addition(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_numeric_expr(NumericOperator::Addition, &lhs, &rhs, expr.span())
+            }
+            Expr::Subtraction(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_numeric_expr(NumericOperator::Subtraction, &lhs, &rhs, expr.span())
+            }
+            Expr::Multiplication(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_numeric_expr(NumericOperator::Multiplication, &lhs, &rhs, expr.span())
+            }
+            Expr::Division(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_numeric_expr(NumericOperator::Division, &lhs, &rhs, expr.span())
+            }
+            Expr::Modulo(expr) => {
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_numeric_expr(NumericOperator::Modulo, &lhs, &rhs, expr.span())
+            }
+            Expr::Exponentiation(expr) => {
+                if self.context.version() < SupportedVersion::V1(V1::Two) {
+                    return Err(exponentiation_requirement(expr.span()));
+                }
+                let (lhs, rhs) = expr.operands();
+                self.evaluate_numeric_expr(NumericOperator::Exponentiation, &lhs, &rhs, expr.span())
+            }
+            Expr::Call(expr) => self.evaluate_call_expr(expr),
+            Expr::Index(expr) => self.evaluate_index_expr(expr),
+            Expr::Access(expr) => self.evaluate_access_expr(expr),
+        }?;
+
+        self.evaluated_none |= self.placeholders > 0 && value.is_none();
+        Ok(value)
+    }
+
+    /// Evaluates a literal expression.
+    fn evaluate_literal_expr(&mut self, expr: &LiteralExpr) -> Result<Value, Diagnostic> {
+        match expr {
+            LiteralExpr::Boolean(lit) => Ok(lit.value().into()),
+            LiteralExpr::Integer(lit) => {
+                // Check to see if this literal is a direct child of a negation expression; if
+                // so, we want to negate the literal
+                let (value, span) = match lit.syntax().parent() {
+                    Some(parent) if parent.kind() == SyntaxKind::NegationExprNode => {
+                        let start = parent.text_range().start().into();
+                        (lit.negate(), Span::new(start, lit.span().end() - start))
+                    }
+                    _ => (lit.value(), lit.span()),
+                };
+
+                Ok(value.ok_or_else(|| integer_not_in_range(span))?.into())
+            }
+            LiteralExpr::Float(lit) => Ok(lit
+                .value()
+                .ok_or_else(|| float_not_in_range(lit.span()))?
+                .into()),
+            LiteralExpr::String(lit) => self.evaluate_literal_string(lit),
+            LiteralExpr::Array(lit) => self.evaluate_literal_array(lit),
+            LiteralExpr::Pair(lit) => self.evaluate_literal_pair(lit),
+            LiteralExpr::Map(lit) => self.evaluate_literal_map(lit),
+            LiteralExpr::Object(lit) => self.evaluate_literal_object(lit),
+            LiteralExpr::Struct(lit) => self.evaluate_literal_struct(lit),
+            LiteralExpr::None(_) => Ok(Value::None),
+            LiteralExpr::Hints(_) | LiteralExpr::Input(_) | LiteralExpr::Output(_) => {
+                todo!("implement for WDL 1.2 support")
+            }
+        }
+    }
+
+    /// Evaluates a placeholder into the given string buffer.
+    fn evaluate_placeholder(
+        &mut self,
+        placeholder: &Placeholder,
+        buffer: &mut String,
+    ) -> Result<(), Diagnostic> {
+        let expr = placeholder.expr();
+        match self.evaluate_expr(&expr)? {
+            Value::None => {
+                if let Some(o) = placeholder.option().as_ref().and_then(|o| o.as_default()) {
+                    buffer.push_str(&self.evaluate_literal_string(&o.value())?.unwrap_string())
+                }
+            }
+            Value::Primitive(PrimitiveValue::Boolean(v)) => {
+                match placeholder
+                    .option()
+                    .as_ref()
+                    .and_then(|o| o.as_true_false())
+                {
+                    Some(o) => {
+                        let (t, f) = o.values();
+                        if v {
+                            buffer.push_str(&self.evaluate_literal_string(&t)?.unwrap_string());
+                        } else {
+                            buffer.push_str(&self.evaluate_literal_string(&f)?.unwrap_string());
+                        }
+                    }
+                    None => {
+                        if v {
+                            buffer.push_str("true");
+                        } else {
+                            buffer.push_str("false");
+                        }
+                    }
+                }
+            }
+            Value::Primitive(PrimitiveValue::Integer(v)) => write!(buffer, "{v}").unwrap(),
+            Value::Primitive(PrimitiveValue::Float(v)) => write!(buffer, "{v}").unwrap(),
+            Value::Primitive(PrimitiveValue::String(s))
+            | Value::Primitive(PrimitiveValue::File(s))
+            | Value::Primitive(PrimitiveValue::Directory(s)) => buffer.push_str(&s),
+            Value::Compound(CompoundValue::Array(v))
+                if matches!(placeholder.option(), Some(PlaceholderOption::Sep(_)))
+                    && v.elements()
+                        .first()
+                        .map(|e| !matches!(e, Value::None | Value::Compound(_)))
+                        .unwrap_or(false) =>
+            {
+                let option = placeholder.option().unwrap().unwrap_sep();
+
+                let sep = self
+                    .evaluate_literal_string(&option.separator())?
+                    .unwrap_string();
+                for (i, v) in v.elements().iter().enumerate() {
+                    if i > 0 {
+                        buffer.push_str(&sep);
+                    }
+
+                    write!(buffer, "{v}").unwrap();
+                }
+            }
+            Value::Compound(v) => {
+                return Err(cannot_coerce_to_string(
+                    self.context.types(),
+                    v.ty(),
+                    expr.span(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Evaluates a literal string expression.
+    fn evaluate_literal_string(&mut self, expr: &LiteralString) -> Result<Value, Diagnostic> {
+        /// Helper for evaluating placeholders in a string.
+        /// This handles incrementing the nested placeholder count and handling
+        /// failures when a `None` expression was evaluated.
+        fn evaluate_placeholder<C: EvaluationContext>(
+            evaluator: &mut ExprEvaluator<'_, C>,
+            placeholder: &Placeholder,
+            buffer: &mut String,
+        ) -> Result<(), Diagnostic> {
+            // Keep track of the start in case there is a `None` evaluated and an error
+            let start = buffer.len();
+
+            // Bump the placeholder count while evaluating the placeholder
+            evaluator.placeholders += 1;
+            let result = evaluator.evaluate_placeholder(placeholder, buffer);
+            evaluator.placeholders -= 1;
+
+            // Reset the evaluated none flag
+            if evaluator.placeholders == 0 {
+                let evaluated_none = std::mem::replace(&mut evaluator.evaluated_none, false);
+
+                // If a `None` was evaluated and an error occurred, truncate to the start of the
+                // placeholder evaluation
+                if evaluated_none && result.is_err() {
+                    buffer.truncate(start);
+                    return Ok(());
+                }
+            }
+
+            result
+        }
+
+        if expr.kind() == LiteralStringKind::Multiline
+            && self.context.version() < SupportedVersion::V1(V1::Two)
+        {
+            return Err(multiline_string_requirement(expr.span()));
+        }
+
+        let mut s = String::new();
+        if let Some(parts) = expr.strip_whitespace() {
+            for part in parts {
+                match part {
+                    StrippedStringPart::Text(t) => s.push_str(t.as_str()),
+                    StrippedStringPart::Placeholder(placeholder) => {
+                        evaluate_placeholder(self, &placeholder, &mut s)?;
+                    }
+                }
+            }
+        } else {
+            for part in expr.parts() {
+                match part {
+                    StringPart::Text(t) => s.push_str(t.as_str()),
+                    StringPart::Placeholder(placeholder) => {
+                        evaluate_placeholder(self, &placeholder, &mut s)?;
+                    }
+                }
+            }
+        }
+
+        Ok(PrimitiveValue::new_string(s).into())
+    }
+
+    /// Evaluates a literal array expression.
+    fn evaluate_literal_array(&mut self, expr: &LiteralArray) -> Result<Value, Diagnostic> {
+        // Look at the first array element to determine the element type
+        // The remaining elements must have a common type
+        let mut elements = expr.elements();
+        let (element_ty, values) = match elements.next() {
+            Some(expr) => {
+                let mut values = Vec::new();
+                let value = self.evaluate_expr(&expr)?;
+                let mut expected: Type = value.ty();
+                let mut expected_span = expr.span();
+                values.push(value);
+
+                // Ensure the remaining element types share a common type
+                for expr in elements {
+                    let value = self.evaluate_expr(&expr)?;
+                    let actual = value.ty();
+
+                    if let Some(ty) = actual.common_type(self.context.types(), expected) {
+                        expected = ty;
+                        expected_span = expr.span();
+                    } else {
+                        return Err(no_common_type(
+                            self.context.types(),
+                            expected,
+                            expected_span,
+                            actual,
+                            expr.span(),
+                        ));
+                    }
+
+                    values.push(value);
+                }
+
+                (expected, values)
+            }
+            None => (Type::Union, Vec::new()),
+        };
+
+        let ty = self
+            .context
+            .types_mut()
+            .add_array(ArrayType::new(element_ty));
+        Ok(Array::new(self.context.types(), ty, values)
+            .expect("array elements should coerce")
+            .into())
+    }
+
+    /// Evaluates a literal pair expression.
+    fn evaluate_literal_pair(&mut self, expr: &LiteralPair) -> Result<Value, Diagnostic> {
+        let (left, right) = expr.exprs();
+        let left = self.evaluate_expr(&left)?;
+        let right = self.evaluate_expr(&right)?;
+        let ty = self
+            .context
+            .types_mut()
+            .add_pair(PairType::new(left.ty(), right.ty()));
+        Ok(Pair::new(self.context.types(), ty, left, right)
+            .expect("types should coerce")
+            .into())
+    }
+
+    /// Evaluates a literal map expression.
+    fn evaluate_literal_map(&mut self, expr: &LiteralMap) -> Result<Value, Diagnostic> {
+        let mut items = expr.items();
+        let (key_ty, value_ty, elements) = match items.next() {
+            Some(item) => {
+                let mut elements = Vec::new();
+
+                // Evaluate the first key-value pair
+                let (key, value) = item.key_value();
+                let expected_key = self.evaluate_expr(&key)?;
+                let mut expected_key_ty = expected_key.ty();
+                let mut expected_key_span = key.span();
+                let expected_value = self.evaluate_expr(&value)?;
+                let mut expected_value_ty = expected_value.ty();
+                let mut expected_value_span = value.span();
+
+                // The key type must be primitive
+                match expected_key {
+                    Value::Primitive(key) => {
+                        elements.push((key, expected_value));
+                    }
+                    _ => {
+                        return Err(map_key_not_primitive(
+                            self.context.types(),
+                            key.span(),
+                            expected_key.ty(),
+                        ));
+                    }
+                }
+
+                // Ensure the remaining items types share common types
+                for item in items {
+                    let (key, value) = item.key_value();
+                    let actual_key = self.evaluate_expr(&key)?;
+                    let actual_key_ty = actual_key.ty();
+                    let actual_value = self.evaluate_expr(&value)?;
+                    let actual_value_ty = actual_value.ty();
+
+                    if let Some(ty) =
+                        actual_key_ty.common_type(self.context.types(), expected_key_ty)
+                    {
+                        expected_key_ty = ty;
+                        expected_key_span = key.span();
+                    } else {
+                        // No common key type
+                        return Err(no_common_type(
+                            self.context.types(),
+                            expected_key_ty,
+                            expected_key_span,
+                            actual_key_ty,
+                            key.span(),
+                        ));
+                    }
+
+                    if let Some(ty) =
+                        actual_value_ty.common_type(self.context.types(), expected_value_ty)
+                    {
+                        expected_value_ty = ty;
+                        expected_value_span = value.span();
+                    } else {
+                        // No common value type
+                        return Err(no_common_type(
+                            self.context.types(),
+                            expected_value_ty,
+                            expected_value_span,
+                            actual_value_ty,
+                            value.span(),
+                        ));
+                    }
+
+                    match actual_key {
+                        Value::Primitive(key) => {
+                            elements.push((key, actual_value));
+                        }
+                        _ => panic!("the key type is not primitive, but had a common type"),
+                    }
+                }
+
+                (expected_key_ty, expected_value_ty, elements)
+            }
+            None => (Type::Union, Type::Union, Vec::new()),
+        };
+
+        let ty = self
+            .context
+            .types_mut()
+            .add_map(MapType::new(key_ty, value_ty));
+        Ok(Map::new(self.context.types(), ty, elements)
+            .expect("map elements should coerce")
+            .into())
+    }
+
+    /// Evaluates a literal object expression.
+    fn evaluate_literal_object(&mut self, expr: &LiteralObject) -> Result<Value, Diagnostic> {
+        Ok(Object::from(
+            expr.items()
+                .map(|item| {
+                    let (name, value) = item.name_value();
+                    Ok((name.as_str().to_string(), self.evaluate_expr(&value)?))
+                })
+                .collect::<Result<IndexMap<_, _>, _>>()?,
+        )
+        .into())
+    }
+
+    /// Evaluates a literal struct expression.
+    fn evaluate_literal_struct(&mut self, expr: &LiteralStruct) -> Result<Value, Diagnostic> {
+        let name = expr.name();
+        let ty = self.context.resolve_type_name(&name)?;
+
+        // Evaluate the members
+        let mut members =
+            IndexMap::with_capacity(self.context.types().struct_type(ty).members().len());
+        for item in expr.items() {
+            let (n, v) = item.name_value();
+            if let Some(expected) = self
+                .context
+                .types()
+                .struct_type(ty)
+                .members()
+                .get(n.as_str())
+            {
+                let expected = *expected;
+                let value = self.evaluate_expr(&v)?;
+                let value = value.coerce(self.context.types(), expected).map_err(|e| {
+                    struct_member_coercion_failed(
+                        self.context.types(),
+                        &e,
+                        expected,
+                        n.span(),
+                        value.ty(),
+                        v.span(),
+                    )
+                })?;
+
+                members.insert(n.as_str().to_string(), value);
+            } else {
+                // Not a struct member
+                return Err(not_a_struct_member(name.as_str(), &n));
+            }
+        }
+
+        let mut iter = self.context.types().struct_type(ty).members().iter();
+        while let Some((n, ty)) = iter.next() {
+            // Check for optional members that should be set to `None`
+            if ty.is_optional() {
+                if !members.contains_key(n) {
+                    members.insert(n.clone(), Value::None);
+                }
+            } else {
+                // Check for a missing required member
+                if !members.contains_key(n) {
+                    let mut missing = once(n)
+                        .chain(iter.filter_map(|(n, ty)| {
+                            if ty.is_optional() && !members.contains_key(n.as_str()) {
+                                Some(n)
+                            } else {
+                                None
+                            }
+                        }))
+                        .peekable();
+                    let mut names: String = String::new();
+                    let mut count = 0;
+                    while let Some(n) = missing.next() {
+                        match (missing.peek().is_none(), count) {
+                            (true, c) if c > 1 => names.push_str(", and "),
+                            (true, 1) => names.push_str(" and "),
+                            (false, c) if c > 0 => names.push_str(", "),
+                            _ => {}
+                        }
+
+                        write!(&mut names, "`{n}`").ok();
+                        count += 1;
+                    }
+
+                    return Err(missing_struct_members(&name, count, &names));
+                }
+            }
+        }
+
+        Ok(Struct::new_unchecked(
+            ty,
+            self.context.types().struct_type(ty).name().clone(),
+            Arc::new(members),
+        )
+        .into())
+    }
+
+    /// Evaluates an `if` expression.
+    fn evaluate_if_expr(&mut self, expr: &IfExpr) -> Result<Value, Diagnostic> {
+        /// Used to translate an expression evaluation context to an expression
+        /// type evaluation context.
+        struct TypeContext<'a, C: EvaluationContext>(&'a mut C);
+        impl<'a, C: EvaluationContext> wdl_analysis::types::v1::EvaluationContext for TypeContext<'a, C> {
+            fn version(&self) -> SupportedVersion {
+                self.0.version()
+            }
+
+            fn types(&self) -> &wdl_analysis::types::Types {
+                self.0.types()
+            }
+
+            fn types_mut(&mut self) -> &mut wdl_analysis::types::Types {
+                self.0.types_mut()
+            }
+
+            fn resolve_name(&self, name: &wdl_ast::Ident) -> Option<Type> {
+                self.0.resolve_name(name).map(|v| v.ty()).ok()
+            }
+
+            fn resolve_type_name(&mut self, name: &wdl_ast::Ident) -> Result<Type, Diagnostic> {
+                self.0.resolve_type_name(name)
+            }
+
+            fn input(&self, _name: &str) -> Option<wdl_analysis::document::Input> {
+                todo!("implement for WDL 1.2 support")
+            }
+
+            fn output(&self, _name: &str) -> Option<wdl_analysis::document::Output> {
+                todo!("implement for WDL 1.2 support")
+            }
+
+            fn task_name(&self) -> Option<&str> {
+                todo!("implement for WDL 1.2 support")
+            }
+
+            fn supports_hints_type(&self) -> bool {
+                todo!("implement for WDL 1.2 support")
+            }
+
+            fn supports_input_type(&self) -> bool {
+                todo!("implement for WDL 1.2 support")
+            }
+
+            fn supports_output_type(&self) -> bool {
+                todo!("implement for WDL 1.2 support")
+            }
+        }
+
+        let (cond_expr, true_expr, false_expr) = expr.exprs();
+
+        // Evaluate the conditional expression and the true expression or the false
+        // expression, depending on the result of the conditional expression
+        let mut diagnostics = Vec::new();
+        let cond = self.evaluate_expr(&cond_expr)?;
+        let (value, true_ty, false_ty) = if cond
+            .coerce(self.context.types(), PrimitiveTypeKind::Boolean.into())
+            .map_err(|_| {
+                if_conditional_mismatch(self.context.types(), cond.ty(), cond_expr.span())
+            })?
+            .unwrap_boolean()
+        {
+            // Evaluate the `true` expression and calculate the type of the `false`
+            // expression
+            let value = self.evaluate_expr(&true_expr)?;
+            let true_ty = value.ty();
+            let false_ty = ExprTypeEvaluator::new(&mut TypeContext(self.context), &mut diagnostics)
+                .evaluate_expr(&false_expr)
+                .unwrap_or(Type::Union);
+            (value, true_ty, false_ty)
+        } else {
+            // Evaluate the `false` expression and calculate the type of the `true`
+            // expression
+            let value = self.evaluate_expr(&false_expr)?;
+            let true_ty = ExprTypeEvaluator::new(&mut TypeContext(self.context), &mut diagnostics)
+                .evaluate_expr(&true_expr)
+                .unwrap_or(Type::Union);
+            let false_ty = value.ty();
+            (value, true_ty, false_ty)
+        };
+
+        if let Some(diagnostic) = diagnostics.pop() {
+            return Err(diagnostic);
+        }
+
+        // Determine the common type of the true and false expressions
+        // The value must be coerced to that type
+        let ty = false_ty
+            .common_type(self.context.types(), true_ty)
+            .ok_or_else(|| {
+                no_common_type(
+                    self.context.types(),
+                    true_ty,
+                    true_expr.span(),
+                    false_ty,
+                    false_expr.span(),
+                )
+            })?;
+
+        Ok(value
+            .coerce(self.context.types(), ty)
+            .expect("coercion should not fail"))
+    }
+
+    /// Evaluates a `logical not` expression.
+    fn evaluate_logical_not_expr(&mut self, expr: &LogicalNotExpr) -> Result<Value, Diagnostic> {
+        // The operand should be a boolean
+        let operand = expr.operand();
+        let value = self.evaluate_expr(&operand)?;
+        Ok((!value
+            .coerce(self.context.types(), PrimitiveTypeKind::Boolean.into())
+            .map_err(|_| logical_not_mismatch(self.context.types(), value.ty(), operand.span()))?
+            .unwrap_boolean())
+        .into())
+    }
+
+    /// Evaluates a negation expression.
+    fn evaluate_negation_expr(&mut self, expr: &NegationExpr) -> Result<Value, Diagnostic> {
+        let operand = expr.operand();
+        let value = self.evaluate_expr(&operand)?;
+        let ty = value.ty();
+
+        // If the type is `Int`, treat it as `Int`
+        if ty.type_eq(self.context.types(), &PrimitiveTypeKind::Integer.into()) {
+            return match operand {
+                Expr::Literal(LiteralExpr::Integer(_)) => {
+                    // Already negated during integer literal evaluation
+                    Ok(value)
+                }
+                _ => {
+                    let value = value.unwrap_integer();
+                    Ok(value
+                        .checked_neg()
+                        .ok_or_else(|| integer_negation_not_in_range(value, operand.span()))?
+                        .into())
+                }
+            };
+        }
+
+        // If the type is `Float`, treat it as `Float`
+        if ty.type_eq(self.context.types(), &PrimitiveTypeKind::Float.into()) {
+            let value = value.unwrap_float();
+            return Ok((-value).into());
+        }
+
+        // Expected either `Int` or `Float`
+        Err(type_mismatch_custom(
+            self.context.types(),
+            &[
+                PrimitiveTypeKind::Integer.into(),
+                PrimitiveTypeKind::Float.into(),
+            ],
+            operand.span(),
+            ty,
+            operand.span(),
+        ))
+    }
+
+    /// Evaluates a `logical or` expression.
+    fn evaluate_logical_or_expr(&mut self, expr: &LogicalOrExpr) -> Result<Value, Diagnostic> {
+        let (lhs, rhs) = expr.operands();
+
+        // Evaluate the left-hand side first
+        let left = self.evaluate_expr(&lhs)?;
+        if left
+            .coerce(self.context.types(), PrimitiveTypeKind::Boolean.into())
+            .map_err(|_| logical_or_mismatch(self.context.types(), left.ty(), lhs.span()))?
+            .unwrap_boolean()
+        {
+            // Short-circuit if the left-hand side is true
+            return Ok(true.into());
+        }
+
+        // Otherwise, evaluate the right-hand side
+        let right = self.evaluate_expr(&rhs)?;
+        right
+            .coerce(self.context.types(), PrimitiveTypeKind::Boolean.into())
+            .map_err(|_| logical_or_mismatch(self.context.types(), right.ty(), rhs.span()))
+    }
+
+    /// Evaluates a `logical and` expression.
+    fn evaluate_logical_and_expr(&mut self, expr: &LogicalAndExpr) -> Result<Value, Diagnostic> {
+        let (lhs, rhs) = expr.operands();
+
+        // Evaluate the left-hand side first
+        let left = self.evaluate_expr(&lhs)?;
+        if !left
+            .coerce(self.context.types(), PrimitiveTypeKind::Boolean.into())
+            .map_err(|_| logical_and_mismatch(self.context.types(), left.ty(), lhs.span()))?
+            .unwrap_boolean()
+        {
+            // Short-circuit if the left-hand side is false
+            return Ok(false.into());
+        }
+
+        // Otherwise, evaluate the right-hand side
+        let right = self.evaluate_expr(&rhs)?;
+        right
+            .coerce(self.context.types(), PrimitiveTypeKind::Boolean.into())
+            .map_err(|_| logical_and_mismatch(self.context.types(), right.ty(), rhs.span()))
+    }
+
+    /// Evaluates a comparison expression.
+    fn evaluate_comparison_expr(
+        &mut self,
+        op: ComparisonOperator,
+        lhs: &Expr,
+        rhs: &Expr,
+        span: Span,
+    ) -> Result<Value, Diagnostic> {
+        let left = self.evaluate_expr(lhs)?;
+        let right = self.evaluate_expr(rhs)?;
+
+        match op {
+            ComparisonOperator::Equality => Value::equals(self.context.types(), &left, &right),
+            ComparisonOperator::Inequality => {
+                Value::equals(self.context.types(), &left, &right).map(|r| !r)
+            }
+            ComparisonOperator::Less
+            | ComparisonOperator::LessEqual
+            | ComparisonOperator::Greater
+            | ComparisonOperator::GreaterEqual => {
+                // Only primitive types support other comparisons
+                match (&left, &right) {
+                    (Value::Primitive(left), Value::Primitive(right)) => {
+                        PrimitiveValue::compare(left, right).map(|o| match o {
+                            Ordering::Less => matches!(
+                                op,
+                                ComparisonOperator::Less | ComparisonOperator::LessEqual
+                            ),
+                            Ordering::Equal => matches!(
+                                op,
+                                ComparisonOperator::LessEqual | ComparisonOperator::GreaterEqual
+                            ),
+                            Ordering::Greater => matches!(
+                                op,
+                                ComparisonOperator::Greater | ComparisonOperator::GreaterEqual
+                            ),
+                        })
+                    }
+                    _ => None,
+                }
+            }
+        }
+        .map(Into::into)
+        .ok_or_else(|| {
+            comparison_mismatch(
+                self.context.types(),
+                op,
+                span,
+                left.ty(),
+                lhs.span(),
+                right.ty(),
+                rhs.span(),
+            )
+        })
+    }
+
+    /// Evaluates a numeric expression.
+    fn evaluate_numeric_expr(
+        &mut self,
+        op: NumericOperator,
+        lhs: &Expr,
+        rhs: &Expr,
+        span: Span,
+    ) -> Result<Value, Diagnostic> {
+        /// Implements numeric operations on integer operands.
+        fn int_numeric_op(
+            op: NumericOperator,
+            left: i64,
+            right: i64,
+            span: Span,
+            rhs_span: Span,
+        ) -> Result<i64, Diagnostic> {
+            match op {
+                NumericOperator::Addition => left
+                    .checked_add(right)
+                    .ok_or_else(|| numeric_overflow(span)),
+                NumericOperator::Subtraction => left
+                    .checked_sub(right)
+                    .ok_or_else(|| numeric_overflow(span)),
+                NumericOperator::Multiplication => left
+                    .checked_mul(right)
+                    .ok_or_else(|| numeric_overflow(span)),
+                NumericOperator::Division => {
+                    if right == 0 {
+                        return Err(division_by_zero(span, rhs_span));
+                    }
+
+                    left.checked_div(right)
+                        .ok_or_else(|| numeric_overflow(span))
+                }
+                NumericOperator::Modulo => {
+                    if right == 0 {
+                        return Err(division_by_zero(span, rhs_span));
+                    }
+
+                    left.checked_rem(right)
+                        .ok_or_else(|| numeric_overflow(span))
+                }
+                NumericOperator::Exponentiation => left
+                    .checked_pow(
+                        (right)
+                            .try_into()
+                            .map_err(|_| exponent_not_in_range(rhs_span))?,
+                    )
+                    .ok_or_else(|| numeric_overflow(span)),
+            }
+        }
+
+        /// Implements numeric operations on floating point operands.
+        fn float_numeric_op(op: NumericOperator, left: f64, right: f64) -> f64 {
+            match op {
+                NumericOperator::Addition => left + right,
+                NumericOperator::Subtraction => left - right,
+                NumericOperator::Multiplication => left * right,
+                NumericOperator::Division => left / right,
+                NumericOperator::Modulo => left % right,
+                NumericOperator::Exponentiation => left.pow(right),
+            }
+        }
+
+        let left = self.evaluate_expr(lhs)?;
+        let right = self.evaluate_expr(rhs)?;
+        match (&left, &right) {
+            (
+                Value::Primitive(PrimitiveValue::Integer(left)),
+                Value::Primitive(PrimitiveValue::Integer(right)),
+            ) => Some(int_numeric_op(op, *left, *right, span, rhs.span())?.into()),
+            (
+                Value::Primitive(PrimitiveValue::Float(left)),
+                Value::Primitive(PrimitiveValue::Float(right)),
+            ) => Some(float_numeric_op(op, left.0, right.0).into()),
+            (
+                Value::Primitive(PrimitiveValue::Integer(left)),
+                Value::Primitive(PrimitiveValue::Float(right)),
+            ) => Some(float_numeric_op(op, *left as f64, right.0).into()),
+            (
+                Value::Primitive(PrimitiveValue::Float(left)),
+                Value::Primitive(PrimitiveValue::Integer(right)),
+            ) => Some(float_numeric_op(op, left.0, *right as f64).into()),
+            (Value::Primitive(PrimitiveValue::String(left)), Value::Primitive(right))
+                if op == NumericOperator::Addition
+                    && !matches!(right, PrimitiveValue::Boolean(_)) =>
+            {
+                let s = match right {
+                    PrimitiveValue::Boolean(_) => unreachable!(),
+                    PrimitiveValue::Integer(v) => format!("{left}{v}"),
+                    PrimitiveValue::Float(v) => format!("{left}{v}"),
+                    PrimitiveValue::String(v)
+                    | PrimitiveValue::File(v)
+                    | PrimitiveValue::Directory(v) => format!("{left}{v}"),
+                };
+
+                Some(PrimitiveValue::new_string(s).into())
+            }
+            (Value::Primitive(left), Value::Primitive(PrimitiveValue::String(right)))
+                if op == NumericOperator::Addition
+                    && !matches!(left, PrimitiveValue::Boolean(_)) =>
+            {
+                let s = match left {
+                    PrimitiveValue::Boolean(_) => unreachable!(),
+                    PrimitiveValue::Integer(v) => format!("{v}{right}"),
+                    PrimitiveValue::Float(v) => format!("{v}{right}"),
+                    PrimitiveValue::String(v)
+                    | PrimitiveValue::File(v)
+                    | PrimitiveValue::Directory(v) => format!("{v}{right}"),
+                };
+
+                Some(PrimitiveValue::new_string(s).into())
+            }
+            (Value::Primitive(PrimitiveValue::String(_)), Value::None)
+            | (Value::None, Value::Primitive(PrimitiveValue::String(_)))
+                if op == NumericOperator::Addition && self.placeholders > 0 =>
+            {
+                // Allow string concatenation with `None` in placeholders, which evaluates to
+                // `None`
+                Some(Value::None)
+            }
+            _ => None,
+        }
+        .ok_or_else(|| {
+            numeric_mismatch(
+                self.context.types(),
+                op,
+                span,
+                left.ty(),
+                lhs.span(),
+                right.ty(),
+                rhs.span(),
+            )
+        })
+    }
+
+    /// Evaluates a call expression.
+    fn evaluate_call_expr(&mut self, expr: &CallExpr) -> Result<Value, Diagnostic> {
+        let target = expr.target();
+        match STDLIB.function(target.as_str()) {
+            Some(f) => {
+                let minimum_version = f.minimum_version();
+                if minimum_version > self.context.version() {
+                    return Err(unsupported_function(
+                        minimum_version,
+                        target.as_str(),
+                        target.span(),
+                    ));
+                }
+
+                let mut count = 0;
+                let mut types = [Type::Union; MAX_PARAMETERS];
+                let mut arguments = [const { Value::None }; MAX_PARAMETERS];
+
+                // Evaluate the argument expressions
+                for expr in expr.arguments() {
+                    let value = self.evaluate_expr(&expr)?;
+                    types[count] = value.ty();
+                    arguments[count] = value;
+                    count += 1;
+                }
+
+                // Bind the function based on the argument types
+                match f.bind(self.context.types_mut(), &types[0..count]) {
+                    Ok(_) => {
+                        todo!("implement function calls")
+                    }
+                    Err(FunctionBindError::TooFewArguments(minimum)) => Err(too_few_arguments(
+                        target.as_str(),
+                        target.span(),
+                        minimum,
+                        arguments.len(),
+                    )),
+                    Err(FunctionBindError::TooManyArguments(maximum)) => Err(too_many_arguments(
+                        target.as_str(),
+                        target.span(),
+                        maximum,
+                        arguments.len(),
+                        expr.arguments().skip(maximum).map(|e| e.span()),
+                    )),
+                    Err(FunctionBindError::ArgumentTypeMismatch { index, expected }) => {
+                        Err(argument_type_mismatch(
+                            self.context.types(),
+                            target.as_str(),
+                            &expected,
+                            types[index],
+                            expr.arguments()
+                                .nth(index)
+                                .map(|e| e.span())
+                                .expect("should have span"),
+                        ))
+                    }
+                    Err(FunctionBindError::Ambiguous { first, second }) => Err(ambiguous_argument(
+                        target.as_str(),
+                        target.span(),
+                        &first,
+                        &second,
+                    )),
+                }
+            }
+            None => Err(unknown_function(target.as_str(), target.span())),
+        }
+    }
+
+    /// Evaluates the type of an index expression.
+    fn evaluate_index_expr(&mut self, expr: &IndexExpr) -> Result<Value, Diagnostic> {
+        let (target, index) = expr.operands();
+        match self.evaluate_expr(&target)? {
+            Value::Compound(CompoundValue::Array(array)) => match self.evaluate_expr(&index)? {
+                Value::Primitive(PrimitiveValue::Integer(i)) => {
+                    match i.try_into().map(|i: usize| array.elements().get(i)) {
+                        Ok(Some(value)) => Ok(value.clone()),
+                        _ => Err(array_index_out_of_range(
+                            i,
+                            array.elements().len(),
+                            index.span(),
+                            target.span(),
+                        )),
+                    }
+                }
+                value => Err(index_type_mismatch(
+                    self.context.types(),
+                    PrimitiveTypeKind::Integer.into(),
+                    value.ty(),
+                    index.span(),
+                )),
+            },
+            Value::Compound(CompoundValue::Map(map)) => {
+                let ty = map.ty().as_compound().expect("type should be compound");
+                let key_type = match self.context.types().type_definition(ty.definition()) {
+                    CompoundTypeDef::Map(ty) => ty
+                        .key_type()
+                        .as_primitive()
+                        .expect("type should be primitive"),
+                    _ => panic!("expected a map type"),
+                };
+
+                match self.evaluate_expr(&index)? {
+                    Value::Primitive(i)
+                        if i.ty()
+                            .is_coercible_to(self.context.types(), &key_type.into()) =>
+                    {
+                        match map.elements().get(&i) {
+                            Some(value) => Ok(value.clone()),
+                            None => Err(map_key_not_found(index.span())),
+                        }
+                    }
+                    value => Err(index_type_mismatch(
+                        self.context.types(),
+                        key_type.into(),
+                        value.ty(),
+                        index.span(),
+                    )),
+                }
+            }
+            value => Err(cannot_index(
+                self.context.types(),
+                value.ty(),
+                target.span(),
+            )),
+        }
+    }
+
+    /// Evaluates the type of an access expression.
+    fn evaluate_access_expr(&mut self, expr: &AccessExpr) -> Result<Value, Diagnostic> {
+        let (target, name) = expr.operands();
+
+        // TODO: implement support for task values (required for WDL 1.2 support)
+        // TODO: add support for access to call outputs
+
+        match self.evaluate_expr(&target)? {
+            Value::Compound(CompoundValue::Pair(pair)) => match name.as_str() {
+                "left" => Ok(pair.left().clone()),
+                "right" => Ok(pair.right().clone()),
+                _ => Err(not_a_pair_accessor(&name)),
+            },
+            Value::Compound(CompoundValue::Struct(s)) => match s.members().get(name.as_str()) {
+                Some(value) => Ok(value.clone()),
+                None => Err(not_a_struct_member(
+                    self.context.types().struct_type(s.ty()).name(),
+                    &name,
+                )),
+            },
+            Value::Compound(CompoundValue::Object(object)) => {
+                match object.members().get(name.as_str()) {
+                    Some(value) => Ok(value.clone()),
+                    None => Err(not_an_object_member(&name)),
+                }
+            }
+            value => Err(cannot_access(
+                self.context.types(),
+                value.ty(),
+                target.span(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use pretty_assertions::assert_eq;
+    use wdl_analysis::diagnostics::unknown_name;
+    use wdl_analysis::diagnostics::unknown_type;
+    use wdl_analysis::types::StructType;
+    use wdl_grammar::construct_tree;
+    use wdl_grammar::grammar::v1;
+    use wdl_grammar::lexer::Lexer;
+
+    use super::*;
+    use crate::ScopeRef;
+    use crate::eval::Scope;
+
+    /// Represents test evaluation context to an expression evaluator.
+    #[derive(Debug)]
+    pub struct TestEvaluationContext<'a> {
+        /// The types collection.
+        types: &'a mut Types,
+        /// The supported version of WDL being evaluated.
+        version: SupportedVersion,
+        /// The map of known struct types.
+        structs: HashMap<&'static str, Type>,
+        /// The current evaluation scope.
+        scope: ScopeRef<'a>,
+        /// The stdout value from a task's execution.
+        stdout: Option<Value>,
+        /// The stderr value from a task's execution.
+        stderr: Option<Value>,
+    }
+
+    impl<'a> TestEvaluationContext<'a> {
+        /// Constructs a test evaluation context.
+        pub fn new(version: SupportedVersion, types: &'a mut Types, scope: ScopeRef<'a>) -> Self {
+            Self {
+                types,
+                version,
+                structs: HashMap::new(),
+                scope,
+                stdout: None,
+                stderr: None,
+            }
+        }
+    }
+
+    impl EvaluationContext for TestEvaluationContext<'_> {
+        fn version(&self) -> SupportedVersion {
+            self.version
+        }
+
+        fn types(&self) -> &Types {
+            &self.types
+        }
+
+        fn types_mut(&mut self) -> &mut Types {
+            &mut self.types
+        }
+
+        fn resolve_name(&self, name: &Ident) -> Result<Value, Diagnostic> {
+            self.scope
+                .lookup(name.as_str())
+                .map(|v| v.clone())
+                .ok_or_else(|| unknown_name(name.as_str(), name.span()))
+        }
+
+        fn resolve_type_name(&self, name: &Ident) -> Result<Type, Diagnostic> {
+            self.structs
+                .get(name.as_str())
+                .copied()
+                .ok_or_else(|| unknown_type(name.as_str(), name.span()))
+        }
+
+        fn stdout(&self) -> Option<Value> {
+            self.stdout.clone()
+        }
+
+        fn stderr(&self) -> Option<Value> {
+            self.stderr.clone()
+        }
+    }
+
+    /// Evaluates a WDL v1 expression and returns the value or a
+    /// parse/evaluation diagnostic.
+    fn eval_v1_expr(
+        version: V1,
+        source: &str,
+        types: &mut Types,
+        scope: ScopeRef<'_>,
+    ) -> Result<Value, Diagnostic> {
+        eval_v1_expr_with_context(
+            source,
+            &mut TestEvaluationContext::new(SupportedVersion::V1(version), types, scope),
+        )
+    }
+
+    /// Evaluates a WDL v1 expression and returns the value or a
+    /// parse/evaluation diagnostic.
+    fn eval_v1_expr_with_context(
+        source: &str,
+        context: &mut TestEvaluationContext<'_>,
+    ) -> Result<Value, Diagnostic> {
+        let source = source.trim();
+        let mut parser = v1::Parser::new(Lexer::new(source));
+        let marker = parser.start();
+        match v1::expr(&mut parser, marker) {
+            Ok(()) => {
+                // This call to `next` is important as `next` adds any remaining buffered events
+                assert!(
+                    parser.next().is_none(),
+                    "parser is not finished; expected a single expression with no remaining tokens"
+                );
+                let output = parser.finish();
+                assert_eq!(
+                    output.diagnostics.iter().next(),
+                    None,
+                    "the provided WDL source failed to parse"
+                );
+                let expr = Expr::cast(construct_tree(source, output.events))
+                    .expect("should be an expression");
+                let mut evaluator = ExprEvaluator::new(context);
+                evaluator.evaluate_expr(&expr)
+            }
+            Err((marker, diagnostic)) => {
+                marker.abandon(&mut parser);
+                Err(diagnostic)
+            }
+        }
+    }
+
+    #[test]
+    fn literal_none_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "None", &mut types, scope).unwrap();
+        assert_eq!(value.to_string(), "None");
+    }
+
+    #[test]
+    fn literal_bool_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "true", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_boolean(), true);
+
+        let value = eval_v1_expr(V1::Two, "false", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_boolean(), false);
+    }
+
+    #[test]
+    fn literal_int_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "12345", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 12345);
+
+        let value = eval_v1_expr(V1::Two, "-54321", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), -54321);
+
+        let value = eval_v1_expr(V1::Two, "0xdeadbeef", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 0xDEADBEEF);
+
+        let value = eval_v1_expr(V1::Two, "0777", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 0o777);
+
+        let value = eval_v1_expr(V1::Two, "-9223372036854775808", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), -9223372036854775808);
+
+        let diagnostic = eval_v1_expr(V1::Two, "9223372036854775808", &mut types, scope)
+            .expect_err("should fail");
+        assert_eq!(
+            diagnostic.message(),
+            "literal integer exceeds the range for a 64-bit signed integer \
+             (-9223372036854775808..=9223372036854775807)"
+        );
+
+        let diagnostic = eval_v1_expr(V1::Two, "-9223372036854775809", &mut types, scope)
+            .expect_err("should fail");
+        assert_eq!(
+            diagnostic.message(),
+            "literal integer exceeds the range for a 64-bit signed integer \
+             (-9223372036854775808..=9223372036854775807)"
+        );
+    }
+
+    #[test]
+    fn literal_float_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "12345.6789", &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 12345.6789);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "-12345.6789", &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), -12345.6789);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "1.7976931348623157E+308", &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 1.7976931348623157E+308);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "-1.7976931348623157E+308", &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), -1.7976931348623157E+308);
+
+        let diagnostic = eval_v1_expr(V1::Two, "2.7976931348623157E+308", &mut types, scope)
+            .expect_err("should fail");
+        assert_eq!(
+            diagnostic.message(),
+            "literal float exceeds the range for a 64-bit float \
+             (-1.7976931348623157e308..=+1.7976931348623157e308)"
+        );
+
+        let diagnostic = eval_v1_expr(V1::Two, "-2.7976931348623157E+308", &mut types, scope)
+            .expect_err("should fail");
+        assert_eq!(
+            diagnostic.message(),
+            "literal float exceeds the range for a 64-bit float \
+             (-1.7976931348623157e308..=+1.7976931348623157e308)"
+        );
+    }
+
+    #[test]
+    fn literal_string_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "'hello\nworld'", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "hello\nworld");
+
+        let value = eval_v1_expr(V1::Two, r#""hello world""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "hello world");
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#"<<<
+        hello  \
+            world
+    >>>"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "hello  world");
+    }
+
+    #[test]
+    fn string_placeholders() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("str", PrimitiveValue::new_string("foo"));
+        root_scope.insert("file", PrimitiveValue::new_file("bar"));
+        root_scope.insert("dir", PrimitiveValue::new_directory("baz"));
+        root_scope.insert("salutation", PrimitiveValue::new_string("hello"));
+        root_scope.insert("name1", Value::None);
+        root_scope.insert("name2", PrimitiveValue::new_string("Fred"));
+        root_scope.insert("spaces", PrimitiveValue::new_string("  "));
+        root_scope.insert("name", PrimitiveValue::new_string("Henry"));
+        root_scope.insert("company", PrimitiveValue::new_string("Acme"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, r#""~{None}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "");
+
+        let value = eval_v1_expr(V1::Two, r#""~{default="hi" None}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "hi");
+
+        let value = eval_v1_expr(V1::Two, r#""~{true}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "true");
+
+        let value = eval_v1_expr(V1::Two, r#""~{false}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "false");
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#""~{true="yes" false="no" false}""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "no");
+
+        let value = eval_v1_expr(V1::Two, r#""~{12345}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "12345");
+
+        let value = eval_v1_expr(V1::Two, r#""~{12345.6789}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "12345.6789");
+
+        let value = eval_v1_expr(V1::Two, r#""~{str}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foo");
+
+        let value = eval_v1_expr(V1::Two, r#""~{file}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "bar");
+
+        let value = eval_v1_expr(V1::Two, r#""~{dir}""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "baz");
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#""~{sep="+" [1,2,3]} = ~{1 + 2 + 3}""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "1+2+3 = 6");
+
+        let diagnostic =
+            eval_v1_expr(V1::Two, r#""~{[1, 2, 3]}""#, &mut types, scope).expect_err("should fail");
+        assert_eq!(
+            diagnostic.message(),
+            "cannot coerce type `Array[Int]` to `String`"
+        );
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#""~{salutation + ' ' + name1 + ', '}nice to meet you!""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "nice to meet you!");
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#""${salutation + ' ' + name2 + ', '}nice to meet you!""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_string().as_str(),
+            "hello Fred, nice to meet you!"
+        );
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#"
+    <<<
+        ~{spaces}Hello ~{name},
+        ~{spaces}Welcome to ~{company}!
+    >>>"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_string().as_str(),
+            "  Hello Henry,\n  Welcome to Acme!"
+        );
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#""~{1 + 2 + 3 + 4 * 10 * 10} ~{"~{<<<~{'!' + '='}>>>}"} ~{10**3}""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "406 != 1000");
+    }
+
+    #[test]
+    fn literal_array_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "[]", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_array().to_string(), "[]");
+
+        let value = eval_v1_expr(V1::Two, "[1, 2, 3]", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_array().to_string(), "[1, 2, 3]");
+
+        let value = eval_v1_expr(V1::Two, "[[1], [2], [3.0]]", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_array().to_string(), "[[1.0], [2.0], [3.0]]");
+
+        let value = eval_v1_expr(V1::Two, r#"["foo", "bar", "baz"]"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_array().to_string(), r#"["foo", "bar", "baz"]"#);
+    }
+
+    #[test]
+    fn literal_pair_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "(true, false)", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_pair().to_string(), "(true, false)");
+
+        let value = eval_v1_expr(V1::Two, "([1, 2, 3], [4, 5, 6])", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_pair().to_string(), "([1, 2, 3], [4, 5, 6])");
+
+        let value = eval_v1_expr(V1::Two, "([], {})", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_pair().to_string(), "([], {})");
+
+        let value = eval_v1_expr(V1::Two, r#"("foo", "bar")"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_pair().to_string(), r#"("foo", "bar")"#);
+    }
+
+    #[test]
+    fn literal_map_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "{}", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_map().to_string(), "{}");
+
+        let value = eval_v1_expr(V1::Two, "{ 1: 2, 3: 4, 5: 6 }", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_map().to_string(), "{1: 2, 3: 4, 5: 6}");
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#"{"foo": "bar", "baz": "qux"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_map().to_string(),
+            r#"{"foo": "bar", "baz": "qux"}"#
+        );
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#"{"foo": { 1: 2 }, "baz": {}}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_map().to_string(),
+            r#"{"foo": {1: 2}, "baz": {}}"#
+        );
+
+        let value =
+            eval_v1_expr(V1::Two, r#"{"foo": 100, "baz": 2.5}"#, &mut types, scope).unwrap();
+        assert_eq!(
+            value.unwrap_map().to_string(),
+            r#"{"foo": 100.0, "baz": 2.5}"#
+        );
+    }
+
+    #[test]
+    fn literal_object_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Two, "object {}", &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_object().to_string(), "object {}");
+
+        let value = eval_v1_expr(
+            V1::Two,
+            "object { foo: 2, bar: 4, baz: 6 }",
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_object().to_string(),
+            "object {foo: 2, bar: 4, baz: 6}"
+        );
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#"object {foo: "bar", baz: "qux"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_object().to_string(),
+            r#"object {foo: "bar", baz: "qux"}"#
+        );
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#"object {foo: { 1: 2 }, bar: [], qux: "jam"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_object().to_string(),
+            r#"object {foo: {1: 2}, bar: [], qux: "jam"}"#
+        );
+
+        let value = eval_v1_expr(
+            V1::Two,
+            r#"object {foo: 1.0, bar: object { baz: "qux" }}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_object().to_string(),
+            r#"object {foo: 1.0, bar: object {baz: "qux"}}"#
+        );
+    }
+
+    #[test]
+    fn literal_struct_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let bar_ty = types.add_struct(StructType::new("Bar", [
+            ("foo", PrimitiveTypeKind::File),
+            ("bar", PrimitiveTypeKind::Integer),
+        ]));
+
+        let foo_ty = types.add_struct(StructType::new("Foo", [
+            ("foo", PrimitiveTypeKind::Float.into()),
+            (
+                "bar",
+                Type::Compound(bar_ty.as_compound().expect("should be a compound type")),
+            ),
+        ]));
+
+        let mut context =
+            TestEvaluationContext::new(SupportedVersion::V1(V1::Two), &mut types, scope);
+        context.structs.insert("Foo", foo_ty);
+        context.structs.insert("Bar", bar_ty);
+
+        let value = eval_v1_expr_with_context(
+            r#"Foo { foo: 1.0, bar: Bar { foo: "baz", bar: 2 }}"#,
+            &mut context,
+        )
+        .unwrap();
+        assert_eq!(
+            value.unwrap_struct().to_string(),
+            r#"Foo {foo: 1.0, bar: Bar {foo: "baz", bar: 2}}"#
+        );
+
+        let value = eval_v1_expr_with_context(r#"Foo { foo: 1, bar: Bar { foo: "baz", bar: 2 }} == Foo { foo: 1.0, bar: Bar { foo: "baz", bar: 2 }}"#, &mut context)
+            .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr_with_context(r#"Foo { foo: 1, bar: Bar { foo: "baz", bar: 2 }} == Foo { foo: 1.0, bar: Bar { foo: "jam", bar: 2 }}"#, &mut context)
+            .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr_with_context(r#"Foo { foo: 1, bar: Bar { foo: "baz", bar: 2 }} != Foo { foo: 1.0, bar: Bar { foo: "baz", bar: 2 }}"#, &mut context)
+            .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr_with_context(r#"Foo { foo: 1, bar: Bar { foo: "baz", bar: 2 }} != Foo { foo: 1.0, bar: Bar { foo: "jam", bar: 2 }}"#, &mut context)
+            .unwrap();
+        assert!(value.unwrap_boolean());
+    }
+
+    #[test]
+    fn name_ref_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", 1234);
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"foo"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 1234);
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"bar"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "unknown name `bar`");
+    }
+
+    #[test]
+    fn parenthesized_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", 1234);
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value =
+            eval_v1_expr(V1::Zero, r#"(foo - foo) + (1234 - foo)"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 0);
+    }
+
+    #[test]
+    fn if_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", true);
+        root_scope.insert("bar", false);
+        root_scope.insert("baz", PrimitiveValue::new_file("file"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"if (foo) then "foo" else "bar""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foo");
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"if (bar) then "foo" else "bar""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "bar");
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"if (foo) then 1234 else 0.5"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 1234.0);
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"if (bar) then 1234 else 0.5"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 0.5);
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"if (foo) then baz else "str""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_file().as_str(), "file");
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"if (bar) then baz else "path""#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_file().as_str(), "path");
+    }
+
+    #[test]
+    fn logical_not_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"!true"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"!false"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+    }
+
+    #[test]
+    fn negation_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"-1234"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), -1234);
+
+        let value = eval_v1_expr(V1::Zero, r#"-(1234)"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), -1234);
+
+        let value = eval_v1_expr(V1::Zero, r#"----1234"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 1234);
+
+        let value = eval_v1_expr(V1::Zero, r#"-1234.5678"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), -1234.5678);
+
+        let value = eval_v1_expr(V1::Zero, r#"-(1234.5678)"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), -1234.5678);
+
+        let value = eval_v1_expr(V1::Zero, r#"----1234.5678"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 1234.5678);
+    }
+
+    #[test]
+    fn logical_or_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"false || false"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"false || true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true || false"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true || true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true || nope"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"false || nope"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "unknown name `nope`");
+    }
+
+    #[test]
+    fn logical_and_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"false && false"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"false && true"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true && false"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true && true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"false && nope"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"true && nope"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "unknown name `nope`");
+    }
+
+    #[test]
+    fn equality_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", PrimitiveValue::new_file("foo"));
+        root_scope.insert("bar", PrimitiveValue::new_directory("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"None == None"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true == true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234 == 1234"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234 == 4321"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234 == 1234.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"4321 == 1234.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.0 == 1234"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.0 == 4321"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.5678 == 1234.5678"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.5678 == 8765.4321"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" == "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" == "bar""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" == foo"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" == bar"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo == "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo == "bar""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar == "bar""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar == "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"(1234, "bar") == (1234, "bar")"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"(1234, "bar") == (1234, "baz")"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"[1, 2, 3] == [1, 2, 3]"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"[1] == [2, 3]"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"[1] == [2]"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"{"foo": 1, "bar": 2, "baz": 3} == {"foo": 1, "bar": 2, "baz": 3}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"{"foo": 1, "bar": 2, "baz": 3} == {"foo": 1, "baz": 3}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"{"foo": 1, "bar": 2, "baz": 3} == {"foo": 3, "bar": 2, "baz": 1}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object {foo: 1, bar: 2, baz: "3"} == object {foo: 1, bar: 2, baz: "3"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object {foo: 1, bar: 2, baz: "3"} == object {foo: 1, baz: "3"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object {foo: 1, bar: 2, baz: "3"} == object {foo: 3, bar: 2, baz: "1"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        // Note: struct equality is handled in the struct literal test
+    }
+
+    #[test]
+    fn inequality_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", PrimitiveValue::new_file("foo"));
+        root_scope.insert("bar", PrimitiveValue::new_directory("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"None != None"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true != true"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234 != 1234"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234 != 4321"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234 != 1234.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"4321 != 1234.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.0 != 1234"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.0 != 4321"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.5678 != 1234.5678"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.5678 != 8765.4321"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" != "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" != "bar""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" != foo"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" != bar"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo != "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo != "bar""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar != "bar""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar != "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"(1234, "bar") != (1234, "bar")"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"(1234, "bar") != (1234, "baz")"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"[1, 2, 3] != [1, 2, 3]"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"[1] != [2, 3]"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"[1] != [2]"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"{"foo": 1, "bar": 2, "baz": 3} != {"foo": 1, "bar": 2, "baz": 3}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"{"foo": 1, "bar": 2, "baz": 3} != {"foo": 1, "baz": 3}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"{"foo": 1, "bar": 2, "baz": 3} != {"foo": 3, "bar": 2, "baz": 1}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object {foo: 1, bar: 2, baz: "3"} != object {foo: 1, bar: 2, baz: "3"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object {foo: 1, bar: 2, baz: "3"} != object {foo: 1, baz: "3"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object {foo: 1, bar: 2, baz: "3"} != object {foo: 3, bar: 2, baz: "1"}"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert!(value.unwrap_boolean());
+
+        // Note: struct inequality is handled in the struct literal test
+    }
+
+    #[test]
+    fn less_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", PrimitiveValue::new_file("foo"));
+        root_scope.insert("bar", PrimitiveValue::new_directory("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"false < true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true < false"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true < true"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 < 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 < 0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 < 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 < 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 < 0.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 < 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 < 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 < 0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 < 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 < 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 < 0.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 < 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""bar" < "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" < "bar""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" < "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar < "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar < bar"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo < "bar""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo < foo"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+    }
+
+    #[test]
+    fn less_equal_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", PrimitiveValue::new_file("foo"));
+        root_scope.insert("bar", PrimitiveValue::new_directory("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"false <= true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true <= false"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true <= true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 <= 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 <= 0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 <= 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 <= 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 <= 0.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 <= 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 <= 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 <= 0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 <= 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 <= 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 <= 0.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 <= 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""bar" <= "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" <= "bar""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" <= "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar <= "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar <= bar"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo <= "bar""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo <= foo"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+    }
+
+    #[test]
+    fn greater_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", PrimitiveValue::new_file("foo"));
+        root_scope.insert("bar", PrimitiveValue::new_directory("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"false > true"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true > false"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true > true"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 > 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 > 0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 > 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 > 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 > 0.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 > 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 > 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 > 0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 > 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 > 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 > 0.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 > 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""bar" > "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" > "bar""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" > "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar > "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar > bar"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo > "bar""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo > foo"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+    }
+
+    #[test]
+    fn greater_equal_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", PrimitiveValue::new_file("foo"));
+        root_scope.insert("bar", PrimitiveValue::new_directory("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"false >= true"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true >= false"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"true >= true"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 >= 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 >= 0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 >= 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0 >= 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 >= 0.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1 >= 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 >= 1"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 >= 0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 >= 1"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"0.0 >= 1.0"#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 >= 0.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"1.0 >= 1.0"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""bar" >= "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" >= "bar""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" >= "foo""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar >= "foo""#, &mut types, scope).unwrap();
+        assert!(!value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"bar >= bar"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo >= "bar""#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+
+        let value = eval_v1_expr(V1::Zero, r#"foo >= foo"#, &mut types, scope).unwrap();
+        assert!(value.unwrap_boolean());
+    }
+
+    #[test]
+    fn addition_expr() {
+        let mut root_scope = Scope::new(None);
+        root_scope.insert("foo", PrimitiveValue::new_file("foo"));
+        root_scope.insert("bar", PrimitiveValue::new_directory("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"1 + 2 + 3 + 4"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 10);
+
+        let value = eval_v1_expr(V1::Zero, r#"10 + 20.0 + 30 + 40.0"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 100.0);
+
+        let value =
+            eval_v1_expr(V1::Zero, r#"100.0 + 200 + 300.0 + 400"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 1000.0);
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"1000.5 + 2000.5 + 3000.5 + 4000.5"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 10002.0);
+
+        let diagnostic = eval_v1_expr(
+            V1::Zero,
+            &format!(r#"{max} + 1"#, max = i64::MAX),
+            &mut types,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "evaluation of arithmetic expression resulted in overflow"
+        );
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" + 1234"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foo1234");
+
+        let value = eval_v1_expr(V1::Zero, r#"1234 + "foo""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "1234foo");
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" + 1234.456"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foo1234.456");
+
+        let value = eval_v1_expr(V1::Zero, r#"1234.456 + "foo""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "1234.456foo");
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" + "bar""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foobar");
+
+        let value = eval_v1_expr(V1::Zero, r#""bar" + "foo""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "barfoo");
+
+        let value = eval_v1_expr(V1::Zero, r#"foo + "bar""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foobar");
+
+        let value = eval_v1_expr(V1::Zero, r#""bar" + foo"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "barfoo");
+
+        let value = eval_v1_expr(V1::Zero, r#""foo" + bar"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foobar");
+
+        let value = eval_v1_expr(V1::Zero, r#"bar + "foo""#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "barfoo");
+    }
+
+    #[test]
+    fn subtraction_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"-1 - 2 - 3 - 4"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), -10);
+
+        let value = eval_v1_expr(V1::Zero, r#"-10 - 20.0 - 30 - 40.0"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), -100.0);
+
+        let value =
+            eval_v1_expr(V1::Zero, r#"-100.0 - 200 - 300.0 - 400"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), -1000.0);
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"-1000.5 - 2000.5 - 3000.5 - 4000.5"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), -10002.0);
+
+        let diagnostic = eval_v1_expr(
+            V1::Zero,
+            &format!(r#"{min} - 1"#, min = i64::MIN),
+            &mut types,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "evaluation of arithmetic expression resulted in overflow"
+        );
+    }
+
+    #[test]
+    fn multiplication_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"1 * 2 * 3 * 4"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 24);
+
+        let value = eval_v1_expr(V1::Zero, r#"10 * 20.0 * 30 * 40.0"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 240000.0);
+
+        let value =
+            eval_v1_expr(V1::Zero, r#"100.0 * 200 * 300.0 * 400"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 2400000000.0);
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"1000.5 * 2000.5 * 3000.5 * 4000.5"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 24025008751250.063);
+
+        let diagnostic = eval_v1_expr(
+            V1::Zero,
+            &format!(r#"{max} * 2"#, max = i64::MAX),
+            &mut types,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "evaluation of arithmetic expression resulted in overflow"
+        );
+    }
+
+    #[test]
+    fn division_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"5 / 2"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 2);
+
+        let value = eval_v1_expr(V1::Zero, r#"10 / 20.0 / 30 / 40.0"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 0.00041666666666666664);
+
+        let value =
+            eval_v1_expr(V1::Zero, r#"100.0 / 200 / 300.0 / 400"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 4.166666666666667e-6);
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"1000.5 / 2000.5 / 3000.5 / 4000.5"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 4.166492759125078e-8);
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"10 / 0"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "attempt to divide by zero");
+
+        let diagnostic = eval_v1_expr(
+            V1::Zero,
+            &format!(r#"{min} / -1"#, min = i64::MIN),
+            &mut types,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "evaluation of arithmetic expression resulted in overflow"
+        );
+    }
+
+    #[test]
+    fn modulo_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let value = eval_v1_expr(V1::Zero, r#"5 % 2"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 1);
+
+        let value = eval_v1_expr(V1::Zero, r#"5.5 % 2"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 1.5);
+
+        let value = eval_v1_expr(V1::Zero, r#"5 % 2.5"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 0.0);
+
+        let value = eval_v1_expr(V1::Zero, r#"5.25 % 1.3"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 0.04999999999999982);
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"5 % 0"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "attempt to divide by zero");
+
+        let diagnostic = eval_v1_expr(
+            V1::Zero,
+            &format!(r#"{min} % -1"#, min = i64::MIN),
+            &mut types,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "evaluation of arithmetic expression resulted in overflow"
+        );
+    }
+
+    #[test]
+    fn exponentiation_expr() {
+        let scopes = &[Scope::new(None)];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let mut types = Types::default();
+        let diagnostic = eval_v1_expr(V1::Zero, r#"10 ** 0"#, &mut types, scope).unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "use of the exponentiation operator requires WDL version 1.2"
+        );
+
+        let value = eval_v1_expr(V1::Two, r#"5 ** 2 ** 2"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 625);
+
+        let value = eval_v1_expr(V1::Two, r#"5 ** 2.0 ** 2"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 625.0);
+
+        let value = eval_v1_expr(V1::Two, r#"5 ** 2 ** 2.0"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 625.0);
+
+        let value = eval_v1_expr(V1::Two, r#"5.0 ** 2.0 ** 2.0"#, &mut types, scope).unwrap();
+        approx::assert_relative_eq!(value.unwrap_float(), 625.0);
+
+        let diagnostic = eval_v1_expr(
+            V1::Two,
+            &format!(r#"{max} ** 2"#, max = i64::MAX),
+            &mut types,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "evaluation of arithmetic expression resulted in overflow"
+        );
+    }
+
+    #[test]
+    fn index_expr() {
+        let mut types = Types::default();
+        let array_ty = types.add_array(ArrayType::new(PrimitiveTypeKind::Integer));
+        let map_ty = types.add_map(MapType::new(
+            PrimitiveTypeKind::String,
+            PrimitiveTypeKind::Integer,
+        ));
+
+        let mut root_scope = Scope::new(None);
+        root_scope.insert(
+            "foo",
+            Array::new(&types, array_ty, [1, 2, 3, 4, 5]).unwrap(),
+        );
+        root_scope.insert(
+            "bar",
+            Map::new(&types, map_ty, [
+                (PrimitiveValue::new_string("foo"), 1),
+                (PrimitiveValue::new_string("bar"), 2),
+            ])
+            .unwrap(),
+        );
+        root_scope.insert("baz", PrimitiveValue::new_file("bar"));
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let value = eval_v1_expr(V1::Zero, r#"foo[1]"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 2);
+
+        let value = eval_v1_expr(V1::Zero, r#"foo[foo[[1, 2, 3][0]]]"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 3);
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"foo[10]"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "array index 10 is out of range");
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"foo["10"]"#, &mut types, scope).unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "type mismatch: expected index to be type `Int`, but found type `String`"
+        );
+
+        let value = eval_v1_expr(V1::Zero, r#"bar["foo"]"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 1);
+
+        let value = eval_v1_expr(V1::Zero, r#"bar[baz]"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 2);
+
+        let value = eval_v1_expr(V1::Zero, r#"foo[bar["foo"]]"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 2);
+
+        let diagnostic =
+            eval_v1_expr(V1::Zero, r#"bar["does not exist"]"#, &mut types, scope).unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "the map does not contain an entry for the specified key"
+        );
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"bar[1]"#, &mut types, scope).unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "type mismatch: expected index to be type `String`, but found type `Int`"
+        );
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"1[0]"#, &mut types, scope).unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "indexing is only allowed on `Array` and `Map` types"
+        );
+    }
+
+    #[test]
+    fn access_expr() {
+        let mut types = Types::default();
+        let pair_ty = types.add_pair(PairType::new(
+            PrimitiveTypeKind::Integer,
+            PrimitiveTypeKind::String,
+        ));
+        let struct_ty = types.add_struct(StructType::new("Foo", [
+            ("foo", PrimitiveTypeKind::Integer),
+            ("bar", PrimitiveTypeKind::String),
+        ]));
+
+        let mut root_scope = Scope::new(None);
+        root_scope.insert(
+            "foo",
+            Pair::new(&types, pair_ty, 1, PrimitiveValue::new_string("foo")).unwrap(),
+        );
+        root_scope.insert(
+            "bar",
+            Struct::new(&types, struct_ty, [
+                ("foo", 1.into()),
+                ("bar", PrimitiveValue::new_string("bar")),
+            ])
+            .unwrap(),
+        );
+        root_scope.insert("baz", 1);
+
+        let scopes = &[root_scope];
+        let scope = ScopeRef::new(scopes, 0);
+
+        let value = eval_v1_expr(V1::Zero, r#"foo.left"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 1);
+
+        let value = eval_v1_expr(V1::Zero, r#"foo.right"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foo");
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"foo.bar"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "cannot access a pair with name `bar`");
+
+        let value = eval_v1_expr(V1::Zero, r#"bar.foo"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_integer(), 1);
+
+        let value = eval_v1_expr(V1::Zero, r#"bar.bar"#, &mut types, scope).unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "bar");
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"bar.baz"#, &mut types, scope).unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "struct `Foo` does not have a member named `baz`"
+        );
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object { foo: 1, bar: "bar" }.foo"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_integer(), 1);
+
+        let value = eval_v1_expr(
+            V1::Zero,
+            r#"object { foo: 1, bar: "bar" }.bar"#,
+            &mut types,
+            scope,
+        )
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "bar");
+
+        let diagnostic = eval_v1_expr(
+            V1::Zero,
+            r#"object { foo: 1, bar: "bar" }.baz"#,
+            &mut types,
+            scope,
+        )
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "object does not have a member named `baz`"
+        );
+
+        let diagnostic = eval_v1_expr(V1::Zero, r#"baz.foo"#, &mut types, scope).unwrap_err();
+        assert_eq!(diagnostic.message(), "cannot access type `Int`");
+    }
+}

--- a/wdl-engine/src/lib.rs
+++ b/wdl-engine/src/lib.rs
@@ -1,11 +1,14 @@
 //! Execution engine for Workflow Description Language (WDL) documents.
 
+pub mod diagnostics;
 mod engine;
+mod eval;
 mod inputs;
 mod outputs;
 mod value;
 
 pub use engine::*;
+pub use eval::*;
 pub use inputs::*;
 pub use outputs::*;
 pub use value::*;

--- a/wdl-engine/src/value.rs
+++ b/wdl-engine/src/value.rs
@@ -1,64 +1,55 @@
 //! Implementation of the WDL runtime and values.
 
+use std::cmp::Ordering;
 use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::Arc;
 
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
-use id_arena::Id;
 use indexmap::IndexMap;
 use ordered_float::OrderedFloat;
 use serde_json::Value as JsonValue;
-use string_interner::symbol::SymbolU32;
 use wdl_analysis::types::ArrayType;
 use wdl_analysis::types::CompoundTypeDef;
 use wdl_analysis::types::Optional;
 use wdl_analysis::types::PrimitiveTypeKind;
 use wdl_analysis::types::Type;
-
-use crate::Engine;
+use wdl_analysis::types::TypeEq;
+use wdl_analysis::types::Types;
 
 /// Implemented on coercible values.
 pub trait Coercible: Sized {
     /// Coerces the value into the given type.
     ///
-    /// Returns `None` if the coercion is not supported.
+    /// Returns an error if the coercion is not supported.
     ///
     /// # Panics
     ///
-    /// Panics if the provided target type is not from the given engine's type
+    /// Panics if the provided target type is not from the given types
     /// collection.
-    fn coerce(&self, engine: &mut Engine, target: Type) -> Result<Self>;
+    fn coerce(&self, types: &Types, target: Type) -> Result<Self>;
 }
 
 /// Represents a WDL runtime value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub enum Value {
-    /// The value is a `Boolean`.
-    Boolean(bool),
-    /// The value is an `Int`.
-    Integer(i64),
-    /// The value is a `Float`.
-    Float(OrderedFloat<f64>),
-    /// The value is a `String`.
-    String(SymbolU32),
-    /// The value is a `File`.
-    File(SymbolU32),
-    /// The value is a `Directory`.
-    Directory(SymbolU32),
     /// The value is a literal `None` value.
     None,
+    /// The value is a primitive value.
+    Primitive(PrimitiveValue),
     /// The value is a compound value.
-    Compound(CompoundValueId),
+    Compound(CompoundValue),
 }
 
 impl Value {
     /// Converts a JSON value into a WDL value.
     ///
     /// Returns an error if the JSON value cannot be represented as a WDL value.
-    pub fn from_json(engine: &mut Engine, value: JsonValue) -> Result<Self> {
+    pub fn from_json(types: &mut Types, value: JsonValue) -> Result<Self> {
         match value {
             JsonValue::Null => Ok(Value::None),
             JsonValue::Bool(value) => Ok(value.into()),
@@ -71,52 +62,450 @@ impl Value {
                     bail!("number `{number}` is out of range for a WDL value")
                 }
             }
-            JsonValue::String(s) => Ok(engine.new_string(s)),
+            JsonValue::String(s) => Ok(PrimitiveValue::new_string(s).into()),
             JsonValue::Array(elements) => {
                 let elements = elements
                     .into_iter()
-                    .map(|v| Self::from_json(engine, v))
+                    .map(|v| Self::from_json(types, v))
                     .collect::<Result<Vec<_>>>()?;
 
                 let element_ty = elements
                     .iter()
                     .try_fold(None, |mut ty, element| {
-                        let element_ty = element.ty(engine);
+                        let element_ty = element.ty();
                         let ty = ty.get_or_insert(element_ty);
-                        ty.common_type(engine.types(), element_ty)
-                            .map(Some)
-                            .ok_or_else(|| {
-                                anyhow!(
-                                    "a common element type does not exist between `{ty}` and \
-                                     `{element_ty}`",
-                                    ty = ty.display(engine.types()),
-                                    element_ty = element_ty.display(engine.types())
-                                )
-                            })
+                        ty.common_type(types, element_ty).map(Some).ok_or_else(|| {
+                            anyhow!(
+                                "a common element type does not exist between `{ty}` and \
+                                 `{element_ty}`",
+                                ty = ty.display(types),
+                                element_ty = element_ty.display(types)
+                            )
+                        })
                     })
                     .context("invalid WDL array value")?
                     .unwrap_or(Type::Union);
 
-                let ty = engine.types_mut().add_array(ArrayType::new(element_ty));
-                engine.new_array(ty, elements).with_context(|| {
-                    format!(
-                        "cannot coerce value to `{ty}`",
-                        ty = ty.display(engine.types())
-                    )
-                })
+                let ty = types.add_array(ArrayType::new(element_ty));
+                Ok(Array::new(types, ty, elements)
+                    .with_context(|| {
+                        format!("cannot coerce value to `{ty}`", ty = ty.display(types))
+                    })?
+                    .into())
             }
-            JsonValue::Object(elements) => {
-                let elements = elements
+            JsonValue::Object(elements) => Ok(Object::new(
+                elements
                     .into_iter()
-                    .map(|(k, v)| Ok((k, Self::from_json(engine, v)?)))
-                    .collect::<Result<Vec<_>>>()?;
-                Ok(engine.new_object(elements))
-            }
+                    .map(|(k, v)| Ok((k, Self::from_json(types, v)?)))
+                    .collect::<Result<Vec<_>>>()?,
+            )
+            .into()),
         }
     }
 
     /// Gets the type of the value.
-    pub fn ty(&self, engine: &Engine) -> Type {
+    pub fn ty(&self) -> Type {
+        match self {
+            Self::None => Type::None,
+            Self::Primitive(v) => v.ty(),
+            Self::Compound(v) => v.ty(),
+        }
+    }
+
+    /// Determines if the value is `None`.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    /// Gets the value as a `Boolean`.
+    ///
+    /// Returns `None` if the value is not a `Boolean`.
+    pub fn as_boolean(&self) -> Option<bool> {
+        match self {
+            Self::Primitive(PrimitiveValue::Boolean(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Boolean`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Boolean`.
+    pub fn unwrap_boolean(self) -> bool {
+        match self {
+            Self::Primitive(PrimitiveValue::Boolean(v)) => v,
+            _ => panic!("value is not a boolean"),
+        }
+    }
+
+    /// Gets the value as an `Int`.
+    ///
+    /// Returns `None` if the value is not an `Int`.
+    pub fn as_integer(&self) -> Option<i64> {
+        match self {
+            Self::Primitive(PrimitiveValue::Integer(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into an integer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not an integer.
+    pub fn unwrap_integer(self) -> i64 {
+        match self {
+            Self::Primitive(PrimitiveValue::Integer(v)) => v,
+            _ => panic!("value is not an integer"),
+        }
+    }
+
+    /// Gets the value as a `Float`.
+    ///
+    /// Returns `None` if the value is not a `Float`.
+    pub fn as_float(&self) -> Option<f64> {
+        match self {
+            Self::Primitive(PrimitiveValue::Float(v)) => Some((*v).into()),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Float`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Float`.
+    pub fn unwrap_float(self) -> f64 {
+        match self {
+            Self::Primitive(PrimitiveValue::Float(v)) => v.into(),
+            _ => panic!("value is not a float"),
+        }
+    }
+
+    /// Gets the value as a `String`.
+    ///
+    /// Returns `None` if the value is not a `String`.
+    pub fn as_string(&self) -> Option<&Arc<String>> {
+        match self {
+            Self::Primitive(PrimitiveValue::String(s)) => Some(s),
+            _ => panic!("value is not a string"),
+        }
+    }
+
+    /// Unwraps the value into a `String`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `String`.
+    pub fn unwrap_string(self) -> Arc<String> {
+        match self {
+            Self::Primitive(PrimitiveValue::String(s)) => s,
+            _ => panic!("value is not a string"),
+        }
+    }
+
+    /// Gets the value as a `File`.
+    ///
+    /// Returns `None` if the value is not a `File`.
+    pub fn as_file(&self) -> Option<&Arc<String>> {
+        match self {
+            Self::Primitive(PrimitiveValue::File(s)) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `File`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `File`.
+    pub fn unwrap_file(self) -> Arc<String> {
+        match self {
+            Self::Primitive(PrimitiveValue::File(s)) => s,
+            _ => panic!("value is not a file"),
+        }
+    }
+
+    /// Gets the value as a `Directory`.
+    ///
+    /// Returns `None` if the value is not a `Directory`.
+    pub fn as_directory(&self) -> Option<&Arc<String>> {
+        match self {
+            Self::Primitive(PrimitiveValue::Directory(s)) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Directory`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Directory`.
+    pub fn unwrap_directory(self) -> Arc<String> {
+        match self {
+            Self::Primitive(PrimitiveValue::Directory(s)) => s,
+            _ => panic!("value is not a directory"),
+        }
+    }
+
+    /// Gets the value as a `Pair`.
+    ///
+    /// Returns `None` if the value is not a `Pair`.
+    pub fn as_pair(&self) -> Option<&Pair> {
+        match self {
+            Self::Compound(CompoundValue::Pair(v)) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Pair`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Pair`.
+    pub fn unwrap_pair(self) -> Pair {
+        match self {
+            Self::Compound(CompoundValue::Pair(v)) => v,
+            _ => panic!("value is not a pair"),
+        }
+    }
+
+    /// Gets the value as an `Array`.
+    ///
+    /// Returns `None` if the value is not an `Array`.
+    pub fn as_array(&self) -> Option<&Array> {
+        match self {
+            Self::Compound(CompoundValue::Array(v)) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into an `Array`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not an `Array`.
+    pub fn unwrap_array(self) -> Array {
+        match self {
+            Self::Compound(CompoundValue::Array(v)) => v,
+            _ => panic!("value is not an array"),
+        }
+    }
+
+    /// Gets the value as a `Map`.
+    ///
+    /// Returns `None` if the value is not a `Map`.
+    pub fn as_map(&self) -> Option<&Map> {
+        match self {
+            Self::Compound(CompoundValue::Map(v)) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Map`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Map`.
+    pub fn unwrap_map(self) -> Map {
+        match self {
+            Self::Compound(CompoundValue::Map(v)) => v,
+            _ => panic!("value is not a map"),
+        }
+    }
+
+    /// Gets the value as an `Object`.
+    ///
+    /// Returns `None` if the value is not an `Object`.
+    pub fn as_object(&self) -> Option<&Object> {
+        match self {
+            Self::Compound(CompoundValue::Object(v)) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into an `Object`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not an `Object`.
+    pub fn unwrap_object(self) -> Object {
+        match self {
+            Self::Compound(CompoundValue::Object(v)) => v,
+            _ => panic!("value is not an object"),
+        }
+    }
+
+    /// Gets the value as a `Struct`.
+    ///
+    /// Returns `None` if the value is not a `Struct`.
+    pub fn as_struct(&self) -> Option<&Struct> {
+        match self {
+            Self::Compound(CompoundValue::Struct(v)) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Struct`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Map`.
+    pub fn unwrap_struct(self) -> Struct {
+        match self {
+            Self::Compound(CompoundValue::Struct(v)) => v,
+            _ => panic!("value is not a struct"),
+        }
+    }
+
+    /// Determines if two values have equality according to the WDL
+    /// specification.
+    ///
+    /// Returns `None` if the two values cannot be compared for equality.
+    pub fn equals(types: &Types, left: &Self, right: &Self) -> Option<bool> {
+        match (left, right) {
+            (Value::None, Value::None) => Some(true),
+            (Value::None, _) | (_, Value::None) => Some(false),
+            (Value::Primitive(left), Value::Primitive(right)) => {
+                Some(PrimitiveValue::compare(left, right)? == Ordering::Equal)
+            }
+            (Value::Compound(left), Value::Compound(right)) => {
+                CompoundValue::equals(types, left, right)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::None => write!(f, "None"),
+            Value::Primitive(v) => v.fmt(f),
+            Value::Compound(v) => v.fmt(f),
+        }
+    }
+}
+
+impl Coercible for Value {
+    fn coerce(&self, types: &Types, target: Type) -> Result<Self> {
+        if self.ty().type_eq(types, &target) {
+            return Ok(self.clone());
+        }
+
+        match self {
+            Self::None => {
+                if target.is_optional() {
+                    Ok(Self::None)
+                } else {
+                    bail!(
+                        "cannot coerce `None` to non-optional type `{target}`",
+                        target = target.display(types)
+                    );
+                }
+            }
+            Self::Primitive(v) => v.coerce(types, target).map(Self::Primitive),
+            Self::Compound(v) => v.coerce(types, target).map(Self::Compound),
+        }
+    }
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Self::Primitive(value.into())
+    }
+}
+
+impl From<i64> for Value {
+    fn from(value: i64) -> Self {
+        Self::Primitive(value.into())
+    }
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Self {
+        Self::Primitive(value.into())
+    }
+}
+
+impl From<PrimitiveValue> for Value {
+    fn from(value: PrimitiveValue) -> Self {
+        Self::Primitive(value)
+    }
+}
+
+impl From<Pair> for Value {
+    fn from(value: Pair) -> Self {
+        Self::Compound(value.into())
+    }
+}
+
+impl From<Array> for Value {
+    fn from(value: Array) -> Self {
+        Self::Compound(value.into())
+    }
+}
+
+impl From<Map> for Value {
+    fn from(value: Map) -> Self {
+        Self::Compound(value.into())
+    }
+}
+
+impl From<Object> for Value {
+    fn from(value: Object) -> Self {
+        Self::Compound(value.into())
+    }
+}
+
+impl From<Struct> for Value {
+    fn from(value: Struct) -> Self {
+        Self::Compound(value.into())
+    }
+}
+
+impl From<CompoundValue> for Value {
+    fn from(value: CompoundValue) -> Self {
+        Self::Compound(value)
+    }
+}
+
+/// Represents a primitive WDL value.
+#[derive(Debug, Clone)]
+pub enum PrimitiveValue {
+    /// The value is a `Boolean`.
+    Boolean(bool),
+    /// The value is an `Int`.
+    Integer(i64),
+    /// The value is a `Float`.
+    Float(OrderedFloat<f64>),
+    /// The value is a `String`.
+    String(Arc<String>),
+    /// The value is a `File`.
+    File(Arc<String>),
+    /// The value is a `Directory`.
+    Directory(Arc<String>),
+}
+
+impl PrimitiveValue {
+    /// Creates a new `String` value.
+    pub fn new_string(s: impl Into<String>) -> Self {
+        Self::String(Arc::new(s.into()))
+    }
+
+    /// Creates a new `File` value.
+    pub fn new_file(s: impl Into<String>) -> Self {
+        Self::File(Arc::new(s.into()))
+    }
+
+    /// Creates a new `Directory` value.
+    pub fn new_directory(s: impl Into<String>) -> Self {
+        Self::Directory(Arc::new(s.into()))
+    }
+
+    /// Gets the type of the value.
+    pub fn ty(&self) -> Type {
         match self {
             Self::Boolean(_) => PrimitiveTypeKind::Boolean.into(),
             Self::Integer(_) => PrimitiveTypeKind::Integer.into(),
@@ -124,17 +513,15 @@ impl Value {
             Self::String(_) => PrimitiveTypeKind::String.into(),
             Self::File(_) => PrimitiveTypeKind::File.into(),
             Self::Directory(_) => PrimitiveTypeKind::Directory.into(),
-            Self::None => Type::None,
-            Self::Compound(id) => engine.value(*id).ty(),
         }
     }
 
     /// Gets the value as a `Boolean`.
     ///
     /// Returns `None` if the value is not a `Boolean`.
-    pub fn as_boolean(self) -> Option<bool> {
+    pub fn as_boolean(&self) -> Option<bool> {
         match self {
-            Self::Boolean(v) => Some(v),
+            Self::Boolean(v) => Some(*v),
             _ => None,
         }
     }
@@ -154,9 +541,9 @@ impl Value {
     /// Gets the value as an `Int`.
     ///
     /// Returns `None` if the value is not an `Int`.
-    pub fn as_integer(self) -> Option<i64> {
+    pub fn as_integer(&self) -> Option<i64> {
         match self {
-            Self::Integer(v) => Some(v),
+            Self::Integer(v) => Some(*v),
             _ => None,
         }
     }
@@ -176,9 +563,9 @@ impl Value {
     /// Gets the value as a `Float`.
     ///
     /// Returns `None` if the value is not a `Float`.
-    pub fn as_float(self) -> Option<f64> {
+    pub fn as_float(&self) -> Option<f64> {
         match self {
-            Self::Float(v) => Some(v.into()),
+            Self::Float(v) => Some((*v).into()),
             _ => None,
         }
     }
@@ -198,9 +585,9 @@ impl Value {
     /// Gets the value as a `String`.
     ///
     /// Returns `None` if the value is not a `String`.
-    pub fn as_string(self, engine: &Engine) -> Option<&str> {
+    pub fn as_string(&self) -> Option<&Arc<String>> {
         match self {
-            Self::String(_) => Some(self.to_str(engine).expect("string should be interned")),
+            Self::String(s) => Some(s),
             _ => panic!("value is not a string"),
         }
     }
@@ -210,9 +597,9 @@ impl Value {
     /// # Panics
     ///
     /// Panics if the value is not a `String`.
-    pub fn unwrap_string(self, engine: &Engine) -> &str {
+    pub fn unwrap_string(self) -> Arc<String> {
         match self {
-            Self::String(_) => self.to_str(engine).expect("string should be interned"),
+            Self::String(s) => s,
             _ => panic!("value is not a string"),
         }
     }
@@ -220,9 +607,9 @@ impl Value {
     /// Gets the value as a `File`.
     ///
     /// Returns `None` if the value is not a `File`.
-    pub fn as_file(self, engine: &Engine) -> Option<&str> {
+    pub fn as_file(&self) -> Option<&Arc<String>> {
         match self {
-            Self::File(_) => Some(self.to_str(engine).expect("string should be interned")),
+            Self::File(s) => Some(s),
             _ => None,
         }
     }
@@ -232,9 +619,9 @@ impl Value {
     /// # Panics
     ///
     /// Panics if the value is not a `File`.
-    pub fn unwrap_file(self, engine: &Engine) -> &str {
+    pub fn unwrap_file(self) -> Arc<String> {
         match self {
-            Self::File(_) => self.to_str(engine).expect("string should be interned"),
+            Self::File(s) => s,
             _ => panic!("value is not a file"),
         }
     }
@@ -242,9 +629,9 @@ impl Value {
     /// Gets the value as a `Directory`.
     ///
     /// Returns `None` if the value is not a `Directory`.
-    pub fn as_directory(self, engine: &Engine) -> Option<&str> {
+    pub fn as_directory(&self) -> Option<&Arc<String>> {
         match self {
-            Self::Directory(_) => Some(self.to_str(engine).expect("string should be interned")),
+            Self::Directory(s) => Some(s),
             _ => None,
         }
     }
@@ -254,222 +641,121 @@ impl Value {
     /// # Panics
     ///
     /// Panics if the value is not a `Directory`.
-    pub fn unwrap_directory(self, engine: &Engine) -> &str {
+    pub fn unwrap_directory(self) -> Arc<String> {
         match self {
-            Self::Directory(_) => self.to_str(engine).expect("string should be interned"),
+            Self::Directory(s) => s,
             _ => panic!("value is not a directory"),
         }
     }
 
-    /// Gets the value as a `Pair`.
+    /// Compares two values for an ordering according to the WDL specification.
     ///
-    /// Returns `None` if the value is not a `Pair`.
-    pub fn as_pair(self, engine: &Engine) -> Option<&Pair> {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Pair(v) => Some(v),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Unwraps the value into a `Pair`.
+    /// Unlike a `PartialOrd` implementation, this takes into account automatic
+    /// coercions.
     ///
-    /// # Panics
-    ///
-    /// Panics if the value is not a `Pair`.
-    pub fn unwrap_pair(self, engine: &Engine) -> &Pair {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Pair(v) => v,
-                _ => panic!("value is not a pair"),
-            },
-            _ => panic!("value is not a pair"),
-        }
-    }
-
-    /// Gets the value as an `Array`.
-    ///
-    /// Returns `None` if the value is not an `Array`.
-    pub fn as_array(self, engine: &Engine) -> Option<&Array> {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Array(v) => Some(v),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Unwraps the value into an `Array`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is not an `Array`.
-    pub fn unwrap_array(self, engine: &Engine) -> &Array {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Array(v) => v,
-                _ => panic!("value is not an array"),
-            },
-            _ => panic!("value is not an array"),
-        }
-    }
-
-    /// Gets the value as a `Map`.
-    ///
-    /// Returns `None` if the value is not a `Map`.
-    pub fn as_map(self, engine: &Engine) -> Option<&Map> {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Map(v) => Some(v),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Unwraps the value into a `Map`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is not a `Map`.
-    pub fn unwrap_map(self, engine: &Engine) -> &Map {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Map(v) => v,
-                _ => panic!("value is not a map"),
-            },
-            _ => panic!("value is not a map"),
-        }
-    }
-
-    /// Gets the value as an `Object`.
-    ///
-    /// Returns `None` if the value is not an `Object`.
-    pub fn as_object(self, engine: &Engine) -> Option<&Object> {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Object(v) => Some(v),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Unwraps the value into an `Object`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is not an `Object`.
-    pub fn unwrap_object(self, engine: &Engine) -> &Object {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Object(v) => v,
-                _ => panic!("value is not an object"),
-            },
-            _ => panic!("value is not an object"),
-        }
-    }
-
-    /// Gets the value as a `Struct`.
-    ///
-    /// Returns `None` if the value is not a `Struct`.
-    pub fn as_struct(self, engine: &Engine) -> Option<&Struct> {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Struct(v) => Some(v),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Unwraps the value into a `Struct`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is not a `Map`.
-    pub fn unwrap_struct(self, engine: &Engine) -> &Struct {
-        match self {
-            Self::Compound(id) => match engine.value(id) {
-                CompoundValue::Struct(v) => v,
-                _ => panic!("value is not a struct"),
-            },
-            _ => panic!("value is not a struct"),
-        }
-    }
-
-    /// Gets the string representation of a `String`, `File`, or `Directory`
-    /// value.
-    ///
-    /// Returns `None` if the value is not a `String`, `File`, or `Directory`.
-    pub fn to_str<'a>(&self, engine: &'a Engine) -> Option<&'a str> {
-        match self {
-            Self::String(sym) | Self::File(sym) | Self::Directory(sym) => {
-                engine.interner().resolve(*sym)
+    /// Returns `None` if the values cannot be compared based on their types.
+    pub fn compare(left: &Self, right: &Self) -> Option<Ordering> {
+        match (left, right) {
+            (PrimitiveValue::Boolean(left), PrimitiveValue::Boolean(right)) => {
+                Some(left.cmp(right))
+            }
+            (PrimitiveValue::Integer(left), PrimitiveValue::Integer(right)) => {
+                Some(left.cmp(right))
+            }
+            (PrimitiveValue::Integer(left), PrimitiveValue::Float(right)) => {
+                Some(OrderedFloat(*left as f64).cmp(right))
+            }
+            (PrimitiveValue::Float(left), PrimitiveValue::Integer(right)) => {
+                Some(left.cmp(&OrderedFloat(*right as f64)))
+            }
+            (PrimitiveValue::Float(left), PrimitiveValue::Float(right)) => Some(left.cmp(right)),
+            (PrimitiveValue::String(left), PrimitiveValue::String(right))
+            | (PrimitiveValue::String(left), PrimitiveValue::File(right))
+            | (PrimitiveValue::String(left), PrimitiveValue::Directory(right))
+            | (PrimitiveValue::File(left), PrimitiveValue::File(right))
+            | (PrimitiveValue::File(left), PrimitiveValue::String(right))
+            | (PrimitiveValue::Directory(left), PrimitiveValue::Directory(right))
+            | (PrimitiveValue::Directory(left), PrimitiveValue::String(right)) => {
+                Some(left.cmp(right))
             }
             _ => None,
-        }
-    }
-
-    /// Used to display the value.
-    pub fn display<'a>(&'a self, engine: &'a Engine) -> impl fmt::Display + 'a {
-        /// Helper type for implementing display.
-        struct Display<'a> {
-            /// A reference to the engine.
-            engine: &'a Engine,
-            /// The value to display.
-            value: Value,
-        }
-
-        impl fmt::Display for Display<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                match self.value {
-                    Value::Boolean(v) => write!(f, "{v}"),
-                    Value::Integer(v) => write!(f, "{v}"),
-                    Value::Float(v) => write!(f, "{v:?}"),
-                    Value::String(_) | Value::File(_) | Value::Directory(_) => {
-                        // TODO: handle necessary escape sequences
-                        write!(
-                            f,
-                            "\"{v}\"",
-                            v = self
-                                .value
-                                .to_str(self.engine)
-                                .expect("string should be interned")
-                        )
-                    }
-                    Value::None => write!(f, "None"),
-                    Value::Compound(id) => {
-                        write!(f, "{v}", v = self.engine.value(id).display(self.engine))
-                    }
-                }
-            }
-        }
-
-        Display {
-            engine,
-            value: *self,
-        }
-    }
-
-    /// Asserts that the value is valid for the given engine.
-    pub(crate) fn assert_valid(&self, engine: &Engine) {
-        match self {
-            Self::Boolean(_) | Self::Integer(_) | Self::Float(_) | Self::None => {}
-            Self::String(sym) | Self::File(sym) | Self::Directory(sym) => assert!(
-                engine.interner().resolve(*sym).is_some(),
-                "value comes from a different engine"
-            ),
-            Self::Compound(id) => engine.assert_same_arena(*id),
         }
     }
 }
 
-impl Coercible for Value {
-    fn coerce(&self, engine: &mut Engine, target: Type) -> Result<Self> {
+impl fmt::Display for PrimitiveValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PrimitiveValue::Boolean(v) => write!(f, "{v}"),
+            PrimitiveValue::Integer(v) => write!(f, "{v}"),
+            PrimitiveValue::Float(v) => write!(f, "{v:?}"),
+            PrimitiveValue::String(s) | PrimitiveValue::File(s) | PrimitiveValue::Directory(s) => {
+                // TODO: handle necessary escape sequences
+                write!(f, "\"{s}\"")
+            }
+        }
+    }
+}
+
+impl PartialEq for PrimitiveValue {
+    fn eq(&self, other: &Self) -> bool {
+        Self::compare(self, other) == Some(Ordering::Equal)
+    }
+}
+
+impl Eq for PrimitiveValue {}
+
+impl Hash for PrimitiveValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Boolean(v) => {
+                0.hash(state);
+                v.hash(state);
+            }
+            Self::Integer(v) => {
+                1.hash(state);
+                v.hash(state);
+            }
+            Self::Float(v) => {
+                // Hash this with the same discriminant as integer; this allows coercion from
+                // int to float.
+                1.hash(state);
+                v.hash(state);
+            }
+            Self::String(v) | Self::File(v) | Self::Directory(v) => {
+                // Hash these with the same discriminant; this allows coercion from file and
+                // directory to string
+                2.hash(state);
+                v.hash(state);
+            }
+        }
+    }
+}
+
+impl From<bool> for PrimitiveValue {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+impl From<i64> for PrimitiveValue {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<f64> for PrimitiveValue {
+    fn from(value: f64) -> Self {
+        Self::Float(value.into())
+    }
+}
+
+impl Coercible for PrimitiveValue {
+    fn coerce(&self, types: &Types, target: Type) -> Result<Self> {
+        if self.ty().type_eq(types, &target) {
+            return Ok(self.clone());
+        }
+
         match self {
             Self::Boolean(v) => {
                 target
@@ -482,7 +768,7 @@ impl Coercible for Value {
                     .ok_or_else(|| {
                         anyhow!(
                             "cannot coerce type `Boolean` to type `{target}`",
-                            target = target.display(engine.types())
+                            target = target.display(types)
                         )
                     })
             }
@@ -499,7 +785,7 @@ impl Coercible for Value {
                     .ok_or_else(|| {
                         anyhow!(
                             "cannot coerce type `Int` to type `{target}`",
-                            target = target.display(engine.types())
+                            target = target.display(types)
                         )
                     })
             }
@@ -514,114 +800,116 @@ impl Coercible for Value {
                     .ok_or_else(|| {
                         anyhow!(
                             "cannot coerce type `Float` to type `{target}`",
-                            target = target.display(engine.types())
+                            target = target.display(types)
                         )
                     })
             }
-            Self::String(sym) => {
+            Self::String(s) => {
                 target
                     .as_primitive()
                     .and_then(|ty| match ty.kind() {
                         // String -> String
-                        PrimitiveTypeKind::String => Some(Self::String(*sym)),
+                        PrimitiveTypeKind::String => Some(Self::String(s.clone())),
                         // String -> File
-                        PrimitiveTypeKind::File => Some(Self::File(*sym)),
+                        PrimitiveTypeKind::File => Some(Self::File(s.clone())),
                         // String -> Directory
-                        PrimitiveTypeKind::Directory => Some(Self::Directory(*sym)),
+                        PrimitiveTypeKind::Directory => Some(Self::Directory(s.clone())),
                         _ => None,
                     })
                     .ok_or_else(|| {
                         anyhow!(
                             "cannot coerce type `String` to type `{target}`",
-                            target = target.display(engine.types())
+                            target = target.display(types)
                         )
                     })
             }
-            Self::File(sym) => {
+            Self::File(s) => {
                 target
                     .as_primitive()
                     .and_then(|ty| match ty.kind() {
                         // File -> File
-                        PrimitiveTypeKind::File => Some(Self::File(*sym)),
+                        PrimitiveTypeKind::File => Some(Self::File(s.clone())),
                         // File -> String
-                        PrimitiveTypeKind::String => Some(Self::String(*sym)),
+                        PrimitiveTypeKind::String => Some(Self::String(s.clone())),
                         _ => None,
                     })
                     .ok_or_else(|| {
                         anyhow!(
                             "cannot coerce type `File` to type `{target}`",
-                            target = target.display(engine.types())
+                            target = target.display(types)
                         )
                     })
             }
-            Self::Directory(sym) => {
+            Self::Directory(s) => {
                 target
                     .as_primitive()
                     .and_then(|ty| match ty.kind() {
                         // Directory -> Directory
-                        PrimitiveTypeKind::Directory => Some(Self::Directory(*sym)),
+                        PrimitiveTypeKind::Directory => Some(Self::Directory(s.clone())),
                         // Directory -> String
-                        PrimitiveTypeKind::String => Some(Self::String(*sym)),
+                        PrimitiveTypeKind::String => Some(Self::String(s.clone())),
                         _ => None,
                     })
                     .ok_or_else(|| {
                         anyhow!(
                             "cannot coerce type `Directory` to type `{target}`",
-                            target = target.display(engine.types())
+                            target = target.display(types)
                         )
                     })
-            }
-            Self::None => {
-                if target.is_optional() {
-                    Ok(Self::None)
-                } else {
-                    bail!(
-                        "cannot coerce `None` to non-optional type `{target}`",
-                        target = target.display(engine.types())
-                    );
-                }
-            }
-            Self::Compound(id) => {
-                let value = engine.value(*id).clone().coerce(engine, target)?;
-                Ok(Self::Compound(engine.alloc(value)))
             }
         }
     }
 }
 
-impl From<bool> for Value {
-    fn from(value: bool) -> Self {
-        Self::Boolean(value)
-    }
-}
-
-impl From<i64> for Value {
-    fn from(value: i64) -> Self {
-        Self::Integer(value)
-    }
-}
-
-impl From<f64> for Value {
-    fn from(value: f64) -> Self {
-        Self::Float(value.into())
-    }
-}
-
 /// Represents a `Pair` value.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Pair {
     /// The type of the pair.
     ty: Type,
     /// The left value of the pair.
-    left: Value,
+    left: Arc<Value>,
     /// The right value of the pair.
-    right: Value,
+    right: Arc<Value>,
 }
 
 impl Pair {
-    /// Constructs a new `Pair` value.
-    pub(crate) fn new(ty: Type, left: Value, right: Value) -> Self {
-        Self { ty, left, right }
+    /// Creates a new `Pair` value.
+    ///
+    /// Returns an error if either the `left` value or the `right` value did not
+    /// coerce to the pair's `left` type or `right` type, respectively.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given type is not a pair type from the given types
+    /// collection.
+    pub fn new(
+        types: &Types,
+        ty: Type,
+        left: impl Into<Value>,
+        right: impl Into<Value>,
+    ) -> Result<Self> {
+        if let Type::Compound(compound_ty) = ty {
+            if let CompoundTypeDef::Pair(pair_ty) = types.type_definition(compound_ty.definition())
+            {
+                let left_ty = pair_ty.left_type();
+                let right_ty = pair_ty.right_type();
+                return Ok(Self {
+                    ty,
+                    left: left
+                        .into()
+                        .coerce(types, left_ty)
+                        .context("failed to coerce pair's left value")?
+                        .into(),
+                    right: right
+                        .into()
+                        .coerce(types, right_ty)
+                        .context("failed to coerce pair's right value")?
+                        .into(),
+                });
+            }
+        }
+
+        panic!("type `{ty}` is not a pair type", ty = ty.display(types));
     }
 
     /// Gets the type of the `Pair`.
@@ -630,40 +918,19 @@ impl Pair {
     }
 
     /// Gets the left value of the `Pair`.
-    pub fn left(&self) -> Value {
-        self.left
+    pub fn left(&self) -> &Value {
+        &self.left
     }
 
     /// Gets the right value of the `Pair`.
-    pub fn right(&self) -> Value {
-        self.right
+    pub fn right(&self) -> &Value {
+        &self.right
     }
+}
 
-    /// Used to display the value.
-    pub fn display<'a>(&'a self, engine: &'a Engine) -> impl fmt::Display + 'a {
-        /// Helper type for implementing display.
-        struct Display<'a> {
-            /// A reference to the engine.
-            engine: &'a Engine,
-            /// The value to display.
-            value: &'a Pair,
-        }
-
-        impl fmt::Display for Display<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "({left}, {right})",
-                    left = self.value.left.display(self.engine),
-                    right = self.value.right.display(self.engine)
-                )
-            }
-        }
-
-        Display {
-            engine,
-            value: self,
-        }
+impl fmt::Display for Pair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({left}, {right})", left = self.left, right = self.right)
     }
 }
 
@@ -677,9 +944,40 @@ pub struct Array {
 }
 
 impl Array {
-    /// Constructs a new `Array` value.
-    pub(crate) fn new(ty: Type, elements: Arc<[Value]>) -> Self {
-        Self { ty, elements }
+    /// Creates a new `Array` value for the given array type.
+    ///
+    /// Returns an error if an element did not coerce to the array's element
+    /// type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given type is not an array type from the types collection.
+    pub fn new<V>(types: &Types, ty: Type, elements: impl IntoIterator<Item = V>) -> Result<Self>
+    where
+        V: Into<Value>,
+    {
+        if let Type::Compound(compound_ty) = ty {
+            if let CompoundTypeDef::Array(array_ty) =
+                types.type_definition(compound_ty.definition())
+            {
+                let element_type = array_ty.element_type();
+                return Ok(Self {
+                    ty,
+                    elements: elements
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, v)| {
+                            let v = v.into();
+                            v.coerce(types, element_type).with_context(|| {
+                                format!("failed to coerce array element at index {i}")
+                            })
+                        })
+                        .collect::<Result<_>>()?,
+                });
+            }
+        }
+
+        panic!("type `{ty}` is not an array type", ty = ty.display(types));
     }
 
     /// Gets the type of the `Array` value.
@@ -691,37 +989,21 @@ impl Array {
     pub fn elements(&self) -> &[Value] {
         &self.elements
     }
+}
 
-    /// Used to display the value.
-    pub fn display<'a>(&'a self, engine: &'a Engine) -> impl fmt::Display + 'a {
-        /// Helper type for implementing display.
-        struct Display<'a> {
-            /// A reference to the engine.
-            engine: &'a Engine,
-            /// The value to display.
-            value: &'a Array,
-        }
+impl fmt::Display for Array {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
 
-        impl fmt::Display for Display<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "[")?;
-
-                for (i, element) in self.value.elements.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-
-                    write!(f, "{element}", element = element.display(self.engine))?;
-                }
-
-                write!(f, "]")
+        for (i, element) in self.elements.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
             }
+
+            write!(f, "{element}")?;
         }
 
-        Display {
-            engine,
-            value: self,
-        }
+        write!(f, "]")
     }
 }
 
@@ -731,13 +1013,60 @@ pub struct Map {
     /// The type of the map value.
     ty: Type,
     /// The elements of the map value.
-    elements: Arc<IndexMap<Value, Value>>,
+    elements: Arc<IndexMap<PrimitiveValue, Value>>,
 }
 
 impl Map {
-    /// Constructs a new `Map` value.
-    pub(crate) fn new(ty: Type, elements: Arc<IndexMap<Value, Value>>) -> Self {
-        Self { ty, elements }
+    /// Creates a new `Map` value.
+    ///
+    /// Returns an error if an key or value did not coerce to the map's key or
+    /// value type, respectively.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given type is not a map type from the given types
+    /// collection.
+    pub fn new<K, V>(
+        types: &Types,
+        ty: Type,
+        elements: impl IntoIterator<Item = (K, V)>,
+    ) -> Result<Self>
+    where
+        K: Into<PrimitiveValue>,
+        V: Into<Value>,
+    {
+        if let Type::Compound(compound_ty) = ty {
+            if let CompoundTypeDef::Map(map_ty) = types.type_definition(compound_ty.definition()) {
+                let key_type = map_ty.key_type();
+                let value_type = map_ty.value_type();
+
+                return Ok(Self {
+                    ty,
+                    elements: Arc::new(
+                        elements
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, (k, v))| {
+                                let k = k.into();
+                                let v = v.into();
+                                Ok((
+                                    k.coerce(types, key_type).with_context(|| {
+                                        format!("failed to coerce map key for element at index {i}")
+                                    })?,
+                                    v.coerce(types, value_type).with_context(|| {
+                                        format!(
+                                            "failed to coerce map value for element at index {i}"
+                                        )
+                                    })?,
+                                ))
+                            })
+                            .collect::<Result<_>>()?,
+                    ),
+                });
+            }
+        }
+
+        panic!("type `{ty}` is not a map type", ty = ty.display(types));
     }
 
     /// Gets the type of the `Map` value.
@@ -746,45 +1075,24 @@ impl Map {
     }
 
     /// Gets the elements of the `Map` value.
-    pub fn elements(&self) -> &IndexMap<Value, Value> {
+    pub fn elements(&self) -> &IndexMap<PrimitiveValue, Value> {
         &self.elements
     }
+}
 
-    /// Used to display the value.
-    pub fn display<'a>(&'a self, engine: &'a Engine) -> impl fmt::Display + 'a {
-        /// Helper type for implementing display.
-        struct Display<'a> {
-            /// A reference to the engine.
-            engine: &'a Engine,
-            /// The value to display.
-            value: &'a Map,
-        }
+impl fmt::Display for Map {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
 
-        impl fmt::Display for Display<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{{")?;
-
-                for (i, (k, v)) in self.value.elements.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-
-                    write!(
-                        f,
-                        "{k}: {v}",
-                        k = k.display(self.engine),
-                        v = v.display(self.engine)
-                    )?;
-                }
-
-                write!(f, "}}")
+        for (i, (k, v)) in self.elements.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
             }
+
+            write!(f, "{k}: {v}")?;
         }
 
-        Display {
-            engine,
-            value: self,
-        }
+        write!(f, "}}")
     }
 }
 
@@ -796,9 +1104,24 @@ pub struct Object {
 }
 
 impl Object {
-    /// Constructs a new `Object` value.
-    pub(crate) fn new(members: Arc<IndexMap<String, Value>>) -> Self {
-        Self { members }
+    /// Creates a new `Object` value.
+    pub fn new<S, V>(items: impl IntoIterator<Item = (S, V)>) -> Self
+    where
+        S: Into<String>,
+        V: Into<Value>,
+    {
+        Self {
+            members: Arc::new(
+                items
+                    .into_iter()
+                    .map(|(n, v)| {
+                        let n = n.into();
+                        let v = v.into();
+                        (n, v)
+                    })
+                    .collect(),
+            ),
+        }
     }
 
     /// Gets the type of the `Object` value.
@@ -810,36 +1133,28 @@ impl Object {
     pub fn members(&self) -> &IndexMap<String, Value> {
         &self.members
     }
+}
 
-    /// Used to display the value.
-    pub fn display<'a>(&'a self, engine: &'a Engine) -> impl fmt::Display + 'a {
-        /// Helper type for implementing display.
-        struct Display<'a> {
-            /// A reference to the engine.
-            engine: &'a Engine,
-            /// The value to display.
-            value: &'a Object,
-        }
+impl fmt::Display for Object {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "object {{")?;
 
-        impl fmt::Display for Display<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "object {{")?;
-
-                for (i, (k, v)) in self.value.members.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-
-                    write!(f, "{k}: {v}", v = v.display(self.engine))?;
-                }
-
-                write!(f, "}}")
+        for (i, (k, v)) in self.members.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
             }
+
+            write!(f, "{k}: {v}")?;
         }
 
-        Display {
-            engine,
-            value: self,
+        write!(f, "}}")
+    }
+}
+
+impl From<IndexMap<String, Value>> for Object {
+    fn from(members: IndexMap<String, Value>) -> Self {
+        Self {
+            members: Arc::new(members),
         }
     }
 }
@@ -849,14 +1164,77 @@ impl Object {
 pub struct Struct {
     /// The type of the struct value.
     ty: Type,
+    /// The name of the struct.
+    name: Arc<String>,
     /// The members of the struct value.
     members: Arc<IndexMap<String, Value>>,
 }
 
 impl Struct {
-    /// Constructs a new `Struct` value.
-    pub(crate) fn new(ty: Type, members: Arc<IndexMap<String, Value>>) -> Self {
-        Self { ty, members }
+    /// Creates a new struct value.
+    ///
+    /// Returns an error if the struct type does not contain a member of a given
+    /// name or if a value does not coerce to the corresponding member's type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given type is not a struct type from the given types
+    /// collection.
+    pub fn new<S, V>(
+        types: &Types,
+        ty: Type,
+        members: impl IntoIterator<Item = (S, V)>,
+    ) -> Result<Self>
+    where
+        S: Into<String>,
+        V: Into<Value>,
+    {
+        let mut members = members
+            .into_iter()
+            .map(|(n, v)| {
+                let n = n.into();
+                let v = v.into();
+                let v = v
+                    .coerce(
+                        types,
+                        *types.struct_type(ty).members().get(&n).ok_or_else(|| {
+                            anyhow!("struct does not contain a member named `{n}`")
+                        })?,
+                    )
+                    .with_context(|| format!("failed to coerce struct member `{n}`"))?;
+                Ok((n, v))
+            })
+            .collect::<Result<IndexMap<_, _>>>()?;
+
+        for (name, ty) in types.struct_type(ty).members().iter() {
+            // Check for optional members that should be set to `None`
+            if ty.is_optional() {
+                if !members.contains_key(name) {
+                    members.insert(name.clone(), Value::None);
+                }
+            } else {
+                // Check for a missing required member
+                if !members.contains_key(name) {
+                    bail!("missing a value for struct member `{name}`");
+                }
+            }
+        }
+
+        Ok(Self {
+            ty,
+            name: types.struct_type(ty).name().clone(),
+            members: Arc::new(members),
+        })
+    }
+
+    /// Constructs a new struct without checking the given members conform to
+    /// the given type.
+    pub(crate) fn new_unchecked(
+        ty: Type,
+        name: Arc<String>,
+        members: Arc<IndexMap<String, Value>>,
+    ) -> Self {
+        Self { ty, name, members }
     }
 
     /// Gets the type of the `Struct` value.
@@ -864,54 +1242,30 @@ impl Struct {
         self.ty
     }
 
+    /// Gets the name of the struct.
+    pub fn name(&self) -> &Arc<String> {
+        &self.name
+    }
+
     /// Gets the members of the `Struct` value.
     pub fn members(&self) -> &IndexMap<String, Value> {
         &self.members
     }
+}
 
-    /// Used to display the value.
-    pub fn display<'a>(&'a self, engine: &'a Engine) -> impl fmt::Display + 'a {
-        /// Helper type for implementing display.
-        struct Display<'a> {
-            /// A reference to the engine.
-            engine: &'a Engine,
-            /// The value to display.
-            value: &'a Struct,
-        }
+impl fmt::Display for Struct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{name} {{", name = self.name)?;
 
-        impl fmt::Display for Display<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    f,
-                    "{name} {{",
-                    name = self
-                        .engine
-                        .types()
-                        .type_definition(match self.value.ty {
-                            Type::Compound(ty) => ty.definition(),
-                            _ => unreachable!("expected a struct type"),
-                        })
-                        .as_struct()
-                        .expect("should be a struct")
-                        .name()
-                )?;
-
-                for (i, (k, v)) in self.value.members.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-
-                    write!(f, "{k}: {v}", v = v.display(self.engine))?;
-                }
-
-                write!(f, "}}")
+        for (i, (k, v)) in self.members.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
             }
+
+            write!(f, "{k}: {v}")?;
         }
 
-        Display {
-            engine,
-            value: self,
-        }
+        write!(f, "}}")
     }
 }
 
@@ -944,52 +1298,190 @@ impl CompoundValue {
         }
     }
 
-    /// Used to display the value.
-    pub fn display<'a>(&'a self, engine: &'a Engine) -> impl fmt::Display + 'a {
-        /// Helper type for implementing display.
-        struct Display<'a> {
-            /// A reference to the engine.
-            engine: &'a Engine,
-            /// The value to display.
-            value: &'a CompoundValue,
+    /// Gets the value as a `Pair`.
+    ///
+    /// Returns `None` if the value is not a `Pair`.
+    pub fn as_pair(&self) -> Option<&Pair> {
+        match self {
+            Self::Pair(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Pair`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Pair`.
+    pub fn unwrap_pair(self) -> Pair {
+        match self {
+            Self::Pair(v) => v,
+            _ => panic!("value is not a pair"),
+        }
+    }
+
+    /// Gets the value as an `Array`.
+    ///
+    /// Returns `None` if the value is not an `Array`.
+    pub fn as_array(&self) -> Option<&Array> {
+        match self {
+            Self::Array(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into an `Array`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not an `Array`.
+    pub fn unwrap_array(self) -> Array {
+        match self {
+            Self::Array(v) => v,
+            _ => panic!("value is not an array"),
+        }
+    }
+
+    /// Gets the value as a `Map`.
+    ///
+    /// Returns `None` if the value is not a `Map`.
+    pub fn as_map(&self) -> Option<&Map> {
+        match self {
+            Self::Map(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Map`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Map`.
+    pub fn unwrap_map(self) -> Map {
+        match self {
+            Self::Map(v) => v,
+            _ => panic!("value is not a map"),
+        }
+    }
+
+    /// Gets the value as an `Object`.
+    ///
+    /// Returns `None` if the value is not an `Object`.
+    pub fn as_object(&self) -> Option<&Object> {
+        match self {
+            Self::Object(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into an `Object`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not an `Object`.
+    pub fn unwrap_object(self) -> Object {
+        match self {
+            Self::Object(v) => v,
+            _ => panic!("value is not an object"),
+        }
+    }
+
+    /// Gets the value as a `Struct`.
+    ///
+    /// Returns `None` if the value is not a `Struct`.
+    pub fn as_struct(&self) -> Option<&Struct> {
+        match self {
+            Self::Struct(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Unwraps the value into a `Struct`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a `Map`.
+    pub fn unwrap_struct(self) -> Struct {
+        match self {
+            Self::Struct(v) => v,
+            _ => panic!("value is not a struct"),
+        }
+    }
+
+    /// Compares two compound values for equality based on the WDL
+    /// specification.
+    ///
+    /// Returns `None` if the two compound values cannot be compared for
+    /// equality.
+    pub fn equals(types: &Types, left: &Self, right: &Self) -> Option<bool> {
+        // The values must have type equivalence to compare for compound values
+        // Coercion doesn't take place for this check
+        if !left.ty().type_eq(types, &right.ty()) {
+            return None;
         }
 
-        impl fmt::Display for Display<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                match self.value {
-                    CompoundValue::Pair(v) => {
-                        write!(f, "{v}", v = v.display(self.engine))
-                    }
-                    CompoundValue::Array(v) => {
-                        write!(f, "{v}", v = v.display(self.engine))
-                    }
-                    CompoundValue::Map(v) => {
-                        write!(f, "{v}", v = v.display(self.engine))
-                    }
-                    CompoundValue::Object(v) => {
-                        write!(f, "{v}", v = v.display(self.engine))
-                    }
-                    CompoundValue::Struct(v) => {
-                        write!(f, "{v}", v = v.display(self.engine))
-                    }
-                }
-            }
+        match (left, right) {
+            (Self::Pair(left), Self::Pair(right)) => Some(
+                Value::equals(types, &left.left, &right.left)?
+                    && Value::equals(types, &left.right, &right.right)?,
+            ),
+            (CompoundValue::Array(left), CompoundValue::Array(right)) => Some(
+                left.elements.len() == right.elements.len()
+                    && left
+                        .elements
+                        .iter()
+                        .zip(right.elements.iter())
+                        .all(|(l, r)| Value::equals(types, l, r).unwrap_or(false)),
+            ),
+            (CompoundValue::Map(left), CompoundValue::Map(right)) => Some(
+                left.elements.len() == right.elements.len()
+                    && left
+                        .elements
+                        .iter()
+                        .all(|(k, left)| match right.elements.get(k) {
+                            Some(right) => Value::equals(types, left, right).unwrap_or(false),
+                            None => false,
+                        }),
+            ),
+            (
+                CompoundValue::Object(Object { members: left }),
+                CompoundValue::Object(Object { members: right }),
+            )
+            | (
+                CompoundValue::Struct(Struct { members: left, .. }),
+                CompoundValue::Struct(Struct { members: right, .. }),
+            ) => Some(
+                left.len() == right.len()
+                    && left.iter().all(|(k, left)| match right.get(k) {
+                        Some(right) => Value::equals(types, left, right).unwrap_or(false),
+                        None => false,
+                    }),
+            ),
+            _ => None,
         }
+    }
+}
 
-        Display {
-            engine,
-            value: self,
+impl fmt::Display for CompoundValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompoundValue::Pair(v) => v.fmt(f),
+            CompoundValue::Array(v) => v.fmt(f),
+            CompoundValue::Map(v) => v.fmt(f),
+            CompoundValue::Object(v) => v.fmt(f),
+            CompoundValue::Struct(v) => v.fmt(f),
         }
     }
 }
 
 impl Coercible for CompoundValue {
-    fn coerce(&self, engine: &mut Engine, target: Type) -> Result<Self> {
+    fn coerce(&self, types: &Types, target: Type) -> Result<Self> {
+        if self.ty().type_eq(types, &target) {
+            return Ok(self.clone());
+        }
+
         if let Type::Compound(compound_ty) = target {
-            match (
-                self,
-                engine.types().type_definition(compound_ty.definition()),
-            ) {
+            match (self, types.type_definition(compound_ty.definition())) {
                 // Array[X] -> Array[Y](+) where X -> Y
                 (Self::Array(v), CompoundTypeDef::Array(array_ty)) => {
                     // Don't allow coercion when the source is empty but the target has the
@@ -997,118 +1489,84 @@ impl Coercible for CompoundValue {
                     if v.elements.is_empty() && array_ty.is_non_empty() {
                         bail!(
                             "cannot coerce empty array value to non-empty array type `{ty}`",
-                            ty = array_ty.display(engine.types())
+                            ty = array_ty.display(types)
                         );
                     }
 
-                    let element_type = array_ty.element_type();
                     return Ok(Self::Array(Array::new(
+                        types,
                         target,
-                        v.elements
-                            .iter()
-                            .enumerate()
-                            .map(|(i, e)| {
-                                e.coerce(engine, element_type).with_context(|| {
-                                    format!("failed to coerce array element at index {i}")
-                                })
-                            })
-                            .collect::<Result<_>>()?,
-                    )));
+                        v.elements.iter().cloned(),
+                    )?));
                 }
                 // Map[W, Y] -> Map[X, Z] where W -> X and Y -> Z
-                (Self::Map(v), CompoundTypeDef::Map(map_ty)) => {
-                    let key_type = map_ty.key_type();
-                    let value_type = map_ty.value_type();
+                (Self::Map(v), CompoundTypeDef::Map(_)) => {
                     return Ok(Self::Map(Map::new(
+                        types,
                         target,
-                        Arc::new(
-                            v.elements
-                                .iter()
-                                .enumerate()
-                                .map(|(i, (k, v))| {
-                                    let k = k.coerce(engine, key_type).with_context(|| {
-                                        format!("failed to coerce map key at index {i}")
-                                    })?;
-                                    let v = v.coerce(engine, value_type).with_context(|| {
-                                        format!("failed to coerce map value at index {i}")
-                                    })?;
-                                    Ok((k, v))
-                                })
-                                .collect::<Result<_>>()?,
-                        ),
-                    )));
+                        v.elements.iter().map(|(k, v)| (k.clone(), v.clone())),
+                    )?));
                 }
                 // Pair[W, Y] -> Pair[X, Z] where W -> X and Y -> Z
-                (Self::Pair(v), CompoundTypeDef::Pair(pair_ty)) => {
-                    let left_type = pair_ty.left_type();
-                    let right_type: Type = pair_ty.right_type();
-                    let left = v
-                        .left
-                        .coerce(engine, left_type)
-                        .context("failed to coerce pair's left value")?;
-                    let right = v
-                        .right
-                        .coerce(engine, right_type)
-                        .context("failed to coerce pair's right value")?;
-                    return Ok(Self::Pair(Pair::new(target, left, right)));
+                (Self::Pair(v), CompoundTypeDef::Pair(_)) => {
+                    return Ok(Self::Pair(Pair::new(
+                        types,
+                        target,
+                        v.left.as_ref().clone(),
+                        v.right.as_ref().clone(),
+                    )?));
                 }
                 // Map[String, Y] -> Struct
-                (Self::Map(v), CompoundTypeDef::Struct(_)) => {
+                (Self::Map(v), CompoundTypeDef::Struct(struct_ty)) => {
                     let len = v.elements.len();
-                    let expected_len = engine
-                        .types()
-                        .type_definition(compound_ty.definition())
-                        .as_struct()
-                        .expect("should be struct")
-                        .members()
-                        .len();
+                    let expected_len = types.struct_type(target).members().len();
 
                     if len != expected_len {
                         bail!(
                             "cannot coerce a map of {len} element{s1} to struct type `{ty}` as \
                              the struct has {expected_len} member{s2}",
                             s1 = if len == 1 { "" } else { "s" },
-                            ty = compound_ty.display(engine.types()),
+                            ty = compound_ty.display(types),
                             s2 = if expected_len == 1 { "" } else { "s" }
                         );
                     }
 
-                    let members = v
-                        .elements
-                        .iter()
-                        .map(|(k, v)| {
-                            let k = k
-                                .as_string(engine)
-                                .ok_or_else(|| {
-                                    anyhow!(
-                                        "cannot coerce a map with a non-string key type to struct \
-                                         type `{ty}`",
-                                        ty = compound_ty.display(engine.types())
-                                    )
-                                })?
-                                .to_string();
-                            let ty = *engine
-                                .types()
-                                .type_definition(compound_ty.definition())
-                                .as_struct()
-                                .expect("should be struct")
-                                .members()
-                                .get(&k)
-                                .ok_or_else(|| {
-                                    anyhow!(
-                                        "cannot coerce a map with key `{k}` to struct type `{ty}` \
-                                         as the struct does not contain a member with that name",
-                                        ty = compound_ty.display(engine.types())
-                                    )
-                                })?;
-                            let v = v.coerce(engine, ty).with_context(|| {
-                                format!("failed to coerce value of map key `{k}")
-                            })?;
-                            Ok((k, v))
-                        })
-                        .collect::<Result<_>>()?;
-
-                    return Ok(Self::Struct(Struct::new(target, Arc::new(members))));
+                    return Ok(Self::Struct(Struct {
+                        ty: target,
+                        name: struct_ty.name().clone(),
+                        members: Arc::new(
+                            v.elements
+                                .iter()
+                                .map(|(k, v)| {
+                                    let k: String = k
+                                        .as_string()
+                                        .ok_or_else(|| {
+                                            anyhow!(
+                                                "cannot coerce a map with a non-string key type \
+                                                 to struct type `{ty}`",
+                                                ty = compound_ty.display(types)
+                                            )
+                                        })?
+                                        .to_string();
+                                    let ty =
+                                        *types.struct_type(target).members().get(&k).ok_or_else(
+                                            || {
+                                                anyhow!(
+                                                    "cannot coerce a map with key `{k}` to struct \
+                                                     type `{ty}` as the struct does not contain a \
+                                                     member with that name",
+                                                    ty = compound_ty.display(types)
+                                                )
+                                            },
+                                        )?;
+                                    let v = v.coerce(types, ty).with_context(|| {
+                                        format!("failed to coerce value of map key `{k}")
+                                    })?;
+                                    Ok((k, v))
+                                })
+                                .collect::<Result<_>>()?,
+                        ),
+                    }));
                 }
                 // Struct -> Map[String, Y]
                 // Object -> Map[String, Y]
@@ -1118,123 +1576,107 @@ impl Coercible for CompoundValue {
                         bail!(
                             "cannot coerce a struct or object to type `{ty}` as it requires a \
                              `String` key type",
-                            ty = compound_ty.display(engine.types())
+                            ty = compound_ty.display(types)
                         );
                     }
 
                     let value_ty = map_ty.value_type();
-                    return Ok(Self::Map(Map::new(
-                        target,
-                        Arc::new(
+                    return Ok(Self::Map(Map {
+                        ty: target,
+                        elements: Arc::new(
                             members
                                 .iter()
                                 .map(|(n, v)| {
-                                    let v = v.coerce(engine, value_ty).with_context(|| {
+                                    let v = v.coerce(types, value_ty).with_context(|| {
                                         format!("failed to coerce member `{n}`")
                                     })?;
-                                    Ok((engine.new_string(n), v))
+                                    Ok((PrimitiveValue::new_string(n), v))
                                 })
                                 .collect::<Result<_>>()?,
                         ),
-                    )));
+                    }));
                 }
                 // Object -> Struct
-                (Self::Object(v), CompoundTypeDef::Struct(_)) => {
+                (Self::Object(v), CompoundTypeDef::Struct(struct_ty)) => {
                     let len = v.members.len();
-                    let expected_len = engine
-                        .types()
-                        .type_definition(compound_ty.definition())
-                        .as_struct()
-                        .expect("should be struct")
-                        .members()
-                        .len();
+                    let expected_len = struct_ty.members().len();
 
                     if len != expected_len {
                         bail!(
                             "cannot coerce an object of {len} members{s1} to struct type `{ty}` \
                              as the target struct has {expected_len} member{s2}",
                             s1 = if len == 1 { "" } else { "s" },
-                            ty = compound_ty.display(engine.types()),
+                            ty = compound_ty.display(types),
                             s2 = if expected_len == 1 { "" } else { "s" }
                         );
                     }
 
-                    let members = Arc::new(
-                        v.members
-                            .iter()
-                            .map(|(k, v)| {
-                                let ty = engine
-                                    .types()
-                                    .type_definition(compound_ty.definition())
-                                    .as_struct()
-                                    .expect("should be struct")
-                                    .members()
-                                    .get(k)
-                                    .ok_or_else(|| {
-                                        anyhow!(
-                                            "cannot coerce an object with member `{k}` to struct \
-                                             type `{ty}` as the struct does not contain a member \
-                                             with that name",
-                                            ty = compound_ty.display(engine.types())
-                                        )
-                                    })?;
-                                let v = v.coerce(engine, *ty)?;
-                                Ok((k.clone(), v))
-                            })
-                            .collect::<Result<_>>()?,
-                    );
-
-                    return Ok(Self::Struct(Struct::new(target, members)));
+                    return Ok(Self::Struct(Struct {
+                        ty: target,
+                        name: struct_ty.name().clone(),
+                        members: Arc::new(
+                            v.members
+                                .iter()
+                                .map(|(k, v)| {
+                                    let ty =
+                                        types.struct_type(target).members().get(k).ok_or_else(
+                                            || {
+                                                anyhow!(
+                                                    "cannot coerce an object with member `{k}` to \
+                                                     struct type `{ty}` as the struct does not \
+                                                     contain a member with that name",
+                                                    ty = compound_ty.display(types)
+                                                )
+                                            },
+                                        )?;
+                                    let v = v.coerce(types, *ty)?;
+                                    Ok((k.clone(), v))
+                                })
+                                .collect::<Result<_>>()?,
+                        ),
+                    }));
                 }
                 // Struct -> Struct
-                (Self::Struct(v), CompoundTypeDef::Struct(_)) => {
+                (Self::Struct(v), CompoundTypeDef::Struct(struct_ty)) => {
                     let len = v.members.len();
-                    let expected_len = engine
-                        .types()
-                        .type_definition(compound_ty.definition())
-                        .as_struct()
-                        .expect("should be struct")
-                        .members()
-                        .len();
+                    let expected_len = struct_ty.members().len();
 
                     if len != expected_len {
                         bail!(
                             "cannot coerce a struct of {len} members{s1} to struct type `{ty}` as \
                              the target struct has {expected_len} member{s2}",
                             s1 = if len == 1 { "" } else { "s" },
-                            ty = compound_ty.display(engine.types()),
+                            ty = compound_ty.display(types),
                             s2 = if expected_len == 1 { "" } else { "s" }
                         );
                     }
 
-                    let members = Arc::new(
-                        v.members
-                            .iter()
-                            .map(|(k, v)| {
-                                let ty = engine
-                                    .types()
-                                    .type_definition(compound_ty.definition())
-                                    .as_struct()
-                                    .expect("should be struct")
-                                    .members()
-                                    .get(k)
-                                    .ok_or_else(|| {
-                                        anyhow!(
-                                            "cannot coerce a struct with member `{k}` to struct \
-                                             type `{ty}` as the target struct does not contain a \
-                                             member with that name",
-                                            ty = compound_ty.display(engine.types())
-                                        )
+                    return Ok(Self::Struct(Struct {
+                        ty: target,
+                        name: struct_ty.name().clone(),
+                        members: Arc::new(
+                            v.members
+                                .iter()
+                                .map(|(k, v)| {
+                                    let ty =
+                                        types.struct_type(target).members().get(k).ok_or_else(
+                                            || {
+                                                anyhow!(
+                                                    "cannot coerce a struct with member `{k}` to \
+                                                     struct type `{ty}` as the target struct does \
+                                                     not contain a member with that name",
+                                                    ty = compound_ty.display(types)
+                                                )
+                                            },
+                                        )?;
+                                    let v = v.coerce(types, *ty).with_context(|| {
+                                        format!("failed to coerce member `{k}`")
                                     })?;
-                                let v = v
-                                    .coerce(engine, *ty)
-                                    .with_context(|| format!("failed to coerce member `{k}`"))?;
-                                Ok((k.clone(), v))
-                            })
-                            .collect::<Result<_>>()?,
-                    );
-
-                    return Ok(Self::Struct(Struct::new(target, members)));
+                                    Ok((k.clone(), v))
+                                })
+                                .collect::<Result<_>>()?,
+                        ),
+                    }));
                 }
                 _ => {}
             };
@@ -1244,43 +1686,77 @@ impl Coercible for CompoundValue {
             match self {
                 // Map[String, Y] -> Object
                 Self::Map(v) => {
-                    return Ok(Self::Object(Object::new(Arc::new(
-                        v.elements
-                            .iter()
-                            .map(|(k, v)| {
-                                let k = k
-                                    .as_string(engine)
-                                    .ok_or_else(|| {
-                                        anyhow!(
-                                            "cannot coerce a map with a non-string key type to \
-                                             type `Object`"
-                                        )
-                                    })?
-                                    .to_string();
-                                Ok((k, *v))
-                            })
-                            .collect::<Result<_>>()?,
-                    ))));
+                    return Ok(Self::Object(Object {
+                        members: Arc::new(
+                            v.elements
+                                .iter()
+                                .map(|(k, v)| {
+                                    let k = k
+                                        .as_string()
+                                        .ok_or_else(|| {
+                                            anyhow!(
+                                                "cannot coerce a map with a non-string key type \
+                                                 to type `Object`"
+                                            )
+                                        })?
+                                        .to_string();
+                                    Ok((k, v.clone()))
+                                })
+                                .collect::<Result<_>>()?,
+                        ),
+                    }));
                 }
                 // Struct -> Object
-                Self::Struct(v) => return Ok(Self::Object(Object::new(v.members.clone()))),
+                Self::Struct(v) => {
+                    return Ok(Self::Object(Object {
+                        members: v.members.clone(),
+                    }));
+                }
                 _ => {}
             };
         }
 
         bail!(
             "cannot coerce a value of type `{ty}` to type `{expected}`",
-            ty = self.ty().display(engine.types()),
-            expected = target.display(engine.types())
+            ty = self.ty().display(types),
+            expected = target.display(types)
         );
     }
 }
 
-/// Represents an identifier of a compound value.
-pub type CompoundValueId = Id<CompoundValue>;
+impl From<Pair> for CompoundValue {
+    fn from(value: Pair) -> Self {
+        Self::Pair(value)
+    }
+}
+
+impl From<Array> for CompoundValue {
+    fn from(value: Array) -> Self {
+        Self::Array(value)
+    }
+}
+
+impl From<Map> for CompoundValue {
+    fn from(value: Map) -> Self {
+        Self::Map(value)
+    }
+}
+
+impl From<Object> for CompoundValue {
+    fn from(value: Object) -> Self {
+        Self::Object(value)
+    }
+}
+
+impl From<Struct> for CompoundValue {
+    fn from(value: Struct) -> Self {
+        Self::Struct(value)
+    }
+}
 
 #[cfg(test)]
 mod test {
+    use approx::assert_relative_eq;
     use pretty_assertions::assert_eq;
     use wdl_analysis::types::ArrayType;
     use wdl_analysis::types::MapType;
@@ -1291,21 +1767,22 @@ mod test {
 
     #[test]
     fn boolean_coercion() {
-        let mut engine = Engine::default();
+        let types = Types::default();
 
         // Boolean -> Boolean
         assert_eq!(
             Value::from(false)
-                .coerce(&mut engine, PrimitiveTypeKind::Boolean.into())
-                .expect("should coerce"),
-            Value::from(false)
+                .coerce(&types, PrimitiveTypeKind::Boolean.into())
+                .expect("should coerce")
+                .unwrap_boolean(),
+            Value::from(false).unwrap_boolean()
         );
         // Boolean -> String (invalid)
         assert_eq!(
             format!(
                 "{e:?}",
                 e = Value::from(true)
-                    .coerce(&mut engine, PrimitiveTypeKind::String.into())
+                    .coerce(&types, PrimitiveTypeKind::String.into())
                     .unwrap_err()
             ),
             "cannot coerce type `Boolean` to type `String`"
@@ -1314,36 +1791,36 @@ mod test {
 
     #[test]
     fn boolean_display() {
-        let engine = Engine::default();
-
-        assert_eq!(Value::from(false).display(&engine).to_string(), "false");
-        assert_eq!(Value::from(true).display(&engine).to_string(), "true");
+        assert_eq!(Value::from(false).to_string(), "false");
+        assert_eq!(Value::from(true).to_string(), "true");
     }
 
     #[test]
     fn integer_coercion() {
-        let mut engine = Engine::default();
+        let types = Types::default();
 
         // Int -> Int
         assert_eq!(
             Value::from(12345)
-                .coerce(&mut engine, PrimitiveTypeKind::Integer.into())
-                .expect("should coerce"),
-            Value::from(12345)
+                .coerce(&types, PrimitiveTypeKind::Integer.into())
+                .expect("should coerce")
+                .unwrap_integer(),
+            Value::from(12345).unwrap_integer()
         );
         // Int -> Float
-        assert_eq!(
+        assert_relative_eq!(
             Value::from(12345)
-                .coerce(&mut engine, PrimitiveTypeKind::Float.into())
-                .expect("should coerce"),
-            Value::from(12345.0)
+                .coerce(&types, PrimitiveTypeKind::Float.into())
+                .expect("should coerce")
+                .unwrap_float(),
+            Value::from(12345.0).unwrap_float()
         );
         // Int -> Boolean (invalid)
         assert_eq!(
             format!(
                 "{e:?}",
                 e = Value::from(12345)
-                    .coerce(&mut engine, PrimitiveTypeKind::Boolean.into())
+                    .coerce(&types, PrimitiveTypeKind::Boolean.into())
                     .unwrap_err()
             ),
             "cannot coerce type `Int` to type `Boolean`"
@@ -1352,29 +1829,28 @@ mod test {
 
     #[test]
     fn integer_display() {
-        let engine = Engine::default();
-
-        assert_eq!(Value::from(12345).display(&engine).to_string(), "12345");
-        assert_eq!(Value::from(-12345).display(&engine).to_string(), "-12345");
+        assert_eq!(Value::from(12345).to_string(), "12345");
+        assert_eq!(Value::from(-12345).to_string(), "-12345");
     }
 
     #[test]
     fn float_coercion() {
-        let mut engine = Engine::default();
+        let types = Types::default();
 
         // Float -> Float
-        assert_eq!(
+        assert_relative_eq!(
             Value::from(12345.0)
-                .coerce(&mut engine, PrimitiveTypeKind::Float.into())
-                .expect("should coerce"),
-            Value::from(12345.0)
+                .coerce(&types, PrimitiveTypeKind::Float.into())
+                .expect("should coerce")
+                .unwrap_float(),
+            Value::from(12345.0).unwrap_float()
         );
         // Float -> Int (invalid)
         assert_eq!(
             format!(
                 "{e:?}",
                 e = Value::from(12345.0)
-                    .coerce(&mut engine, PrimitiveTypeKind::Integer.into())
+                    .coerce(&types, PrimitiveTypeKind::Integer.into())
                     .unwrap_err()
             ),
             "cannot coerce type `Float` to type `Int`"
@@ -1383,55 +1859,42 @@ mod test {
 
     #[test]
     fn float_display() {
-        let engine = Engine::default();
-
-        assert_eq!(
-            Value::from(12345.12345).display(&engine).to_string(),
-            "12345.12345"
-        );
-        assert_eq!(
-            Value::from(-12345.12345).display(&engine).to_string(),
-            "-12345.12345"
-        );
+        assert_eq!(Value::from(12345.12345).to_string(), "12345.12345");
+        assert_eq!(Value::from(-12345.12345).to_string(), "-12345.12345");
     }
 
     #[test]
     fn string_coercion() {
-        let mut engine = Engine::default();
+        let types = Types::default();
 
-        let value = engine.new_string("foo");
-        let sym = match value {
-            Value::String(sym) => sym,
-            _ => panic!("expected a string value"),
-        };
-
+        let value = PrimitiveValue::new_string("foo");
         // String -> String
         assert_eq!(
             value
-                .coerce(&mut engine, PrimitiveTypeKind::String.into())
+                .coerce(&types, PrimitiveTypeKind::String.into())
                 .expect("should coerce"),
             value
         );
         // String -> File
         assert_eq!(
             value
-                .coerce(&mut engine, PrimitiveTypeKind::File.into())
+                .coerce(&types, PrimitiveTypeKind::File.into())
                 .expect("should coerce"),
-            Value::File(sym)
+            PrimitiveValue::File(value.as_string().expect("should be string").clone())
         );
         // String -> Directory
         assert_eq!(
             value
-                .coerce(&mut engine, PrimitiveTypeKind::Directory.into())
+                .coerce(&types, PrimitiveTypeKind::Directory.into())
                 .expect("should coerce"),
-            Value::Directory(sym)
+            PrimitiveValue::Directory(value.as_string().expect("should be string").clone())
         );
         // String -> Boolean (invalid)
         assert_eq!(
             format!(
                 "{e:?}",
                 e = value
-                    .coerce(&mut engine, PrimitiveTypeKind::Boolean.into())
+                    .coerce(&types, PrimitiveTypeKind::Boolean.into())
                     .unwrap_err()
             ),
             "cannot coerce type `String` to type `Boolean`"
@@ -1440,42 +1903,36 @@ mod test {
 
     #[test]
     fn string_display() {
-        let mut engine = Engine::default();
-
-        let value = engine.new_string("hello world!");
-        assert_eq!(value.display(&engine).to_string(), "\"hello world!\"");
+        let value = PrimitiveValue::new_string("hello world!");
+        assert_eq!(value.to_string(), "\"hello world!\"");
     }
 
     #[test]
     fn file_coercion() {
-        let mut engine = Engine::default();
+        let types = Types::default();
 
-        let value = engine.new_file("foo");
-        let sym = match value {
-            Value::File(sym) => sym,
-            _ => panic!("expected a file value"),
-        };
+        let value = PrimitiveValue::new_file("foo");
 
         // File -> File
         assert_eq!(
             value
-                .coerce(&mut engine, PrimitiveTypeKind::File.into())
+                .coerce(&types, PrimitiveTypeKind::File.into())
                 .expect("should coerce"),
             value
         );
         // File -> String
         assert_eq!(
             value
-                .coerce(&mut engine, PrimitiveTypeKind::String.into())
+                .coerce(&types, PrimitiveTypeKind::String.into())
                 .expect("should coerce"),
-            Value::String(sym)
+            PrimitiveValue::String(value.as_file().expect("should be file").clone())
         );
         // File -> Directory (invalid)
         assert_eq!(
             format!(
                 "{e:?}",
                 e = value
-                    .coerce(&mut engine, PrimitiveTypeKind::Directory.into())
+                    .coerce(&types, PrimitiveTypeKind::Directory.into())
                     .unwrap_err()
             ),
             "cannot coerce type `File` to type `Directory`"
@@ -1484,42 +1941,35 @@ mod test {
 
     #[test]
     fn file_display() {
-        let mut engine = Engine::default();
-
-        let value = engine.new_file("/foo/bar/baz.txt");
-        assert_eq!(value.display(&engine).to_string(), "\"/foo/bar/baz.txt\"");
+        let value = PrimitiveValue::new_file("/foo/bar/baz.txt");
+        assert_eq!(value.to_string(), "\"/foo/bar/baz.txt\"");
     }
 
     #[test]
     fn directory_coercion() {
-        let mut engine = Engine::default();
-
-        let value = engine.new_directory("foo");
-        let sym = match value {
-            Value::Directory(sym) => sym,
-            _ => panic!("expected a directory value"),
-        };
+        let types = Types::default();
+        let value = PrimitiveValue::new_directory("foo");
 
         // Directory -> Directory
         assert_eq!(
             value
-                .coerce(&mut engine, PrimitiveTypeKind::Directory.into())
+                .coerce(&types, PrimitiveTypeKind::Directory.into())
                 .expect("should coerce"),
             value
         );
         // Directory -> String
         assert_eq!(
             value
-                .coerce(&mut engine, PrimitiveTypeKind::String.into())
+                .coerce(&types, PrimitiveTypeKind::String.into())
                 .expect("should coerce"),
-            Value::String(sym)
+            PrimitiveValue::String(value.as_directory().expect("should be directory").clone())
         );
         // Directory -> File (invalid)
         assert_eq!(
             format!(
                 "{e:?}",
                 e = value
-                    .coerce(&mut engine, PrimitiveTypeKind::File.into())
+                    .coerce(&types, PrimitiveTypeKind::File.into())
                     .unwrap_err()
             ),
             "cannot coerce type `Directory` to type `File`"
@@ -1528,25 +1978,20 @@ mod test {
 
     #[test]
     fn directory_display() {
-        let mut engine = Engine::default();
-
-        let value = engine.new_file("/foo/bar/baz");
-        assert_eq!(value.display(&engine).to_string(), "\"/foo/bar/baz\"");
+        let value = PrimitiveValue::new_directory("/foo/bar/baz");
+        assert_eq!(value.to_string(), "\"/foo/bar/baz\"");
     }
 
     #[test]
     fn none_coercion() {
-        let mut engine = Engine::default();
+        let types = Types::default();
 
         // None -> String?
-        assert_eq!(
+        assert!(
             Value::None
-                .coerce(
-                    &mut engine,
-                    Type::from(PrimitiveTypeKind::String).optional()
-                )
-                .expect("should coerce"),
-            Value::None
+                .coerce(&types, Type::from(PrimitiveTypeKind::String).optional())
+                .expect("should coerce")
+                .is_none(),
         );
 
         // None -> String (invalid)
@@ -1554,7 +1999,7 @@ mod test {
             format!(
                 "{e:?}",
                 e = Value::None
-                    .coerce(&mut engine, PrimitiveTypeKind::String.into())
+                    .coerce(&types, PrimitiveTypeKind::String.into())
                     .unwrap_err()
             ),
             "cannot coerce `None` to non-optional type `String`"
@@ -1563,39 +2008,27 @@ mod test {
 
     #[test]
     fn none_display() {
-        let engine = Engine::default();
-
-        assert_eq!(Value::None.display(&engine).to_string(), "None");
+        assert_eq!(Value::None.to_string(), "None");
     }
 
     #[test]
     fn array_coercion() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let src_ty = engine
-            .types_mut()
-            .add_array(ArrayType::new(PrimitiveTypeKind::Integer));
-        let target_ty = engine
-            .types_mut()
-            .add_array(ArrayType::new(PrimitiveTypeKind::Float));
+        let src_ty = types.add_array(ArrayType::new(PrimitiveTypeKind::Integer));
+        let target_ty = types.add_array(ArrayType::new(PrimitiveTypeKind::Float));
 
         // Array[Int] -> Array[Float]
-        let src = engine
-            .new_array(src_ty, [1, 2, 3])
-            .expect("should create array value");
-        let target = src.coerce(&mut engine, target_ty).expect("should coerce");
-        assert_eq!(target.unwrap_array(&engine).elements(), &[
-            1.0.into(),
-            2.0.into(),
-            3.0.into()
-        ]);
+        let src: CompoundValue = Array::new(&types, src_ty, [1, 2, 3])
+            .expect("should create array value")
+            .into();
+        let target = src.coerce(&types, target_ty).expect("should coerce");
+        assert_eq!(target.unwrap_array().to_string(), "[1.0, 2.0, 3.0]");
 
         // Array[Int] -> Array[String] (invalid)
-        let target_ty = engine
-            .types_mut()
-            .add_array(ArrayType::new(PrimitiveTypeKind::String));
+        let target_ty = types.add_array(ArrayType::new(PrimitiveTypeKind::String));
         assert_eq!(
-            format!("{e:?}", e = src.coerce(&mut engine, target_ty).unwrap_err()),
+            format!("{e:?}", e = src.coerce(&types, target_ty).unwrap_err()),
             r#"failed to coerce array element at index 0
 
 Caused by:
@@ -1605,168 +2038,165 @@ Caused by:
 
     #[test]
     fn non_empty_array_coercion() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let ty = engine
-            .types_mut()
-            .add_array(ArrayType::new(PrimitiveTypeKind::String));
-        let target_ty = engine
-            .types_mut()
-            .add_array(ArrayType::non_empty(PrimitiveTypeKind::String));
+        let ty = types.add_array(ArrayType::new(PrimitiveTypeKind::String));
+        let target_ty = types.add_array(ArrayType::non_empty(PrimitiveTypeKind::String));
 
         // Array[String] (non-empty) -> Array[String]+
-        let string = engine.new_string("foo");
-        let value = engine.new_array(ty, [string]).expect("should create array");
-        assert!(
-            value.coerce(&mut engine, target_ty).is_ok(),
-            "should coerce"
-        );
+        let string = PrimitiveValue::new_string("foo");
+        let value: Value = Array::new(&types, ty, [string])
+            .expect("should create array")
+            .into();
+        assert!(value.coerce(&types, target_ty).is_ok(), "should coerce");
 
         // Array[String] (empty) -> Array[String]+ (invalid)
-        let value = engine
-            .new_array::<Value>(ty, [])
-            .expect("should create array");
+        let value: Value = Array::new::<Value>(&types, ty, [])
+            .expect("should create array")
+            .into();
         assert_eq!(
-            format!(
-                "{e:?}",
-                e = value.coerce(&mut engine, target_ty).unwrap_err()
-            ),
+            format!("{e:?}", e = value.coerce(&types, target_ty).unwrap_err()),
             "cannot coerce empty array value to non-empty array type `Array[String]+`"
         );
     }
 
     #[test]
     fn array_display() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let ty = engine
-            .types_mut()
-            .add_array(ArrayType::new(PrimitiveTypeKind::Integer));
-        let value = engine
-            .new_array(ty, [1, 2, 3])
-            .expect("should create array value");
+        let ty = types.add_array(ArrayType::new(PrimitiveTypeKind::Integer));
+        let value: Value = Array::new(&types, ty, [1, 2, 3])
+            .expect("should create array")
+            .into();
 
-        assert_eq!(value.display(&engine).to_string(), "[1, 2, 3]");
+        assert_eq!(value.to_string(), "[1, 2, 3]");
     }
 
     #[test]
     fn map_coerce() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let key1 = engine.new_file("foo");
-        let value1 = engine.new_string("bar");
-        let key2 = engine.new_file("baz");
-        let value2 = engine.new_string("qux");
+        let key1 = PrimitiveValue::new_file("foo");
+        let value1 = PrimitiveValue::new_string("bar");
+        let key2 = PrimitiveValue::new_file("baz");
+        let value2 = PrimitiveValue::new_string("qux");
 
-        let ty = engine.types_mut().add_map(MapType::new(
+        let ty = types.add_map(MapType::new(
             PrimitiveTypeKind::File,
             PrimitiveTypeKind::String,
         ));
-        let value = engine
-            .new_map(ty, [(key1, value1), (key2, value2)])
-            .expect("should create map value");
+        let value: Value = Map::new(&types, ty, [(key1, value1), (key2, value2)])
+            .expect("should create map value")
+            .into();
 
         // Map[File, String] -> Map[String, File]
-        let ty = engine.types_mut().add_map(MapType::new(
+        let ty = types.add_map(MapType::new(
             PrimitiveTypeKind::String,
             PrimitiveTypeKind::File,
         ));
-        let value = value.coerce(&mut engine, ty).expect("value should coerce");
-        assert_eq!(
-            value.display(&engine).to_string(),
-            r#"{"foo": "bar", "baz": "qux"}"#
-        );
+        let value = value.coerce(&types, ty).expect("value should coerce");
+        assert_eq!(value.to_string(), r#"{"foo": "bar", "baz": "qux"}"#);
 
         // Map[String, File] -> Map[Int, File] (invalid)
-        let ty = engine.types_mut().add_map(MapType::new(
+        let ty = types.add_map(MapType::new(
             PrimitiveTypeKind::Integer,
             PrimitiveTypeKind::File,
         ));
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&mut engine, ty).unwrap_err()),
-            r#"failed to coerce map key at index 0
+            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
+            r#"failed to coerce map key for element at index 0
 
 Caused by:
     cannot coerce type `String` to type `Int`"#
         );
 
+        // Map[String, File] -> Map[String, Int] (invalid)
+        let ty = types.add_map(MapType::new(
+            PrimitiveTypeKind::String,
+            PrimitiveTypeKind::Integer,
+        ));
+        assert_eq!(
+            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
+            r#"failed to coerce map value for element at index 0
+
+Caused by:
+    cannot coerce type `File` to type `Int`"#
+        );
+
         // Map[String, File] -> Struct
-        let ty = engine.types_mut().add_struct(StructType::new("Foo", [
+        let ty = types.add_struct(StructType::new("Foo", [
             ("foo", PrimitiveTypeKind::File),
             ("baz", PrimitiveTypeKind::File),
         ]));
-        let struct_value = value.coerce(&mut engine, ty).expect("value should coerce");
-        assert_eq!(
-            struct_value.display(&engine).to_string(),
-            r#"Foo {foo: "bar", baz: "qux"}"#
-        );
+        let struct_value = value.coerce(&types, ty).expect("value should coerce");
+        assert_eq!(struct_value.to_string(), r#"Foo {foo: "bar", baz: "qux"}"#);
 
         // Map[String, File] -> Struct (invalid)
-        let ty = engine.types_mut().add_struct(StructType::new("Foo", [
+        let ty = types.add_struct(StructType::new("Foo", [
             ("foo", PrimitiveTypeKind::File),
             ("baz", PrimitiveTypeKind::File),
             ("qux", PrimitiveTypeKind::File),
         ]));
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&mut engine, ty).unwrap_err()),
+            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
             "cannot coerce a map of 2 elements to struct type `Foo` as the struct has 3 members"
         );
 
         // Map[String, File] -> Object
         let object_value = value
-            .coerce(&mut engine, Type::Object)
+            .coerce(&types, Type::Object)
             .expect("value should coerce");
         assert_eq!(
-            object_value.display(&engine).to_string(),
+            object_value.to_string(),
             r#"object {foo: "bar", baz: "qux"}"#
         );
     }
 
     #[test]
     fn map_display() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let ty = engine.types_mut().add_map(MapType::new(
+        let ty = types.add_map(MapType::new(
             PrimitiveTypeKind::Integer,
             PrimitiveTypeKind::Boolean,
         ));
 
-        let value = engine
-            .new_map(ty, [(1, true), (2, false)])
-            .expect("should create map value");
-        assert_eq!(value.display(&engine).to_string(), "{1: true, 2: false}");
+        let value: Value = Map::new(&types, ty, [(1, true), (2, false)])
+            .expect("should create map value")
+            .into();
+        assert_eq!(value.to_string(), "{1: true, 2: false}");
     }
 
     #[test]
     fn pair_coercion() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let left = engine.new_file("foo");
-        let right = engine.new_string("bar");
+        let left = PrimitiveValue::new_file("foo");
+        let right = PrimitiveValue::new_string("bar");
 
-        let ty = engine.types_mut().add_pair(PairType::new(
+        let ty = types.add_pair(PairType::new(
             PrimitiveTypeKind::File,
             PrimitiveTypeKind::String,
         ));
-        let value = engine
-            .new_pair(ty, left, right)
-            .expect("should create map value");
+        let value: Value = Pair::new(&types, ty, left, right)
+            .expect("should create map value")
+            .into();
 
         // Pair[File, String] -> Pair[String, File]
-        let ty = engine.types_mut().add_pair(PairType::new(
+        let ty = types.add_pair(PairType::new(
             PrimitiveTypeKind::String,
             PrimitiveTypeKind::File,
         ));
-        let value = value.coerce(&mut engine, ty).expect("value should coerce");
-        assert_eq!(value.display(&engine).to_string(), r#"("foo", "bar")"#);
+        let value = value.coerce(&types, ty).expect("value should coerce");
+        assert_eq!(value.to_string(), r#"("foo", "bar")"#);
 
         // Pair[String, File] -> Pair[Int, Int]
-        let ty = engine.types_mut().add_pair(PairType::new(
+        let ty = types.add_pair(PairType::new(
             PrimitiveTypeKind::Integer,
             PrimitiveTypeKind::Integer,
         ));
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&mut engine, ty).unwrap_err()),
+            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
             r#"failed to coerce pair's left value
 
 Caused by:
@@ -1776,61 +2206,61 @@ Caused by:
 
     #[test]
     fn pair_display() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let ty = engine.types_mut().add_pair(PairType::new(
+        let ty = types.add_pair(PairType::new(
             PrimitiveTypeKind::Integer,
             PrimitiveTypeKind::Boolean,
         ));
 
-        let value = engine
-            .new_pair(ty, 12345, false)
-            .expect("should create pair value");
-        assert_eq!(value.display(&engine).to_string(), "(12345, false)");
+        let value: Value = Pair::new(&types, ty, 12345, false)
+            .expect("should create pair value")
+            .into();
+        assert_eq!(value.to_string(), "(12345, false)");
     }
 
     #[test]
     fn struct_coercion() {
-        let mut engine = Engine::default();
+        let mut types = Types::default();
 
-        let ty = engine.types_mut().add_struct(StructType::new("Foo", [
+        let ty = types.add_struct(StructType::new("Foo", [
             ("foo", PrimitiveTypeKind::Float),
             ("bar", PrimitiveTypeKind::Float),
             ("baz", PrimitiveTypeKind::Float),
         ]));
-        let value = engine
-            .new_struct(ty, [("foo", 1.0), ("bar", 2.0), ("baz", 3.0)])
-            .expect("should create map value");
+        let value: Value = Struct::new(&types, ty, [("foo", 1.0), ("bar", 2.0), ("baz", 3.0)])
+            .expect("should create map value")
+            .into();
 
         // Struct -> Map[String, Float]
-        let ty = engine.types_mut().add_map(MapType::new(
+        let ty = types.add_map(MapType::new(
             PrimitiveTypeKind::String,
             PrimitiveTypeKind::Float,
         ));
-        let map_value = value.coerce(&mut engine, ty).expect("value should coerce");
+        let map_value = value.coerce(&types, ty).expect("value should coerce");
         assert_eq!(
-            map_value.display(&engine).to_string(),
+            map_value.to_string(),
             r#"{"foo": 1.0, "bar": 2.0, "baz": 3.0}"#
         );
 
         // Struct -> Struct
-        let ty = engine.types_mut().add_struct(StructType::new("Bar", [
+        let ty = types.add_struct(StructType::new("Bar", [
             ("foo", PrimitiveTypeKind::Float),
             ("bar", PrimitiveTypeKind::Float),
             ("baz", PrimitiveTypeKind::Float),
         ]));
-        let struct_value = value.coerce(&mut engine, ty).expect("value should coerce");
+        let struct_value = value.coerce(&types, ty).expect("value should coerce");
         assert_eq!(
-            struct_value.display(&engine).to_string(),
+            struct_value.to_string(),
             r#"Bar {foo: 1.0, bar: 2.0, baz: 3.0}"#
         );
 
         // Struct -> Object
         let object_value = value
-            .coerce(&mut engine, Type::Object)
+            .coerce(&types, Type::Object)
             .expect("value should coerce");
         assert_eq!(
-            object_value.display(&engine).to_string(),
+            object_value.to_string(),
             r#"object {foo: 1.0, bar: 2.0, baz: 3.0}"#
         );
     }

--- a/wdl-engine/tests/inputs.rs
+++ b/wdl-engine/tests/inputs.rs
@@ -149,12 +149,12 @@ fn run_test(test: &Path, result: AnalysisResult) -> Result<()> {
 
     let mut engine = Engine::default();
     let document = result.document();
-    let result = match InputsFile::parse(&mut engine, document, test.join("inputs.json")) {
+    let result = match InputsFile::parse(engine.types_mut(), document, test.join("inputs.json")) {
         Ok(inputs) => {
             if let Some((task, inputs)) = inputs.as_task_inputs() {
                 match inputs
                     .validate(
-                        &mut engine,
+                        engine.types_mut(),
                         document,
                         document.task_by_name(task).expect("task should be present"),
                     )
@@ -166,7 +166,7 @@ fn run_test(test: &Path, result: AnalysisResult) -> Result<()> {
             } else if let Some(inputs) = inputs.as_workflow_inputs() {
                 let workflow = document.workflow().expect("workflow should be present");
                 match inputs
-                    .validate(&mut engine, document, workflow)
+                    .validate(engine.types_mut(), document, workflow)
                     .with_context(|| {
                         format!(
                             "failed to validate the inputs to workflow `{workflow}`",

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Made construction of a CST from a list of parser events public via the
+`construct_tree` function ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
+
 ## 0.10.0 - 10-22-2024
 
 ### Changed

--- a/wdl-grammar/src/grammar/v1.rs
+++ b/wdl-grammar/src/grammar/v1.rs
@@ -1829,7 +1829,7 @@ fn call_input_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marke
 
 /// Parses an expression.
 #[inline]
-fn expr(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Diagnostic)> {
+pub fn expr(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, Diagnostic)> {
     expr_with_precedence(parser, marker, 0)?;
     Ok(())
 }


### PR DESCRIPTION
This PR implements expression evaluation in `wdl-engine` with the exception of function calls, which are dependent upon an upcoming implementation of the WDL standard library.

Additionally, certain WDL 1.2 features (such as task variables) and call output access expressions haven't been fully implemented yet; those require changes to the representation of WDL values, which will be completed alongside task and workflow evaluation.

These changes also include some refactorings:

* String interning was removed from `Engine` as it complicated the API; we can reintroduce interning of strings if it proves necessary. This change removed the requirement that values needed to be constructed via the engine.
* Likewise, values are no longer stored in an arena to simplify the API.
* An `EvaluationContext` trait was introduced in `wdl-analysis` so that context could be provided for expression type evaluation that wasn't dependent on `wdl-analysis`'s representation of scopes; expression evaluation in `wdl-engine` needs to statically determine types in the ternary operator, but use its own scope representation.
* `Document` in `wdl-analysis` now keeps a reference to the root CST node.
* A maximum number of parameters for functions in the standard library was added; this allows call expression evaluation to stack alloc space for the values and types of the arguments; the number will increase when more functions are defined in future specifications.
* `Type` and `Value` no longer implement `PartialEq`/`Eq`, as the former has a separate concept of "type equality" that resolves through the types arena and the latter has to handle certain type coercions for value equality.
* The underlying representation of `Value` has been split into `PrimitiveValue` and `CompoundValue`. This helped to simplify the coercion logic and make it so that only `PrimitiveValue` can implement `PartialEq`, `Eq`, and `Hash` for use in maps.
* Constructing a CST from parser events was made public in `wdl-grammar`; this will allow for `wdl-engine` unit tests to parse expressions directly. In the future, it'll be used for partial reparses in `wdl-analysis`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
