### PR TITLE
chore: update deny.toml.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ feature-depth = 1
 # output a note when they are encountered.
 ignore = [
     { id = "RUSTSEC-2024-0384", reason = "dependency only activated for wasm32, which is not a supported target" },
+    { id = "RUSTSEC-2024-0436", reason = "dependency is unmaintained, but a relatively small macro helper for creating identifiers" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
This update ignores the RUSTSEC advisory for the `paste` crate.

While the crate is no longer maintained, it is a relatively small crate that is used primarily for generating identifiers in macros.

We use it in AST for generating some boiler plate implementations on AST types.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
