### PR TITLE
revise: relax CommentWhitespace lint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,9 +33,9 @@ Rule specific checks:
       (`wdl-ast/src/validation.rs`) and `LintVisitor`
       (`wdl-lint/src/visitor.rs`) visitors. These are required to ensure the new
       visitor callback will execute.
-- [ ] You have run `wdl-gauntlet --refresh` to ensure that there are no 
+- [ ] You have run `gauntlet --refresh` to ensure that there are no 
       unintended changes to the baseline configuration file (`Gauntlet.toml`).
-- [ ] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the 
+- [ ] You have run `gauntlet --refresh --arena` to ensure that all of the 
       rules added/removed are now reflected in the baseline configuration file 
       (`Arena.toml`).
 

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,19 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Relaxed `CommentWhitespace` rule so that it doesn't fire when a comment has extra spaces before it ([#314](https://github.com/stjude-rust-labs/wdl/pull/314)).
+
 ## 0.9.0 - 01-17-2025
 
-## Added
+### Added
 
 * Improved `ShellCheck` rule fix messages and implemented the `fix` module ([#284](https://github.com/stjude-rust-labs/wdl/pull/284))
 * Added a `ShellCheck` rule ([#264](https://github.com/stjude-rust-labs/wdl/pull/264)).
 * Added a `RedundantInputAssignment` rule ([#244](https://github.com/stjude-rust-labs/wdl/pull/244)).
 
-## Changed
+### Changed
 
 * Upgraded some `note` diagnostics to `warning` in `ContainerValue` rule  ([#244](https://github.com/stjude-rust-labs/wdl/pull/244)).
 
-## Fixed
+### Fixed
 
 * Shortened many reported spans and ensured all lint diagnostics use a `fix` message ([#260](https://github.com/stjude-rust-labs/wdl/pull/260)).
 * `BlankLinesBetweenElements` logic was tweaked to prevent firing a redundant message with `VersionFormatting` rule ([#260](https://github.com/stjude-rust-labs/wdl/pull/260)).

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -37,10 +37,10 @@ fn inline_preceding_whitespace(span: Span) -> Diagnostic {
 /// Creates a diagnostic when the comment token is not followed by a single
 /// space.
 fn following_whitespace(span: Span) -> Diagnostic {
-    Diagnostic::note("comment delimiter should be followed by a single space")
+    Diagnostic::note("comment delimiter should be followed by at least one space")
         .with_rule(ID)
         .with_highlight(span)
-        .with_fix("add a single space after the comment delimiter")
+        .with_fix("add at least one space after the comment delimiter")
 }
 
 /// Creates a diagnostic when non-inline comment has insufficient indentation.
@@ -206,8 +206,6 @@ impl Visitor for CommentWhitespaceRule {
             comment_chars.next();
         }
 
-        let preamble = n_delimiter == 2;
-
         if let Some('@') = comment_chars.peek() {
             n_delimiter += 1;
             comment_chars.next();
@@ -215,9 +213,7 @@ impl Visitor for CommentWhitespaceRule {
 
         let n_whitespace = comment_chars.by_ref().take_while(|c| *c == ' ').count();
 
-        if comment_chars.skip(n_whitespace).count() > 0
-            && ((n_whitespace != 1 && !preamble) || (preamble && n_whitespace == 0))
-        {
+        if comment_chars.skip(n_whitespace).count() > 0 && n_whitespace == 0 {
             state.exceptable_add(
                 following_whitespace(Span::new(comment.span().start(), n_delimiter)),
                 SyntaxElement::from(comment.syntax().clone()),

--- a/wdl-lint/tests/lints/comment-whitespace/source.errors
+++ b/wdl-lint/tests/lints/comment-whitespace/source.errors
@@ -1,10 +1,10 @@
-note[CommentWhitespace]: comment delimiter should be followed by a single space
+note[CommentWhitespace]: comment delimiter should be followed by at least one space
   ┌─ tests/lints/comment-whitespace/source.wdl:5:1
   │
 5 │ #a bad comment
   │ ^
   │
-  = fix: add a single space after the comment delimiter
+  = fix: add at least one space after the comment delimiter
 
 note[CommentWhitespace]: comment has too much indentation
   ┌─ tests/lints/comment-whitespace/source.wdl:6:5


### PR DESCRIPTION
This pull request ~adds~ modifies a ~new~ rule to `wdl-lint`.

- **Rule Name**: `CommentWhitespace`

_Describe the rules you have implemented and link to any relevant issues._

Relaxes `CommentWhitespace` to fix #313 

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

Rule specific checks:

- [x] You have added the rule as an entry within `RULES.md`.
- [x] You have added the rule to the `rules()` function in `wdl-lint/src/lib.rs`.
- [x] You have added a test case in `wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
- [x] If you have implemented a new `Visitor` callback, you have also
      overridden that callback method for the special `Validator`
      (`wdl-ast/src/validation.rs`) and `LintVisitor`
      (`wdl-lint/src/visitor.rs`) visitors. These are required to ensure the new
      visitor callback will execute.
- [x] You have run `wdl-gauntlet --refresh` to ensure that there are no 
      unintended changes to the baseline configuration file (`Gauntlet.toml`).
- [x] You have run `wdl-gauntlet --refresh --arena` to ensure that all of the 
      rules added/removed are now reflected in the baseline configuration file 
      (`Arena.toml`).

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
