### PR TITLE
release: bump versions

### DIFF
--- a/gauntlet/Cargo.toml
+++ b/gauntlet/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wdl = { path = "../wdl", version = "0.10.0", features = ["codespan", "analysis"] }
+wdl = { path = "../wdl", version = "0.11.0", features = ["codespan", "analysis"] }
 clap.workspace = true
 colored.workspace = true
 dirs.workspace = true

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.0 - 01-17-2025
+
 ### Added
 
 * Added analysis support for the WDL 1.2 `env` declaration modifier ([#296](https://github.com/stjude-rust-labs/wdl/pull/296)).

--- a/wdl-analysis/Cargo.toml
+++ b/wdl-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-analysis"
-version = "0.5.0"
+version = "0.6.0"
 rust-version.workspace = true
 license.workspace = true
 edition.workspace = true
@@ -11,8 +11,8 @@ description = "Analysis of Workflow Description Language (WDL) documents."
 documentation = "https://docs.rs/wdl-analysis"
 
 [dependencies]
-wdl-ast = { path = "../wdl-ast", version = "0.9.0" }
-wdl-format = { path = "../wdl-format", version = "0.3.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.10.0" }
+wdl-format = { path = "../wdl-format", version = "0.4.0" }
 
 anyhow = { workspace = true }
 rowan = { workspace = true }

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.10.0 - 01-17-2025
+
 ### Added
 
 * Added AST support for the WDL 1.2 `env` declaration modifier ([#296](https://github.com/stjude-rust-labs/wdl/pull/296)).

--- a/wdl-ast/Cargo.toml
+++ b/wdl-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-ast"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Clay McLeod <clay.l.mcleod@gmail.com>"]
 rust-version.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository = "https://github.com/stjude-rust-labs/wdl"
 documentation = "https://docs.rs/wdl-ast"
 
 [dependencies]
-wdl-grammar = { path = "../wdl-grammar", version = "0.10.0" }
+wdl-grammar = { path = "../wdl-grammar", version = "0.11.0" }
 macropol = "0.1.3"
 paste = "1.0.15"
 rowan = { workspace = true }

--- a/wdl-doc/CHANGELOG.md
+++ b/wdl-doc/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.0 - 01-17-2025
+
 ### Added
 
 * `wdl-doc` crate for documenting WDL codebases ([#258](https://github.com/stjude-rust-labs/wdl/pull/248)).

--- a/wdl-doc/Cargo.toml
+++ b/wdl-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-doc"
-version = "0.0.0"
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -14,8 +14,8 @@ html = "0.6.3"
 indexmap.workspace = true
 pulldown-cmark = "0.12.2"
 tokio.workspace = true
-wdl-analysis = { path = "../wdl-analysis", version = "0.5.0" }
-wdl-ast = { path = "../wdl-ast", version = "0.9.0" }
+wdl-analysis = { path = "../wdl-analysis", version = "0.6.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.10.0" }
 
 [lints]
 workspace = true

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.0 - 01-17-2025
+
 ### Fixed
 
 * Limited the local task executor to a maximum level of concurrency ([#292](https://github.com/stjude-rust-labs/wdl/pull/292))

--- a/wdl-engine/Cargo.toml
+++ b/wdl-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-engine"
-version = "0.0.0"
+version = "0.1.0"
 rust-version.workspace = true
 license.workspace = true
 edition.workspace = true
@@ -11,9 +11,9 @@ description = "Execution engine for Workflow Description Language (WDL) document
 documentation = "https://docs.rs/wdl-engine"
 
 [dependencies]
-wdl-grammar = { version = "0.10.0", path = "../wdl-grammar" }
-wdl-ast = { version = "0.9.0", path = "../wdl-ast" }
-wdl-analysis = { version = "0.5.0", path = "../wdl-analysis" }
+wdl-grammar = { version = "0.11.0", path = "../wdl-grammar" }
+wdl-ast = { version = "0.10.0", path = "../wdl-ast" }
+wdl-analysis = { version = "0.6.0", path = "../wdl-analysis" }
 anyhow = { workspace = true }
 ordered-float = { workspace = true }
 indexmap = { workspace = true }

--- a/wdl-format/CHANGELOG.md
+++ b/wdl-format/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.4.0 - 01-17-2025
+
 ### Added
 
 * Leading whitespace in command text is now normalized ([#240](https://github.com/stjude-rust-labs/wdl/pull/240)).

--- a/wdl-format/Cargo.toml
+++ b/wdl-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-format"
-version = "0.3.0"
+version = "0.4.0"
 description = "Formatting of WDL (Workflow Description Language) documents"
 license.workspace = true
 edition.workspace = true
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-wdl-ast = { path = "../wdl-ast", version = "0.9.0", features = ["codespan"] }
+wdl-ast = { path = "../wdl-ast", version = "0.10.0", features = ["codespan"] }
 nonempty.workspace = true
 
 [dev-dependencies]

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.11.0 - 01-17-2025
+
 ### Added
 
 * Added parsing support for the WDL 1.2 `env` declaration modifier ([#296](https://github.com/stjude-rust-labs/wdl/pull/296)).

--- a/wdl-grammar/Cargo.toml
+++ b/wdl-grammar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-grammar"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Clay McLeod <clay.l.mcleod@gmail.com>"]
 rust-version.workspace = true
 edition.workspace = true

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.9.0 - 01-17-2025
+
 ## Added
 
 * Improved `ShellCheck` rule fix messages and implemented the `fix` module ([#284](https://github.com/stjude-rust-labs/wdl/pull/284))

--- a/wdl-lint/Cargo.toml
+++ b/wdl-lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-lint"
-version = "0.8.0"
+version = "0.9.0"
 description = "Lint rules for Workflow Description Language (WDL) documents"
 rust-version.workspace = true
 authors.workspace = true
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/wdl-lint"
 readme = "../README.md"
 
 [dependencies]
-wdl-ast = { path = "../wdl-ast", version = "0.9.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.10.0" }
 anyhow = { workspace = true }
 convert_case = { workspace = true }
 ftree = { workspace = true }

--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.0 - 01-17-2025
+
 ## 0.5.0 - 10-22-2024
 
 ### Added

--- a/wdl-lsp/Cargo.toml
+++ b/wdl-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-lsp"
-version = "0.5.0"
+version = "0.6.0"
 license.workspace = true
 rust-version.workspace = true
 edition.workspace = true
@@ -11,10 +11,10 @@ description = "Language Server Protocol implementation for WDL"
 documentation = "https://docs.rs/wdl-lsp"
 
 [dependencies]
-wdl-analysis = { path = "../wdl-analysis", version = "0.5.0" }
-wdl-ast = { path = "../wdl-ast", version = "0.9.0" }
-wdl-format = { path = "../wdl-format", version = "0.3.0" }
-wdl-lint = { path = "../wdl-lint", version = "0.8.0" }
+wdl-analysis = { path = "../wdl-analysis", version = "0.6.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.10.0" }
+wdl-format = { path = "../wdl-format", version = "0.4.0" }
+wdl-lint = { path = "../wdl-lint", version = "0.9.0" }
 
 anyhow = { workspace = true }
 tokio = { workspace = true }

--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.11.0 - 01-17-2025
+
 ### Added
 
 * Added support for workflow evaluation to `wdl run` ([#292](https://github.com/stjude-rust-labs/wdl/pull/292))

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -18,7 +18,7 @@ wdl-lint = { path = "../wdl-lint", version = "0.9.0", optional = true }
 wdl-analysis = { path = "../wdl-analysis", version = "0.6.0", optional = true }
 wdl-lsp = { path = "../wdl-lsp", version = "0.6.0", optional = true }
 wdl-format = { path = "../wdl-format", version = "0.4.0", optional = true }
-wdl-doc = { version = "0.1.0", path = "../wdl-doc", optional = true }
+wdl-doc = { path = "../wdl-doc", version = "0.1.0", optional = true }
 wdl-engine = { path = "../wdl-engine", version = "0.1.0", optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Clay McLeod <clay.l.mcleod@gmail.com>"]
 rust-version.workspace = true
 license.workspace = true
@@ -12,14 +12,14 @@ documentation = "https://docs.rs/wdl"
 readme = "../README.md"
 
 [dependencies]
-wdl-grammar = { path = "../wdl-grammar", version = "0.10.0", optional = true }
-wdl-ast = { path = "../wdl-ast", version = "0.9.0", optional = true }
-wdl-lint = { path = "../wdl-lint", version = "0.8.0", optional = true }
-wdl-analysis = { path = "../wdl-analysis", version = "0.5.0", optional = true }
-wdl-lsp = { path = "../wdl-lsp", version = "0.5.0", optional = true }
-wdl-format = { path = "../wdl-format", version = "0.3.0", optional = true }
-wdl-doc = { version = "0.0.0", path = "../wdl-doc", optional = true }
-wdl-engine = { path = "../wdl-engine", version = "0.0.0", optional = true }
+wdl-grammar = { path = "../wdl-grammar", version = "0.11.0", optional = true }
+wdl-ast = { path = "../wdl-ast", version = "0.10.0", optional = true }
+wdl-lint = { path = "../wdl-lint", version = "0.9.0", optional = true }
+wdl-analysis = { path = "../wdl-analysis", version = "0.6.0", optional = true }
+wdl-lsp = { path = "../wdl-lsp", version = "0.6.0", optional = true }
+wdl-format = { path = "../wdl-format", version = "0.4.0", optional = true }
+wdl-doc = { version = "0.1.0", path = "../wdl-doc", optional = true }
+wdl-engine = { path = "../wdl-engine", version = "0.1.0", optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }


### PR DESCRIPTION
running `ci bump` manually to get around failing github action
