### PR TITLE
fix: misplaced shellcheck spans

### DIFF
--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Updated `strip_whitespace` to return the amount of leading whitespace that was removed ([#317](https://github.com/stjude-rust-labs/wdl/pull/317)).
+* Refactored whitespace counting out of `strip_whitespace` into `count_whitespace` method ([#317](https://github.com/stjude-rust-labs/wdl/pull/317)).
 
 ## 0.10.0 - 01-17-2025
 

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Updated `strip_whitespace` to return the amount of leading whitespace that was removed ([#317](https://github.com/stjude-rust-labs/wdl/pull/317)).
+
 ## 0.10.0 - 01-17-2025
 
 ### Added

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -875,7 +875,7 @@ impl CommandSection {
     /// Counts the leading whitespace of the command.
     ///
     /// If the command has mixed indentation, this will return None.
-    pub fn count_whitepsace(&self) -> Option<usize> {
+    pub fn count_whitespace(&self) -> Option<usize> {
         let mut min_leading_spaces = usize::MAX;
         let mut min_leading_tabs = usize::MAX;
         let mut parsing_leading_whitespace = false; // init to false so that the first line is skipped
@@ -998,7 +998,7 @@ impl CommandSection {
         }
 
         // Return immediately if command contains mixed indentation
-        let num_stripped_chars = self.count_whitepsace()?;
+        let num_stripped_chars = self.count_whitespace()?;
 
         // If there is no leading whitespace, we're done
         if num_stripped_chars == 0 {

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -874,6 +874,9 @@ impl CommandSection {
 
     /// Strips leading whitespace from the command.
     ///
+    /// Returns a vector of [StrippedCommandPart]s and the amount
+    /// of leading whitespace that was stripped.
+    ///
     /// If the command has mixed indentation, this will return `None`.
     pub fn strip_whitespace(&self) -> Option<Vec<StrippedCommandPart>> {
         let mut min_leading_spaces = usize::MAX;

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -1,7 +1,5 @@
 //! V1 AST representation for task definitions.
 
-use core::num;
-
 use super::BoundDecl;
 use super::Decl;
 use super::Expr;

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -872,7 +872,7 @@ impl CommandSection {
         None
     }
 
-    /// Counts leading whitespace for the command.
+    /// Counts the leading whitespace of the command.
     ///
     /// If the command has mixed indentation, this will return None.
     pub fn count_whitepsace(&self) -> Option<usize> {

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -1,5 +1,7 @@
 //! V1 AST representation for task definitions.
 
+use core::num;
+
 use super::BoundDecl;
 use super::Decl;
 use super::Expr;
@@ -872,13 +874,10 @@ impl CommandSection {
         None
     }
 
-    /// Strips leading whitespace from the command.
+    /// Counts leading whitespace for the command.
     ///
-    /// Returns a vector of [StrippedCommandPart]s and the amount
-    /// of leading whitespace that was stripped.
-    ///
-    /// If the command has mixed indentation, this will return `None`.
-    pub fn strip_whitespace(&self) -> Option<Vec<StrippedCommandPart>> {
+    /// If the command has mixed indentation, this will return None.
+    pub fn count_whitepsace(&self) -> Option<usize> {
         let mut min_leading_spaces = usize::MAX;
         let mut min_leading_tabs = usize::MAX;
         let mut parsing_leading_whitespace = false; // init to false so that the first line is skipped
@@ -929,6 +928,35 @@ impl CommandSection {
             }
         }
 
+        // Check for no indentation or all whitespace, in which case we're done
+        if (min_leading_spaces == 0 && min_leading_tabs == 0)
+            || (min_leading_spaces == usize::MAX && min_leading_tabs == usize::MAX)
+        {
+            return Some(0);
+        }
+
+        // Check for mixed indentation
+        if (min_leading_spaces > 0 && min_leading_spaces != usize::MAX)
+            && (min_leading_tabs > 0 && min_leading_tabs != usize::MAX)
+        {
+            return None;
+        }
+
+        // Exactly one of the two will be equal to usize::MAX because it never appeared.
+        // The other will be the number of leading spaces or tabs to strip.
+        let final_leading_whitespace = if min_leading_spaces < min_leading_tabs {
+            min_leading_spaces
+        } else {
+            min_leading_tabs
+        };
+
+        Some(final_leading_whitespace)
+    }
+
+    /// Strips leading whitespace from the command.
+    ///
+    /// If the command has mixed indentation, this will return `None`.
+    pub fn strip_whitespace(&self) -> Option<Vec<StrippedCommandPart>> {
         let mut result = Vec::new();
         let heredoc = self.is_heredoc();
         for part in self.parts() {
@@ -971,27 +999,13 @@ impl CommandSection {
             }
         }
 
-        // Check for no indentation or all whitespace, in which case we're done
-        if (min_leading_spaces == 0 && min_leading_tabs == 0)
-            || (min_leading_spaces == usize::MAX && min_leading_tabs == usize::MAX)
-        {
+        // Return immediately if command contains mixed indentation
+        let num_stripped_chars = self.count_whitepsace()?;
+
+        // If there is no leading whitespace, we're done
+        if num_stripped_chars == 0 {
             return Some(result);
         }
-
-        // Check for mixed indentation
-        if (min_leading_spaces > 0 && min_leading_spaces != usize::MAX)
-            && (min_leading_tabs > 0 && min_leading_tabs != usize::MAX)
-        {
-            return None;
-        }
-
-        // Exactly one of the two will be equal to usize::MAX because it never appeared.
-        // The other will be the number of leading spaces or tabs to strip.
-        let num_stripped_chars = if min_leading_spaces < min_leading_tabs {
-            min_leading_spaces
-        } else {
-            min_leading_tabs
-        };
 
         // Finally, strip the leading whitespace on each line
         // This is done in place using the `replace_range` method; the method will

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed misplacement of highlighted spans for some ShellCheck lints ([#317](https://github.com/stjude-rust-labs/wdl/pull/317)).
+
 ### Changed
 
-* Fixed misplacement of highlighted spans for some ShellCheck lints ([#317](https://github.com/stjude-rust-labs/wdl/pull/317))
 * Relaxed `CommentWhitespace` rule so that it doesn't fire when a comment has extra spaces before it ([#314](https://github.com/stjude-rust-labs/wdl/pull/314)).
 
 ## 0.9.0 - 01-17-2025

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed misplacement of highlighted spans for some ShellCheck lints ([#317](https://github.com/stjude-rust-labs/wdl/pull/317))
 * Relaxed `CommentWhitespace` rule so that it doesn't fire when a comment has extra spaces before it ([#314](https://github.com/stjude-rust-labs/wdl/pull/314)).
 
 ## 0.9.0 - 01-17-2025

--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -345,11 +345,13 @@ fn shellcheck_lint(
 ///
 /// If the section contains mixed indentation, returns None.
 fn sanitize_command(section: &CommandSection) -> Option<(String, HashSet<String>, usize)> {
+    let amount_stripped = section.count_whitepsace()?;
     let mut sanitized_command = String::new();
     let mut decls = HashSet::new();
     let mut needs_quotes = true;
     let mut is_literal = false;
-    if let Some((cmd_parts, amount_stripped)) = section.strip_whitespace() {
+
+    if let Some(cmd_parts) = section.strip_whitespace() {
         cmd_parts.iter().for_each(|part| match part {
             StrippedCommandPart::Text(text) => {
                 sanitized_command.push_str(text);

--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -40,7 +40,6 @@ use crate::TagSet;
 use crate::fix::Fixer;
 use crate::fix::InsertionPoint;
 use crate::fix::Replacement;
-use crate::util::count_leading_whitespace;
 use crate::util::is_properly_quoted;
 use crate::util::lines_with_offset;
 use crate::util::program_exists;
@@ -345,12 +344,12 @@ fn shellcheck_lint(
 /// with dummy bash variables or literals, and records declarations.
 ///
 /// If the section contains mixed indentation, returns None.
-fn sanitize_command(section: &CommandSection) -> Option<(String, HashSet<String>)> {
+fn sanitize_command(section: &CommandSection) -> Option<(String, HashSet<String>, usize)> {
     let mut sanitized_command = String::new();
     let mut decls = HashSet::new();
     let mut needs_quotes = true;
     let mut is_literal = false;
-    if let Some(cmd_parts) = section.strip_whitespace() {
+    if let Some((cmd_parts, amount_stripped)) = section.strip_whitespace() {
         cmd_parts.iter().for_each(|part| match part {
             StrippedCommandPart::Text(text) => {
                 sanitized_command.push_str(text);
@@ -380,7 +379,7 @@ fn sanitize_command(section: &CommandSection) -> Option<(String, HashSet<String>
                 }
             }
         });
-        Some((sanitized_command, decls))
+        Some((sanitized_command, decls, amount_stripped))
     } else {
         None
     }
@@ -388,7 +387,10 @@ fn sanitize_command(section: &CommandSection) -> Option<(String, HashSet<String>
 
 /// Maps each line as shellcheck sees it to its corresponding span in the
 /// source.
-fn map_shellcheck_lines(section: &CommandSection) -> HashMap<usize, Span> {
+fn map_shellcheck_lines(
+    section: &CommandSection,
+    leading_whitespace: usize,
+) -> HashMap<usize, Span> {
     let mut line_map = HashMap::new();
     let mut line_num = 1;
     let mut skip_next_line = false;
@@ -401,14 +403,12 @@ fn map_shellcheck_lines(section: &CommandSection) -> HashMap<usize, Span> {
                         skip_next_line = false;
                         continue;
                     }
-                    // Add back leading whitespace that is stripped from the sanitized command.
                     // The first line is removed entirely, UNLESS there is content on it.
-                    let leading_ws = if line_num > 1 || !line.trim().is_empty() {
-                        count_leading_whitespace(line)
-                    } else {
+                    if line_num == 1 && line.is_empty() {
                         continue;
-                    };
-                    let adjusted_start = text.span().start() + line_start + leading_ws;
+                    }
+                    // Add back the leading whitespace that was stripped.
+                    let adjusted_start = text.span().start() + line_start + leading_whitespace;
                     line_map.insert(line_num, Span::new(adjusted_start, line.len()));
                     line_num += 1;
                 }
@@ -439,8 +439,7 @@ fn calculate_span(diagnostic: &ShellCheckDiagnostic, line_map: &HashMap<usize, S
             .start()
             + diagnostic.end_column
             - 1;
-        // - 2 to discount first and last newlines
-        end_line_end.saturating_sub(start) - 2
+        end_line_end.saturating_sub(start)
     } else {
         // single line diagnostic
         (diagnostic.end_column).saturating_sub(diagnostic.column)
@@ -508,14 +507,15 @@ impl Visitor for ShellCheckRule {
         let mut decls = gather_task_declarations(&parent_task);
 
         // Replace all placeholders in the command with dummy bash variables
-        let Some((sanitized_command, cmd_decls)) = sanitize_command(section) else {
+        let Some((sanitized_command, cmd_decls, amount_stripped)) = sanitize_command(section)
+        else {
             // This is the case where the command section contains
             // mixed indentation. We silently return and allow
             // the mixed indentation lint to report this.
             return;
         };
         decls.extend(cmd_decls);
-        let line_map = map_shellcheck_lines(section);
+        let line_map = map_shellcheck_lines(section, amount_stripped);
 
         // create a Fenwick tree where each index is a line number
         // and each value is the length of the line.

--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -345,7 +345,7 @@ fn shellcheck_lint(
 ///
 /// If the section contains mixed indentation, returns None.
 fn sanitize_command(section: &CommandSection) -> Option<(String, HashSet<String>, usize)> {
-    let amount_stripped = section.count_whitepsace()?;
+    let amount_stripped = section.count_whitespace()?;
     let mut sanitized_command = String::new();
     let mut decls = HashSet::new();
     let mut needs_quotes = true;

--- a/wdl-lint/src/util.rs
+++ b/wdl-lint/src/util.rs
@@ -7,13 +7,6 @@ use wdl_ast::AstToken;
 use wdl_ast::Comment;
 use wdl_ast::SyntaxKind;
 
-/// Counts the amount of leading whitespace in a string slice.
-///
-/// Returns when the first non-whitespace character is encountered.
-pub fn count_leading_whitespace(input: &str) -> usize {
-    input.chars().take_while(|ch| ch.is_whitespace()).count()
-}
-
 /// Detect if a comment is in-line or not by looking for `\n` in the prior
 /// whitespace.
 pub fn is_inline_comment(token: &Comment) -> bool {
@@ -186,20 +179,6 @@ task foo {  # an in-line comment
             ("", 51, 53),
             ("and even a \r that should not be a newline", 53, 95),
         ]);
-    }
-
-    #[test]
-    fn test_count_leading_whitespace() {
-        let s = "    this string has four leading spaces";
-        assert_eq!(count_leading_whitespace(s), 4);
-        let s = "\t\t\t\tthis string has four leading tabs";
-        assert_eq!(count_leading_whitespace(s), 4);
-        let s = "\r\r\r\rthis has four leading carriage returns";
-        assert_eq!(count_leading_whitespace(s), 4);
-        let s = "\n starts with a newline";
-        assert_eq!(count_leading_whitespace(s), 2);
-        let s = "I have no leading whitespace";
-        assert_eq!(count_leading_whitespace(s), 0);
     }
 
     #[test]

--- a/wdl-lint/tests/lints/shellcheck-warn/source.errors
+++ b/wdl-lint/tests/lints/shellcheck-warn/source.errors
@@ -779,3 +779,91 @@ note[ShellCheck]: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
     │
     = fix: did you mean `cd "DIR" || exit`?
 
+note[ShellCheck]: Double quote to prevent globbing and word splitting.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:185:13
+    │
+185 │             $fasta_name /
+    │             ^^^^^^^^^^^
+    │             │
+    │             SC2086[info]: Double quote to prevent globbing and word splitting.
+    │             more info: https://www.shellcheck.net/wiki/SC2086
+    │
+    = fix: did you mean `"$fasta_name"`?
+
+note[ShellCheck]: fasta_name is referenced but not assigned.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:185:13
+    │
+185 │             $fasta_name /
+    │             ^^^^^^^^^^^
+    │             │
+    │             SC2154[warning]: fasta_name is referenced but not assigned.
+    │             more info: https://www.shellcheck.net/wiki/SC2154
+    │
+    = fix: address the diagnostic as recommended in the message
+
+note[ShellCheck]: Since you double quoted this, it will not word split, and the loop will only run once.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:189:21
+    │
+189 │         for file in ~{sep(" ", bams)}
+    │                     ^^^^^^^^^^^^^^^^^
+    │                     │
+    │                     SC2066[error]: Since you double quoted this, it will not word split, and the loop will only run once.
+    │                     more info: https://www.shellcheck.net/wiki/SC2066
+    │
+    = fix: address the diagnostic as recommended in the message
+
+note[ShellCheck]: Double quote to prevent globbing and word splitting.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:193:17
+    │
+193 │           ln -s $file
+    │                 ^^^^^
+    │                 │
+    │                 SC2086[info]: Double quote to prevent globbing and word splitting.
+    │                 more info: https://www.shellcheck.net/wiki/SC2086
+    │
+    = fix: did you mean `"$file"`?
+
+note[ShellCheck]: Double quote to prevent globbing and word splitting.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:194:30
+    │
+194 │           bams+=" $(basename $file)"
+    │                              ^^^^^
+    │                              │
+    │                              SC2086[info]: Double quote to prevent globbing and word splitting.
+    │                              more info: https://www.shellcheck.net/wiki/SC2086
+    │
+    = fix: did you mean `"$file"`?
+
+note[ShellCheck]: Double quote to prevent globbing and word splitting.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:198:46
+    │
+198 │             && [ "$(grep -Ec "$GREP_PATTERN" ~{outfile_name})" -gt 0 ]
+    │                                              ^^^^^^^^^^^^^^^
+    │                                              │
+    │                                              SC2086[info]: Double quote to prevent globbing and word splitting.
+    │                                              more info: https://www.shellcheck.net/wiki/SC2086
+    │
+    = fix: did you mean `"${WDLKC0gutybX}"`?
+
+note[ShellCheck]: Double quote to prevent globbing and word splitting.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:202:18
+    │
+202 │             exit $rc
+    │                  ^^^
+    │                  │
+    │                  SC2086[info]: Double quote to prevent globbing and word splitting.
+    │                  more info: https://www.shellcheck.net/wiki/SC2086
+    │
+    = fix: did you mean `"$rc"`?
+
+note[ShellCheck]: rc is referenced but not assigned.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:202:18
+    │
+202 │             exit $rc
+    │                  ^^^
+    │                  │
+    │                  SC2154[warning]: rc is referenced but not assigned.
+    │                  more info: https://www.shellcheck.net/wiki/SC2154
+    │
+    = fix: address the diagnostic as recommended in the message
+

--- a/wdl-lint/tests/lints/shellcheck-warn/source.errors
+++ b/wdl-lint/tests/lints/shellcheck-warn/source.errors
@@ -837,13 +837,24 @@ note[ShellCheck]: Double quote to prevent globbing and word splitting.
 note[ShellCheck]: Double quote to prevent globbing and word splitting.
     ┌─ tests/lints/shellcheck-warn/source.wdl:198:46
     │
-198 │             && [ "$(grep -Ec "$GREP_PATTERN" ~{outfile_name})" -gt 0 ]
-    │                                              ^^^^^^^^^^^^^^^
+198 │             && [ "$(grep -Ec "$GREP_PATTERN" $outfile_name)" -gt 0 ]
+    │                                              ^^^^^^^^^^^^^
     │                                              │
     │                                              SC2086[info]: Double quote to prevent globbing and word splitting.
     │                                              more info: https://www.shellcheck.net/wiki/SC2086
     │
-    = fix: did you mean `"${WDLqqXIAEUdv}"`?
+    = fix: did you mean `"$outfile_name"`?
+
+note[ShellCheck]: outfile_name is referenced but not assigned.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:198:46
+    │
+198 │             && [ "$(grep -Ec "$GREP_PATTERN" $outfile_name)" -gt 0 ]
+    │                                              ^^^^^^^^^^^^^
+    │                                              │
+    │                                              SC2154[warning]: outfile_name is referenced but not assigned.
+    │                                              more info: https://www.shellcheck.net/wiki/SC2154
+    │
+    = fix: address the diagnostic as recommended in the message
 
 note[ShellCheck]: Double quote to prevent globbing and word splitting.
     ┌─ tests/lints/shellcheck-warn/source.wdl:202:18

--- a/wdl-lint/tests/lints/shellcheck-warn/source.errors
+++ b/wdl-lint/tests/lints/shellcheck-warn/source.errors
@@ -843,7 +843,7 @@ note[ShellCheck]: Double quote to prevent globbing and word splitting.
     │                                              SC2086[info]: Double quote to prevent globbing and word splitting.
     │                                              more info: https://www.shellcheck.net/wiki/SC2086
     │
-    = fix: did you mean `"${WDLKC0gutybX}"`?
+    = fix: did you mean `"${WDLqqXIAEUdv}"`?
 
 note[ShellCheck]: Double quote to prevent globbing and word splitting.
     ┌─ tests/lints/shellcheck-warn/source.wdl:202:18

--- a/wdl-lint/tests/lints/shellcheck-warn/source.wdl
+++ b/wdl-lint/tests/lints/shellcheck-warn/source.wdl
@@ -172,3 +172,41 @@ task test6 {
 
     runtime {}
 }
+
+task test6 {
+    meta {}
+
+    parameter_meta {}
+
+    input {}
+
+    command <<<
+        convert_fusions_to_vcf.sh \
+            $fasta_name \
+            ~{fusions} \
+            ~{prefix}.vcf
+
+        for file in ~{sep(" ", bams)}
+        do
+          # This will fail (intentionally) if there are duplicate names
+          # in the input BAM array.
+          ln -s $file
+          bams+=" $(basename $file)"
+        done
+        
+        if ! ~{succeed_on_errors} \
+            && [ "$(grep -Ec "$GREP_PATTERN" ~{outfile_name})" -gt 0 ]
+        then
+            >&2 echo "Problems detected by Picard ValidateSamFile"
+            >&2 grep -E "$GREP_PATTERN" ~{outfile_name}
+            exit $rc
+        fi
+
+
+
+    >>>
+
+    output {}
+
+    runtime {}
+}

--- a/wdl-lint/tests/lints/shellcheck-warn/source.wdl
+++ b/wdl-lint/tests/lints/shellcheck-warn/source.wdl
@@ -195,7 +195,7 @@ task test6 {
         done
         
         if ! ~{succeed_on_errors} \
-            && [ "$(grep -Ec "$GREP_PATTERN" ~{outfile_name})" -gt 0 ]
+            && [ "$(grep -Ec "$GREP_PATTERN" $outfile_name)" -gt 0 ]
         then
             >&2 echo "Problems detected by Picard ValidateSamFile"
             >&2 grep -E "$GREP_PATTERN" ~{outfile_name}


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

This PR addresses the bug described in #307, wherein shellcheck highlight spans were sometimes misplaced. This was due to incorrect counting of the amount of leading whitespace stripped by `CommandSection::strip_whitespace`. To avoid duplicating logic from the aforementioned method, the whitespace counting portion was refactored into a separate method, `count_whitespace` so that both `strip_whitespace` and `sanitize_command` can make use of it. 

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
