### PR TITLE
refactor: remove `Types` collection from `wdl-analysis`. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ faster-hex = "0.9.0"
 futures = "0.3.30"
 git2 = "0.18.3"
 glob = "0.3.1"
-id-arena = "2.2.1"
 indexmap = { version = "2.2.6", features = ["serde"] }
 indicatif = "0.17.8"
 itertools = "0.13.0"

--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -1313,11 +1313,6 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308b
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
-message = "BenchmarkSVs.wdl:242:26: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L242"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/BenchmarkSVs/BenchmarkSVs.wdl"
 message = "BenchmarkSVs.wdl:243:35: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkSVs/BenchmarkSVs.wdl/#L243"
 
@@ -1447,21 +1442,6 @@ message = "BenchmarkAndCompareVCFs.wdl:23:21: warning[UnusedInput]: unused input
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L23"
 
 [[diagnostics]]
-document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
-message = "BenchmarkAndCompareVCFs.wdl:75:32: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L75"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
-message = "BenchmarkAndCompareVCFs.wdl:76:39: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L76"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl"
-message = "BenchmarkAndCompareVCFs.wdl:77:22: error: type mismatch: expected type `Array[Int]`, but found type `Array[Int]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkAndCompareVCFs.wdl/#L77"
-
-[[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:178:26: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L178"
@@ -1475,11 +1455,6 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308b
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
 message = "BenchmarkVCFs.wdl:180:26: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L180"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
-message = "BenchmarkVCFs.wdl:189:18: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/BenchmarkVCFs/BenchmarkVCFs.wdl/#L189"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/BenchmarkVCFs/BenchmarkVCFs.wdl"
@@ -1698,16 +1673,6 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308b
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:48:21: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L48"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
-message = "Glimpse2ImputationAndCheckQC.wdl:49:28: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L49"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl"
 message = "Glimpse2ImputationAndCheckQC.wdl:55:46: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl/#L55"
 
@@ -1877,16 +1842,6 @@ message = "PCARE.wdl:3:8: warning[UnusedImport]: unused import namespace `Struct
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCARE.wdl/#L3"
 
 [[diagnostics]]
-document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCARE.wdl"
-message = "PCARE.wdl:44:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCARE.wdl/#L44"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
-message = "PCAREAndQC.wdl:49:28: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCAREAndQC.wdl/#L49"
-
-[[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/PCAREAndQC.wdl"
 message = "PCAREAndQC.wdl:61:35: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/PCAREAndQC.wdl/#L61"
@@ -1958,23 +1913,8 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308b
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
-message = "FullImputationPRSValidation.wdl:52:18: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L52"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/FullImputationPRSValidation.wdl"
 message = "FullImputationPRSValidation.wdl:5:8: warning[UnusedImport]: unused import namespace `Structs`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/FullImputationPRSValidation.wdl/#L5"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
-message = "SubsetWeightSet.wdl:27:7: warning[UnnecessaryFunctionCall]: unnecessary call to function `defined`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L27"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/SubsetWeightSet.wdl"
-message = "SubsetWeightSet.wdl:28:53: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_first`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/58f72308bdf511a760dea92dbf2ac21eb2c7dc0e/ImputationPipeline/Validation/SubsetWeightSet.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/ImputationPipeline/Validation/ValidateImputation.wdl"
@@ -2348,16 +2288,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
-message = "UltimaGenomicsWholeGenomeGermline.wdl:62:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L62"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
-message = "UltimaGenomicsWholeGenomeGermline.wdl:63:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L63"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:7:104: warning[UnusedImport]: unused import namespace `UltimaGenomicsWholeGenomeGermlineAlignmentMarkDuplicates`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L7"
 
@@ -2375,11 +2305,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl"
 message = "UltimaGenomicsWholeGenomeGermline.wdl:9:50: warning[UnusedImport]: unused import namespace `QC`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/germline/single_sample/ugwgs/UltimaGenomicsWholeGenomeGermline.wdl/#L9"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
-message = "WholeGenomeGermlineSingleSample.wdl:109:37: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl/#L109"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/germline/single_sample/wgs/WholeGenomeGermlineSingleSample.wdl"
@@ -2410,16 +2335,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
 message = "UltimaGenomicsWholeGenomeCramOnly.wdl:46:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L46"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
-message = "UltimaGenomicsWholeGenomeCramOnly.wdl:58:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L58"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
-message = "UltimaGenomicsWholeGenomeCramOnly.wdl:59:25: error: type mismatch: expected type `Array[String]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl/#L59"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/dna_seq/somatic/single_sample/ugwgs/UltimaGenomicsWholeGenomeCramOnly.wdl"
@@ -2475,16 +2390,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
 message = "BroadInternalUltimaGenomics.wdl:4:95: warning[UnusedImport]: unused import namespace `Structs`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L4"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:63:25: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L63"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
-message = "BroadInternalUltimaGenomics.wdl:64:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl/#L64"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/broad/internal/dna_seq/germline/single_sample/UltimaGenomics/BroadInternalUltimaGenomics.wdl"
@@ -2647,16 +2552,6 @@ message = "Multiome.wdl:105:13: error: duplicate call input `cloud_provider` in 
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/multiome/Multiome.wdl/#L105"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/multiome/Multiome.wdl"
-message = "Multiome.wdl:90:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/multiome/Multiome.wdl/#L90"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
-message = "Optimus.wdl:164:18: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/optimus/Optimus.wdl/#L164"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/optimus/Optimus.wdl"
 message = "Optimus.wdl:228:22: error: type mismatch: expected type `String`, but found type `String?`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/optimus/Optimus.wdl/#L228"
@@ -2687,11 +2582,6 @@ message = "PairedTag.wdl:5:49: warning[UnusedImport]: unused import namespace `H
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/paired_tag/PairedTag.wdl/#L5"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/paired_tag/PairedTag.wdl"
-message = "PairedTag.wdl:86:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/paired_tag/PairedTag.wdl/#L86"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/scATAC/scATAC.wdl"
 message = "scATAC.wdl:203:9: error: duplicate key `cpu` in runtime section"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/scATAC/scATAC.wdl/#L203"
@@ -2707,19 +2597,9 @@ message = "SlideSeq.wdl:7:51: warning[UnusedImport]: unused import namespace `Op
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/slideseq/SlideSeq.wdl/#L7"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/slideseq/SlideSeq.wdl"
-message = "SlideSeq.wdl:98:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/slideseq/SlideSeq.wdl/#L98"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl"
 message = "MultiSampleSmartSeq2.wdl:71:28: warning[UnusedCall]: unused call `checkArrays`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/smartseq2_multisample/MultiSampleSmartSeq2.wdl/#L71"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
-message = "MultiSampleSmartSeq2SingleNucleus.wdl:135:27: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L135"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
@@ -2757,11 +2637,6 @@ message = "MultiSampleSmartSeq2SingleNucleus.wdl:81:40: warning[UnusedCall]: unu
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L81"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl"
-message = "MultiSampleSmartSeq2SingleNucleus.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/smartseq2_single_nucleus_multisample/MultiSampleSmartSeq2SingleNucleus.wdl/#L84"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/pipelines/skylab/snm3C/snm3C.wdl"
 message = "snm3C.wdl:278:14: warning[UnusedInput]: unused input `chromosome_sizes`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/pipelines/skylab/snm3C/snm3C.wdl/#L278"
@@ -2773,11 +2648,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
-message = "CreateOptimusAdapterMetadata.wdl:131:61: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L131"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:217:14: warning[UnusedCall]: unused call `ValidateStagingArea`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L217"
 
@@ -2785,26 +2655,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 document = "broadinstitute/warp:/projects/optimus/CreateOptimusAdapterMetadata.wdl"
 message = "CreateOptimusAdapterMetadata.wdl:45:10: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/projects/optimus/CreateOptimusAdapterMetadata.wdl/#L45"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
-message = "CreateSs2AdapterMetadata.wdl:141:62: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L141"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
-message = "CreateSs2AdapterMetadata.wdl:142:61: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L142"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
-message = "CreateSs2AdapterMetadata.wdl:143:61: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L143"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
-message = "CreateSs2AdapterMetadata.wdl:175:57: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/projects/smartseq2/CreateSs2AdapterMetadata.wdl/#L175"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/projects/smartseq2/CreateSs2AdapterMetadata.wdl"
@@ -3177,11 +3027,6 @@ message = "UnmappedBamToAlignedBam.wdl:25:53: warning[UnusedImport]: unused impo
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/tasks/broad/UnmappedBamToAlignedBam.wdl/#L25"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/tasks/broad/UnmappedBamToAlignedBam.wdl"
-message = "UnmappedBamToAlignedBam.wdl:85:31: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/tasks/broad/UnmappedBamToAlignedBam.wdl/#L85"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/tasks/broad/Utilities.wdl"
 message = "Utilities.wdl:152:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/tasks/broad/Utilities.wdl/#L152"
@@ -3283,18 +3128,8 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
-message = "test_smartseq2_multisample_PR.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L48"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl"
 message = "test_smartseq2_multisample_PR.wdl:58:46: warning[UnusedCall]: unused call `checker_workflow`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/tests/skylab/smartseq2_multisample/pr/test_smartseq2_multisample_PR.wdl/#L58"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
-message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:48:21: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl"
@@ -3892,16 +3727,6 @@ message = "TestBroadInternalRNAWithUMIs.wdl:106:43: warning[UnnecessaryFunctionC
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestBroadInternalRNAWithUMIs.wdl/#L106"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
-message = "TestBroadInternalUltimaGenomics.wdl:57:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L57"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl"
-message = "TestBroadInternalUltimaGenomics.wdl:58:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestBroadInternalUltimaGenomics.wdl/#L58"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestCheckFingerprint.wdl"
 message = "TestCheckFingerprint.wdl:33:15: warning[UnusedInput]: unused input `vault_token_path_arrays`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestCheckFingerprint.wdl/#L33"
@@ -3917,94 +3742,9 @@ message = "TestExternalWholeGenomeReprocessing.wdl:6:45: warning[UnusedImport]: 
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestExternalWholeGenomeReprocessing.wdl/#L6"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl"
-message = "TestGDCWholeGenomeSomaticSingleSample.wdl:77:35: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestGDCWholeGenomeSomaticSingleSample.wdl/#L77"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
-message = "TestImputation.wdl:141:12: warning[UnnecessaryFunctionCall]: unnecessary call to function `defined`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestImputation.wdl/#L141"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
-message = "TestImputation.wdl:162:38: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestImputation.wdl/#L162"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
-message = "TestImputation.wdl:163:46: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestImputation.wdl/#L163"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
-message = "TestImputation.wdl:54:30: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestImputation.wdl/#L54"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
-message = "TestImputation.wdl:55:37: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestImputation.wdl/#L55"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestImputation.wdl"
-message = "TestImputation.wdl:86:45: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestImputation.wdl/#L86"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
 message = "TestJointGenotyping.wdl:110:20: error: type mismatch: expected type `Boolean`, but found type `Boolean?`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestJointGenotyping.wdl/#L110"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
-message = "TestJointGenotyping.wdl:85:44: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestJointGenotyping.wdl/#L85"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
-message = "TestJointGenotyping.wdl:87:46: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestJointGenotyping.wdl/#L87"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestJointGenotyping.wdl"
-message = "TestJointGenotyping.wdl:88:49: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestJointGenotyping.wdl/#L88"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
-message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:51:23: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L51"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
-message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:56:22: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L56"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
-message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:57:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L57"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
-message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:58:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L58"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
-message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:59:19: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L59"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl"
-message = "TestMultiSampleSmartSeq2SingleNucleus.wdl:60:17: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestMultiSampleSmartSeq2SingleNucleus.wdl/#L60"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestMultiome.wdl"
-message = "TestMultiome.wdl:67:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestMultiome.wdl/#L67"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
@@ -4022,19 +3762,9 @@ message = "TestOptimus.wdl:28:11: warning[UnusedInput]: unused input `mt_genes`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestOptimus.wdl/#L28"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestOptimus.wdl"
-message = "TestOptimus.wdl:76:36: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestOptimus.wdl/#L76"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
 message = "TestPairedTag.wdl:57:15: warning[UnusedInput]: unused input `run_cellbender`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestPairedTag.wdl/#L57"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestPairedTag.wdl"
-message = "TestPairedTag.wdl:71:24: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestPairedTag.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/verification/test-wdls/TestRNAWithUMIsPipeline.wdl"
@@ -4055,36 +3785,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd4345
 document = "broadinstitute/warp:/verification/test-wdls/TestReblockGVCF.wdl"
 message = "TestReblockGVCF.wdl:49:31: error: type mismatch: expected type `String`, but found type `String?`"
 permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestReblockGVCF.wdl/#L49"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestSlideSeq.wdl"
-message = "TestSlideSeq.wdl:40:20: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestSlideSeq.wdl/#L40"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
-message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:39:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L39"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl"
-message = "TestUltimaGenomicsWholeGenomeCramOnly.wdl:40:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestUltimaGenomicsWholeGenomeCramOnly.wdl/#L40"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
-message = "TestUltimaGenomicsWholeGenomeGermline.wdl:43:27: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L43"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl"
-message = "TestUltimaGenomicsWholeGenomeGermline.wdl:44:26: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestUltimaGenomicsWholeGenomeGermline.wdl/#L44"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl"
-message = "TestWholeGenomeGermlineSingleSample.wdl:54:45: error: type mismatch: expected type `DragmapReference`, but found type `DragmapReference?`"
-permalink = "https://github.com/broadinstitute/warp/blob/158772d35e6e83ecbdd43450e6cd2d7f3519bfc7/verification/test-wdls/TestWholeGenomeGermlineSingleSample.wdl/#L54"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/amr/run.wdl"
@@ -4175,26 +3875,6 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a527117
 document = "chanzuckerberg/czid-workflows:/workflows/benchmark/long-read-mngs-benchmark.wdl"
 message = "long-read-mngs-benchmark.wdl:88:31: warning[UnnecessaryFunctionCall]: unnecessary call to function `select_all`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/benchmark/long-read-mngs-benchmark.wdl/#L88"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/benchmark/run.wdl"
-message = "run.wdl:37:17: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/benchmark/run.wdl/#L37"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/benchmark/run.wdl"
-message = "run.wdl:38:17: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/benchmark/run.wdl/#L38"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/benchmark/run.wdl"
-message = "run.wdl:53:17: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/benchmark/run.wdl/#L53"
-
-[[diagnostics]]
-document = "chanzuckerberg/czid-workflows:/workflows/benchmark/run.wdl"
-message = "run.wdl:54:17: error: type mismatch: expected type `Array[File]`, but found type `Array[File]?`"
-permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/a04293a5271176885ce7f876b6353b20da3f7b98/workflows/benchmark/run.wdl/#L54"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/benchmark/short-read-mngs-benchmark.wdl"
@@ -4677,11 +4357,6 @@ message = "wf_freyja_fastq.wdl:135:38: error: type mismatch: expected type `Stri
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2bf8822c7acfed9e8e6319f51e44594173c6ae75/workflows/freyja/wf_freyja_fastq.wdl/#L135"
 
 [[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_plot.wdl"
-message = "wf_freyja_plot.wdl:18:25: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2bf8822c7acfed9e8e6319f51e44594173c6ae75/workflows/freyja/wf_freyja_plot.wdl/#L18"
-
-[[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/freyja/wf_freyja_update.wdl"
 message = "wf_freyja_update.wdl:13:17: warning[UnusedCall]: unused call `transfer_files`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2bf8822c7acfed9e8e6319f51e44594173c6ae75/workflows/freyja/wf_freyja_update.wdl/#L13"
@@ -4695,16 +4370,6 @@ permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2bf88
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_augur.wdl"
 message = "wf_augur.wdl:62:21: error: type mismatch: expected type `String`, but found type `String?`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2bf8822c7acfed9e8e6319f51e44594173c6ae75/workflows/phylogenetics/wf_augur.wdl/#L62"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_core_gene_snp.wdl"
-message = "wf_core_gene_snp.wdl:84:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2bf8822c7acfed9e8e6319f51e44594173c6ae75/workflows/phylogenetics/wf_core_gene_snp.wdl/#L84"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_mashtree_fasta.wdl"
-message = "wf_mashtree_fasta.wdl:37:24: error: type mismatch: expected type `Array[String]`, but found type `Array[String]?`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/2bf8822c7acfed9e8e6319f51e44594173c6ae75/workflows/phylogenetics/wf_mashtree_fasta.wdl/#L37"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/workflows/phylogenetics/wf_nextclade_addToRefTree.wdl"

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Removed `Types` collection from `wdl-analysis` to simplify the API ([#277](https://github.com/stjude-rust-labs/wdl/pull/277)).
 * Changed the `new` and `new_with_validator` methods of `Analyzer` to take the 
   diagnostics configuration rather than a rule iterator ([#274](https://github.com/stjude-rust-labs/wdl/pull/274)).
 * Refactored the `AnalysisResult` and `Document` types to move properties of

--- a/wdl-analysis/Cargo.toml
+++ b/wdl-analysis/Cargo.toml
@@ -28,7 +28,6 @@ indexmap = { workspace = true }
 line-index = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 walkdir = { workspace = true }
-id-arena = { workspace = true }
 tracing = { workspace = true }
 convert_case = { workspace = true }
 

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -17,7 +17,6 @@ use crate::UNUSED_INPUT_RULE_ID;
 use crate::types::CallKind;
 use crate::types::CallType;
 use crate::types::Type;
-use crate::types::Types;
 use crate::types::display_types;
 use crate::types::v1::ComparisonOperator;
 use crate::types::v1::NumericOperator;
@@ -140,11 +139,9 @@ pub fn name_conflict(name: &str, conflicting: Context, first: Context) -> Diagno
 }
 
 /// Constructs a "cannot index" diagnostic.
-pub fn cannot_index(types: &Types, actual: Type, span: Span) -> Diagnostic {
-    Diagnostic::error("indexing is only allowed on `Array` and `Map` types").with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        span,
-    )
+pub fn cannot_index(actual: &Type, span: Span) -> Diagnostic {
+    Diagnostic::error("indexing is only allowed on `Array` and `Map` types")
+        .with_label(format!("this is type `{actual}`"), span)
 }
 
 /// Creates an "unknown name" diagnostic.
@@ -354,28 +351,16 @@ pub fn unknown_type(name: &str, span: Span) -> Diagnostic {
 
 /// Creates a "type mismatch" diagnostic.
 pub fn type_mismatch(
-    types: &Types,
-    expected: Type,
+    expected: &Type,
     expected_span: Span,
-    actual: Type,
+    actual: &Type,
     actual_span: Span,
 ) -> Diagnostic {
     Diagnostic::error(format!(
-        "type mismatch: expected type `{expected}`, but found type `{actual}`",
-        expected = expected.display(types),
-        actual = actual.display(types)
+        "type mismatch: expected type `{expected}`, but found type `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
-    .with_label(
-        format!(
-            "this expects type `{expected}`",
-            expected = expected.display(types)
-        ),
-        expected_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
+    .with_label(format!("this expects type `{expected}`"), expected_span)
 }
 
 /// Creates a "non-empty array assignment" diagnostic.
@@ -386,23 +371,14 @@ pub fn non_empty_array_assignment(expected_span: Span, actual_span: Span) -> Dia
 }
 
 /// Creates a "call input type mismatch" diagnostic.
-pub fn call_input_type_mismatch(
-    types: &Types,
-    name: &Ident,
-    expected: Type,
-    actual: Type,
-) -> Diagnostic {
+pub fn call_input_type_mismatch(name: &Ident, expected: &Type, actual: &Type) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: expected type `{expected}`, but found type `{actual}`",
-        expected = expected.display(types),
-        actual = actual.display(types)
     ))
     .with_label(
         format!(
             "input `{name}` is type `{expected}`, but name `{name}` is type `{actual}`",
             name = name.as_str(),
-            expected = expected.display(types),
-            actual = actual.display(types)
         ),
         name.span(),
     )
@@ -410,51 +386,34 @@ pub fn call_input_type_mismatch(
 
 /// Creates a "no common type" diagnostic.
 pub fn no_common_type(
-    types: &Types,
-    expected: Type,
+    expected: &Type,
     expected_span: Span,
-    actual: Type,
+    actual: &Type,
     actual_span: Span,
 ) -> Diagnostic {
     Diagnostic::error(format!(
-        "type mismatch: a type common to both type `{expected}` and type `{actual}` does not exist",
-        expected = expected.display(types),
-        actual = actual.display(types)
+        "type mismatch: a type common to both type `{expected}` and type `{actual}` does not exist"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
-    .with_label(
-        format!(
-            "this is type `{expected}`",
-            expected = expected.display(types)
-        ),
-        expected_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
+    .with_label(format!("this is type `{expected}`"), expected_span)
 }
 
 /// Creates a "multiple type mismatch" diagnostic.
 pub fn multiple_type_mismatch(
-    types: &Types,
     expected: &[Type],
     expected_span: Span,
-    actual: Type,
+    actual: &Type,
     actual_span: Span,
 ) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: expected {expected}, but found type `{actual}`",
-        expected = display_types(types, expected),
-        actual = actual.display(types),
+        expected = display_types(expected),
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
     .with_label(
         format!(
             "this expects {expected}",
-            expected = display_types(types, expected)
+            expected = display_types(expected)
         ),
         expected_span,
     )
@@ -509,142 +468,97 @@ pub fn missing_struct_members(name: &Ident, count: usize, members: &str) -> Diag
 }
 
 /// Creates a "map key not primitive" diagnostic.
-pub fn map_key_not_primitive(types: &Types, span: Span, actual: Type) -> Diagnostic {
+pub fn map_key_not_primitive(span: Span, actual: &Type) -> Diagnostic {
     Diagnostic::error("expected map literal to use primitive type keys")
         .with_highlight(span)
-        .with_label(
-            format!("this is type `{actual}`", actual = actual.display(types)),
-            span,
-        )
+        .with_label(format!("this is type `{actual}`"), span)
 }
 
 /// Creates a "if conditional mismatch" diagnostic.
-pub fn if_conditional_mismatch(types: &Types, actual: Type, actual_span: Span) -> Diagnostic {
+pub fn if_conditional_mismatch(actual: &Type, actual_span: Span) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: expected `if` conditional expression to be type `Boolean`, but found type \
-         `{actual}`",
-        actual = actual.display(types)
+         `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
 }
 
 /// Creates a "logical not mismatch" diagnostic.
-pub fn logical_not_mismatch(types: &Types, actual: Type, actual_span: Span) -> Diagnostic {
+pub fn logical_not_mismatch(actual: &Type, actual_span: Span) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: expected `logical not` operand to be type `Boolean`, but found type \
-         `{actual}`",
-        actual = actual.display(types)
+         `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
 }
 
 /// Creates a "negation mismatch" diagnostic.
-pub fn negation_mismatch(types: &Types, actual: Type, actual_span: Span) -> Diagnostic {
+pub fn negation_mismatch(actual: &Type, actual_span: Span) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: expected negation operand to be type `Int` or `Float`, but found type \
-         `{actual}`",
-        actual = actual.display(types)
+         `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
 }
 
 /// Creates a "logical or mismatch" diagnostic.
-pub fn logical_or_mismatch(types: &Types, actual: Type, actual_span: Span) -> Diagnostic {
+pub fn logical_or_mismatch(actual: &Type, actual_span: Span) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: expected `logical or` operand to be type `Boolean`, but found type \
-         `{actual}`",
-        actual = actual.display(types)
+         `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
 }
 
 /// Creates a "logical and mismatch" diagnostic.
-pub fn logical_and_mismatch(types: &Types, actual: Type, actual_span: Span) -> Diagnostic {
+pub fn logical_and_mismatch(actual: &Type, actual_span: Span) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: expected `logical and` operand to be type `Boolean`, but found type \
-         `{actual}`",
-        actual = actual.display(types)
+         `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
 }
 
 /// Creates a "comparison mismatch" diagnostic.
 pub fn comparison_mismatch(
-    types: &Types,
     op: ComparisonOperator,
     span: Span,
-    lhs: Type,
+    lhs: &Type,
     lhs_span: Span,
-    rhs: Type,
+    rhs: &Type,
     rhs_span: Span,
 ) -> Diagnostic {
     Diagnostic::error(format!(
-        "type mismatch: operator `{op}` cannot compare type `{lhs}` to type `{rhs}`",
-        lhs = lhs.display(types),
-        rhs = rhs.display(types),
+        "type mismatch: operator `{op}` cannot compare type `{lhs}` to type `{rhs}`"
     ))
     .with_highlight(span)
-    .with_label(
-        format!("this is type `{lhs}`", lhs = lhs.display(types)),
-        lhs_span,
-    )
-    .with_label(
-        format!("this is type `{rhs}`", rhs = rhs.display(types)),
-        rhs_span,
-    )
+    .with_label(format!("this is type `{lhs}`"), lhs_span)
+    .with_label(format!("this is type `{rhs}`"), rhs_span)
 }
 
 /// Creates a "numeric mismatch" diagnostic.
 pub fn numeric_mismatch(
-    types: &Types,
     op: NumericOperator,
     span: Span,
-    lhs: Type,
+    lhs: &Type,
     lhs_span: Span,
-    rhs: Type,
+    rhs: &Type,
     rhs_span: Span,
 ) -> Diagnostic {
     Diagnostic::error(format!(
-        "type mismatch: {op} operator is not supported for type `{lhs}` and type `{rhs}`",
-        lhs = lhs.display(types),
-        rhs = rhs.display(types)
+        "type mismatch: {op} operator is not supported for type `{lhs}` and type `{rhs}`"
     ))
     .with_highlight(span)
-    .with_label(
-        format!("this is type `{lhs}`", lhs = lhs.display(types)),
-        lhs_span,
-    )
-    .with_label(
-        format!("this is type `{rhs}`", rhs = rhs.display(types)),
-        rhs_span,
-    )
+    .with_label(format!("this is type `{lhs}`"), lhs_span)
+    .with_label(format!("this is type `{rhs}`"), rhs_span)
 }
 
 /// Creates a "string concat mismatch" diagnostic.
-pub fn string_concat_mismatch(types: &Types, actual: Type, actual_span: Span) -> Diagnostic {
+pub fn string_concat_mismatch(actual: &Type, actual_span: Span) -> Diagnostic {
     Diagnostic::error(format!(
-        "type mismatch: string concatenation is not supported for type `{actual}`",
-        actual = actual.display(types),
+        "type mismatch: string concatenation is not supported for type `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+    .with_label(format!("this is type `{actual}`"), actual_span)
 }
 
 /// Creates an "unknown function" diagnostic.
@@ -696,22 +610,12 @@ pub fn too_many_arguments(
 }
 
 /// Constructs an "argument type mismatch" diagnostic.
-pub fn argument_type_mismatch(
-    types: &Types,
-    name: &str,
-    expected: &str,
-    actual: Type,
-    span: Span,
-) -> Diagnostic {
+pub fn argument_type_mismatch(name: &str, expected: &str, actual: &Type, span: Span) -> Diagnostic {
     Diagnostic::error(format!(
         "type mismatch: argument to function `{name}` expects type {expected}, but found type \
-         `{actual}`",
-        actual = actual.display(types)
+         `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        span,
-    )
+    .with_label(format!("this is type `{actual}`"), span)
 }
 
 /// Constructs an "ambiguous argument" diagnostic.
@@ -723,52 +627,31 @@ pub fn ambiguous_argument(name: &str, span: Span, first: &str, second: &str) -> 
 }
 
 /// Constructs an "index type mismatch" diagnostic.
-pub fn index_type_mismatch(types: &Types, expected: Type, actual: Type, span: Span) -> Diagnostic {
+pub fn index_type_mismatch(expected: &Type, actual: &Type, span: Span) -> Diagnostic {
     Diagnostic::error(format!(
-        "type mismatch: expected index to be type `{expected}`, but found type `{actual}`",
-        expected = expected.display(types),
-        actual = actual.display(types)
+        "type mismatch: expected index to be type `{expected}`, but found type `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        span,
-    )
+    .with_label(format!("this is type `{actual}`"), span)
 }
 
 /// Constructs an "type is not array" diagnostic.
-pub fn type_is_not_array(types: &Types, actual: Type, span: Span) -> Diagnostic {
+pub fn type_is_not_array(actual: &Type, span: Span) -> Diagnostic {
     Diagnostic::error(format!(
-        "type mismatch: expected an array type, but found type `{actual}`",
-        actual = actual.display(types)
+        "type mismatch: expected an array type, but found type `{actual}`"
     ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        span,
-    )
+    .with_label(format!("this is type `{actual}`"), span)
 }
 
 /// Constructs a "cannot access" diagnostic.
-pub fn cannot_access(types: &Types, actual: Type, actual_span: Span) -> Diagnostic {
-    Diagnostic::error(format!(
-        "cannot access type `{actual}`",
-        actual = actual.display(types)
-    ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        actual_span,
-    )
+pub fn cannot_access(actual: &Type, actual_span: Span) -> Diagnostic {
+    Diagnostic::error(format!("cannot access type `{actual}`"))
+        .with_label(format!("this is type `{actual}`"), actual_span)
 }
 
 /// Constructs a "cannot coerce to string" diagnostic.
-pub fn cannot_coerce_to_string(types: &Types, actual: Type, span: Span) -> Diagnostic {
-    Diagnostic::error(format!(
-        "cannot coerce type `{actual}` to `String`",
-        actual = actual.display(types)
-    ))
-    .with_label(
-        format!("this is type `{actual}`", actual = actual.display(types)),
-        span,
-    )
+pub fn cannot_coerce_to_string(actual: &Type, span: Span) -> Diagnostic {
+    Diagnostic::error(format!("cannot coerce type `{actual}` to `String`"))
+        .with_label(format!("this is type `{actual}`"), span)
 }
 
 /// Creates an "unknown task or workflow" diagnostic.

--- a/wdl-analysis/tests/analysis/imported-optional-type/foo.wdl
+++ b/wdl-analysis/tests/analysis/imported-optional-type/foo.wdl
@@ -1,0 +1,10 @@
+version 1.1
+
+task foo {
+    input {
+        #@ except: UnusedInput
+        Array[String]? foo
+    }
+
+    command <<<>>>
+}

--- a/wdl-analysis/tests/analysis/imported-optional-type/source.wdl
+++ b/wdl-analysis/tests/analysis/imported-optional-type/source.wdl
@@ -1,0 +1,16 @@
+## This is a test of using an optional input type from an imported document.
+## No diagnostics should be generated.
+## See https://github.com/stjude-rust-labs/wdl/pull/277#issuecomment-2562199340
+
+version 1.1
+
+import "foo.wdl"
+
+workflow bar {
+    input {
+        Array[String]? bar
+    }
+
+    #@ except: UnusedCall
+    call foo.foo { input: foo = bar }
+}

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Reduced size of the `Value` type ([#277](https://github.com/stjude-rust-labs/wdl/pull/277)).
 * Implement task evaluation with local execution and remaining WDL 1.2
   functionality ([#265](https://github.com/stjude-rust-labs/wdl/pull/265)).
 * Implement the `defined` and `length` functions from the WDL standard library ([#258](https://github.com/stjude-rust-labs/wdl/pull/258)).

--- a/wdl-engine/src/backend/local.rs
+++ b/wdl-engine/src/backend/local.rs
@@ -15,7 +15,7 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::process::Command;
 use tracing::info;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::v1::TASK_REQUIREMENT_CPU;
 use wdl_ast::v1::TASK_REQUIREMENT_MEMORY;
 
@@ -110,7 +110,7 @@ impl TaskExecution for LocalTaskExecution {
         let min_cpu = requirements
             .get(TASK_REQUIREMENT_CPU)
             .map(|v| {
-                v.coerce(engine.types(), PrimitiveTypeKind::Float.into())
+                v.coerce(&PrimitiveType::Float.into())
                     .expect("type should coerce")
                     .unwrap_float()
             })

--- a/wdl-engine/src/diagnostics.rs
+++ b/wdl-engine/src/diagnostics.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 
 use wdl_analysis::types::Type;
-use wdl_analysis::types::Types;
 use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
 use wdl_ast::Ident;
@@ -83,31 +82,19 @@ pub fn call_failed(target: &Ident, error: &anyhow::Error) -> Diagnostic {
 
 /// Creates a "runtime type mismatch" diagnostic.
 pub fn runtime_type_mismatch(
-    types: &Types,
     e: anyhow::Error,
-    expected: Type,
+    expected: &Type,
     expected_span: Span,
-    actual: Type,
+    actual: &Type,
     actual_span: Span,
 ) -> Diagnostic {
     let e = e.context(format!(
-        "type mismatch: expected type `{expected}`, but found type `{actual}`",
-        expected = expected.display(types),
-        actual = actual.display(types)
+        "type mismatch: expected type `{expected}`, but found type `{actual}`"
     ));
 
     Diagnostic::error(format!("{e:?}"))
-        .with_label(
-            format!("this is type `{actual}`", actual = actual.display(types)),
-            actual_span,
-        )
-        .with_label(
-            format!(
-                "this expects type `{expected}`",
-                expected = expected.display(types)
-            ),
-            expected_span,
-        )
+        .with_label(format!("this is type `{actual}`"), actual_span)
+        .with_label(format!("this expects type `{expected}`"), expected_span)
 }
 
 /// Creates an "array index out of range" diagnostic.

--- a/wdl-engine/src/engine.rs
+++ b/wdl-engine/src/engine.rs
@@ -1,39 +1,19 @@
 //! Implementation of the WDL evaluation engine.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use sysinfo::CpuRefreshKind;
 use sysinfo::MemoryRefreshKind;
 use sysinfo::System;
 use wdl_analysis::diagnostics::unknown_type;
 use wdl_analysis::document::Document;
 use wdl_analysis::types::Type;
-use wdl_analysis::types::Types;
 use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
 use wdl_ast::Ident;
 
 use crate::TaskExecutionBackend;
 
-/// Represents a cache of imported types for a specific document.
-///
-/// Maps a document-specific type name to a previously imported type.
-#[derive(Debug, Default)]
-struct DocumentTypeCache(HashMap<String, Type>);
-
-/// Represents a cache of imported types for all evaluated documents.
-///
-/// Maps a document identifier to that document's type cache.
-#[derive(Debug, Default)]
-struct TypeCache(HashMap<Arc<String>, DocumentTypeCache>);
-
 /// Represents an evaluation engine.
 pub struct Engine {
-    /// The types collection for evaluation.
-    types: Types,
-    /// The type cache for evaluation.
-    cache: TypeCache,
     /// The task execution backend to use.
     backend: Box<dyn TaskExecutionBackend>,
     /// Information about the current system.
@@ -48,21 +28,9 @@ impl Engine {
         system.refresh_memory_specifics(MemoryRefreshKind::new().with_ram());
 
         Self {
-            types: Default::default(),
-            cache: Default::default(),
             backend: Box::new(backend),
             system,
         }
-    }
-
-    /// Gets the engine's type collection.
-    pub fn types(&self) -> &Types {
-        &self.types
-    }
-
-    /// Gets a mutable reference to the engine's type collection.
-    pub fn types_mut(&mut self) -> &mut Types {
-        &mut self.types
     }
 
     /// Gets a reference to the task execution backend.
@@ -84,21 +52,9 @@ impl Engine {
         document: &Document,
         name: &Ident,
     ) -> Result<Type, Diagnostic> {
-        let cache = self.cache.0.entry(document.id().clone()).or_default();
-
-        match cache.0.get(name.as_str()) {
-            Some(ty) => Ok(*ty),
-            None => {
-                let ty = document
-                    .struct_by_name(name.as_str())
-                    .map(|s| s.ty().expect("struct should have type"))
-                    .ok_or_else(|| unknown_type(name.as_str(), name.span()))?;
-
-                // Cache the imported type for future expression evaluations
-                let ty = self.types.import(document.types(), ty);
-                cache.0.insert(name.as_str().into(), ty);
-                Ok(ty)
-            }
-        }
+        document
+            .struct_by_name(name.as_str())
+            .map(|s| s.ty().expect("struct should have type").clone())
+            .ok_or_else(|| unknown_type(name.as_str(), name.span()))
     }
 }

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -10,7 +10,6 @@ use anyhow::bail;
 use indexmap::IndexMap;
 use wdl_analysis::document::Task;
 use wdl_analysis::types::Type;
-use wdl_analysis::types::Types;
 use wdl_ast::Diagnostic;
 use wdl_ast::Ident;
 use wdl_ast::SupportedVersion;
@@ -54,12 +53,6 @@ pub trait EvaluationContext {
     /// Gets the supported version of the document being evaluated.
     fn version(&self) -> SupportedVersion;
 
-    /// Gets the types collection associated with the evaluation.
-    fn types(&self) -> &Types;
-
-    /// Gets the mutable types collection associated with the evaluation.
-    fn types_mut(&mut self) -> &mut Types;
-
     /// Gets the value of the given name in scope.
     fn resolve_name(&self, name: &Ident) -> Result<Value, Diagnostic>;
 
@@ -86,9 +79,6 @@ pub trait EvaluationContext {
     ///
     /// This is only `Some` when evaluating task hints sections.
     fn task(&self) -> Option<&Task>;
-
-    /// Gets the types collection associated with the document being evaluated.
-    fn document_types(&self) -> &Types;
 }
 
 /// Represents an index of a scope in a collection of scopes.

--- a/wdl-engine/src/outputs.rs
+++ b/wdl-engine/src/outputs.rs
@@ -3,7 +3,6 @@
 use std::cmp::Ordering;
 
 use indexmap::IndexMap;
-use wdl_analysis::types::Types;
 
 use crate::Scope;
 use crate::Value;
@@ -47,7 +46,7 @@ impl Outputs {
     }
 
     /// Serializes the value to the given serializer.
-    pub fn serialize<S>(&self, types: &Types, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -55,8 +54,6 @@ impl Outputs {
 
         /// Helper `Serialize` implementation for serializing element values.
         struct Serialize<'a> {
-            /// The types collection.
-            types: &'a Types,
             /// The value being serialized.
             value: &'a Value,
         }
@@ -66,7 +63,7 @@ impl Outputs {
             where
                 S: serde::Serializer,
             {
-                self.value.serialize(self.types, serializer)
+                self.value.serialize(serializer)
             }
         }
 
@@ -74,9 +71,9 @@ impl Outputs {
         for (k, v) in &self.values {
             match &self.name {
                 Some(prefix) => {
-                    s.serialize_entry(&format!("{prefix}.{k}"), &Serialize { types, value: v })?
+                    s.serialize_entry(&format!("{prefix}.{k}"), &Serialize { value: v })?
                 }
-                None => s.serialize_entry(k, &Serialize { types, value: v })?,
+                None => s.serialize_entry(k, &Serialize { value: v })?,
             }
         }
 

--- a/wdl-engine/src/stdlib/as_map.rs
+++ b/wdl-engine/src/stdlib/as_map.rs
@@ -41,17 +41,7 @@ impl fmt::Display for DuplicateKeyError {
 fn as_map(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                context
-                    .return_type
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition()
-            )
-            .as_map()
-            .is_some(),
+        context.return_type.as_map().is_some(),
         "return type should be a map"
     );
 

--- a/wdl-engine/src/stdlib/as_pairs.rs
+++ b/wdl-engine/src/stdlib/as_pairs.rs
@@ -24,21 +24,14 @@ fn as_pairs(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .expect("argument should be a map");
 
     let element_ty = context
-        .types()
-        .type_definition(
-            context
-                .return_type
-                .as_compound()
-                .expect("type should be compound")
-                .definition(),
-        )
+        .return_type
         .as_array()
         .expect("type should be an array")
         .element_type();
 
     let elements = map
         .iter()
-        .map(|(k, v)| Pair::new_unchecked(element_ty, k.clone().into(), v.clone()).into())
+        .map(|(k, v)| Pair::new_unchecked(element_ty.clone(), k.clone().into(), v.clone()).into())
         .collect();
 
     Ok(Array::new_unchecked(context.return_type, elements).into())

--- a/wdl-engine/src/stdlib/basename.rs
+++ b/wdl-engine/src/stdlib/basename.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -21,10 +21,10 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#basename
 fn basename(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(!context.arguments.is_empty() && context.arguments.len() < 3);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::String));
+    debug_assert!(context.return_type_eq(PrimitiveType::String));
 
     let path = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
     match Path::new(path.as_str()).file_name() {
@@ -33,7 +33,7 @@ fn basename(context: CallContext<'_>) -> Result<Value, Diagnostic> {
             let base = if context.arguments.len() == 2 {
                 base.strip_suffix(
                     context
-                        .coerce_argument(1, PrimitiveTypeKind::String)
+                        .coerce_argument(1, PrimitiveType::String)
                         .unwrap_string()
                         .as_str(),
                 )

--- a/wdl-engine/src/stdlib/ceil.rs
+++ b/wdl-engine/src/stdlib/ceil.rs
@@ -1,6 +1,6 @@
 //! Implements the `ceil` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -13,10 +13,10 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#ceil
 fn ceil(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
     let arg = context
-        .coerce_argument(0, PrimitiveTypeKind::Float)
+        .coerce_argument(0, PrimitiveType::Float)
         .unwrap_float();
     Ok((arg.ceil() as i64).into())
 }

--- a/wdl-engine/src/stdlib/chunk.rs
+++ b/wdl-engine/src/stdlib/chunk.rs
@@ -38,14 +38,7 @@ fn chunk(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     }
 
     let element_ty = context
-        .types()
-        .type_definition(
-            context
-                .return_type
-                .as_compound()
-                .expect("type should be compound")
-                .definition(),
-        )
+        .return_type
         .as_array()
         .expect("type should be an array")
         .element_type();
@@ -53,7 +46,9 @@ fn chunk(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     let elements = array
         .as_slice()
         .chunks(size as usize)
-        .map(|chunk| Array::new_unchecked(element_ty, Vec::from_iter(chunk.iter().cloned())).into())
+        .map(|chunk| {
+            Array::new_unchecked(element_ty.clone(), Vec::from_iter(chunk.iter().cloned())).into()
+        })
         .collect();
 
     Ok(Array::new_unchecked(context.return_type, elements).into())

--- a/wdl-engine/src/stdlib/collect_by_key.rs
+++ b/wdl-engine/src/stdlib/collect_by_key.rs
@@ -34,28 +34,11 @@ fn collect_by_key(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .expect("value should be an array");
 
     let map_ty = context
-        .types()
-        .type_definition(
-            context
-                .return_type
-                .as_compound()
-                .expect("type should be compound")
-                .definition(),
-        )
+        .return_type
         .as_map()
         .expect("return type should be a map");
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                map_ty
-                    .value_type()
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition(),
-            )
-            .as_array()
-            .is_some(),
+        map_ty.value_type().as_array().is_some(),
         "return type's value type should be an array"
     );
 
@@ -75,7 +58,12 @@ fn collect_by_key(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     // Transform each `Vec<Value>` into an array value
     let elements = map
         .into_iter()
-        .map(|(k, v)| (k, Array::new_unchecked(map_ty.value_type(), v).into()))
+        .map(|(k, v)| {
+            (
+                k,
+                Array::new_unchecked(map_ty.value_type().clone(), v).into(),
+            )
+        })
         .collect();
 
     Ok(Map::new_unchecked(context.return_type, elements).into())

--- a/wdl-engine/src/stdlib/contains.rs
+++ b/wdl-engine/src/stdlib/contains.rs
@@ -1,6 +1,6 @@
 //! Implements the `contains` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -14,7 +14,7 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#-contains
 fn contains(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Boolean));
+    debug_assert!(context.return_type_eq(PrimitiveType::Boolean));
 
     let array = context.arguments[0]
         .value
@@ -26,7 +26,7 @@ fn contains(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     Ok(array
         .as_slice()
         .iter()
-        .any(|e| Value::equals(context.types(), e, item).unwrap_or(false))
+        .any(|e| Value::equals(e, item).unwrap_or(false))
         .into())
 }
 

--- a/wdl-engine/src/stdlib/cross.rs
+++ b/wdl-engine/src/stdlib/cross.rs
@@ -24,17 +24,7 @@ use crate::Value;
 fn cross(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                context
-                    .return_type
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition()
-            )
-            .as_array()
-            .is_some(),
+        context.return_type.as_array().is_some(),
         "type should be an array"
     );
 
@@ -48,24 +38,13 @@ fn cross(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .as_array()
         .expect("argument should be an array");
 
-    let element_ty = context
-        .types()
-        .type_definition(
-            context
-                .return_type
-                .as_compound()
-                .expect("type should be compound")
-                .definition(),
-        )
-        .as_array()
-        .unwrap()
-        .element_type();
+    let element_ty = context.return_type.as_array().unwrap().element_type();
 
     let elements = left
         .as_slice()
         .iter()
         .cartesian_product(right.as_slice().iter())
-        .map(|(l, r)| Pair::new_unchecked(element_ty, l.clone(), r.clone()).into())
+        .map(|(l, r)| Pair::new_unchecked(element_ty.clone(), l.clone(), r.clone()).into())
         .collect();
     Ok(Array::new_unchecked(context.return_type, elements).into())
 }

--- a/wdl-engine/src/stdlib/defined.rs
+++ b/wdl-engine/src/stdlib/defined.rs
@@ -1,6 +1,6 @@
 //! Implements the `defined` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -14,7 +14,7 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#defined
 fn defined(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Boolean));
+    debug_assert!(context.return_type_eq(PrimitiveType::Boolean));
     Ok((!context.arguments[0].value.is_none()).into())
 }
 

--- a/wdl-engine/src/stdlib/find.rs
+++ b/wdl-engine/src/stdlib/find.rs
@@ -2,7 +2,7 @@
 
 use regex::Regex;
 use wdl_analysis::types::Optional;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 
@@ -20,13 +20,13 @@ use crate::diagnostics::invalid_regex;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#-find
 fn find(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(Type::from(PrimitiveTypeKind::String).optional()));
+    debug_assert!(context.return_type_eq(Type::from(PrimitiveType::String).optional()));
 
     let input = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
     let pattern = context
-        .coerce_argument(1, PrimitiveTypeKind::String)
+        .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
     let regex =

--- a/wdl-engine/src/stdlib/flatten.rs
+++ b/wdl-engine/src/stdlib/flatten.rs
@@ -20,17 +20,7 @@ use crate::Value;
 fn flatten(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                context
-                    .return_type
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition(),
-            )
-            .as_array()
-            .is_some(),
+        context.return_type.as_array().is_some(),
         "return type should be an array"
     );
 

--- a/wdl-engine/src/stdlib/floor.rs
+++ b/wdl-engine/src/stdlib/floor.rs
@@ -1,6 +1,6 @@
 //! Implements the `floor` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -13,10 +13,10 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#floor
 fn floor(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
     let arg = context
-        .coerce_argument(0, PrimitiveTypeKind::Float)
+        .coerce_argument(0, PrimitiveType::Float)
         .unwrap_float();
     Ok((arg.floor() as i64).into())
 }

--- a/wdl-engine/src/stdlib/glob.rs
+++ b/wdl-engine/src/stdlib/glob.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -21,10 +21,10 @@ use crate::diagnostics::invalid_glob_pattern;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#glob
 fn glob(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_file_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_file_type().clone()));
 
     let path = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
     // TODO: replace glob with walkpath and globmatch

--- a/wdl-engine/src/stdlib/join_paths.rs
+++ b/wdl-engine/src/stdlib/join_paths.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -27,14 +27,14 @@ use crate::diagnostics::path_not_relative;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#-join_paths
 fn join_paths_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::File));
+    debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     let first = context
-        .coerce_argument(0, PrimitiveTypeKind::File)
+        .coerce_argument(0, PrimitiveType::File)
         .unwrap_file();
 
     let second = context
-        .coerce_argument(1, PrimitiveTypeKind::String)
+        .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
     let second = Path::new(second.as_str());
@@ -71,12 +71,12 @@ fn join_paths_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#-join_paths
 fn join_paths(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(!context.arguments.is_empty() && context.arguments.len() < 3);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::File));
+    debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     // Handle being provided one or two arguments
     let (first, array, skip, array_span) = if context.arguments.len() == 1 {
         let array = context
-            .coerce_argument(0, ANALYSIS_STDLIB.array_string_non_empty_type())
+            .coerce_argument(0, ANALYSIS_STDLIB.array_string_non_empty_type().clone())
             .unwrap_array();
 
         (
@@ -87,11 +87,11 @@ fn join_paths(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         )
     } else {
         let first = context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
         let array = context
-            .coerce_argument(1, ANALYSIS_STDLIB.array_string_non_empty_type())
+            .coerce_argument(1, ANALYSIS_STDLIB.array_string_non_empty_type().clone())
             .unwrap_array();
 
         (first, array, false, context.arguments[1].span)

--- a/wdl-engine/src/stdlib/keys.rs
+++ b/wdl-engine/src/stdlib/keys.rs
@@ -26,17 +26,7 @@ use crate::Value;
 fn keys(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                context
-                    .return_type
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition()
-            )
-            .as_array()
-            .is_some(),
+        context.return_type.as_array().is_some(),
         "return type should be an array"
     );
 
@@ -75,7 +65,7 @@ pub const fn descriptor() -> Function {
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
-    use wdl_analysis::types::PrimitiveTypeKind;
+    use wdl_analysis::types::PrimitiveType;
     use wdl_analysis::types::StructType;
     use wdl_ast::version::V1;
 
@@ -87,11 +77,11 @@ mod test {
     fn keys() {
         let mut env = TestEnv::default();
 
-        let ty = env.types_mut().add_struct(StructType::new("Foo", [
-            ("foo", PrimitiveTypeKind::Float),
-            ("bar", PrimitiveTypeKind::String),
-            ("baz", PrimitiveTypeKind::Integer),
-        ]));
+        let ty = StructType::new("Foo", [
+            ("foo", PrimitiveType::Float),
+            ("bar", PrimitiveType::String),
+            ("baz", PrimitiveType::Integer),
+        ]);
 
         env.insert_struct("Foo", ty);
 

--- a/wdl-engine/src/stdlib/length.rs
+++ b/wdl-engine/src/stdlib/length.rs
@@ -1,6 +1,6 @@
 //! Implements the `length` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 
@@ -17,7 +17,7 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#length
 fn array_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
     Ok(i64::try_from(
         context.arguments[0]
             .value
@@ -42,7 +42,7 @@ fn array_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#length
 fn map_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
     Ok(i64::try_from(
         context.arguments[0]
             .value
@@ -67,7 +67,7 @@ fn map_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#length
 fn object_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
     let object = context.coerce_argument(0, Type::Object).unwrap_object();
 
     Ok(i64::try_from(object.len())
@@ -88,9 +88,9 @@ fn object_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#length
 fn string_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
     let s = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
     // Note: the function is defined in terms of characters and not bytes

--- a/wdl-engine/src/stdlib/matches.rs
+++ b/wdl-engine/src/stdlib/matches.rs
@@ -1,7 +1,7 @@
 //! Implements the `matches` function from the WDL standard library.
 
 use regex::Regex;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -16,13 +16,13 @@ use crate::diagnostics::invalid_regex;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#-matches
 fn matches(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Boolean));
+    debug_assert!(context.return_type_eq(PrimitiveType::Boolean));
 
     let input = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
     let pattern = context
-        .coerce_argument(1, PrimitiveTypeKind::String)
+        .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
     let regex =

--- a/wdl-engine/src/stdlib/max.rs
+++ b/wdl-engine/src/stdlib/max.rs
@@ -1,6 +1,6 @@
 //! Implements the `max` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -13,13 +13,13 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#max
 fn int_max(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
     let first = context
-        .coerce_argument(0, PrimitiveTypeKind::Integer)
+        .coerce_argument(0, PrimitiveType::Integer)
         .unwrap_integer();
     let second = context
-        .coerce_argument(1, PrimitiveTypeKind::Integer)
+        .coerce_argument(1, PrimitiveType::Integer)
         .unwrap_integer();
     Ok(first.max(second).into())
 }
@@ -29,13 +29,13 @@ fn int_max(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#max
 fn float_max(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Float));
+    debug_assert!(context.return_type_eq(PrimitiveType::Float));
 
     let first = context
-        .coerce_argument(0, PrimitiveTypeKind::Float)
+        .coerce_argument(0, PrimitiveType::Float)
         .unwrap_float();
     let second = context
-        .coerce_argument(1, PrimitiveTypeKind::Float)
+        .coerce_argument(1, PrimitiveType::Float)
         .unwrap_float();
     Ok(first.max(second).into())
 }

--- a/wdl-engine/src/stdlib/min.rs
+++ b/wdl-engine/src/stdlib/min.rs
@@ -1,6 +1,6 @@
 //! Implements the `min` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -13,13 +13,13 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#min
 fn int_min(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
     let first = context
-        .coerce_argument(0, PrimitiveTypeKind::Integer)
+        .coerce_argument(0, PrimitiveType::Integer)
         .unwrap_integer();
     let second = context
-        .coerce_argument(1, PrimitiveTypeKind::Integer)
+        .coerce_argument(1, PrimitiveType::Integer)
         .unwrap_integer();
     Ok(first.min(second).into())
 }
@@ -29,13 +29,13 @@ fn int_min(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#min
 fn float_min(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Float));
+    debug_assert!(context.return_type_eq(PrimitiveType::Float));
 
     let first = context
-        .coerce_argument(0, PrimitiveTypeKind::Float)
+        .coerce_argument(0, PrimitiveType::Float)
         .unwrap_float();
     let second = context
-        .coerce_argument(1, PrimitiveTypeKind::Float)
+        .coerce_argument(1, PrimitiveType::Float)
         .unwrap_float();
     Ok(first.min(second).into())
 }

--- a/wdl-engine/src/stdlib/prefix.rs
+++ b/wdl-engine/src/stdlib/prefix.rs
@@ -1,7 +1,7 @@
 //! Implements the `prefix` function from the WDL standard library.
 
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -19,10 +19,10 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#prefix
 fn prefix(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
 
     let prefix = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
     let array = context.arguments[1]

--- a/wdl-engine/src/stdlib/quote.rs
+++ b/wdl-engine/src/stdlib/quote.rs
@@ -18,7 +18,7 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#quote
 fn quote(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
 
     let array = context.arguments[0]
         .value

--- a/wdl-engine/src/stdlib/range.rs
+++ b/wdl-engine/src/stdlib/range.rs
@@ -1,7 +1,7 @@
 //! Implements the `range` function from the WDL standard library.
 
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -19,10 +19,10 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#range
 fn range(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_int_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_int_type().clone()));
 
     let n = context
-        .coerce_argument(0, PrimitiveTypeKind::Integer)
+        .coerce_argument(0, PrimitiveType::Integer)
         .unwrap_integer();
 
     if n < 0 {

--- a/wdl-engine/src/stdlib/read_boolean.rs
+++ b/wdl-engine/src/stdlib/read_boolean.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::BufRead;
 use std::io::BufReader;
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -23,11 +23,11 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_boolean
 fn read_boolean(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Boolean));
+    debug_assert!(context.return_type_eq(PrimitiveType::Boolean));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );

--- a/wdl-engine/src/stdlib/read_float.rs
+++ b/wdl-engine/src/stdlib/read_float.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::BufRead;
 use std::io::BufReader;
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -22,11 +22,11 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_float
 fn read_float(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Float));
+    debug_assert!(context.return_type_eq(PrimitiveType::Float));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );

--- a/wdl-engine/src/stdlib/read_int.rs
+++ b/wdl-engine/src/stdlib/read_int.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::BufRead;
 use std::io::BufReader;
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -22,11 +22,11 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_int
 fn read_int(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );

--- a/wdl-engine/src/stdlib/read_lines.rs
+++ b/wdl-engine/src/stdlib/read_lines.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 
 use anyhow::Context;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -30,11 +30,11 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_lines
 fn read_lines(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );

--- a/wdl-engine/src/stdlib/read_map.rs
+++ b/wdl-engine/src/stdlib/read_map.rs
@@ -7,7 +7,7 @@ use std::io::BufReader;
 use anyhow::Context;
 use indexmap::IndexMap;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -34,11 +34,11 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_map
 fn read_map(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.map_string_string_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.map_string_string_type().clone()));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );
@@ -86,7 +86,7 @@ fn read_map(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         }
     }
 
-    Ok(Map::new_unchecked(ANALYSIS_STDLIB.map_string_string_type(), map).into())
+    Ok(Map::new_unchecked(ANALYSIS_STDLIB.map_string_string_type().clone(), map).into())
 }
 
 /// Gets the function describing `read_map`.

--- a/wdl-engine/src/stdlib/read_object.rs
+++ b/wdl-engine/src/stdlib/read_object.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use indexmap::IndexMap;
 use itertools::EitherOrBoth;
 use itertools::Itertools;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 use wdl_grammar::lexer::v1::is_ident;
@@ -42,7 +42,7 @@ fn read_object(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );

--- a/wdl-engine/src/stdlib/read_objects.rs
+++ b/wdl-engine/src/stdlib/read_objects.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use itertools::EitherOrBoth;
 use itertools::Itertools;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 use wdl_grammar::lexer::v1::is_ident;
 
@@ -42,11 +42,11 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_objects
 fn read_objects(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_object_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_object_type().clone()));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );
@@ -63,9 +63,11 @@ fn read_objects(context: CallContext<'_>) -> Result<Value, Diagnostic> {
                 function_call_failed("read_objects", format!("{e:?}"), context.call_site)
             })?,
         None => {
-            return Ok(
-                Array::new_unchecked(ANALYSIS_STDLIB.array_object_type(), Vec::new()).into(),
-            );
+            return Ok(Array::new_unchecked(
+                ANALYSIS_STDLIB.array_object_type().clone(),
+                Vec::new(),
+            )
+            .into());
         }
     };
 
@@ -127,7 +129,7 @@ fn read_objects(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         objects.push(Object::from(members).into());
     }
 
-    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_object_type(), objects).into())
+    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_object_type().clone(), objects).into())
 }
 
 /// Gets the function describing `read_objects`.

--- a/wdl-engine/src/stdlib/read_string.rs
+++ b/wdl-engine/src/stdlib/read_string.rs
@@ -3,7 +3,7 @@
 use std::fs;
 
 use anyhow::Context;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -21,11 +21,11 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_string
 fn read_string(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::String));
+    debug_assert!(context.return_type_eq(PrimitiveType::String));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );

--- a/wdl-engine/src/stdlib/read_tsv.rs
+++ b/wdl-engine/src/stdlib/read_tsv.rs
@@ -10,7 +10,7 @@ use itertools::Either;
 use itertools::EitherOrBoth;
 use itertools::Itertools;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 use wdl_grammar::lexer::v1::is_ident;
 
@@ -61,11 +61,11 @@ impl TsvHeader {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
 fn read_tsv_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_array_string_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_array_string_type().clone()));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );
@@ -83,10 +83,10 @@ fn read_tsv_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
             .split('\t')
             .map(|s| PrimitiveValue::new_string(s).into())
             .collect::<Vec<Value>>();
-        rows.push(Array::new_unchecked(ANALYSIS_STDLIB.array_string_type(), values).into());
+        rows.push(Array::new_unchecked(ANALYSIS_STDLIB.array_string_type().clone(), values).into());
     }
 
-    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_array_string_type(), rows).into())
+    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_array_string_type().clone(), rows).into())
 }
 
 /// Reads a tab-separated value (TSV) file as an Array[Object] representing a
@@ -111,11 +111,11 @@ fn read_tsv_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
 fn read_tsv(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() >= 2 && context.arguments.len() <= 3);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_object_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_object_type().clone()));
 
     let path = context.work_dir().join(
         context
-            .coerce_argument(0, PrimitiveTypeKind::File)
+            .coerce_argument(0, PrimitiveType::File)
             .unwrap_file()
             .as_str(),
     );
@@ -129,7 +129,7 @@ fn read_tsv(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     // Read the file header if there is one; ignore it if the header was directly
     // specified.
     let file_has_header = context
-        .coerce_argument(1, PrimitiveTypeKind::Boolean)
+        .coerce_argument(1, PrimitiveType::Boolean)
         .unwrap_boolean();
     let header = if context.arguments.len() == 3 {
         if file_has_header {
@@ -138,7 +138,7 @@ fn read_tsv(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
         TsvHeader::Specified(
             context
-                .coerce_argument(2, ANALYSIS_STDLIB.array_string_type())
+                .coerce_argument(2, ANALYSIS_STDLIB.array_string_type().clone())
                 .unwrap_array(),
         )
     } else if !file_has_header {
@@ -225,7 +225,7 @@ fn read_tsv(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         rows.push(CompoundValue::Object(members.into()).into());
     }
 
-    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_object_type(), rows).into())
+    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_object_type().clone(), rows).into())
 }
 
 /// Gets the function describing `read_tsv`.

--- a/wdl-engine/src/stdlib/round.rs
+++ b/wdl-engine/src/stdlib/round.rs
@@ -1,6 +1,6 @@
 //! Implements the `round` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -14,10 +14,10 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#round
 fn round(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Integer));
+    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
     let arg = context
-        .coerce_argument(0, PrimitiveTypeKind::Float)
+        .coerce_argument(0, PrimitiveType::Float)
         .unwrap_float();
     Ok((arg.round() as i64).into())
 }

--- a/wdl-engine/src/stdlib/select_all.rs
+++ b/wdl-engine/src/stdlib/select_all.rs
@@ -19,17 +19,7 @@ use crate::Value;
 fn select_all(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                context
-                    .return_type
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition(),
-            )
-            .as_array()
-            .is_some(),
+        context.return_type.as_array().is_some(),
         "return type should be an array"
     );
     let array = context.arguments[0]

--- a/wdl-engine/src/stdlib/sep.rs
+++ b/wdl-engine/src/stdlib/sep.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Write;
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -24,10 +24,10 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#sep-1
 fn sep(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::String));
+    debug_assert!(context.return_type_eq(PrimitiveType::String));
 
     let sep = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
     let array = context.arguments[1]

--- a/wdl-engine/src/stdlib/size.rs
+++ b/wdl-engine/src/stdlib/size.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -29,11 +29,11 @@ use crate::diagnostics::invalid_storage_unit;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#glob
 fn size(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(!context.arguments.is_empty() && context.arguments.len() < 3);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::Float));
+    debug_assert!(context.return_type_eq(PrimitiveType::Float));
 
     let unit = if context.arguments.len() == 2 {
         let unit = context
-            .coerce_argument(1, PrimitiveTypeKind::String)
+            .coerce_argument(1, PrimitiveType::String)
             .unwrap_string();
 
         unit.parse()

--- a/wdl-engine/src/stdlib/squote.rs
+++ b/wdl-engine/src/stdlib/squote.rs
@@ -18,7 +18,7 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#squote
 fn squote(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
 
     let array = context.arguments[0]
         .value

--- a/wdl-engine/src/stdlib/stderr.rs
+++ b/wdl-engine/src/stdlib/stderr.rs
@@ -1,6 +1,6 @@
 //! Implements the `stderr` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -15,7 +15,7 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#stderr
 fn stderr(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.is_empty());
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::File));
+    debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     match context.stderr() {
         Some(stderr) => {

--- a/wdl-engine/src/stdlib/stdout.rs
+++ b/wdl-engine/src/stdlib/stdout.rs
@@ -1,6 +1,6 @@
 //! Implements the `stdout` function from the WDL standard library.
 
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -15,7 +15,7 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#stdout
 fn stdout(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.is_empty());
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::File));
+    debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     match context.stdout() {
         Some(stdout) => {

--- a/wdl-engine/src/stdlib/sub.rs
+++ b/wdl-engine/src/stdlib/sub.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use regex::Regex;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -20,16 +20,16 @@ use crate::diagnostics::invalid_regex;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#sub
 fn sub(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 3);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::String));
+    debug_assert!(context.return_type_eq(PrimitiveType::String));
 
     let input = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
     let pattern = context
-        .coerce_argument(1, PrimitiveTypeKind::String)
+        .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
     let replacement = context
-        .coerce_argument(2, PrimitiveTypeKind::String)
+        .coerce_argument(2, PrimitiveType::String)
         .unwrap_string();
 
     let regex =

--- a/wdl-engine/src/stdlib/suffix.rs
+++ b/wdl-engine/src/stdlib/suffix.rs
@@ -1,7 +1,7 @@
 //! Implements the `suffix` function from the WDL standard library.
 
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -19,10 +19,10 @@ use crate::Value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#suffix
 fn suffix(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 2);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type()));
+    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
 
     let suffix = context
-        .coerce_argument(0, PrimitiveTypeKind::String)
+        .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
     let array = context.arguments[1]

--- a/wdl-engine/src/stdlib/transpose.rs
+++ b/wdl-engine/src/stdlib/transpose.rs
@@ -23,17 +23,7 @@ use crate::diagnostics::function_call_failed;
 fn transpose(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                context
-                    .return_type
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition()
-            )
-            .as_array()
-            .is_some(),
+        context.return_type.as_array().is_some(),
         "type should be an array"
     );
 
@@ -75,7 +65,7 @@ fn transpose(context: CallContext<'_>) -> Result<Value, Diagnostic> {
             transposed_inner.push(inner.as_slice()[i].clone())
         }
 
-        transposed_outer.push(Array::new_unchecked(ty, transposed_inner).into());
+        transposed_outer.push(Array::new_unchecked(ty.clone(), transposed_inner).into());
     }
 
     Ok(Array::new_unchecked(context.return_type, transposed_outer).into())

--- a/wdl-engine/src/stdlib/unzip.rs
+++ b/wdl-engine/src/stdlib/unzip.rs
@@ -26,44 +26,16 @@ fn unzip(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .expect("argument should be an array");
 
     let pair_ty = context
-        .types()
-        .type_definition(
-            context
-                .return_type
-                .as_compound()
-                .expect("type should be compound")
-                .definition(),
-        )
+        .return_type
         .as_pair()
         .expect("type should be a pair");
 
     let left_ty = pair_ty.left_type();
-    debug_assert!(
-        context
-            .types()
-            .type_definition(
-                left_ty
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition(),
-            )
-            .as_array()
-            .is_some(),
-        "left type should be an array"
-    );
+    debug_assert!(left_ty.as_array().is_some(), "left type should be an array");
 
     let right_ty = pair_ty.right_type();
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                right_ty
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition(),
-            )
-            .as_array()
-            .is_some(),
+        right_ty.as_array().is_some(),
         "right type should be an array"
     );
 
@@ -76,9 +48,9 @@ fn unzip(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     }
 
     Ok(Pair::new_unchecked(
-        context.return_type,
-        Array::new_unchecked(left_ty, left).into(),
-        Array::new_unchecked(right_ty, right).into(),
+        context.return_type.clone(),
+        Array::new_unchecked(left_ty.clone(), left).into(),
+        Array::new_unchecked(right_ty.clone(), right).into(),
     )
     .into())
 }

--- a/wdl-engine/src/stdlib/values.rs
+++ b/wdl-engine/src/stdlib/values.rs
@@ -17,17 +17,7 @@ use crate::Value;
 fn values(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert_eq!(context.arguments.len(), 1);
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                context
-                    .return_type
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition()
-            )
-            .as_array()
-            .is_some(),
+        context.return_type.as_array().is_some(),
         "return type should be an array"
     );
 
@@ -56,7 +46,7 @@ pub const fn descriptor() -> Function {
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
-    use wdl_analysis::types::PrimitiveTypeKind;
+    use wdl_analysis::types::PrimitiveType;
     use wdl_analysis::types::StructType;
     use wdl_ast::version::V1;
 
@@ -68,11 +58,11 @@ mod test {
     fn values() {
         let mut env = TestEnv::default();
 
-        let ty = env.types_mut().add_struct(StructType::new("Foo", [
-            ("foo", PrimitiveTypeKind::Float),
-            ("bar", PrimitiveTypeKind::String),
-            ("baz", PrimitiveTypeKind::Integer),
-        ]));
+        let ty = StructType::new("Foo", [
+            ("foo", PrimitiveType::Float),
+            ("bar", PrimitiveType::String),
+            ("baz", PrimitiveType::Integer),
+        ]);
 
         env.insert_struct("Foo", ty);
 

--- a/wdl-engine/src/stdlib/write_lines.rs
+++ b/wdl-engine/src/stdlib/write_lines.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use tempfile::NamedTempFile;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -26,7 +26,7 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_lines
 fn write_lines(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::File));
+    debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     // Helper for handling errors while writing to the file.
     let write_error = |e: std::io::Error| {
@@ -38,7 +38,7 @@ fn write_lines(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     };
 
     let lines = context
-        .coerce_argument(0, ANALYSIS_STDLIB.array_string_type())
+        .coerce_argument(0, ANALYSIS_STDLIB.array_string_type().clone())
         .unwrap_array();
 
     // Create a temporary file that will be persisted after writing the lines

--- a/wdl-engine/src/stdlib/write_map.rs
+++ b/wdl-engine/src/stdlib/write_map.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use tempfile::NamedTempFile;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
@@ -29,7 +29,7 @@ use crate::diagnostics::function_call_failed;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_map
 fn write_map(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::File));
+    debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     // Helper for handling errors while writing to the file.
     let write_error = |e: std::io::Error| {
@@ -41,7 +41,7 @@ fn write_map(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     };
 
     let map = context
-        .coerce_argument(0, ANALYSIS_STDLIB.map_string_string_type())
+        .coerce_argument(0, ANALYSIS_STDLIB.map_string_string_type().clone())
         .unwrap_map();
 
     // Create a temporary file that will be persisted after writing the map

--- a/wdl-engine/src/stdlib/write_object.rs
+++ b/wdl-engine/src/stdlib/write_object.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::Path;
 
 use tempfile::NamedTempFile;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 
@@ -31,7 +31,7 @@ use crate::stdlib::write_tsv::write_tsv_value;
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_object
 fn write_object(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveTypeKind::File));
+    debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     // Helper for handling errors while writing to the file.
     let write_error = |e: std::io::Error| {
@@ -143,7 +143,7 @@ mod test {
     use std::fs;
 
     use pretty_assertions::assert_eq;
-    use wdl_analysis::types::PrimitiveTypeKind;
+    use wdl_analysis::types::PrimitiveType;
     use wdl_analysis::types::StructType;
     use wdl_ast::version::V1;
 
@@ -154,11 +154,11 @@ mod test {
     fn write_object() {
         let mut env = TestEnv::default();
 
-        let ty = env.types_mut().add_struct(StructType::new("Foo", [
-            ("foo", PrimitiveTypeKind::Integer),
-            ("bar", PrimitiveTypeKind::String),
-            ("baz", PrimitiveTypeKind::Boolean),
-        ]));
+        let ty = StructType::new("Foo", [
+            ("foo", PrimitiveType::Integer),
+            ("bar", PrimitiveType::String),
+            ("baz", PrimitiveType::Boolean),
+        ]);
 
         env.insert_struct("Foo", ty);
 

--- a/wdl-engine/src/stdlib/zip.rs
+++ b/wdl-engine/src/stdlib/zip.rs
@@ -45,29 +45,13 @@ fn zip(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     }
 
     let element_ty = context
-        .types()
-        .type_definition(
-            context
-                .return_type
-                .as_compound()
-                .expect("type should be compound")
-                .definition(),
-        )
+        .return_type
         .as_array()
         .expect("type should be an array")
         .element_type();
 
     debug_assert!(
-        context
-            .types()
-            .type_definition(
-                element_ty
-                    .as_compound()
-                    .expect("type should be compound")
-                    .definition(),
-            )
-            .as_pair()
-            .is_some(),
+        element_ty.as_pair().is_some(),
         "element type should be a pair"
     );
 
@@ -75,7 +59,7 @@ fn zip(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .as_slice()
         .iter()
         .zip(right.as_slice())
-        .map(|(l, r)| Pair::new_unchecked(element_ty, l.clone(), r.clone()).into())
+        .map(|(l, r)| Pair::new_unchecked(element_ty.clone(), l.clone(), r.clone()).into())
         .collect();
 
     Ok(Array::new_unchecked(context.return_type, elements).into())

--- a/wdl-engine/src/value.rs
+++ b/wdl-engine/src/value.rs
@@ -48,11 +48,6 @@ pub trait Coercible: Sized {
     /// Coerces the value into the given type.
     ///
     /// Returns an error if the coercion is not supported.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided target type is not from the given types
-    /// collection.
     fn coerce(&self, target: &Type) -> Result<Self>;
 }
 

--- a/wdl-engine/src/value.rs
+++ b/wdl-engine/src/value.rs
@@ -19,12 +19,10 @@ use serde::ser::SerializeSeq;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::ArrayType;
 use wdl_analysis::types::Coercible as _;
-use wdl_analysis::types::CompoundTypeDef;
+use wdl_analysis::types::CompoundType;
 use wdl_analysis::types::Optional;
-use wdl_analysis::types::PrimitiveTypeKind;
+use wdl_analysis::types::PrimitiveType;
 use wdl_analysis::types::Type;
-use wdl_analysis::types::TypeEq;
-use wdl_analysis::types::Types;
 use wdl_ast::AstToken;
 use wdl_ast::v1;
 use wdl_ast::v1::TASK_FIELD_ATTEMPT;
@@ -55,7 +53,7 @@ pub trait Coercible: Sized {
     ///
     /// Panics if the provided target type is not from the given types
     /// collection.
-    fn coerce(&self, types: &Types, target: Type) -> Result<Self>;
+    fn coerce(&self, target: &Type) -> Result<Self>;
 }
 
 /// Represents a WDL runtime value.
@@ -108,7 +106,7 @@ impl Value {
             v1::MetadataValue::Null(_) => Self::None,
             v1::MetadataValue::Object(o) => Object::from_v1_metadata(o.items()).into(),
             v1::MetadataValue::Array(a) => Array::new_unchecked(
-                ANALYSIS_STDLIB.array_object_type(),
+                ANALYSIS_STDLIB.array_object_type().clone(),
                 a.elements().map(|v| Value::from_v1_metadata(&v)).collect(),
             )
             .into(),
@@ -446,7 +444,6 @@ impl Value {
     /// `None`.
     pub(crate) fn join_paths(
         &mut self,
-        types: &Types,
         path: &Path,
         check_existence: bool,
         optional: bool,
@@ -457,7 +454,7 @@ impl Value {
                     *self = Value::None;
                 }
             }
-            Self::Compound(v) => v.join_paths(types, path, check_existence)?,
+            Self::Compound(v) => v.join_paths(path, check_existence)?,
             _ => {}
         }
 
@@ -478,217 +475,36 @@ impl Value {
     /// specification.
     ///
     /// Returns `None` if the two values cannot be compared for equality.
-    pub fn equals(types: &Types, left: &Self, right: &Self) -> Option<bool> {
+    pub fn equals(left: &Self, right: &Self) -> Option<bool> {
         match (left, right) {
             (Value::None, Value::None) => Some(true),
             (Value::None, _) | (_, Value::None) => Some(false),
             (Value::Primitive(left), Value::Primitive(right)) => {
                 Some(PrimitiveValue::compare(left, right)? == Ordering::Equal)
             }
-            (Value::Compound(left), Value::Compound(right)) => {
-                CompoundValue::equals(types, left, right)
-            }
+            (Value::Compound(left), Value::Compound(right)) => CompoundValue::equals(left, right),
             _ => None,
         }
-    }
-
-    /// Serializes the value to the given serializer.
-    pub fn serialize<S>(&self, types: &Types, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::Serialize;
-        use serde::ser::Error;
-
-        match self {
-            Self::None => serializer.serialize_none(),
-            Self::Primitive(v) => v.serialize(serializer),
-            Self::Compound(v) => v.serialize(types, serializer),
-            Self::Task(_) | Self::Hints(_) | Self::Input(_) | Self::Output(_) => {
-                Err(S::Error::custom("value cannot be serialized"))
-            }
-        }
-    }
-
-    /// Deserializes a value from the given deserializer.
-    pub fn deserialize<'de, D>(
-        types: &mut Types,
-        deserializer: D,
-    ) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        /// Helper for deserializing the elements of sequences and maps
-        struct Deserialize<'a>(&'a mut Types);
-
-        impl<'de> serde::de::DeserializeSeed<'de> for Deserialize<'_> {
-            type Value = Value;
-
-            fn deserialize<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                deserializer.deserialize_any(Visitor(self.0))
-            }
-        }
-
-        /// Visitor for deserialization.
-        struct Visitor<'a>(&'a mut Types);
-
-        impl<'de> serde::de::Visitor<'de> for Visitor<'_> {
-            type Value = Value;
-
-            fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::None)
-            }
-
-            fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::None)
-            }
-
-            fn visit_some<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                Value::deserialize(self.0, deserializer)
-            }
-
-            fn visit_bool<E>(self, v: bool) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Primitive(PrimitiveValue::Boolean(v)))
-            }
-
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Primitive(PrimitiveValue::Integer(v)))
-            }
-
-            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Primitive(PrimitiveValue::Integer(
-                    v.try_into().map_err(|_| {
-                        E::custom("integer not in range for a 64-bit signed integer")
-                    })?,
-                )))
-            }
-
-            fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Primitive(PrimitiveValue::Float(v.into())))
-            }
-
-            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Primitive(PrimitiveValue::new_string(v)))
-            }
-
-            fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Primitive(PrimitiveValue::new_string(v)))
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                use serde::de::Error;
-
-                let mut elements = Vec::new();
-                while let Some(v) = seq.next_element_seed(Deserialize(self.0))? {
-                    elements.push(v);
-                }
-
-                let element_ty = elements
-                    .iter()
-                    .try_fold(None, |mut ty, element| {
-                        let element_ty = element.ty();
-                        let ty = ty.get_or_insert(element_ty);
-                        ty.common_type(self.0, element_ty).map(Some).ok_or_else(|| {
-                            A::Error::custom(format!(
-                                "a common element type does not exist between `{ty}` and \
-                                 `{element_ty}`",
-                                ty = ty.display(self.0),
-                                element_ty = element_ty.display(self.0)
-                            ))
-                        })
-                    })?
-                    .unwrap_or(Type::Union);
-
-                let ty = self.0.add_array(ArrayType::new(element_ty));
-                Ok(Array::new(self.0, ty, elements)
-                    .map_err(|e| {
-                        A::Error::custom(format!(
-                            "cannot coerce value to `{ty}`: {e:#}",
-                            ty = ty.display(self.0)
-                        ))
-                    })?
-                    .into())
-            }
-
-            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                use serde::de::Error;
-
-                let mut members = IndexMap::new();
-                while let Some(key) = map.next_key::<String>()? {
-                    if !is_ident(&key) {
-                        return Err(A::Error::custom(format!(
-                            "object key `{key}` is not a valid WDL identifier"
-                        )));
-                    }
-
-                    members.insert(key, map.next_value_seed(Deserialize(self.0))?);
-                }
-
-                Ok(Value::Compound(CompoundValue::Object(members.into())))
-            }
-
-            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "a WDL value")
-            }
-        }
-
-        deserializer.deserialize_any(Visitor(types))
     }
 }
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Value::None => write!(f, "None"),
-            Value::Primitive(v) => v.fmt(f),
-            Value::Compound(v) => v.fmt(f),
-            Value::Task(_) => write!(f, "task"),
-            Value::Hints(v) => v.fmt(f),
-            Value::Input(v) => v.fmt(f),
-            Value::Output(v) => v.fmt(f),
+            Self::None => write!(f, "None"),
+            Self::Primitive(v) => v.fmt(f),
+            Self::Compound(v) => v.fmt(f),
+            Self::Task(_) => write!(f, "task"),
+            Self::Hints(v) => v.fmt(f),
+            Self::Input(v) => v.fmt(f),
+            Self::Output(v) => v.fmt(f),
         }
     }
 }
 
 impl Coercible for Value {
-    fn coerce(&self, types: &Types, target: Type) -> Result<Self> {
-        if target.is_union() || target.is_none() || self.ty().type_eq(types, &target) {
+    fn coerce(&self, target: &Type) -> Result<Self> {
+        if target.is_union() || target.is_none() || self.ty().eq(target) {
             return Ok(self.clone());
         }
 
@@ -697,14 +513,11 @@ impl Coercible for Value {
                 if target.is_optional() {
                     Ok(Self::None)
                 } else {
-                    bail!(
-                        "cannot coerce `None` to non-optional type `{target}`",
-                        target = target.display(types)
-                    );
+                    bail!("cannot coerce `None` to non-optional type `{target}`");
                 }
             }
-            Self::Primitive(v) => v.coerce(types, target).map(Self::Primitive),
-            Self::Compound(v) => v.coerce(types, target).map(Self::Compound),
+            Self::Primitive(v) => v.coerce(target).map(Self::Primitive),
+            Self::Compound(v) => v.coerce(target).map(Self::Compound),
             Self::Task(_) => {
                 if matches!(target, Type::Task) {
                     return Ok(self.clone());
@@ -818,6 +631,178 @@ impl From<CompoundValue> for Value {
     }
 }
 
+impl serde::Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+
+        match self {
+            Self::None => serializer.serialize_none(),
+            Self::Primitive(v) => v.serialize(serializer),
+            Self::Compound(v) => v.serialize(serializer),
+            Self::Task(_) | Self::Hints(_) | Self::Input(_) | Self::Output(_) => {
+                Err(S::Error::custom("value cannot be serialized"))
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Value {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::Deserialize as _;
+
+        /// Helper for deserializing the elements of sequences and maps
+        struct Deserialize;
+
+        impl<'de> serde::de::DeserializeSeed<'de> for Deserialize {
+            type Value = Value;
+
+            fn deserialize<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(Visitor)
+            }
+        }
+
+        /// Visitor for deserialization.
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Value;
+
+            fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::None)
+            }
+
+            fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Value::deserialize(deserializer)
+            }
+
+            fn visit_bool<E>(self, v: bool) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Primitive(PrimitiveValue::Boolean(v)))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Primitive(PrimitiveValue::Integer(v)))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Primitive(PrimitiveValue::Integer(
+                    v.try_into().map_err(|_| {
+                        E::custom("integer not in range for a 64-bit signed integer")
+                    })?,
+                )))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Primitive(PrimitiveValue::Float(v.into())))
+            }
+
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Primitive(PrimitiveValue::new_string(v)))
+            }
+
+            fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Primitive(PrimitiveValue::new_string(v)))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                use serde::de::Error;
+
+                let mut elements = Vec::new();
+                while let Some(v) = seq.next_element_seed(Deserialize)? {
+                    elements.push(v);
+                }
+
+                let element_ty = elements
+                    .iter()
+                    .try_fold(None, |mut ty, element| {
+                        let element_ty = element.ty();
+                        let ty = ty.get_or_insert(element_ty.clone());
+                        ty.common_type(&element_ty).map(Some).ok_or_else(|| {
+                            A::Error::custom(format!(
+                                "a common element type does not exist between `{ty}` and \
+                                 `{element_ty}`"
+                            ))
+                        })
+                    })?
+                    .unwrap_or(Type::Union);
+
+                let ty: Type = ArrayType::new(element_ty).into();
+                Ok(Array::new(ty.clone(), elements)
+                    .map_err(|e| A::Error::custom(format!("cannot coerce value to `{ty}`: {e:#}")))?
+                    .into())
+            }
+
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                use serde::de::Error;
+
+                let mut members = IndexMap::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if !is_ident(&key) {
+                        return Err(A::Error::custom(format!(
+                            "object key `{key}` is not a valid WDL identifier"
+                        )));
+                    }
+
+                    members.insert(key, map.next_value_seed(Deserialize)?);
+                }
+
+                Ok(Value::Compound(CompoundValue::Object(members.into())))
+            }
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "a WDL value")
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
 /// Represents a primitive WDL value.
 ///
 /// Primitive values are cheap to clone.
@@ -856,12 +841,12 @@ impl PrimitiveValue {
     /// Gets the type of the value.
     pub fn ty(&self) -> Type {
         match self {
-            Self::Boolean(_) => PrimitiveTypeKind::Boolean.into(),
-            Self::Integer(_) => PrimitiveTypeKind::Integer.into(),
-            Self::Float(_) => PrimitiveTypeKind::Float.into(),
-            Self::String(_) => PrimitiveTypeKind::String.into(),
-            Self::File(_) => PrimitiveTypeKind::File.into(),
-            Self::Directory(_) => PrimitiveTypeKind::Directory.into(),
+            Self::Boolean(_) => PrimitiveType::Boolean.into(),
+            Self::Integer(_) => PrimitiveType::Integer.into(),
+            Self::Float(_) => PrimitiveType::Float.into(),
+            Self::String(_) => PrimitiveType::String.into(),
+            Self::File(_) => PrimitiveType::File.into(),
+            Self::Directory(_) => PrimitiveType::Directory.into(),
         }
     }
 
@@ -1168,8 +1153,8 @@ impl From<f64> for PrimitiveValue {
 }
 
 impl Coercible for PrimitiveValue {
-    fn coerce(&self, types: &Types, target: Type) -> Result<Self> {
-        if target.is_union() || target.is_none() || self.ty().type_eq(types, &target) {
+    fn coerce(&self, target: &Type) -> Result<Self> {
+        if target.is_union() || target.is_none() || self.ty().eq(target) {
             return Ok(self.clone());
         }
 
@@ -1177,102 +1162,72 @@ impl Coercible for PrimitiveValue {
             Self::Boolean(v) => {
                 target
                     .as_primitive()
-                    .and_then(|ty| match ty.kind() {
+                    .and_then(|ty| match ty {
                         // Boolean -> Boolean
-                        PrimitiveTypeKind::Boolean => Some(Self::Boolean(*v)),
+                        PrimitiveType::Boolean => Some(Self::Boolean(*v)),
                         _ => None,
                     })
-                    .with_context(|| {
-                        format!(
-                            "cannot coerce type `Boolean` to type `{target}`",
-                            target = target.display(types)
-                        )
-                    })
+                    .with_context(|| format!("cannot coerce type `Boolean` to type `{target}`"))
             }
             Self::Integer(v) => {
                 target
                     .as_primitive()
-                    .and_then(|ty| match ty.kind() {
+                    .and_then(|ty| match ty {
                         // Int -> Int
-                        PrimitiveTypeKind::Integer => Some(Self::Integer(*v)),
+                        PrimitiveType::Integer => Some(Self::Integer(*v)),
                         // Int -> Float
-                        PrimitiveTypeKind::Float => Some(Self::Float((*v as f64).into())),
+                        PrimitiveType::Float => Some(Self::Float((*v as f64).into())),
                         _ => None,
                     })
-                    .with_context(|| {
-                        format!(
-                            "cannot coerce type `Int` to type `{target}`",
-                            target = target.display(types)
-                        )
-                    })
+                    .with_context(|| format!("cannot coerce type `Int` to type `{target}`"))
             }
             Self::Float(v) => {
                 target
                     .as_primitive()
-                    .and_then(|ty| match ty.kind() {
+                    .and_then(|ty| match ty {
                         // Float -> Float
-                        PrimitiveTypeKind::Float => Some(Self::Float(*v)),
+                        PrimitiveType::Float => Some(Self::Float(*v)),
                         _ => None,
                     })
-                    .with_context(|| {
-                        format!(
-                            "cannot coerce type `Float` to type `{target}`",
-                            target = target.display(types)
-                        )
-                    })
+                    .with_context(|| format!("cannot coerce type `Float` to type `{target}`"))
             }
             Self::String(s) => {
                 target
                     .as_primitive()
-                    .and_then(|ty| match ty.kind() {
+                    .and_then(|ty| match ty {
                         // String -> String
-                        PrimitiveTypeKind::String => Some(Self::String(s.clone())),
+                        PrimitiveType::String => Some(Self::String(s.clone())),
                         // String -> File
-                        PrimitiveTypeKind::File => Some(Self::File(s.clone())),
+                        PrimitiveType::File => Some(Self::File(s.clone())),
                         // String -> Directory
-                        PrimitiveTypeKind::Directory => Some(Self::Directory(s.clone())),
+                        PrimitiveType::Directory => Some(Self::Directory(s.clone())),
                         _ => None,
                     })
-                    .with_context(|| {
-                        format!(
-                            "cannot coerce type `String` to type `{target}`",
-                            target = target.display(types)
-                        )
-                    })
+                    .with_context(|| format!("cannot coerce type `String` to type `{target}`"))
             }
             Self::File(s) => {
                 target
                     .as_primitive()
-                    .and_then(|ty| match ty.kind() {
+                    .and_then(|ty| match ty {
                         // File -> File
-                        PrimitiveTypeKind::File => Some(Self::File(s.clone())),
+                        PrimitiveType::File => Some(Self::File(s.clone())),
                         // File -> String
-                        PrimitiveTypeKind::String => Some(Self::String(s.clone())),
+                        PrimitiveType::String => Some(Self::String(s.clone())),
                         _ => None,
                     })
-                    .with_context(|| {
-                        format!(
-                            "cannot coerce type `File` to type `{target}`",
-                            target = target.display(types)
-                        )
-                    })
+                    .with_context(|| format!("cannot coerce type `File` to type `{target}`"))
             }
             Self::Directory(s) => {
                 target
                     .as_primitive()
-                    .and_then(|ty| match ty.kind() {
+                    .and_then(|ty| match ty {
                         // Directory -> Directory
-                        PrimitiveTypeKind::Directory => Some(Self::Directory(s.clone())),
+                        PrimitiveType::Directory => Some(Self::Directory(s.clone())),
                         // Directory -> String
-                        PrimitiveTypeKind::String => Some(Self::String(s.clone())),
+                        PrimitiveType::String => Some(Self::String(s.clone())),
                         _ => None,
                     })
-                    .with_context(|| {
-                        format!(
-                            "cannot coerce type `Directory` to type `{target}`",
-                            target = target.display(types)
-                        )
-                    })
+                    .with_context(|| format!("cannot coerce type `Directory` to type `{target}`"))
             }
         }
     }
@@ -1313,33 +1268,30 @@ impl Pair {
     ///
     /// # Panics
     ///
-    /// Panics if the given type is not a pair type from the given types
-    /// collection.
+    /// Panics if the given type is not a pair type.
     pub fn new(
-        types: &Types,
-        ty: Type,
+        ty: impl Into<Type>,
         left: impl Into<Value>,
         right: impl Into<Value>,
     ) -> Result<Self> {
-        if let Type::Compound(compound_ty) = ty {
-            if let CompoundTypeDef::Pair(pair_ty) = types.type_definition(compound_ty.definition())
-            {
-                let left_ty = pair_ty.left_type();
-                let right_ty = pair_ty.right_type();
-                return Ok(Self::new_unchecked(
-                    ty,
-                    left.into()
-                        .coerce(types, left_ty)
-                        .context("failed to coerce pair's left value")?,
-                    right
-                        .into()
-                        .coerce(types, right_ty)
-                        .context("failed to coerce pair's right value")?,
-                ));
-            }
+        let ty = ty.into();
+        if let Type::Compound(CompoundType::Pair(ty), optional) = ty {
+            let left = left
+                .into()
+                .coerce(ty.left_type())
+                .context("failed to coerce pair's left value")?;
+            let right = right
+                .into()
+                .coerce(ty.right_type())
+                .context("failed to coerce pair's right value")?;
+            return Ok(Self::new_unchecked(
+                Type::Compound(CompoundType::Pair(ty), optional),
+                left,
+                right,
+            ));
         }
 
-        panic!("type `{ty}` is not a pair type", ty = ty.display(types));
+        panic!("type `{ty}` is not a pair type");
     }
 
     /// Constructs a new pair without checking the given left and right conform
@@ -1354,7 +1306,7 @@ impl Pair {
 
     /// Gets the type of the `Pair`.
     pub fn ty(&self) -> Type {
-        self.ty
+        self.ty.clone()
     }
 
     /// Gets the left value of the `Pair`.
@@ -1395,31 +1347,31 @@ impl Array {
     ///
     /// # Panics
     ///
-    /// Panics if the given type is not an array type from the types collection.
-    pub fn new<V>(types: &Types, ty: Type, elements: impl IntoIterator<Item = V>) -> Result<Self>
+    /// Panics if the given type is not an array type.
+    pub fn new<V>(ty: impl Into<Type>, elements: impl IntoIterator<Item = V>) -> Result<Self>
     where
         V: Into<Value>,
     {
-        if let Type::Compound(compound_ty) = ty {
-            if let CompoundTypeDef::Array(array_ty) =
-                types.type_definition(compound_ty.definition())
-            {
-                let element_type = array_ty.element_type();
-                let elements = elements
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, v)| {
-                        let v = v.into();
-                        v.coerce(types, element_type)
-                            .with_context(|| format!("failed to coerce array element at index {i}"))
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+        let ty = ty.into();
+        if let Type::Compound(CompoundType::Array(ty), optional) = ty {
+            let element_type = ty.element_type();
+            let elements = elements
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let v = v.into();
+                    v.coerce(element_type)
+                        .with_context(|| format!("failed to coerce array element at index {i}"))
+                })
+                .collect::<Result<Vec<_>>>()?;
 
-                return Ok(Self::new_unchecked(ty, elements));
-            }
+            return Ok(Self::new_unchecked(
+                Type::Compound(CompoundType::Array(ty), optional),
+                elements,
+            ));
         }
 
-        panic!("type `{ty}` is not an array type", ty = ty.display(types));
+        panic!("type `{ty}` is not an array type");
     }
 
     /// Constructs a new array without checking the given elements conform to
@@ -1437,7 +1389,7 @@ impl Array {
 
     /// Gets the type of the `Array` value.
     pub fn ty(&self) -> Type {
-        self.ty
+        self.ty.clone()
     }
 
     /// Converts the array value to a slice of values.
@@ -1495,54 +1447,54 @@ impl Map {
     ///
     /// # Panics
     ///
-    /// Panics if the given type is not a map type from the given types
-    /// collection.
+    /// Panics if the given type is not a map type.
     pub fn new<K, V>(
-        types: &Types,
-        ty: Type,
+        ty: impl Into<Type>,
         elements: impl IntoIterator<Item = (K, V)>,
     ) -> Result<Self>
     where
         K: Into<Value>,
         V: Into<Value>,
     {
-        if let Type::Compound(compound_ty) = ty {
-            if let CompoundTypeDef::Map(map_ty) = types.type_definition(compound_ty.definition()) {
-                let key_type = map_ty.key_type();
-                let value_type = map_ty.value_type();
+        let ty = ty.into();
+        if let Type::Compound(CompoundType::Map(ty), optional) = ty {
+            let key_type = ty.key_type();
+            let value_type = ty.value_type();
 
-                let elements = elements
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, (k, v))| {
-                        let k = k.into();
-                        let v = v.into();
-                        Ok((
-                            if k.is_none() {
-                                None
-                            } else {
-                                match k.coerce(types, key_type).with_context(|| {
-                                    format!("failed to coerce map key for element at index {i}")
-                                })? {
-                                    Value::None => None,
-                                    Value::Primitive(v) => Some(v),
-                                    _ => {
-                                        bail!("not all key values are primitive")
-                                    }
+            let elements = elements
+                .into_iter()
+                .enumerate()
+                .map(|(i, (k, v))| {
+                    let k = k.into();
+                    let v = v.into();
+                    Ok((
+                        if k.is_none() {
+                            None
+                        } else {
+                            match k.coerce(key_type).with_context(|| {
+                                format!("failed to coerce map key for element at index {i}")
+                            })? {
+                                Value::None => None,
+                                Value::Primitive(v) => Some(v),
+                                _ => {
+                                    bail!("not all key values are primitive")
                                 }
-                            },
-                            v.coerce(types, value_type).with_context(|| {
-                                format!("failed to coerce map value for element at index {i}")
-                            })?,
-                        ))
-                    })
-                    .collect::<Result<_>>()?;
+                            }
+                        },
+                        v.coerce(value_type).with_context(|| {
+                            format!("failed to coerce map value for element at index {i}")
+                        })?,
+                    ))
+                })
+                .collect::<Result<_>>()?;
 
-                return Ok(Self::new_unchecked(ty, elements));
-            }
+            return Ok(Self::new_unchecked(
+                Type::Compound(CompoundType::Map(ty), optional),
+                elements,
+            ));
         }
 
-        panic!("type `{ty}` is not a map type", ty = ty.display(types));
+        panic!("type `{ty}` is not a map type");
     }
 
     /// Constructs a new map without checking the given elements conform to the
@@ -1563,7 +1515,7 @@ impl Map {
 
     /// Gets the type of the `Map` value.
     pub fn ty(&self) -> Type {
-        self.ty
+        self.ty.clone()
     }
 
     /// Iterates the elements of the map.
@@ -1782,53 +1734,51 @@ impl Struct {
     ///
     /// # Panics
     ///
-    /// Panics if the given type is not a struct type from the given types
-    /// collection.
-    pub fn new<S, V>(
-        types: &Types,
-        ty: Type,
-        members: impl IntoIterator<Item = (S, V)>,
-    ) -> Result<Self>
+    /// Panics if the given type is not a struct type.
+    pub fn new<S, V>(ty: impl Into<Type>, members: impl IntoIterator<Item = (S, V)>) -> Result<Self>
     where
         S: Into<String>,
         V: Into<Value>,
     {
-        let mut members = members
-            .into_iter()
-            .map(|(n, v)| {
-                let n = n.into();
-                let v = v.into();
-                let v = v
-                    .coerce(
-                        types,
-                        *types.struct_type(ty).members().get(&n).ok_or_else(|| {
+        let ty = ty.into();
+        if let Type::Compound(CompoundType::Struct(ty), optional) = ty {
+            let mut members = members
+                .into_iter()
+                .map(|(n, v)| {
+                    let n = n.into();
+                    let v = v.into();
+                    let v = v
+                        .coerce(ty.members().get(&n).ok_or_else(|| {
                             anyhow!("struct does not contain a member named `{n}`")
-                        })?,
-                    )
-                    .with_context(|| format!("failed to coerce struct member `{n}`"))?;
-                Ok((n, v))
-            })
-            .collect::<Result<IndexMap<_, _>>>()?;
+                        })?)
+                        .with_context(|| format!("failed to coerce struct member `{n}`"))?;
+                    Ok((n, v))
+                })
+                .collect::<Result<IndexMap<_, _>>>()?;
 
-        for (name, ty) in types.struct_type(ty).members().iter() {
-            // Check for optional members that should be set to `None`
-            if ty.is_optional() {
-                if !members.contains_key(name) {
-                    members.insert(name.clone(), Value::None);
-                }
-            } else {
-                // Check for a missing required member
-                if !members.contains_key(name) {
-                    bail!("missing a value for struct member `{name}`");
+            for (name, ty) in ty.members().iter() {
+                // Check for optional members that should be set to `None`
+                if ty.is_optional() {
+                    if !members.contains_key(name) {
+                        members.insert(name.clone(), Value::None);
+                    }
+                } else {
+                    // Check for a missing required member
+                    if !members.contains_key(name) {
+                        bail!("missing a value for struct member `{name}`");
+                    }
                 }
             }
+
+            let name = ty.name().to_string();
+            return Ok(Self {
+                ty: Type::Compound(CompoundType::Struct(ty), optional),
+                name: Arc::new(name),
+                members: Arc::new(members),
+            });
         }
 
-        Ok(Self {
-            ty,
-            name: types.struct_type(ty).name().clone(),
-            members: Arc::new(members),
-        })
+        panic!("type `{ty}` is not a struct type");
     }
 
     /// Constructs a new struct without checking the given members conform to
@@ -1843,7 +1793,7 @@ impl Struct {
 
     /// Gets the type of the `Struct` value.
     pub fn ty(&self) -> Type {
-        self.ty
+        self.ty.clone()
     }
 
     /// Gets the name of the struct.
@@ -2037,17 +1987,17 @@ impl CompoundValue {
     ///
     /// Returns `None` if the two compound values cannot be compared for
     /// equality.
-    pub fn equals(types: &Types, left: &Self, right: &Self) -> Option<bool> {
+    pub fn equals(left: &Self, right: &Self) -> Option<bool> {
         // The values must have type equivalence to compare for compound values
         // Coercion doesn't take place for this check
-        if !left.ty().type_eq(types, &right.ty()) {
+        if left.ty() != right.ty() {
             return None;
         }
 
         match (left, right) {
             (Self::Pair(left), Self::Pair(right)) => Some(
-                Value::equals(types, &left.left, &right.left)?
-                    && Value::equals(types, &left.right, &right.right)?,
+                Value::equals(&left.left, &right.left)?
+                    && Value::equals(&left.right, &right.right)?,
             ),
             (CompoundValue::Array(left), CompoundValue::Array(right)) => Some(
                 left.len() == right.len()
@@ -2055,7 +2005,7 @@ impl CompoundValue {
                         .as_slice()
                         .iter()
                         .zip(right.as_slice())
-                        .all(|(l, r)| Value::equals(types, l, r).unwrap_or(false)),
+                        .all(|(l, r)| Value::equals(l, r).unwrap_or(false)),
             ),
             (CompoundValue::Map(left), CompoundValue::Map(right)) => Some(
                 left.len() == right.len()
@@ -2067,13 +2017,13 @@ impl CompoundValue {
                             _ => return false
                         }
 
-                        Value::equals(types, lv, rv).unwrap_or(false)
+                        Value::equals(lv, rv).unwrap_or(false)
                     }),
             ),
             (CompoundValue::Object(left), CompoundValue::Object(right)) => Some(
                 left.len() == right.len()
                     && left.iter().all(|(k, left)| match right.get(k) {
-                        Some(right) => Value::equals(types, left, right).unwrap_or(false),
+                        Some(right) => Value::equals(left, right).unwrap_or(false),
                         None => false,
                     }),
             ),
@@ -2083,89 +2033,11 @@ impl CompoundValue {
             ) => Some(
                 left.len() == right.len()
                     && left.iter().all(|(k, left)| match right.get(k) {
-                        Some(right) => Value::equals(types, left, right).unwrap_or(false),
+                        Some(right) => Value::equals(left, right).unwrap_or(false),
                         None => false,
                     }),
             ),
             _ => None,
-        }
-    }
-
-    /// Serializes the value to the given serializer.
-    pub fn serialize<S>(&self, types: &Types, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::Error;
-
-        /// Helper `Serialize` implementation for serializing element values.
-        struct Serialize<'a> {
-            /// The types collection.
-            types: &'a Types,
-            /// The value being serialized.
-            value: &'a Value,
-        }
-
-        impl serde::Serialize for Serialize<'_> {
-            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-            where
-                S: serde::Serializer,
-            {
-                self.value.serialize(self.types, serializer)
-            }
-        }
-
-        match self {
-            Self::Pair(_) => Err(S::Error::custom("a pair cannot be serialized")),
-            Self::Array(v) => {
-                let mut s = serializer.serialize_seq(Some(v.len()))?;
-                for e in v.as_slice() {
-                    s.serialize_element(&Serialize { types, value: e })?;
-                }
-
-                s.end()
-            }
-            Self::Map(v) => {
-                if !types
-                    .type_definition(
-                        v.ty()
-                            .as_compound()
-                            .expect("type should be compound")
-                            .definition(),
-                    )
-                    .as_map()
-                    .expect("type should be a map")
-                    .key_type()
-                    .is_coercible_to(types, &PrimitiveTypeKind::String.into())
-                {
-                    return Err(S::Error::custom(
-                        "only maps with `String` key types may be serialized",
-                    ));
-                }
-
-                let mut s = serializer.serialize_map(Some(v.len()))?;
-                for (k, v) in v.iter() {
-                    s.serialize_entry(k, &Serialize { types, value: v })?;
-                }
-
-                s.end()
-            }
-            Self::Object(object) => {
-                let mut s = serializer.serialize_map(Some(object.len()))?;
-                for (k, v) in object.iter() {
-                    s.serialize_entry(k, &Serialize { types, value: v })?;
-                }
-
-                s.end()
-            }
-            Self::Struct(Struct { members, .. }) => {
-                let mut s = serializer.serialize_map(Some(members.len()))?;
-                for (k, v) in members.iter() {
-                    s.serialize_entry(k, &Serialize { types, value: v })?;
-                }
-
-                s.end()
-            }
         }
     }
 
@@ -2209,41 +2081,26 @@ impl CompoundValue {
     /// If `check_existence` is `true` and a required path does not exist, an
     /// error is returned. An optional path that does not exist is replaced with
     /// `None`.
-    pub(crate) fn join_paths(
-        &mut self,
-        types: &Types,
-        path: &Path,
-        check_existence: bool,
-    ) -> Result<()> {
+    pub(crate) fn join_paths(&mut self, path: &Path, check_existence: bool) -> Result<()> {
         match self {
             Self::Pair(pair) => {
-                let ty = types.pair_type(pair.ty);
+                let ty = pair.ty.as_pair().expect("should be a pair type");
                 let (left_optional, right_optional) =
                     (ty.left_type().is_optional(), ty.right_type().is_optional());
-                Arc::make_mut(&mut pair.left).join_paths(
-                    types,
-                    path,
-                    check_existence,
-                    left_optional,
-                )?;
-                Arc::make_mut(&mut pair.right).join_paths(
-                    types,
-                    path,
-                    check_existence,
-                    right_optional,
-                )?;
+                Arc::make_mut(&mut pair.left).join_paths(path, check_existence, left_optional)?;
+                Arc::make_mut(&mut pair.right).join_paths(path, check_existence, right_optional)?;
             }
             Self::Array(array) => {
-                let ty = types.array_type(array.ty);
+                let ty = array.ty.as_array().expect("should be an array type");
                 let optional = ty.element_type().is_optional();
                 if let Some(elements) = &mut array.elements {
                     for v in Arc::make_mut(elements) {
-                        v.join_paths(types, path, check_existence, optional)?;
+                        v.join_paths(path, check_existence, optional)?;
                     }
                 }
             }
             Self::Map(map) => {
-                let ty = types.map_type(map.ty);
+                let ty = map.ty.as_map().expect("should be a map type");
                 let (key_optional, value_optional) =
                     (ty.key_type().is_optional(), ty.value_type().is_optional());
                 if let Some(elements) = &mut map.elements {
@@ -2268,7 +2125,7 @@ impl CompoundValue {
                                     }
                                 }
 
-                                v.join_paths(types, path, check_existence, value_optional)?;
+                                v.join_paths(path, check_existence, value_optional)?;
                                 Ok((k, v))
                             })
                             .collect::<Result<Vec<_>>>()?;
@@ -2276,7 +2133,7 @@ impl CompoundValue {
                     } else {
                         // Otherwise, we can just mutable the values in place
                         for v in Arc::make_mut(elements).values_mut() {
-                            v.join_paths(types, path, check_existence, value_optional)?;
+                            v.join_paths(path, check_existence, value_optional)?;
                         }
                     }
                 }
@@ -2284,14 +2141,14 @@ impl CompoundValue {
             Self::Object(object) => {
                 if let Some(members) = &mut object.members {
                     for v in Arc::make_mut(members).values_mut() {
-                        v.join_paths(types, path, check_existence, false)?;
+                        v.join_paths(path, check_existence, false)?;
                     }
                 }
             }
             Self::Struct(s) => {
-                let ty = types.struct_type(s.ty);
+                let ty = s.ty.as_struct().expect("should be a struct type");
                 for (n, v) in Arc::make_mut(&mut s.members).iter_mut() {
-                    v.join_paths(types, path, check_existence, ty.members()[n].is_optional())?;
+                    v.join_paths(path, check_existence, ty.members()[n].is_optional())?;
                 }
             }
         }
@@ -2328,77 +2185,70 @@ impl CompoundValue {
 impl fmt::Display for CompoundValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CompoundValue::Pair(v) => v.fmt(f),
-            CompoundValue::Array(v) => v.fmt(f),
-            CompoundValue::Map(v) => v.fmt(f),
-            CompoundValue::Object(v) => v.fmt(f),
-            CompoundValue::Struct(v) => v.fmt(f),
+            Self::Pair(v) => v.fmt(f),
+            Self::Array(v) => v.fmt(f),
+            Self::Map(v) => v.fmt(f),
+            Self::Object(v) => v.fmt(f),
+            Self::Struct(v) => v.fmt(f),
         }
     }
 }
 
 impl Coercible for CompoundValue {
-    fn coerce(&self, types: &Types, target: Type) -> Result<Self> {
-        if target.is_union() || target.is_none() || self.ty().type_eq(types, &target) {
+    fn coerce(&self, target: &Type) -> Result<Self> {
+        if target.is_union() || target.is_none() || self.ty().eq(target) {
             return Ok(self.clone());
         }
 
-        if let Type::Compound(compound_ty) = target {
-            match (self, types.type_definition(compound_ty.definition())) {
+        if let Type::Compound(target_ty, _) = target {
+            match (self, target_ty) {
                 // Array[X] -> Array[Y](+) where X -> Y
-                (Self::Array(v), CompoundTypeDef::Array(array_ty)) => {
+                (Self::Array(v), CompoundType::Array(target_ty)) => {
                     // Don't allow coercion when the source is empty but the target has the
                     // non-empty qualifier
-                    if v.is_empty() && array_ty.is_non_empty() {
-                        bail!(
-                            "cannot coerce empty array value to non-empty array type `{ty}`",
-                            ty = array_ty.display(types)
-                        );
+                    if v.is_empty() && target_ty.is_non_empty() {
+                        bail!("cannot coerce empty array value to non-empty array type `{target}`",);
                     }
 
                     return Ok(Self::Array(Array::new(
-                        types,
-                        target,
+                        target.clone(),
                         v.as_slice().iter().cloned(),
                     )?));
                 }
                 // Map[W, Y] -> Map[X, Z] where W -> X and Y -> Z
-                (Self::Map(v), CompoundTypeDef::Map(_)) => {
+                (Self::Map(v), CompoundType::Map(_)) => {
                     return Ok(Self::Map(Map::new(
-                        types,
-                        target,
+                        target.clone(),
                         v.iter().map(|(k, v)| {
                             (k.clone().map(Into::into).unwrap_or(Value::None), v.clone())
                         }),
                     )?));
                 }
                 // Pair[W, Y] -> Pair[X, Z] where W -> X and Y -> Z
-                (Self::Pair(v), CompoundTypeDef::Pair(_)) => {
+                (Self::Pair(v), CompoundType::Pair(_)) => {
                     return Ok(Self::Pair(Pair::new(
-                        types,
-                        target,
+                        target.clone(),
                         v.left.as_ref().clone(),
                         v.right.as_ref().clone(),
                     )?));
                 }
                 // Map[String, Y] -> Struct
-                (Self::Map(v), CompoundTypeDef::Struct(struct_ty)) => {
+                (Self::Map(v), CompoundType::Struct(target_ty)) => {
                     let len = v.len();
-                    let expected_len = types.struct_type(target).members().len();
+                    let expected_len = target_ty.members().len();
 
                     if len != expected_len {
                         bail!(
-                            "cannot coerce a map of {len} element{s1} to struct type `{ty}` as \
-                             the struct has {expected_len} member{s2}",
+                            "cannot coerce a map of {len} element{s1} to struct type `{target}` \
+                             as the struct has {expected_len} member{s2}",
                             s1 = if len == 1 { "" } else { "s" },
-                            ty = compound_ty.display(types),
                             s2 = if expected_len == 1 { "" } else { "s" }
                         );
                     }
 
                     return Ok(Self::Struct(Struct {
-                        ty: target,
-                        name: struct_ty.name().clone(),
+                        ty: target.clone(),
+                        name: target_ty.name().clone(),
                         members: Arc::new(
                             v.iter()
                                 .map(|(k, v)| {
@@ -2408,23 +2258,18 @@ impl Coercible for CompoundValue {
                                         .with_context(|| {
                                             format!(
                                                 "cannot coerce a map with a non-string key type \
-                                                 to struct type `{ty}`",
-                                                ty = compound_ty.display(types)
+                                                 to struct type `{target}`"
                                             )
                                         })?
                                         .to_string();
-                                    let ty =
-                                        *types.struct_type(target).members().get(&k).with_context(
-                                            || {
-                                                format!(
-                                                    "cannot coerce a map with key `{k}` to struct \
-                                                     type `{ty}` as the struct does not contain a \
-                                                     member with that name",
-                                                    ty = compound_ty.display(types)
-                                                )
-                                            },
-                                        )?;
-                                    let v = v.coerce(types, ty).with_context(|| {
+                                    let ty = target_ty.members().get(&k).with_context(|| {
+                                        format!(
+                                            "cannot coerce a map with key `{k}` to struct type \
+                                             `{target}` as the struct does not contain a member \
+                                             with that name"
+                                        )
+                                    })?;
+                                    let v = v.coerce(ty).with_context(|| {
                                         format!("failed to coerce value of map key `{k}")
                                     })?;
                                     Ok((k, v))
@@ -2435,46 +2280,44 @@ impl Coercible for CompoundValue {
                 }
                 // Struct -> Map[String, Y]
                 // Object -> Map[String, Y]
-                (Self::Struct(Struct { members, .. }), CompoundTypeDef::Map(map_ty)) => {
-                    if map_ty.key_type().as_primitive() != Some(PrimitiveTypeKind::String.into()) {
+                (Self::Struct(Struct { members, .. }), CompoundType::Map(map_ty)) => {
+                    if map_ty.key_type().as_primitive() != Some(PrimitiveType::String) {
                         bail!(
-                            "cannot coerce a struct or object to type `{ty}` as it requires a \
-                             `String` key type",
-                            ty = compound_ty.display(types)
+                            "cannot coerce a struct or object to type `{target}` as it requires a \
+                             `String` key type"
                         );
                     }
 
                     let value_ty = map_ty.value_type();
                     return Ok(Self::Map(Map::new_unchecked(
-                        target,
+                        target.clone(),
                         members
                             .iter()
                             .map(|(n, v)| {
                                 let v = v
-                                    .coerce(types, value_ty)
+                                    .coerce(value_ty)
                                     .with_context(|| format!("failed to coerce member `{n}`"))?;
                                 Ok((PrimitiveValue::new_string(n).into(), v))
                             })
                             .collect::<Result<_>>()?,
                     )));
                 }
-                (Self::Object(object), CompoundTypeDef::Map(map_ty)) => {
-                    if map_ty.key_type().as_primitive() != Some(PrimitiveTypeKind::String.into()) {
+                (Self::Object(object), CompoundType::Map(map_ty)) => {
+                    if map_ty.key_type().as_primitive() != Some(PrimitiveType::String) {
                         bail!(
-                            "cannot coerce a struct or object to type `{ty}` as it requires a \
+                            "cannot coerce a struct or object to type `{target}` as it requires a \
                              `String` key type",
-                            ty = compound_ty.display(types)
                         );
                     }
 
                     let value_ty = map_ty.value_type();
                     return Ok(Self::Map(Map::new_unchecked(
-                        target,
+                        target.clone(),
                         object
                             .iter()
                             .map(|(n, v)| {
                                 let v = v
-                                    .coerce(types, value_ty)
+                                    .coerce(value_ty)
                                     .with_context(|| format!("failed to coerce member `{n}`"))?;
                                 Ok((PrimitiveValue::new_string(n).into(), v))
                             })
@@ -2482,47 +2325,41 @@ impl Coercible for CompoundValue {
                     )));
                 }
                 // Object -> Struct
-                (Self::Object(v), CompoundTypeDef::Struct(_)) => {
+                (Self::Object(v), CompoundType::Struct(_)) => {
                     return Ok(Self::Struct(Struct::new(
-                        types,
-                        target,
+                        target.clone(),
                         v.iter().map(|(k, v)| (k, v.clone())),
                     )?));
                 }
                 // Struct -> Struct
-                (Self::Struct(v), CompoundTypeDef::Struct(struct_ty)) => {
+                (Self::Struct(v), CompoundType::Struct(struct_ty)) => {
                     let len = v.members.len();
                     let expected_len = struct_ty.members().len();
 
                     if len != expected_len {
                         bail!(
-                            "cannot coerce a struct of {len} members{s1} to struct type `{ty}` as \
-                             the target struct has {expected_len} member{s2}",
+                            "cannot coerce a struct of {len} members{s1} to struct type \
+                             `{target}` as the target struct has {expected_len} member{s2}",
                             s1 = if len == 1 { "" } else { "s" },
-                            ty = compound_ty.display(types),
                             s2 = if expected_len == 1 { "" } else { "s" }
                         );
                     }
 
                     return Ok(Self::Struct(Struct {
-                        ty: target,
+                        ty: target.clone(),
                         name: struct_ty.name().clone(),
                         members: Arc::new(
                             v.members
                                 .iter()
                                 .map(|(k, v)| {
-                                    let ty =
-                                        types.struct_type(target).members().get(k).ok_or_else(
-                                            || {
-                                                anyhow!(
-                                                    "cannot coerce a struct with member `{k}` to \
-                                                     struct type `{ty}` as the target struct does \
-                                                     not contain a member with that name",
-                                                    ty = compound_ty.display(types)
-                                                )
-                                            },
-                                        )?;
-                                    let v = v.coerce(types, *ty).with_context(|| {
+                                    let ty = struct_ty.members().get(k).ok_or_else(|| {
+                                        anyhow!(
+                                            "cannot coerce a struct with member `{k}` to struct \
+                                             type `{target}` as the target struct does not \
+                                             contain a member with that name",
+                                        )
+                                    })?;
+                                    let v = v.coerce(ty).with_context(|| {
                                         format!("failed to coerce member `{k}`")
                                     })?;
                                     Ok((k.clone(), v))
@@ -2532,7 +2369,7 @@ impl Coercible for CompoundValue {
                     }));
                 }
                 _ => {}
-            };
+            }
         }
 
         if let Type::Object = target {
@@ -2567,9 +2404,8 @@ impl Coercible for CompoundValue {
         }
 
         bail!(
-            "cannot coerce a value of type `{ty}` to type `{expected}`",
-            ty = self.ty().display(types),
-            expected = target.display(types)
+            "cannot coerce a value of type `{ty}` to type `{target}`",
+            ty = self.ty()
         );
     }
 }
@@ -2601,6 +2437,63 @@ impl From<Object> for CompoundValue {
 impl From<Struct> for CompoundValue {
     fn from(value: Struct) -> Self {
         Self::Struct(value)
+    }
+}
+
+impl serde::Serialize for CompoundValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+
+        match self {
+            Self::Pair(_) => Err(S::Error::custom("a pair cannot be serialized")),
+            Self::Array(v) => {
+                let mut s = serializer.serialize_seq(Some(v.len()))?;
+                for v in v.as_slice() {
+                    s.serialize_element(v)?;
+                }
+
+                s.end()
+            }
+            Self::Map(v) => {
+                if !v
+                    .ty()
+                    .as_map()
+                    .expect("type should be a map")
+                    .key_type()
+                    .is_coercible_to(&PrimitiveType::String.into())
+                {
+                    return Err(S::Error::custom(
+                        "only maps with `String` key types may be serialized",
+                    ));
+                }
+
+                let mut s = serializer.serialize_map(Some(v.len()))?;
+                for (k, v) in v.iter() {
+                    s.serialize_entry(k, v)?;
+                }
+
+                s.end()
+            }
+            Self::Object(object) => {
+                let mut s = serializer.serialize_map(Some(object.len()))?;
+                for (k, v) in object.iter() {
+                    s.serialize_entry(k, v)?;
+                }
+
+                s.end()
+            }
+            Self::Struct(Struct { members, .. }) => {
+                let mut s = serializer.serialize_map(Some(members.len()))?;
+                for (k, v) in members.iter() {
+                    s.serialize_entry(k, v)?;
+                }
+
+                s.end()
+            }
+        }
     }
 }
 
@@ -2672,7 +2565,7 @@ impl TaskValue {
             cpu: constraints.cpu,
             memory: constraints.memory,
             gpu: Array::new_unchecked(
-                ANALYSIS_STDLIB.array_string_type(),
+                ANALYSIS_STDLIB.array_string_type().clone(),
                 constraints
                     .gpu
                     .into_iter()
@@ -2680,7 +2573,7 @@ impl TaskValue {
                     .collect(),
             ),
             fpga: Array::new_unchecked(
-                ANALYSIS_STDLIB.array_string_type(),
+                ANALYSIS_STDLIB.array_string_type().clone(),
                 constraints
                     .fpga
                     .into_iter()
@@ -2688,7 +2581,7 @@ impl TaskValue {
                     .collect(),
             ),
             disks: Map::new_unchecked(
-                ANALYSIS_STDLIB.map_string_int_type(),
+                ANALYSIS_STDLIB.map_string_int_type().clone(),
                 constraints
                     .disks
                     .into_iter()
@@ -2954,12 +2847,10 @@ mod test {
 
     #[test]
     fn boolean_coercion() {
-        let types = Types::default();
-
         // Boolean -> Boolean
         assert_eq!(
             Value::from(false)
-                .coerce(&types, PrimitiveTypeKind::Boolean.into())
+                .coerce(&PrimitiveType::Boolean.into())
                 .expect("should coerce")
                 .unwrap_boolean(),
             Value::from(false).unwrap_boolean()
@@ -2969,7 +2860,7 @@ mod test {
             format!(
                 "{e:?}",
                 e = Value::from(true)
-                    .coerce(&types, PrimitiveTypeKind::String.into())
+                    .coerce(&PrimitiveType::String.into())
                     .unwrap_err()
             ),
             "cannot coerce type `Boolean` to type `String`"
@@ -2984,12 +2875,10 @@ mod test {
 
     #[test]
     fn integer_coercion() {
-        let types = Types::default();
-
         // Int -> Int
         assert_eq!(
             Value::from(12345)
-                .coerce(&types, PrimitiveTypeKind::Integer.into())
+                .coerce(&PrimitiveType::Integer.into())
                 .expect("should coerce")
                 .unwrap_integer(),
             Value::from(12345).unwrap_integer()
@@ -2997,7 +2886,7 @@ mod test {
         // Int -> Float
         assert_relative_eq!(
             Value::from(12345)
-                .coerce(&types, PrimitiveTypeKind::Float.into())
+                .coerce(&PrimitiveType::Float.into())
                 .expect("should coerce")
                 .unwrap_float(),
             Value::from(12345.0).unwrap_float()
@@ -3007,7 +2896,7 @@ mod test {
             format!(
                 "{e:?}",
                 e = Value::from(12345)
-                    .coerce(&types, PrimitiveTypeKind::Boolean.into())
+                    .coerce(&PrimitiveType::Boolean.into())
                     .unwrap_err()
             ),
             "cannot coerce type `Int` to type `Boolean`"
@@ -3022,12 +2911,10 @@ mod test {
 
     #[test]
     fn float_coercion() {
-        let types = Types::default();
-
         // Float -> Float
         assert_relative_eq!(
             Value::from(12345.0)
-                .coerce(&types, PrimitiveTypeKind::Float.into())
+                .coerce(&PrimitiveType::Float.into())
                 .expect("should coerce")
                 .unwrap_float(),
             Value::from(12345.0).unwrap_float()
@@ -3037,7 +2924,7 @@ mod test {
             format!(
                 "{e:?}",
                 e = Value::from(12345.0)
-                    .coerce(&types, PrimitiveTypeKind::Integer.into())
+                    .coerce(&PrimitiveType::Integer.into())
                     .unwrap_err()
             ),
             "cannot coerce type `Float` to type `Int`"
@@ -3052,27 +2939,25 @@ mod test {
 
     #[test]
     fn string_coercion() {
-        let types = Types::default();
-
         let value = PrimitiveValue::new_string("foo");
         // String -> String
         assert_eq!(
             value
-                .coerce(&types, PrimitiveTypeKind::String.into())
+                .coerce(&PrimitiveType::String.into())
                 .expect("should coerce"),
             value
         );
         // String -> File
         assert_eq!(
             value
-                .coerce(&types, PrimitiveTypeKind::File.into())
+                .coerce(&PrimitiveType::File.into())
                 .expect("should coerce"),
             PrimitiveValue::File(value.as_string().expect("should be string").clone())
         );
         // String -> Directory
         assert_eq!(
             value
-                .coerce(&types, PrimitiveTypeKind::Directory.into())
+                .coerce(&PrimitiveType::Directory.into())
                 .expect("should coerce"),
             PrimitiveValue::Directory(value.as_string().expect("should be string").clone())
         );
@@ -3080,9 +2965,7 @@ mod test {
         assert_eq!(
             format!(
                 "{e:?}",
-                e = value
-                    .coerce(&types, PrimitiveTypeKind::Boolean.into())
-                    .unwrap_err()
+                e = value.coerce(&PrimitiveType::Boolean.into()).unwrap_err()
             ),
             "cannot coerce type `String` to type `Boolean`"
         );
@@ -3096,21 +2979,19 @@ mod test {
 
     #[test]
     fn file_coercion() {
-        let types = Types::default();
-
         let value = PrimitiveValue::new_file("foo");
 
         // File -> File
         assert_eq!(
             value
-                .coerce(&types, PrimitiveTypeKind::File.into())
+                .coerce(&PrimitiveType::File.into())
                 .expect("should coerce"),
             value
         );
         // File -> String
         assert_eq!(
             value
-                .coerce(&types, PrimitiveTypeKind::String.into())
+                .coerce(&PrimitiveType::String.into())
                 .expect("should coerce"),
             PrimitiveValue::String(value.as_file().expect("should be file").clone())
         );
@@ -3118,9 +2999,7 @@ mod test {
         assert_eq!(
             format!(
                 "{e:?}",
-                e = value
-                    .coerce(&types, PrimitiveTypeKind::Directory.into())
-                    .unwrap_err()
+                e = value.coerce(&PrimitiveType::Directory.into()).unwrap_err()
             ),
             "cannot coerce type `File` to type `Directory`"
         );
@@ -3134,20 +3013,19 @@ mod test {
 
     #[test]
     fn directory_coercion() {
-        let types = Types::default();
         let value = PrimitiveValue::new_directory("foo");
 
         // Directory -> Directory
         assert_eq!(
             value
-                .coerce(&types, PrimitiveTypeKind::Directory.into())
+                .coerce(&PrimitiveType::Directory.into())
                 .expect("should coerce"),
             value
         );
         // Directory -> String
         assert_eq!(
             value
-                .coerce(&types, PrimitiveTypeKind::String.into())
+                .coerce(&PrimitiveType::String.into())
                 .expect("should coerce"),
             PrimitiveValue::String(value.as_directory().expect("should be directory").clone())
         );
@@ -3155,9 +3033,7 @@ mod test {
         assert_eq!(
             format!(
                 "{e:?}",
-                e = value
-                    .coerce(&types, PrimitiveTypeKind::File.into())
-                    .unwrap_err()
+                e = value.coerce(&PrimitiveType::File.into()).unwrap_err()
             ),
             "cannot coerce type `Directory` to type `File`"
         );
@@ -3171,12 +3047,10 @@ mod test {
 
     #[test]
     fn none_coercion() {
-        let types = Types::default();
-
         // None -> String?
         assert!(
             Value::None
-                .coerce(&types, Type::from(PrimitiveTypeKind::String).optional())
+                .coerce(&Type::from(PrimitiveType::String).optional())
                 .expect("should coerce")
                 .is_none(),
         );
@@ -3186,7 +3060,7 @@ mod test {
             format!(
                 "{e:?}",
                 e = Value::None
-                    .coerce(&types, PrimitiveTypeKind::String.into())
+                    .coerce(&PrimitiveType::String.into())
                     .unwrap_err()
             ),
             "cannot coerce `None` to non-optional type `String`"
@@ -3200,25 +3074,23 @@ mod test {
 
     #[test]
     fn array_coercion() {
-        let mut types = Types::default();
-
-        let src_ty = types.add_array(ArrayType::new(PrimitiveTypeKind::Integer));
-        let target_ty = types.add_array(ArrayType::new(PrimitiveTypeKind::Float));
+        let src_ty: Type = ArrayType::new(PrimitiveType::Integer).into();
+        let target_ty: Type = ArrayType::new(PrimitiveType::Float).into();
 
         // Array[Int] -> Array[Float]
-        let src: CompoundValue = Array::new(&types, src_ty, [1, 2, 3])
+        let src: CompoundValue = Array::new(src_ty, [1, 2, 3])
             .expect("should create array value")
             .into();
-        let target = src.coerce(&types, target_ty).expect("should coerce");
+        let target = src.coerce(&target_ty).expect("should coerce");
         assert_eq!(
             target.unwrap_array().to_string(),
             "[1.000000, 2.000000, 3.000000]"
         );
 
         // Array[Int] -> Array[String] (invalid)
-        let target_ty = types.add_array(ArrayType::new(PrimitiveTypeKind::String));
+        let target_ty: Type = ArrayType::new(PrimitiveType::String).into();
         assert_eq!(
-            format!("{e:?}", e = src.coerce(&types, target_ty).unwrap_err()),
+            format!("{e:?}", e = src.coerce(&target_ty).unwrap_err()),
             r#"failed to coerce array element at index 0
 
 Caused by:
@@ -3228,34 +3100,30 @@ Caused by:
 
     #[test]
     fn non_empty_array_coercion() {
-        let mut types = Types::default();
-
-        let ty = types.add_array(ArrayType::new(PrimitiveTypeKind::String));
-        let target_ty = types.add_array(ArrayType::non_empty(PrimitiveTypeKind::String));
+        let ty: Type = ArrayType::new(PrimitiveType::String).into();
+        let target_ty: Type = ArrayType::non_empty(PrimitiveType::String).into();
 
         // Array[String] (non-empty) -> Array[String]+
         let string = PrimitiveValue::new_string("foo");
-        let value: Value = Array::new(&types, ty, [string])
+        let value: Value = Array::new(ty.clone(), [string])
             .expect("should create array")
             .into();
-        assert!(value.coerce(&types, target_ty).is_ok(), "should coerce");
+        assert!(value.coerce(&target_ty).is_ok(), "should coerce");
 
         // Array[String] (empty) -> Array[String]+ (invalid)
-        let value: Value = Array::new::<Value>(&types, ty, [])
+        let value: Value = Array::new::<Value>(ty, [])
             .expect("should create array")
             .into();
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&types, target_ty).unwrap_err()),
+            format!("{e:?}", e = value.coerce(&target_ty).unwrap_err()),
             "cannot coerce empty array value to non-empty array type `Array[String]+`"
         );
     }
 
     #[test]
     fn array_display() {
-        let mut types = Types::default();
-
-        let ty = types.add_array(ArrayType::new(PrimitiveTypeKind::Integer));
-        let value: Value = Array::new(&types, ty, [1, 2, 3])
+        let ty: Type = ArrayType::new(PrimitiveType::Integer).into();
+        let value: Value = Array::new(ty, [1, 2, 3])
             .expect("should create array")
             .into();
 
@@ -3264,36 +3132,25 @@ Caused by:
 
     #[test]
     fn map_coerce() {
-        let mut types = Types::default();
-
         let key1 = PrimitiveValue::new_file("foo");
         let value1 = PrimitiveValue::new_string("bar");
         let key2 = PrimitiveValue::new_file("baz");
         let value2 = PrimitiveValue::new_string("qux");
 
-        let ty = types.add_map(MapType::new(
-            PrimitiveTypeKind::File,
-            PrimitiveTypeKind::String,
-        ));
-        let value: Value = Map::new(&types, ty, [(key1, value1), (key2, value2)])
+        let ty = MapType::new(PrimitiveType::File, PrimitiveType::String);
+        let value: Value = Map::new(ty, [(key1, value1), (key2, value2)])
             .expect("should create map value")
             .into();
 
         // Map[File, String] -> Map[String, File]
-        let ty = types.add_map(MapType::new(
-            PrimitiveTypeKind::String,
-            PrimitiveTypeKind::File,
-        ));
-        let value = value.coerce(&types, ty).expect("value should coerce");
+        let ty = MapType::new(PrimitiveType::String, PrimitiveType::File).into();
+        let value = value.coerce(&ty).expect("value should coerce");
         assert_eq!(value.to_string(), r#"{"foo": "bar", "baz": "qux"}"#);
 
         // Map[String, File] -> Map[Int, File] (invalid)
-        let ty = types.add_map(MapType::new(
-            PrimitiveTypeKind::Integer,
-            PrimitiveTypeKind::File,
-        ));
+        let ty = MapType::new(PrimitiveType::Integer, PrimitiveType::File).into();
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
+            format!("{e:?}", e = value.coerce(&ty).unwrap_err()),
             r#"failed to coerce map key for element at index 0
 
 Caused by:
@@ -3301,12 +3158,9 @@ Caused by:
         );
 
         // Map[String, File] -> Map[String, Int] (invalid)
-        let ty = types.add_map(MapType::new(
-            PrimitiveTypeKind::String,
-            PrimitiveTypeKind::Integer,
-        ));
+        let ty = MapType::new(PrimitiveType::String, PrimitiveType::Integer).into();
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
+            format!("{e:?}", e = value.coerce(&ty).unwrap_err()),
             r#"failed to coerce map value for element at index 0
 
 Caused by:
@@ -3314,28 +3168,28 @@ Caused by:
         );
 
         // Map[String, File] -> Struct
-        let ty = types.add_struct(StructType::new("Foo", [
-            ("foo", PrimitiveTypeKind::File),
-            ("baz", PrimitiveTypeKind::File),
-        ]));
-        let struct_value = value.coerce(&types, ty).expect("value should coerce");
+        let ty = StructType::new("Foo", [
+            ("foo", PrimitiveType::File),
+            ("baz", PrimitiveType::File),
+        ])
+        .into();
+        let struct_value = value.coerce(&ty).expect("value should coerce");
         assert_eq!(struct_value.to_string(), r#"Foo {foo: "bar", baz: "qux"}"#);
 
         // Map[String, File] -> Struct (invalid)
-        let ty = types.add_struct(StructType::new("Foo", [
-            ("foo", PrimitiveTypeKind::File),
-            ("baz", PrimitiveTypeKind::File),
-            ("qux", PrimitiveTypeKind::File),
-        ]));
+        let ty = StructType::new("Foo", [
+            ("foo", PrimitiveType::File),
+            ("baz", PrimitiveType::File),
+            ("qux", PrimitiveType::File),
+        ])
+        .into();
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
+            format!("{e:?}", e = value.coerce(&ty).unwrap_err()),
             "cannot coerce a map of 2 elements to struct type `Foo` as the struct has 3 members"
         );
 
         // Map[String, File] -> Object
-        let object_value = value
-            .coerce(&types, Type::Object)
-            .expect("value should coerce");
+        let object_value = value.coerce(&Type::Object).expect("value should coerce");
         assert_eq!(
             object_value.to_string(),
             r#"object {foo: "bar", baz: "qux"}"#
@@ -3344,14 +3198,8 @@ Caused by:
 
     #[test]
     fn map_display() {
-        let mut types = Types::default();
-
-        let ty = types.add_map(MapType::new(
-            PrimitiveTypeKind::Integer,
-            PrimitiveTypeKind::Boolean,
-        ));
-
-        let value: Value = Map::new(&types, ty, [(1, true), (2, false)])
+        let ty = MapType::new(PrimitiveType::Integer, PrimitiveType::Boolean);
+        let value: Value = Map::new(ty, [(1, true), (2, false)])
             .expect("should create map value")
             .into();
         assert_eq!(value.to_string(), "{1: true, 2: false}");
@@ -3359,34 +3207,23 @@ Caused by:
 
     #[test]
     fn pair_coercion() {
-        let mut types = Types::default();
-
         let left = PrimitiveValue::new_file("foo");
         let right = PrimitiveValue::new_string("bar");
 
-        let ty = types.add_pair(PairType::new(
-            PrimitiveTypeKind::File,
-            PrimitiveTypeKind::String,
-        ));
-        let value: Value = Pair::new(&types, ty, left, right)
+        let ty = PairType::new(PrimitiveType::File, PrimitiveType::String);
+        let value: Value = Pair::new(ty, left, right)
             .expect("should create map value")
             .into();
 
         // Pair[File, String] -> Pair[String, File]
-        let ty = types.add_pair(PairType::new(
-            PrimitiveTypeKind::String,
-            PrimitiveTypeKind::File,
-        ));
-        let value = value.coerce(&types, ty).expect("value should coerce");
+        let ty = PairType::new(PrimitiveType::String, PrimitiveType::File).into();
+        let value = value.coerce(&ty).expect("value should coerce");
         assert_eq!(value.to_string(), r#"("foo", "bar")"#);
 
         // Pair[String, File] -> Pair[Int, Int]
-        let ty = types.add_pair(PairType::new(
-            PrimitiveTypeKind::Integer,
-            PrimitiveTypeKind::Integer,
-        ));
+        let ty = PairType::new(PrimitiveType::Integer, PrimitiveType::Integer).into();
         assert_eq!(
-            format!("{e:?}", e = value.coerce(&types, ty).unwrap_err()),
+            format!("{e:?}", e = value.coerce(&ty).unwrap_err()),
             r#"failed to coerce pair's left value
 
 Caused by:
@@ -3396,14 +3233,8 @@ Caused by:
 
     #[test]
     fn pair_display() {
-        let mut types = Types::default();
-
-        let ty = types.add_pair(PairType::new(
-            PrimitiveTypeKind::Integer,
-            PrimitiveTypeKind::Boolean,
-        ));
-
-        let value: Value = Pair::new(&types, ty, 12345, false)
+        let ty = PairType::new(PrimitiveType::Integer, PrimitiveType::Boolean);
+        let value: Value = Pair::new(ty, 12345, false)
             .expect("should create pair value")
             .into();
         assert_eq!(value.to_string(), "(12345, false)");
@@ -3411,44 +3242,38 @@ Caused by:
 
     #[test]
     fn struct_coercion() {
-        let mut types = Types::default();
-
-        let ty = types.add_struct(StructType::new("Foo", [
-            ("foo", PrimitiveTypeKind::Float),
-            ("bar", PrimitiveTypeKind::Float),
-            ("baz", PrimitiveTypeKind::Float),
-        ]));
-        let value: Value = Struct::new(&types, ty, [("foo", 1.0), ("bar", 2.0), ("baz", 3.0)])
+        let ty = StructType::new("Foo", [
+            ("foo", PrimitiveType::Float),
+            ("bar", PrimitiveType::Float),
+            ("baz", PrimitiveType::Float),
+        ]);
+        let value: Value = Struct::new(ty, [("foo", 1.0), ("bar", 2.0), ("baz", 3.0)])
             .expect("should create map value")
             .into();
 
         // Struct -> Map[String, Float]
-        let ty = types.add_map(MapType::new(
-            PrimitiveTypeKind::String,
-            PrimitiveTypeKind::Float,
-        ));
-        let map_value = value.coerce(&types, ty).expect("value should coerce");
+        let ty = MapType::new(PrimitiveType::String, PrimitiveType::Float).into();
+        let map_value = value.coerce(&ty).expect("value should coerce");
         assert_eq!(
             map_value.to_string(),
             r#"{"foo": 1.000000, "bar": 2.000000, "baz": 3.000000}"#
         );
 
         // Struct -> Struct
-        let ty = types.add_struct(StructType::new("Bar", [
-            ("foo", PrimitiveTypeKind::Float),
-            ("bar", PrimitiveTypeKind::Float),
-            ("baz", PrimitiveTypeKind::Float),
-        ]));
-        let struct_value = value.coerce(&types, ty).expect("value should coerce");
+        let ty = StructType::new("Bar", [
+            ("foo", PrimitiveType::Float),
+            ("bar", PrimitiveType::Float),
+            ("baz", PrimitiveType::Float),
+        ])
+        .into();
+        let struct_value = value.coerce(&ty).expect("value should coerce");
         assert_eq!(
             struct_value.to_string(),
             r#"Bar {foo: 1.000000, bar: 2.000000, baz: 3.000000}"#
         );
 
         // Struct -> Object
-        let object_value = value
-            .coerce(&types, Type::Object)
-            .expect("value should coerce");
+        let object_value = value.coerce(&Type::Object).expect("value should coerce");
         assert_eq!(
             object_value.to_string(),
             r#"object {foo: 1.000000, bar: 2.000000, baz: 3.000000}"#
@@ -3456,5 +3281,22 @@ Caused by:
     }
 
     #[test]
-    fn struct_display() {}
+    fn struct_display() {
+        let ty = StructType::new("Foo", [
+            ("foo", PrimitiveType::Float),
+            ("bar", PrimitiveType::String),
+            ("baz", PrimitiveType::Integer),
+        ]);
+        let value: Value = Struct::new(ty, [
+            ("foo", Value::from(1.101)),
+            ("bar", PrimitiveValue::new_string("foo").into()),
+            ("baz", 1234.into()),
+        ])
+        .expect("should create map value")
+        .into();
+        assert_eq!(
+            value.to_string(),
+            r#"Foo {foo: 1.101000, bar: "foo", baz: 1234}"#
+        );
+    }
 }

--- a/wdl-lint/tests/lints.rs
+++ b/wdl-lint/tests/lints.rs
@@ -142,7 +142,7 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<(), String> {
     } else {
         let mut validator = Validator::default();
         validator.add_visitor(LintVisitor::default());
-        validator.add_visitor(ShellCheckRule::default());
+        validator.add_visitor(ShellCheckRule);
         let errors = match validator.validate(&document) {
             Ok(()) => String::new(),
             Err(diagnostics) => format_diagnostics(&diagnostics, &path, &source),

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -517,7 +517,7 @@ impl RunCommand {
                     path = path.display()
                 )
             })?;
-            match Inputs::parse(engine.types_mut(), document, &abs_path)? {
+            match Inputs::parse(document, &abs_path)? {
                 Some((name, inputs)) => (Some(path), name, inputs),
                 None => bail!(
                     "inputs file `{path}` is empty; use the `--name` option to specify the name \
@@ -587,7 +587,7 @@ impl RunCommand {
                 // Ensure all the paths specified in the inputs file are relative to the file's
                 // directory
                 if let Some(path) = path.as_ref().and_then(|p| p.parent()) {
-                    inputs.join_paths(engine.types_mut(), document, task, path);
+                    inputs.join_paths(task, path);
                 }
 
                 let mut evaluator = TaskEvaluator::new(&mut engine);
@@ -602,7 +602,7 @@ impl RunCommand {
                                 // errors during serialization.
                                 let mut buffer = Vec::new();
                                 let mut serializer = serde_json::Serializer::pretty(&mut buffer);
-                                outputs.serialize(engine.types(), &mut serializer)?;
+                                outputs.serialize(&mut serializer)?;
                                 println!(
                                     "{buffer}\n",
                                     buffer = std::str::from_utf8(&buffer)
@@ -648,7 +648,7 @@ impl RunCommand {
                 // Ensure all the paths specified in the inputs file are relative to the file's
                 // directory
                 if let Some(path) = path.as_ref().and_then(|p| p.parent()) {
-                    inputs.join_paths(engine.types_mut(), document, workflow, path);
+                    inputs.join_paths(workflow, path);
                 }
 
                 bail!("running workflows is not yet supported")


### PR DESCRIPTION
This commit removes the `Types` collection from `wdl-analysis`.

The collection served as an arena to allocate types into which also served as providing type recursion via arena identifiers. The hope was that this would prevent a lot of small allocations from occurring during analysis when calculating expression types.

However, each document had a different `Types` collection, requiring "importing" types between collections. Further complicating things, an evaluation engine had its own `Types` collection which needed importing of types from other document collections. This was a source of bugs in the implementation of the evaluation engine.

Worse, the types collection served as a bottleneck for sharing data across asynchronous tasks in the upcoming implementation of workflow evaluation, requiring a lock.

The alternative is to use an `Arc` in appropriate places where type recursion occurs. After running some simple benchmarks, the removal of the types arena doesn't appear to have any real world impact on performance.

Additionally, the removal of `Types` allows `Type` to implement `PartialEq` rather than a custom trait that uses the arena; likewise for `Display`.

Similarly in `wdl-engine`, `Value` can now directly implement serialization and deserialization traits.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
