### PR TITLE
enchancement: wordsmithing explanation tags

### DIFF
--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -108,7 +108,7 @@ impl Rule for MissingMetasRule {
     fn explanation(&self) -> &'static str {
         "It is important that WDL code is well-documented. Every task and workflow should have \
          both a meta and parameter_meta section. Tasks without an `input` section are permitted to \
-         skip the `parameter_meta` section."
+         skip the `parameter_meta` section. meta sections should include a `description` key." 
     }
 
     fn tags(&self) -> TagSet {


### PR DESCRIPTION
**Requested change in issue #116 along with wordsmithing of explanation texts.**

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
