### PR TITLE
feat: report progress during `wdl run`.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added progress callback to `WorkflowEvaluator` ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).
+
 ## 0.1.0 - 01-17-2025
 
 ### Fixed

--- a/wdl-engine/tests/workflows.rs
+++ b/wdl-engine/tests/workflows.rs
@@ -23,7 +23,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::path::absolute;
 use std::process::exit;
-use std::sync::Arc;
 use std::thread::available_parallelism;
 
 use anyhow::Context;
@@ -182,8 +181,8 @@ async fn run_test(test: &Path, result: AnalysisResult) -> Result<()> {
     inputs.join_paths(workflow, &test_dir);
 
     let dir = TempDir::new().context("failed to create temporary directory")?;
-    let backend = Arc::new(LocalTaskExecutionBackend::new(None));
-    let mut evaluator = WorkflowEvaluator::new(backend);
+    let backend = LocalTaskExecutionBackend::new(None);
+    let mut evaluator = WorkflowEvaluator::new(&backend, |_| {});
     match evaluator
         .evaluate(result.document(), &inputs, dir.path())
         .await

--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added executing task information to the `wdl run` progress bar ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).
+
+### Changed
+
+* `wdl` run now prefers running the workflow in a document containing a single
+  workflow and a single task ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).
+* Changed the default log level of the `wdl` binary from `error` to `warn` ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).
+
 ### Fixed
 
 * Fixed `wdl run` not correctly updating file/directory paths in an inputs file ([#302](https://github.com/stjude-rust-labs/wdl/pull/302)).

--- a/wdl/Cargo.toml
+++ b/wdl/Cargo.toml
@@ -33,6 +33,7 @@ tracing-log = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 webbrowser = { workspace = true, optional = true }
+indexmap = { workspace = true, optional = true }
 
 [dev-dependencies]
 clap = { workspace = true }
@@ -69,6 +70,7 @@ cli = [
     "dep:url",
     "dep:serde_json",
     "dep:webbrowser",
+    "dep:indexmap",
 ]
 
 [lints]

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -17,6 +17,7 @@ use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
 use clap_verbosity_flag::Verbosity;
+use clap_verbosity_flag::WarnLevel;
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term::Config;
 use codespan_reporting::term::emit;
@@ -408,7 +409,7 @@ struct App {
 
     /// The verbosity flags.
     #[command(flatten)]
-    verbose: Verbosity,
+    verbose: Verbosity<WarnLevel>,
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
This PR implements reporting progress during `wdl run`. The `WorkflowEvaluator` now accepts a callback that is called when a task or workflow is evaluated and when it is completed.

The progress bar displayed by `wdl run` has been updated to print out the number of completed tasks, the number of in-process tasks, including up to 10 names of tasks currently being executed.

Additionally, this changes the progress bars displayed by `wdl` to target stdout so that it isn't interleaved with log output on stderr.

The default log level for `wdl` is now `warn` rather than `error` (one less `-v` option required to get to useful log output).

`wdl run` now prefers to run the workflow in a document containing a single workflow and a single task, when not provided either a path to an inputs file or the name of the task/workflow to run. Previously it preferred the task over the workflow.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
