### PR TITLE
feat: implement mount points for task execution.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added calculation for mounting input files for future backends that use
+  containers ([#323](https://github.com/stjude-rust-labs/wdl/pull/323)).
 * Added retry logic for task execution ([#320](https://github.com/stjude-rust-labs/wdl/pull/320)).
 * Added a `Config` type for specifying evaluation configuration ([#320](https://github.com/stjude-rust-labs/wdl/pull/320)).
 * Added progress callback to `WorkflowEvaluator` ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).

--- a/wdl-engine/src/backend.rs
+++ b/wdl-engine/src/backend.rs
@@ -289,8 +289,8 @@ pub trait TaskExecutionBackend: Send + Sync {
     ///
     /// Containerized execution uses the following guest paths:
     ///
-    /// * `<root>/inputs` - where inputs are mounted; this is mounted read-only.
-    /// * `<root>/work` - the task working directory; this is mounted
+    /// * `<root>/inputs/` - where inputs are mounted; this is mounted read-only.
+    /// * `<root>/work/` - the task working directory; this is mounted
     ///   read-write.
     /// * `<root>/command` - the command to execute; this is mounted read-only.
     ///

--- a/wdl-engine/src/backend.rs
+++ b/wdl-engine/src/backend.rs
@@ -96,11 +96,11 @@ pub struct TaskExecutionRoot {
 
 impl TaskExecutionRoot {
     /// Creates a task execution root for the given path and execution attempt.
-    pub fn new(path2: &Path, attempt: u64) -> Result<Self> {
-        let root_dir = absolute(path2).with_context(|| {
+    pub fn new(path: &Path, attempt: u64) -> Result<Self> {
+        let root_dir = absolute(path).with_context(|| {
             format!(
                 "failed to determine absolute path of `{path}`",
-                path = path2.display()
+                path = path.display()
             )
         })?;
 

--- a/wdl-engine/src/backend.rs
+++ b/wdl-engine/src/backend.rs
@@ -289,7 +289,8 @@ pub trait TaskExecutionBackend: Send + Sync {
     ///
     /// Containerized execution uses the following guest paths:
     ///
-    /// * `<root>/inputs/` - where inputs are mounted; this is mounted read-only.
+    /// * `<root>/inputs/` - where inputs are mounted; this is mounted
+    ///   read-only.
     /// * `<root>/work/` - the task working directory; this is mounted
     ///   read-write.
     /// * `<root>/command` - the command to execute; this is mounted read-only.

--- a/wdl-engine/src/backend.rs
+++ b/wdl-engine/src/backend.rs
@@ -13,6 +13,7 @@ use indexmap::IndexMap;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::Receiver;
 
+use crate::MountPoints;
 use crate::Value;
 
 pub mod local;
@@ -72,6 +73,8 @@ pub struct TaskExecutionConstraints {
 /// ```
 #[derive(Debug)]
 pub struct TaskExecutionRoot {
+    /// The root directory for task execution.
+    root_dir: PathBuf,
     /// The path to the directory for files created by the stdlib before and
     /// after command evaluation.
     temp_dir: PathBuf,
@@ -80,7 +83,7 @@ pub struct TaskExecutionRoot {
     ///
     /// This needs to be a different location from `temp_dir` because commands
     /// are re-evaluated on retry.
-    command_temp_dir: PathBuf,
+    attempt_temp_dir: PathBuf,
     /// The path to the working directory for the execution.
     work_dir: PathBuf,
     /// The path to the command file.
@@ -93,19 +96,19 @@ pub struct TaskExecutionRoot {
 
 impl TaskExecutionRoot {
     /// Creates a task execution root for the given path and execution attempt.
-    pub fn new(path: &Path, attempt: u64) -> Result<Self> {
-        let path = absolute(path).with_context(|| {
+    pub fn new(path2: &Path, attempt: u64) -> Result<Self> {
+        let root_dir = absolute(path2).with_context(|| {
             format!(
                 "failed to determine absolute path of `{path}`",
-                path = path.display()
+                path = path2.display()
             )
         })?;
 
-        let mut attempts = path.join("attempts");
+        let mut attempts = root_dir.join("attempts");
         attempts.push(attempt.to_string());
 
         // Create both temp directories now as it may be needed for task evaluation
-        let temp_dir = path.join("tmp");
+        let temp_dir = root_dir.join("tmp");
         fs::create_dir_all(&temp_dir).with_context(|| {
             format!(
                 "failed to create directory `{path}`",
@@ -113,22 +116,28 @@ impl TaskExecutionRoot {
             )
         })?;
 
-        let command_temp_dir = attempts.join("tmp");
-        fs::create_dir_all(&command_temp_dir).with_context(|| {
+        let attempt_temp_dir = attempts.join("tmp");
+        fs::create_dir_all(&attempt_temp_dir).with_context(|| {
             format!(
                 "failed to create directory `{path}`",
-                path = command_temp_dir.display()
+                path = attempt_temp_dir.display()
             )
         })?;
 
         Ok(Self {
+            root_dir,
             temp_dir,
-            command_temp_dir,
+            attempt_temp_dir,
             work_dir: attempts.join("work"),
             command: attempts.join("command"),
             stdout: attempts.join("stdout"),
             stderr: attempts.join("stderr"),
         })
+    }
+
+    /// Gets the path to the root itself.
+    pub fn path(&self) -> &Path {
+        &self.root_dir
     }
 
     /// Gets the temporary directory path for task evaluation before and after
@@ -148,7 +157,7 @@ impl TaskExecutionRoot {
     /// The temporary directory is created before spawning the task so that it
     /// is available for task evaluation.
     pub fn attempt_temp_dir(&self) -> &Path {
-        &self.command_temp_dir
+        &self.attempt_temp_dir
     }
 
     /// Gets the working directory for task execution.
@@ -187,15 +196,13 @@ pub struct TaskSpawnRequest {
     /// The command of the task.
     command: String,
     /// The requirements of the task.
-    requirements: HashMap<String, Value>,
+    requirements: Arc<HashMap<String, Value>>,
     /// The hints of the task.
-    hints: HashMap<String, Value>,
+    hints: Arc<HashMap<String, Value>>,
     /// The environment variables of the task.
-    env: HashMap<String, String>,
-    /// The mapping between host paths and guest paths.
-    ///
-    /// This is only populated for backends that have a container root.
-    mapping: HashMap<String, String>,
+    env: Arc<HashMap<String, String>>,
+    /// The mount points to use for the spawn request.
+    mounts: Arc<MountPoints>,
     /// The channel to send a message on when the task is spawned.
     ///
     /// This value will be `None` once the task is spawned.
@@ -210,10 +217,10 @@ impl TaskSpawnRequest {
     pub fn new(
         root: Arc<TaskExecutionRoot>,
         command: String,
-        requirements: HashMap<String, Value>,
-        hints: HashMap<String, Value>,
-        env: HashMap<String, String>,
-        mapping: HashMap<String, String>,
+        requirements: Arc<HashMap<String, Value>>,
+        hints: Arc<HashMap<String, Value>>,
+        env: Arc<HashMap<String, String>>,
+        mounts: Arc<MountPoints>,
     ) -> (Self, oneshot::Receiver<()>) {
         let (tx, rx) = oneshot::channel();
 
@@ -224,7 +231,7 @@ impl TaskSpawnRequest {
                 requirements,
                 hints,
                 env,
-                mapping,
+                mounts,
                 spawned: Some(tx),
             },
             rx,
@@ -256,27 +263,10 @@ impl TaskSpawnRequest {
         &self.env
     }
 
-    /// Gets the mapping between host paths and guest paths.
-    ///
-    /// This is only populated for backends that have a container root.
-    pub fn mapping(&self) -> &HashMap<String, String> {
-        &self.mapping
+    /// Gets the mount points for the task.
+    pub fn mounts(&self) -> &Arc<MountPoints> {
+        &self.mounts
     }
-}
-
-/// Represents the response from spawning a task.
-#[derive(Debug)]
-pub struct TaskSpawnResponse {
-    /// The requirements the task was spawned with.
-    pub requirements: HashMap<String, Value>,
-    /// The hints the task was spawned with.
-    pub hints: HashMap<String, Value>,
-    /// The environment the task was spawned with.
-    pub env: HashMap<String, String>,
-    /// The status code of the task's execution.
-    ///
-    /// This may be `Err` if the task failed to spawn.
-    pub status_code: Result<i32>,
 }
 
 /// Represents a task execution backend.
@@ -294,13 +284,21 @@ pub trait TaskExecutionBackend: Send + Sync {
         hints: &HashMap<String, Value>,
     ) -> Result<TaskExecutionConstraints>;
 
-    /// Gets the container root directory for the backend (e.g. `/mnt/task`)
+    /// Gets the container (guest) root directory for the backend (e.g.
+    /// `/mnt/task`).
+    ///
+    /// Containerized execution uses the following guest paths:
+    ///
+    /// * `<root>/inputs` - where inputs are mounted; this is mounted read-only.
+    /// * `<root>/work` - the task working directory; this is mounted
+    ///   read-write.
+    /// * `<root>/command` - the command to execute; this is mounted read-only.
     ///
     /// Returns `None` if the task execution does not use a container.
-    fn container_root(&self) -> Option<&Path>;
+    fn container_root_dir(&self) -> Option<&Path>;
 
     /// Spawns a task with the execution backend.
     ///
     /// Upon success, returns a receiver for receiving the response.
-    fn spawn(&self, request: TaskSpawnRequest) -> Result<Receiver<TaskSpawnResponse>>;
+    fn spawn(&self, request: TaskSpawnRequest) -> Result<Receiver<Result<i32>>>;
 }

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -1,11 +1,15 @@
 //! Module for evaluation.
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::path::Component;
 use std::path::MAIN_SEPARATOR;
 use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context;
+use anyhow::Result;
 use anyhow::bail;
 use indexmap::IndexMap;
 use wdl_analysis::document::Task;
@@ -131,7 +135,7 @@ impl Scope {
     }
 
     /// Iterates over the local names and values in the scope.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &Value)> + use<'_> {
+    pub fn local(&self) -> impl Iterator<Item = (&str, &Value)> + use<'_> {
         self.names.iter().map(|(k, v)| (k.as_str(), v))
     }
 
@@ -192,6 +196,20 @@ impl<'a> ScopeRef<'a> {
             .names
             .iter()
             .map(|(n, name)| (n.as_str(), name))
+    }
+
+    /// Iterates over each name and value visible to the scope and calls the
+    /// provided callback.
+    pub fn for_each(&self, mut cb: impl FnMut(&str, &Value)) {
+        let mut current = Some(self.index);
+
+        while let Some(index) = current {
+            for (n, v) in self.scopes[index.0].local() {
+                cb(n, v);
+            }
+
+            current = self.scopes[index.0].parent;
+        }
     }
 
     /// Gets the value of a name local to this scope.
@@ -368,5 +386,282 @@ impl EvaluatedTask {
         }
 
         Ok(())
+    }
+}
+
+/// Represents mount points for mapping host and guest paths for task execution
+/// backends that use containers.
+#[derive(Debug, Default)]
+pub struct MountPoints(Vec<(PathBuf, PathBuf, bool)>);
+
+impl MountPoints {
+    /// Gets the guest path for the given host path.
+    ///
+    /// Returns `None` if there is no guest path mapped for the given path.
+    pub fn guest(&self, host: impl AsRef<Path>) -> Option<PathBuf> {
+        let host = host.as_ref();
+
+        for (mount_host, mount_guest, _) in &self.0 {
+            if let Ok(stripped) = host.strip_prefix(mount_host) {
+                return Some(Path::new(mount_guest).join(stripped));
+            }
+        }
+
+        None
+    }
+
+    /// Gets the host path for the given guest path.
+    ///
+    /// Returns `None` if there is no host path mapped for the given path.
+    pub fn host(&self, guest: impl AsRef<Path>) -> Option<PathBuf> {
+        let guest = guest.as_ref();
+
+        for (mount_host, mount_guest, _) in &self.0 {
+            if let Ok(stripped) = guest.strip_prefix(mount_guest) {
+                return Some(Path::new(mount_host).join(stripped));
+            }
+        }
+
+        None
+    }
+
+    /// Returns an iterator of mount point host path to mount point guest path
+    /// and whether or not the mounting should be read-only.
+    pub fn iter(&self) -> impl Iterator<Item = (&Path, &Path, bool)> {
+        self.0
+            .iter()
+            .map(|(h, g, ro)| (h.as_path(), g.as_path(), *ro))
+    }
+
+    /// Returns the number of mount points in the collection.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the collection contains no mount points.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Inserts a mount point.
+    pub fn insert(&mut self, host: impl Into<PathBuf>, guest: impl Into<PathBuf>, read_only: bool) {
+        self.0.push((host.into(), guest.into(), read_only));
+    }
+}
+
+/// Represents a node in a path trie.
+#[derive(Debug)]
+struct PathTrieNode<'a> {
+    /// The path component represented by this node.
+    component: Component<'a>,
+    /// The children of this node.
+    ///
+    /// A `BTreeMap` is used here to get a consistent walk of the tree.
+    children: BTreeMap<&'a OsStr, Self>,
+}
+
+impl<'a> PathTrieNode<'a> {
+    /// Constructs a new path trie node with the given normal path component.
+    fn new(component: &'a OsStr) -> Self {
+        Self {
+            component: Component::Normal(component),
+            children: Default::default(),
+        }
+    }
+
+    /// Determines if the node is considered a mount point.
+    ///
+    /// A mount point is a non-root node that:
+    ///
+    /// * has more than one child
+    /// * has a single terminal child
+    /// * is a terminal node
+    fn is_mount_point(&self) -> bool {
+        self.component != Component::RootDir
+            && (self.children.is_empty()
+                || self.children.len() > 1
+                || self
+                    .children
+                    .first_key_value()
+                    .map(|(_, v)| v.children.is_empty())
+                    .unwrap_or(false))
+    }
+
+    /// Inserts any mount points for the node.
+    fn insert_mount_points(&self, root: &'a Path, host: &mut PathBuf, mounts: &mut MountPoints) {
+        // Push the component onto the host path and pop it after any traversals
+        host.push(self.component);
+
+        // If this node is a mount point, insert it
+        if self.is_mount_point() {
+            let mut guest = PathBuf::new();
+            guest.push(root);
+            guest.push(mounts.0.len().to_string());
+            mounts.0.push((host.clone(), guest, true));
+        } else {
+            // Otherwise, traverse into the children
+            for child in self.children.values() {
+                child.insert_mount_points(root, host, mounts);
+            }
+        }
+
+        host.pop();
+    }
+}
+
+impl Default for PathTrieNode<'_> {
+    fn default() -> Self {
+        Self {
+            component: Component::RootDir,
+            children: Default::default(),
+        }
+    }
+}
+
+/// Represents a prefix trie based on file system paths.
+///
+/// This is used to determine container mount points.
+///
+/// From the root to the terminal node represents a host path.
+///
+/// A mount point is any non-root node in the tree that is either:
+///
+/// * The ancestor closest to the root that contains more than one child node
+///
+/// or
+///
+/// * The immediate parent of a terminal node where no ancestor has more than
+///   one child node
+///
+/// Paths are mapped according to their mount points.
+#[derive(Debug, Default)]
+pub struct PathTrie<'a> {
+    /// The root node of the trie.
+    root: PathTrieNode<'a>,
+}
+
+impl<'a> PathTrie<'a> {
+    /// Inserts a new path into the trie.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided path is not absolute or if it contains `.` or
+    /// `..` components.
+    pub fn insert(&mut self, path: &'a Path) {
+        assert!(
+            path.is_absolute(),
+            "a path must be absolute to add to the trie"
+        );
+
+        let mut node = &mut self.root;
+        for component in path.components() {
+            let component = match component {
+                Component::RootDir => {
+                    // Skip the root directory as we already have it in the trie
+                    continue;
+                }
+                Component::Prefix(prefix) => {
+                    // Treat a Windows prefix as a normal path component
+                    prefix.as_os_str()
+                }
+                Component::Normal(s) => s,
+                Component::CurDir | Component::ParentDir => {
+                    panic!("path may not contain `.` or `..`");
+                }
+            };
+
+            node = node
+                .children
+                .entry(component)
+                .or_insert_with(|| PathTrieNode::new(component));
+        }
+    }
+
+    /// Converts the path trie into mount points based on the provided guest
+    /// root directory.
+    pub fn into_mount_points(self, root: impl AsRef<Path>) -> MountPoints {
+        let mut mounts = MountPoints::default();
+        let mut host = PathBuf::new();
+        self.root
+            .insert_mount_points(root.as_ref(), &mut host, &mut mounts);
+        mounts
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_trie() {
+        let empty = PathTrie::default();
+        let mounts = empty.into_mount_points("/mnt/");
+        assert_eq!(mounts.iter().count(), 0);
+        assert_eq!(mounts.len(), 0);
+        assert!(mounts.is_empty());
+    }
+
+    #[test]
+    fn root_only_trie() {
+        let mut trie = PathTrie::default();
+        trie.insert(Path::new("/"));
+        let mounts = trie.into_mount_points("/mnt/");
+        assert_eq!(mounts.iter().count(), 0);
+        assert_eq!(mounts.len(), 0);
+        assert!(mounts.is_empty());
+    }
+
+    #[test]
+    fn trie_with_common_paths() {
+        let mut trie = PathTrie::default();
+        trie.insert(Path::new("/foo/bar/foo.txt"));
+        trie.insert(Path::new("/foo/bar/bar.txt"));
+        trie.insert(Path::new("/foo/baz/foo.txt"));
+        trie.insert(Path::new("/foo/baz/bar.txt"));
+        trie.insert(Path::new("/bar/foo/foo.txt"));
+        trie.insert(Path::new("/bar/foo/bar.txt"));
+        trie.insert(Path::new("/baz"));
+
+        let mounts = trie.into_mount_points("/mnt");
+
+        // Note: the mount points are always in lexical order
+        let mapped: Vec<_> = mounts.iter().collect();
+        assert_eq!(
+            mapped,
+            [
+                (Path::new("/bar/foo"), Path::new("/mnt/0"), true),
+                (Path::new("/baz"), Path::new("/mnt/1"), true),
+                (Path::new("/foo"), Path::new("/mnt/2"), true),
+            ]
+        );
+
+        for (host, guest) in [
+            ("/foo", "/mnt/2"),
+            ("/foo/bar/foo.txt", "/mnt/2/bar/foo.txt"),
+            ("/foo/bar/bar.txt", "/mnt/2/bar/bar.txt"),
+            ("/foo/bar/bar.txt", "/mnt/2/bar/bar.txt"),
+            ("/foo/baz/foo.txt", "/mnt/2/baz/foo.txt"),
+            ("/foo/baz/bar.txt", "/mnt/2/baz/bar.txt"),
+            ("/bar/foo/", "/mnt/0"),
+            ("/bar/foo/foo.txt", "/mnt/0/foo.txt"),
+            ("/bar/foo/bar.txt", "/mnt/0/bar.txt"),
+            ("/baz", "/mnt/1"),
+            ("/baz/any/other/path", "/mnt/1/any/other/path"),
+        ] {
+            assert_eq!(
+                mounts.guest(host),
+                Some(PathBuf::from(guest)),
+                "unexpected guest path for host path `{host}`"
+            );
+            assert_eq!(
+                mounts.host(guest),
+                Some(PathBuf::from(host)),
+                "unexpected host path for guest path `{guest}`"
+            );
+        }
+
+        // Check for paths not in the host or guest mapping
+        assert!(mounts.guest("/tmp/foo.txt").is_none());
+        assert!(mounts.host("/tmp/bar.txt").is_none());
     }
 }

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -50,6 +50,7 @@ use super::ProgressKind;
 use crate::Coercible;
 use crate::EvaluationContext;
 use crate::EvaluationResult;
+use crate::MountPoint;
 use crate::Outputs;
 use crate::PathTrie;
 use crate::Scope;
@@ -925,8 +926,16 @@ impl TaskEvaluator {
             let mut mounts = trie.into_mount_points(root.join("inputs"));
 
             // Mount the working directory and command
-            mounts.insert(state.root.work_dir(), root.join("work"), false);
-            mounts.insert(state.root.command(), root.join("command"), true);
+            mounts.insert(MountPoint::new(
+                state.root.work_dir(),
+                root.join("work"),
+                false,
+            ));
+            mounts.insert(MountPoint::new(
+                state.root.command(),
+                root.join("command"),
+                true,
+            ));
             mounts
         } else {
             Default::default()

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -1,7 +1,6 @@
 //! Implementation of evaluation for V1 tasks.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::future::Future;
 use std::mem;
 use std::path::Path;
@@ -52,6 +51,7 @@ use crate::Coercible;
 use crate::EvaluationContext;
 use crate::EvaluationResult;
 use crate::Outputs;
+use crate::PathTrie;
 use crate::Scope;
 use crate::ScopeIndex;
 use crate::ScopeRef;
@@ -66,6 +66,7 @@ use crate::config::MAX_RETRIES;
 use crate::diagnostics::output_evaluation_failed;
 use crate::diagnostics::runtime_type_mismatch;
 use crate::eval::EvaluatedTask;
+use crate::eval::MountPoints;
 use crate::v1::ExprEvaluator;
 
 /// The default value for the `cpu` requirement.
@@ -258,10 +259,6 @@ struct State<'a> {
     ///
     /// Environment variables do not change between retries.
     env: HashMap<String, String>,
-    /// Host paths that need to be mapped to guest paths.
-    ///
-    /// This is only populated for backends that have a container root.
-    paths: HashSet<String>,
 }
 
 impl<'a> State<'a> {
@@ -287,43 +284,12 @@ impl<'a> State<'a> {
             scopes,
             root: Arc::new(TaskExecutionRoot::new(root, 0)?),
             env: Default::default(),
-            paths: Default::default(),
         })
     }
 
-    /// Updates the state for retrying task execution.
-    fn retry(&mut self, root: &Path, attempt: u64, env: HashMap<String, String>) -> Result<()> {
+    /// Changes the root for a new attempt.
+    fn set_root(&mut self, root: &Path, attempt: u64) -> Result<()> {
         self.root = Arc::new(TaskExecutionRoot::new(root, attempt)?);
-        self.env = env;
-        Ok(())
-    }
-
-    /// Updates state for a declaration.
-    fn update_for_decl(
-        &mut self,
-        name: &Ident,
-        value: &Value,
-        is_env_var: bool,
-        map_paths: bool,
-    ) -> Result<(), crate::EvaluationError> {
-        if is_env_var {
-            self.env.insert(
-                name.as_str().to_string(),
-                value
-                    .as_primitive()
-                    .expect("value should be primitive")
-                    .raw()
-                    .to_string(),
-            );
-        }
-
-        if map_paths {
-            value.visit_paths(&mut |path| {
-                self.paths.insert(path.to_string());
-                Ok(())
-            })?;
-        }
-
         Ok(())
     }
 }
@@ -333,11 +299,11 @@ struct EvaluatedSections {
     /// The evaluated command.
     command: String,
     /// The evaluated requirements.
-    requirements: HashMap<String, Value>,
+    requirements: Arc<HashMap<String, Value>>,
     /// The evaluated hints.
-    hints: HashMap<String, Value>,
-    /// The mapped paths from host path to guest path.
-    mapped: HashMap<String, String>,
+    hints: Arc<HashMap<String, Value>>,
+    /// The calculated mount points based on the inputs and declarations.
+    mounts: Arc<MountPoints>,
 }
 
 /// Represents a WDL V1 task evaluator.
@@ -547,14 +513,16 @@ impl TaskEvaluator {
         // TODO: check call cache for a hit. if so, skip task execution and use cache
         // paths for output evaluation
 
+        let env = Arc::new(mem::take(&mut state.env));
+
         // Spawn the task in a retry loop
         let mut attempt = 0;
-        let mut evaluated = loop {
+        let (mut evaluated, mounts) = loop {
             let EvaluatedSections {
                 command,
                 requirements,
                 hints,
-                mapped,
+                mounts,
             } = self.evaluate_sections(&mut state, definition.clone(), inputs, id, attempt)?;
 
             // Get the maximum number of retries, either from the task's requirements or
@@ -577,10 +545,10 @@ impl TaskEvaluator {
             let (request, rx) = TaskSpawnRequest::new(
                 state.root.clone(),
                 command,
-                requirements,
-                hints,
-                std::mem::take(&mut state.env),
-                mapped,
+                requirements.clone(),
+                hints.clone(),
+                env.clone(),
+                mounts.clone(),
             );
             let response = self.backend.spawn(request)?;
 
@@ -589,16 +557,16 @@ impl TaskEvaluator {
 
             progress(ProgressKind::TaskExecutionStarted { id, attempt });
 
-            let response = response
+            let status_code = response
                 .await
                 .expect("failed to receive response from spawned task");
 
             progress(ProgressKind::TaskExecutionCompleted {
                 id,
-                status_code: &response.status_code,
+                status_code: &status_code,
             });
 
-            let status_code = response.status_code?;
+            let status_code = status_code?;
             let evaluated = EvaluatedTask::new(&state.root, status_code)?;
 
             // Update the task variable
@@ -618,15 +586,15 @@ impl TaskEvaluator {
                 task.set_return_code(evaluated.status_code);
             }
 
-            if let Err(e) = evaluated.handle_exit(&response.requirements) {
+            if let Err(e) = evaluated.handle_exit(&requirements) {
                 if attempt >= max_retries {
                     return Err(e.into());
                 }
 
                 attempt += 1;
 
-                // Update the state for the next attempt
-                state.retry(root, attempt, response.env)?;
+                // Update the execution root for the next attempt
+                state.set_root(root, attempt)?;
 
                 info!(
                     "retrying execution of task `{name}` (retry {attempt})",
@@ -635,7 +603,7 @@ impl TaskEvaluator {
                 continue;
             }
 
-            break evaluated;
+            break (evaluated, mounts);
         };
 
         // Evaluate the remaining inputs (unused), and decls, and outputs
@@ -645,7 +613,7 @@ impl TaskEvaluator {
                     self.evaluate_decl(&mut state, &decl)?;
                 }
                 TaskGraphNode::Output(decl) => {
-                    self.evaluate_output(&mut state, &decl, &evaluated)?;
+                    self.evaluate_output(&mut state, &decl, &evaluated, &mounts)?;
                 }
                 _ => {
                     unreachable!(
@@ -711,12 +679,17 @@ impl TaskEvaluator {
             .map_err(|e| runtime_type_mismatch(e, &ty, name.span(), &value.ty(), span))?;
         state.scopes[ROOT_SCOPE_INDEX.0].insert(name.as_str(), value.clone());
 
-        state.update_for_decl(
-            &name,
-            &value,
-            decl.env().is_some(),
-            self.backend.container_root().is_some(),
-        )?;
+        // Insert an environment variable, if it is one
+        if decl.env().is_some() {
+            state.env.insert(
+                name.as_str().to_string(),
+                value
+                    .as_primitive()
+                    .expect("value should be primitive")
+                    .raw()
+                    .to_string(),
+            );
+        }
 
         Ok(())
     }
@@ -747,12 +720,17 @@ impl TaskEvaluator {
             .map_err(|e| runtime_type_mismatch(e, &ty, name.span(), &value.ty(), expr.span()))?;
         state.scopes[ROOT_SCOPE_INDEX.0].insert(name.as_str(), value.clone());
 
-        state.update_for_decl(
-            &name,
-            &value,
-            decl.env().is_some(),
-            self.backend.container_root().is_some(),
-        )?;
+        // Insert an environment variable, if it is one
+        if decl.env().is_some() {
+            state.env.insert(
+                name.as_str().to_string(),
+                value
+                    .as_primitive()
+                    .expect("value should be primitive")
+                    .raw()
+                    .to_string(),
+            );
+        }
 
         Ok(())
     }
@@ -918,15 +896,41 @@ impl TaskEvaluator {
         &self,
         state: &State<'_>,
         section: &CommandSection,
-    ) -> EvaluationResult<(String, HashMap<String, String>)> {
+    ) -> EvaluationResult<(String, MountPoints)> {
         debug!(
             "evaluating command section for task `{task}` in `{uri}`",
             task = state.task.name(),
             uri = state.document.uri()
         );
 
-        // TODO: map paths from host to guest
-        let mapping = Default::default();
+        // Determine the mount points needed to evaluate the command properly
+        let mounts = if let Some(root) = self.backend.container_root_dir() {
+            // For every file or directory value in scope, we need to insert into the tree
+            let mut paths = Vec::new();
+            let mut trie = PathTrie::default();
+
+            // Discover every path and directory that's visible to the scope
+            ScopeRef::new(&state.scopes, TASK_SCOPE_INDEX.0).for_each(|_, v| {
+                v.visit_paths(&mut |p| {
+                    paths.push(p.clone());
+                });
+            });
+
+            // Insert the paths into the trie
+            for path in &paths {
+                trie.insert(Path::new(path.as_str()));
+            }
+
+            // Convert the trie into mount points
+            let mut mounts = trie.into_mount_points(root.join("inputs"));
+
+            // Mount the working directory and command
+            mounts.insert(state.root.work_dir(), root.join("work"), false);
+            mounts.insert(state.root.command(), root.join("command"), true);
+            mounts
+        } else {
+            Default::default()
+        };
 
         let mut command = String::new();
         if let Some(parts) = section.strip_whitespace() {
@@ -942,7 +946,9 @@ impl TaskEvaluator {
                         command.push_str(t.as_str());
                     }
                     StrippedCommandPart::Placeholder(placeholder) => {
-                        evaluator.evaluate_placeholder(&placeholder, &mut command, &mapping)?;
+                        evaluator.evaluate_placeholder(&placeholder, &mut command, |p| {
+                            mounts.guest(p)
+                        })?;
                     }
                 }
             }
@@ -967,13 +973,15 @@ impl TaskEvaluator {
                         t.unescape_to(heredoc, &mut command);
                     }
                     CommandPart::Placeholder(placeholder) => {
-                        evaluator.evaluate_placeholder(&placeholder, &mut command, &mapping)?;
+                        evaluator.evaluate_placeholder(&placeholder, &mut command, |p| {
+                            mounts.guest(p)
+                        })?;
                     }
                 }
             }
         }
 
-        Ok((command, mapping))
+        Ok((command, mounts))
     }
 
     /// Evaluates sections prior to spawning the command.
@@ -1047,15 +1055,16 @@ impl TaskEvaluator {
             }
         }
 
-        let (command, mapped) = self.evaluate_command(
+        let (command, mounts) = self.evaluate_command(
             state,
             &definition.command().expect("must have command section"),
         )?;
+
         Ok(EvaluatedSections {
             command,
-            requirements,
-            hints,
-            mapped,
+            requirements: Arc::new(requirements),
+            hints: Arc::new(hints),
+            mounts: Arc::new(mounts),
         })
     }
 
@@ -1065,6 +1074,7 @@ impl TaskEvaluator {
         state: &mut State<'_>,
         decl: &Decl,
         evaluated: &EvaluatedTask,
+        mounts: &MountPoints,
     ) -> EvaluationResult<()> {
         let name = decl.name();
         debug!(
@@ -1092,7 +1102,22 @@ impl TaskEvaluator {
 
         // Finally, join the path with the working directory, checking for existence
         value
-            .join_paths(&evaluated.work_dir, true, ty.is_optional())
+            .join_paths(&evaluated.work_dir, true, ty.is_optional(), &|p| {
+                let host = mounts.host(p);
+
+                // If the path was absolute, it must map to a host path otherwise the file
+                // exists only within the container
+                if p.is_absolute() && !p.starts_with(state.root.path()) {
+                    return Ok(Some(host.ok_or_else(|| {
+                        anyhow!(
+                            "guest path `{p}` is not within a container mount point",
+                            p = p.display()
+                        )
+                    })?));
+                }
+
+                Ok(host)
+            })
             .map_err(|e| {
                 output_evaluation_failed(e, state.task.name(), true, name.as_str(), name.span())
             })?;

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -43,7 +43,7 @@ fn join_paths(inputs: &mut HashMap<String, Value>, path: &Path, ty: impl Fn(&str
         let mut replacement = std::mem::replace(value, Value::None);
         if let Ok(mut v) = replacement.coerce(&ty) {
             drop(replacement);
-            v.join_paths(path, true, false)
+            v.join_paths(path, true, false, &|_| Ok(None))
                 .expect("joining should not fail");
             replacement = v;
         }


### PR DESCRIPTION
This PR implements the calculation of mount points for task execution backends that use containers.

Paths from `File` and `Directory` values that are visible prior to evaluating the command section of a task are added to a `PathTrie`.

The `PathTrie` is used to determine the minimum number of mounts in the guest environment to be able to send input files to the container.

Command evaluation does a translation from host paths to guest paths so that the generated command script uses only guest paths.

Similarly, evaluation of output values does a translation from guest paths to host paths so that tasks always output the host path.

Fixes #267.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
