### PR TITLE
feat: `missing_call_input` warning

### DIFF
--- a/Gauntlet.toml
+++ b/Gauntlet.toml
@@ -1838,6 +1838,11 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/b450ca0b7
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/PRS/PRSWrapper.wdl"
+message = "PRSWrapper.wdl:36:18: warning: missing required call input `imputed_array_vcf_index` for workflow `ScoringImputedDataset`"
+permalink = "https://github.com/broadinstitute/palantir-workflows/blob/b450ca0b7d9a35945618235de4a2a64f34de880d/PRS/PRSWrapper.wdl/#L36"
+
+[[diagnostics]]
+document = "broadinstitute/palantir-workflows:/PRS/PRSWrapper.wdl"
 message = "PRSWrapper.wdl:48:30: error: type mismatch: expected type `Int`, but found type `Int?`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/b450ca0b7d9a35945618235de4a2a64f34de880d/PRS/PRSWrapper.wdl/#L48"
 
@@ -3097,6 +3102,11 @@ message = "test_smartseq2_multisample_PR_SINGLE_END.wdl:58:46: warning[UnusedCal
 permalink = "https://github.com/broadinstitute/warp/blob/16affa2fbda7455569e1953ef34d8ded1521890f/tests/skylab/smartseq2_multisample/pr_single_end/test_smartseq2_multisample_PR_SINGLE_END.wdl/#L58"
 
 [[diagnostics]]
+document = "broadinstitute/warp:/tests/skylab/smartseq2_single_nucleus/pr/test_smartseq2_single_nucleus_PR.wdl"
+message = "test_smartseq2_single_nucleus_PR.wdl:28:19: warning: missing required call input `cloud_provider` for workflow `MultiSampleSmartSeq2SingleNucleus`"
+permalink = "https://github.com/broadinstitute/warp/blob/16affa2fbda7455569e1953ef34d8ded1521890f/tests/skylab/smartseq2_single_nucleus/pr/test_smartseq2_single_nucleus_PR.wdl/#L28"
+
+[[diagnostics]]
 document = "broadinstitute/warp:/verification/VerifyArrays.wdl"
 message = "VerifyArrays.wdl:46:14: warning[UnusedInput]: unused input `done`"
 permalink = "https://github.com/broadinstitute/warp/blob/16affa2fbda7455569e1953ef34d8ded1521890f/verification/VerifyArrays.wdl/#L46"
@@ -3970,6 +3980,51 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6a
 document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/host_filter.wdl"
 message = "host_filter.wdl:22:11: warning[UnusedInput]: unused input `gtf_gz`"
 permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/host_filter.wdl/#L22"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `adapter_fasta` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `bowtie2_index_tar` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `hisat2_index_tar` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `host_genome` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `human_bowtie2_index_tar` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `human_hisat2_index_tar` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `kallisto_idx` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `max_input_fragments` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
+
+[[diagnostics]]
+document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"
+message = "local_driver.wdl:23:17: warning: missing required call input `max_subsample_fragments` for workflow `czid_host_filter`"
+permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/8d57beab9fd6ab640826af0fdc6bff9b22d95163/workflows/short-read-mngs/local_driver.wdl/#L23"
 
 [[diagnostics]]
 document = "chanzuckerberg/czid-workflows:/workflows/short-read-mngs/local_driver.wdl"

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Changed
+### Added
 
-* `missing_call_input` now gives a warning for missing inputs when `allowNestedInputs:true` ([#344]https://github.com/stjude-rust-labs/wdl/pull/344).
+* `missing_call_input` now generates a warning for missing inputs when nested inputs are allowed, without changing the existing error behavior ([#344]https://github.com/stjude-rust-labs/wdl/pull/344).
 
 ### Added
 

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `missing_call_input` now generates a warning for missing inputs when nested inputs are allowed, without changing the existing error behavior ([#344]https://github.com/stjude-rust-labs/wdl/pull/344).
-
-### Added
-
 * Added `path` method to `Document` ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 
 ### Changed

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `missing_call_input` now gives a warning for missing inputs when `allowNestedInputs:true`.
+* `missing_call_input` now gives a warning for missing inputs when `allowNestedInputs:true` ([#344]https://github.com/stjude-rust-labs/wdl/pull/344).
 
 ### Added
 

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* `missing_call_input` now gives a warning for missing inputs when `allowNestedInputs:true`.
+
 ### Added
 
 * Added `path` method to `Document` ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).

--- a/wdl-analysis/src/diagnostics.rs
+++ b/wdl-analysis/src/diagnostics.rs
@@ -695,12 +695,22 @@ pub fn recursive_workflow_call(name: &str, span: Span) -> Diagnostic {
 }
 
 /// Creates a "missing call input" diagnostic.
-pub fn missing_call_input(kind: CallKind, target: &Ident, input: &str) -> Diagnostic {
-    Diagnostic::error(format!(
+pub fn missing_call_input(
+    kind: CallKind,
+    target: &Ident,
+    input: &str,
+    nested_inputs_allowed: bool,
+) -> Diagnostic {
+    let message = format!(
         "missing required call input `{input}` for {kind} `{target}`",
         target = target.as_str(),
-    ))
-    .with_highlight(target.span())
+    );
+
+    if nested_inputs_allowed {
+        Diagnostic::warning(message).with_highlight(target.span())
+    } else {
+        Diagnostic::error(message).with_highlight(target.span())
+    }
 }
 
 /// Creates an "unused import" diagnostic.

--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -1185,19 +1185,17 @@ fn add_call_statement(
                 },
             }
 
-            // Don't bother keeping track of seen inputs if nested inputs are allowed
-            if !nested_inputs_allowed {
-                seen.insert(TokenStrHash::new(input_name));
-            }
+            seen.insert(TokenStrHash::new(input_name));
         }
 
-        if !nested_inputs_allowed {
-            for (name, input) in ty.inputs() {
-                if input.required && !seen.contains(name.as_str()) {
-                    document
-                        .diagnostics
-                        .push(missing_call_input(ty.kind(), &target_name, name));
-                }
+        for (name, input) in ty.inputs() {
+            if input.required && !seen.contains(name.as_str()) {
+                document.diagnostics.push(missing_call_input(
+                    ty.kind(),
+                    &target_name,
+                    name,
+                    nested_inputs_allowed,
+                ));
             }
         }
 

--- a/wdl-analysis/tests/analysis/allow-nested-inputs-1.0/source.diagnostics
+++ b/wdl-analysis/tests/analysis/allow-nested-inputs-1.0/source.diagnostics
@@ -1,0 +1,6 @@
+warning: missing required call input `required` for task `my_task`
+   ┌─ tests/analysis/allow-nested-inputs-1.0/source.wdl:22:10
+   │
+22 │     call my_task
+   │          ^^^^^^^
+

--- a/wdl-analysis/tests/analysis/allow-nested-inputs-1.1/source.diagnostics
+++ b/wdl-analysis/tests/analysis/allow-nested-inputs-1.1/source.diagnostics
@@ -1,0 +1,6 @@
+warning: missing required call input `required` for task `my_task`
+   ┌─ tests/analysis/allow-nested-inputs-1.1/source.wdl:26:10
+   │
+26 │     call my_task
+   │          ^^^^^^^
+

--- a/wdl-analysis/tests/analysis/allow-nested-inputs-1.2/source.diagnostics
+++ b/wdl-analysis/tests/analysis/allow-nested-inputs-1.2/source.diagnostics
@@ -1,0 +1,6 @@
+warning: missing required call input `required` for task `my_task`
+   ┌─ tests/analysis/allow-nested-inputs-1.2/source.wdl:26:10
+   │
+26 │     call my_task
+   │          ^^^^^^^
+


### PR DESCRIPTION
###  `missing_call_input` now gives warnings for missing inputs when `allowNestedInputs:true` and addresses #237

This pull request adds a feature to `wdl-analysis`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

### **feat:`missing_call_input`** 

- In the meta section of the workflow when `allowedNestedInputs` is true, this function emits a warning for missing inputs.

For the import 

```
workflow my_workflow {
    meta {
        allowNestedInputs: true
    }

    # Missing required input
    call my_task

    # OK
    call my_task as my_task2 { input: required = "required" }

    # OK
    call my_task as my_task3 { input: required = "required", optional = "optional", defaulted = "defaulted" }
}

```

```
warning: missing required call input `required` for task `my_task`
   ┌─ tests/analysis/allow-nested-inputs-1.0/source.wdl:22:10
   │
22 │     call my_task
   │          ^^^^^^^


```
[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
