### PR TITLE
fix: remove trailing carriage return when stripping whitespace.

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed a bug in `strip_whitespace` that left a trailing carriage return at the
+  end of commands and multiline strings when using Windows line endings ([#291](https://github.com/stjude-rust-labs/wdl/pull/291)).
 * Fixed bug in `strip_whitespace()` that erroneously stripped characters from the first line when it had content.
   Closed [issue #268](https://github.com/stjude-rust-labs/wdl/issues/268) ([#271](https://github.com/stjude-rust-labs/wdl/pull/271)).
 * Fixed same #268 bug in mutliline strings as well as command sections  ([#272](https://github.com/stjude-rust-labs/wdl/pull/272)).

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -2238,6 +2238,10 @@ impl LiteralString {
             if text.ends_with('\n') {
                 text.pop();
             }
+
+            if text.ends_with('\r') {
+                text.pop();
+            }
         }
 
         // Now that the string has been unescaped and the first and last lines trimmed,
@@ -7869,6 +7873,33 @@ task test {
         match &stripped[0] {
             StrippedStringPart::Text(text) => {
                 assert_eq!(text.as_str(), "hello world\n    my name is Jeff.")
+            }
+            _ => panic!("expected text part"),
+        }
+    }
+
+    #[test]
+    fn whitespace_stripping_on_windows() {
+        let (document, diagnostics) = Document::parse(
+            "version 1.2\r\ntask test {\r\n    String s = <<<\r\n        hello\r\n    >>>\r\n}\r\n",
+        );
+
+        assert!(diagnostics.is_empty());
+        let ast = document.ast();
+        let ast = ast.as_v1().expect("should be a V1 AST");
+
+        let tasks: Vec<_> = ast.tasks().collect();
+        assert_eq!(tasks.len(), 1);
+
+        let decls: Vec<_> = tasks[0].declarations().collect();
+        assert_eq!(decls.len(), 1);
+
+        let expr = decls[0].expr().unwrap_literal().unwrap_string();
+        let stripped = expr.strip_whitespace().unwrap();
+        assert_eq!(stripped.len(), 1);
+        match &stripped[0] {
+            StrippedStringPart::Text(text) => {
+                assert_eq!(text.as_str(), "hello")
             }
             _ => panic!("expected text part"),
         }

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -264,10 +264,10 @@ impl Visitor for PreambleFormattingRule {
                     if s.chars().filter(|&c| c == '\n').count() == 2 {
                         for (line, start, end) in lines_with_offset(s) {
                             if !line.is_empty() {
-                                let end_offset = if s.ends_with('\n') {
-                                    1
-                                } else if s.ends_with("\r\n") {
+                                let end_offset = if s.ends_with("\r\n") {
                                     2
+                                } else if s.ends_with('\n') {
+                                    1
                                 } else {
                                     0
                                 };

--- a/wdl-lint/src/rules/version_formatting.rs
+++ b/wdl-lint/src/rules/version_formatting.rs
@@ -131,10 +131,10 @@ impl Visitor for VersionFormattingRule {
                     if ws.chars().filter(|&c| c == '\n').count() == 2 {
                         for (line, start, end) in lines_with_offset(ws) {
                             if !line.is_empty() {
-                                let end_offset = if ws.ends_with('\n') {
-                                    1
-                                } else if ws.ends_with("\r\n") {
+                                let end_offset = if ws.ends_with("\r\n") {
                                     2
+                                } else if ws.ends_with('\n') {
+                                    1
                                 } else {
                                     0
                                 };


### PR DESCRIPTION
This fixes whitespace stripping for both commands and multiline strings that left a trailing carriage return when using Windows line endings.

Also fixes the calculation of diagnostic spans for the preamble and version formatting lints when Windows line endings are used.

This should unblock PR #285.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
