### PR TITLE
fix: `wdl run` should join input paths correctly.

### DIFF
--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed `wdl run` not correctly updating file/directory paths in an inputs file ([#302](https://github.com/stjude-rust-labs/wdl/pull/302)).
+
 ## 0.11.0 - 01-17-2025
 
 ### Added

--- a/wdl/src/cli.rs
+++ b/wdl/src/cli.rs
@@ -109,16 +109,21 @@ pub async fn analyze(
 
     let results = analyzer.analyze(bar.clone()).await?;
 
-    anyhow::Ok(results)
+    Ok(results)
 }
 
 /// Parses the inputs for a task or workflow.
+///
+/// Returns the absolute path to the inputs file (if a path was provided), the
+/// name of the workflow or task referenced by the inputs, and the inputs to the
+/// workflow or task.
 pub fn parse_inputs(
     document: &Document,
     name: Option<&str>,
     inputs: Option<&Path>,
 ) -> Result<(Option<PathBuf>, String, Inputs)> {
-    let (path, name, inputs) = if let Some(path) = inputs {
+    if let Some(path) = inputs {
+        // If a inputs file path was provided, parse the inputs from the file
         match Inputs::parse(document, path)? {
             Some((name, inputs)) => {
                 // Make the inputs file path absolute so that we treat any file/directory inputs
@@ -129,22 +134,26 @@ pub fn parse_inputs(
                         path = path.display()
                     )
                 })?;
-                (Some(path), name, inputs)
+                Ok((Some(path), name, inputs))
             }
             None => bail!("inputs file `{path}` is empty", path = path.display()),
         }
     } else if let Some(name) = name {
+        // Otherwise, if a name was provided, look for a task or workflow with that
+        // name
         if document.task_by_name(name).is_some() {
-            (None, name.to_string(), Inputs::Task(Default::default()))
+            Ok((None, name.to_string(), Inputs::Task(Default::default())))
         } else if document.workflow().is_some() {
             if name != document.workflow().unwrap().name() {
                 bail!("document does not contain a workflow named `{name}`");
             }
-            (None, name.to_string(), Inputs::Workflow(Default::default()))
+            Ok((None, name.to_string(), Inputs::Workflow(Default::default())))
         } else {
             bail!("document does not contain a task or workflow named `{name}`");
         }
     } else {
+        // Neither a inputs file or name was provided, look for a single task or
+        // workflow in the document
         let mut iter = document.tasks();
         let (name, inputs) = iter
             .next()
@@ -160,10 +169,8 @@ pub fn parse_inputs(
             bail!("inputs file is empty and the WDL document contains more than one task");
         }
 
-        (None, name, inputs)
-    };
-
-    anyhow::Ok((path, name, inputs))
+        Ok((None, name, inputs))
+    }
 }
 
 /// Validates the inputs for a task or workflow.
@@ -190,7 +197,7 @@ pub async fn validate_inputs(document: &str, inputs: &Path) -> Result<Option<Dia
         }
     }
 
-    anyhow::Ok(None)
+    Ok(None)
 }
 
 /// Run a WDL task or workflow.


### PR DESCRIPTION
This PR fixes the `wdl run` command to properly join input paths relative to the inputs file.

The code to make the path of the inputs file absolute was incorrectly done, resulting in the later `join_paths` call to effectively be a no-op when the inputs file path on the command line was relative to CWD (e.g. `./foo.json`).

As a result, task execution would fail when using the path as the path would then be treated as relative to the task's working directory as it was not made absolute.

The fix is to simply return the absolute path correctly from `parse_inputs`.

Fixes #301.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
