### PR TITLE
chore: update `deny.toml`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,4 +111,4 @@ broken_intra_doc_links = "warn"
 missing_docs_in_private_items = "warn"
 
 [patch.crates-io]
-bollard = { git = "https://github.com/peterhuene/bollard", branch = "nodes-api" }
+bollard = { git = "https://github.com/fussybeaver/bollard", rev = "bf2b924426" }

--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,7 @@ allow = [
     "MPL-2.0",
     "Unicode-3.0",
     "BSL-1.0",
+    "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
This commit updates `deny.toml` to include the allowance of the `zlib` license.

Additionally, this updates our patch of `bollard` to the upstream repository.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
