### PR TITLE
docs: move inlined RULES.md into a public mod

### DIFF
--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -1,6 +1,7 @@
 //! Analysis of Workflow Description Language (WDL) documents.
 //!
 //! An analyzer can be used to implement the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/).
+#![doc = include_str!("../RULES.md")]
 
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]

--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! An analyzer can be used to implement the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/).
 #![doc = include_str!("../RULES.md")]
-
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![warn(rust_2021_compatibility)]

--- a/wdl-analysis/src/rules.rs
+++ b/wdl-analysis/src/rules.rs
@@ -1,5 +1,4 @@
 //! Implementation of analysis rules.
-#![doc = include_str!("../RULES.md")]
 
 use wdl_ast::Severity;
 


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

#303 inlined the RULES.md file in a module that doesn't render on docs.rs. This is a fix.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
