### PR TITLE
refactor: make `Analyzer` accept the diagnostics configuration.

### DIFF
--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -40,6 +40,7 @@ use report::Status;
 use report::UnmatchedStatus;
 pub use repository::Repository;
 use wdl::analysis::Analyzer;
+use wdl::analysis::DiagnosticsConfig;
 use wdl::analysis::rules;
 use wdl::ast::Diagnostic;
 use wdl::lint::LintVisitor;
@@ -174,7 +175,7 @@ pub async fn gauntlet(args: Args) -> Result<()> {
 
         let analyzer = Analyzer::new_with_validator(
             // Don't bother duplicating analysis warnings for arena mode
-            if args.arena { Vec::new() } else { rules() },
+            DiagnosticsConfig::new(if args.arena { Vec::new() } else { rules() }),
             move |_: (), _, _, _| async move {},
             move || {
                 let mut validator = if !args.arena {

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed the `new` and `new_with_validator` methods of `Analyzer` to take the 
+  diagnostics configuration rather than a rule iterator ([#274](https://github.com/stjude-rust-labs/wdl/pull/274)).
 * Refactored the `AnalysisResult` and `Document` types to move properties of
   the former into the latter; this will assist in evaluation of documents in
   that the `Document` alone can be passed into evaluation ([#265](https://github.com/stjude-rust-labs/wdl/pull/265)).

--- a/wdl-analysis/tests/analysis.rs
+++ b/wdl-analysis/tests/analysis.rs
@@ -33,6 +33,7 @@ use path_clean::clean;
 use pretty_assertions::StrComparison;
 use wdl_analysis::AnalysisResult;
 use wdl_analysis::Analyzer;
+use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::path_to_uri;
 use wdl_analysis::rules;
 use wdl_ast::Diagnostic;
@@ -164,7 +165,7 @@ async fn main() {
     println!("\nrunning {} tests\n", tests.len());
 
     // Start with a single analysis pass over all the test files
-    let analyzer = Analyzer::new(rules(), |_, _, _, _| async {});
+    let analyzer = Analyzer::new(DiagnosticsConfig::new(rules()), |_, _, _, _| async {});
     for test in &tests {
         analyzer
             .add_directory(test.clone())
@@ -215,7 +216,7 @@ async fn main() {
     // Some tests are sensitive to the order in which files are parsed (e.g.
     // detecting cycles) For those, use a new analyzer and analyze the
     // `source.wdl` directly
-    let analyzer = Analyzer::new(rules(), |_, _, _, _| async {});
+    let analyzer = Analyzer::new(DiagnosticsConfig::new(rules()), |_, _, _, _| async {});
     for test_name in single_file {
         let test = Path::new("tests/analysis").join(test_name);
         let document = test.join("source.wdl");

--- a/wdl-doc/src/lib.rs
+++ b/wdl-doc/src/lib.rs
@@ -25,6 +25,7 @@ use pulldown_cmark::Options;
 use pulldown_cmark::Parser;
 use tokio::io::AsyncWriteExt;
 use wdl_analysis::Analyzer;
+use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::rules;
 use wdl_ast::AstToken;
 use wdl_ast::Document as AstDocument;
@@ -141,7 +142,7 @@ pub async fn document_workspace(path: PathBuf) -> Result<()> {
         std::fs::create_dir(&docs_dir)?;
     }
 
-    let analyzer = Analyzer::new(rules(), |_: (), _, _, _| async {});
+    let analyzer = Analyzer::new(DiagnosticsConfig::new(rules()), |_: (), _, _, _| async {});
     analyzer.add_directory(abs_path.clone()).await?;
     let results = analyzer.analyze(()).await?;
 

--- a/wdl-engine/tests/inputs.rs
+++ b/wdl-engine/tests/inputs.rs
@@ -37,6 +37,7 @@ use pretty_assertions::StrComparison;
 use rayon::prelude::*;
 use wdl_analysis::AnalysisResult;
 use wdl_analysis::Analyzer;
+use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::rules;
 use wdl_analysis::types::Types;
 use wdl_ast::Diagnostic;
@@ -197,7 +198,7 @@ async fn main() {
     println!("\nrunning {} tests\n", tests.len());
 
     // Start with a single analysis pass over all the test files
-    let analyzer = Analyzer::new(rules(), |_, _, _, _| async {});
+    let analyzer = Analyzer::new(DiagnosticsConfig::new(rules()), |_, _, _, _| async {});
     for test in &tests {
         analyzer
             .add_directory(test.clone())

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -47,6 +47,7 @@ use tempfile::TempDir;
 use walkdir::WalkDir;
 use wdl_analysis::AnalysisResult;
 use wdl_analysis::Analyzer;
+use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::document::Document;
 use wdl_analysis::rules;
 use wdl_ast::Diagnostic;
@@ -411,7 +412,7 @@ async fn main() {
     println!("\nrunning {} tests\n", tests.len());
 
     // Start with a single analysis pass over all the test files
-    let analyzer = Analyzer::new(rules(), |_, _, _, _| async {});
+    let analyzer = Analyzer::new(DiagnosticsConfig::new(rules()), |_, _, _, _| async {});
     for test in &tests {
         analyzer
             .add_directory(test.clone())

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -24,6 +24,7 @@ use tracing::error;
 use tracing::info;
 use uuid::Uuid;
 use wdl_analysis::Analyzer;
+use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::IncrementalChange;
 use wdl_analysis::SourceEdit;
 use wdl_analysis::SourcePosition;
@@ -252,7 +253,7 @@ impl Server {
                 client,
                 options,
                 analyzer: Analyzer::<ProgressToken>::new_with_validator(
-                    rules(),
+                    DiagnosticsConfig::new(rules()),
                     move |token, kind, current, total| {
                         let client = analyzer_client.clone();
                         async move {

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -37,6 +37,7 @@ use wdl::ast::Validator;
 use wdl::lint::LintVisitor;
 use wdl_analysis::AnalysisResult;
 use wdl_analysis::Analyzer;
+use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::Rule;
 use wdl_analysis::path_to_uri;
 use wdl_analysis::rules;
@@ -95,7 +96,7 @@ async fn analyze<T: AsRef<dyn Rule>>(
     );
 
     let analyzer = Analyzer::new_with_validator(
-        rules,
+        DiagnosticsConfig::new(rules),
         move |bar: ProgressBar, kind, completed, total| async move {
             bar.set_position(completed.try_into().unwrap());
             if completed == 0 {


### PR DESCRIPTION
This commit refactors the `new` and `new_with_validator` methods of `Analyzer` to directly accept the `DiagnosticsConfig` rather than an iterator of rules which it immediately uses to create a `DiagnosticsConfig` internally.

By having the `DiagnosticsConfig` (which is `Copy`) passed in directly, we don't have to borrow a rule exception list that might also be used as part of the validator closure passed to `new_with_validator`, sparing us a clone.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
