### PR TITLE
feat: implement the string functions in the WDL standard library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ path-clean = "1.0.1"
 petgraph = "0.6.5"
 pretty_assertions = "1.4.0"
 rayon = "1.10.0"
+regex = "1.11.1"
 reqwest = { version = "0.12.5", default-features = false, features = ["rustls-tls", "http2", "charset"] }
 rowan = "0.15.15"
 serde = { version = "1", features = ["derive"] }

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Implemented the string functions from the WDL standard library ([#252](https://github.com/stjude-rust-labs/wdl/pull/252)).
 * Implemented call evaluation and the numeric functions from the WDL standard
   library ([#251](https://github.com/stjude-rust-labs/wdl/pull/251)).
 * Implemented WDL expression evaluation ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).

--- a/wdl-engine/Cargo.toml
+++ b/wdl-engine/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 ordered-float = { workspace = true }
 indexmap = { workspace = true }
 serde_json = { workspace = true }
+regex = { workspace = true }
 
 [dev-dependencies]
 wdl-grammar = { version = "0.10.0", path = "../wdl-grammar" }

--- a/wdl-engine/src/diagnostics.rs
+++ b/wdl-engine/src/diagnostics.rs
@@ -148,3 +148,8 @@ pub fn exponentiation_requirement(span: Span) -> Diagnostic {
 pub fn multiline_string_requirement(span: Span) -> Diagnostic {
     Diagnostic::error("use of multi-line strings requires WDL version 1.2").with_highlight(span)
 }
+
+/// Creates an "invalid regular expression" diagnostic.
+pub fn invalid_regex(error: &regex::Error, span: Span) -> Diagnostic {
+    Diagnostic::error(error.to_string()).with_highlight(span)
+}

--- a/wdl-engine/src/eval/v1.rs
+++ b/wdl-engine/src/eval/v1.rs
@@ -1064,12 +1064,12 @@ impl<'a, C: EvaluationContext> ExprEvaluator<'a, C> {
                 // Evaluate the argument expressions
                 let mut count = 0;
                 let mut types = [Type::Union; MAX_PARAMETERS];
-                let mut arguments = [const { Value::None }; MAX_PARAMETERS];
+                let mut arguments = [const { (Value::None, Span::new(0, 0)) }; MAX_PARAMETERS];
                 for arg in expr.arguments() {
                     if count < MAX_PARAMETERS {
                         let v = self.evaluate_expr(&arg)?;
                         types[count] = v.ty();
-                        arguments[count] = v;
+                        arguments[count] = (v, arg.span());
                     }
 
                     count += 1;

--- a/wdl-grammar/src/diagnostic.rs
+++ b/wdl-grammar/src/diagnostic.rs
@@ -17,7 +17,7 @@ pub struct Span {
 
 impl Span {
     /// Creates a new span from the given start and end.
-    pub fn new(start: usize, len: usize) -> Self {
+    pub const fn new(start: usize, len: usize) -> Self {
         Self {
             start,
             end: start + len,


### PR DESCRIPTION
This commit implements the following functions in the WDL standard library:

* `find`
* `matches`
* `sub`

Additionally, the spans of the arguments are now passed into the functions so that any returned diagnostics may point at a particular argument.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
