### PR TITLE
fix: fix a regression caused by #282.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed regression in workflow input validation when an input is missing ([#286](https://github.com/stjude-rust-labs/wdl/pull/286)).
 * Fixed input validation to not treat directly specified call inputs as missing ([#282](https://github.com/stjude-rust-labs/wdl/pull/282)).
 
 ### Added

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -358,7 +358,7 @@ impl WorkflowInputs {
         for (name, input) in workflow.inputs() {
             if input.required()
                 && !self.inputs.contains_key(name)
-                && specified.map(|s| !s.contains(name)).unwrap_or(false)
+                && specified.map(|s| !s.contains(name)).unwrap_or(true)
             {
                 bail!(
                     "missing required input `{name}` to workflow `{workflow}`",

--- a/wdl-engine/tests/inputs/missing-workflow-input/error.txt
+++ b/wdl-engine/tests/inputs/missing-workflow-input/error.txt
@@ -1,0 +1,4 @@
+failed to validate the inputs to workflow `test`
+
+Caused by:
+    missing required input `y` to workflow `test`


### PR DESCRIPTION
This fixes a regression in validating workflow inputs caused by an incorrect `false` when `true` should have been used; the regression was introduced in PR #282.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
