### PR TITLE
fix: remove extra end_line() call

### DIFF
--- a/wdl-format/CHANGELOG.md
+++ b/wdl-format/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Multi-line placeholders in command blocks are now indented appropriately ([#240](https://github.com/stjude-rust-labs/wdl/pull/240)).
+* Issue [#289](https://github.com/stjude-rust-labs/wdl/issues/289) (extraneous end line in literal structs)
+  is fixed ([#290](https://github.com/stjude-rust-labs/wdl/pull/290))
 
 ## 0.3.0 - 10-22-2024
 

--- a/wdl-format/src/v1/struct.rs
+++ b/wdl-format/src/v1/struct.rs
@@ -143,5 +143,4 @@ pub fn format_literal_struct(element: &FormatElement, stream: &mut TokenStream<P
 
     stream.decrement_indent();
     (&close_brace.expect("literal struct close brace")).write(stream);
-    stream.end_line();
 }

--- a/wdl-format/tests/format/issue-289/source.formatted.wdl
+++ b/wdl-format/tests/format/issue-289/source.formatted.wdl
@@ -1,0 +1,23 @@
+version 1.2
+
+struct Person {
+    String name
+    Int age
+}
+
+workflow main {
+    Array[Person] person = [
+        Person {
+            name: "Jane Doe",
+            age: 30,
+        },
+        Person {
+            name: "Jane Doe",
+            age: 30,
+        },
+    ]
+
+    output {
+        File result = write_tsv(person)
+    }
+}

--- a/wdl-format/tests/format/issue-289/source.wdl
+++ b/wdl-format/tests/format/issue-289/source.wdl
@@ -1,0 +1,25 @@
+version 1.2
+
+struct Person {
+    String name
+    Int age
+}
+
+workflow main {
+    Array[Person] person = [
+        Person {
+            name: "Jane Doe",
+            age: 30,
+        }
+        ,
+        Person {
+            name: "Jane Doe",
+            age: 30,
+        }
+        ,
+    ]
+
+    output {
+        File result = write_tsv(person)
+    }
+}


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

Fixes issue #289 by removing a bad call to `end_line()`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
