### PR TITLE
chore: update `.gitattributes` for inconsistent newline lint test.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # Ensure that WDL files always use LF line endings.
 *.wdl text eol=lf
+
+# Ignore line endings for this file as it is intentionally inconsistent
+wdl-lint/tests/lints/inconsistent-newlines/source.wdl -text


### PR DESCRIPTION
This PR excludes the `inconsistent-newlines` test source from autocrlf behavior by git.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
