### PR TITLE
chore: update repository to Rust 2024.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,21 +16,22 @@ resolver = "2"
 
 [workspace.package]
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["The Rust WDL project developers"]
 homepage = "https://github.com/stjude-rust-labs/wdl"
 repository = "https://github.com/stjude-rust-labs/wdl"
-rust-version = "1.83.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 ammonia = "4.0.0"
-anyhow = "1.0.95"
+anyhow = "1.0.97"
 approx = "0.5.1"
-clap = { version = "4.5.28", features = ["derive"] }
+chrono = "0.4.40"
+clap = { version = "4.5.32", features = ["derive"] }
 clap-verbosity-flag = "3.0.2"
 codespan-reporting = "0.11.1"
 colored = "3.0.0"
-convert_case = "0.7.1"
+convert_case = "0.8.0"
 crankshaft = { version = "0.1.0", git = "https://github.com/stjude-rust-labs/crankshaft", rev = "00a58e8" }
 dirs = "6.0.0"
 faster-hex = "0.10.0"
@@ -39,7 +40,7 @@ notify = "8.0.0"
 futures = "0.3.31"
 git2 = "0.20.0"
 glob = "0.3.2"
-indexmap = { version = "2.7.1", features = ["serde"] }
+indexmap = { version = "2.8.0", features = ["serde"] }
 indicatif = "0.17.11"
 itertools = "0.14.0"
 line-index = "0.1.2"
@@ -47,27 +48,28 @@ logos = "0.15.0"
 maud = "0.27.0"
 nonempty = "0.11.0"
 opener = "0.7.2"
-ordered-float = "4.6.0"
+ordered-float = "5.0.0"
 pathdiff = "0.2.3"
 parking_lot = "0.12.3"
 path-clean = "1.0.1"
 petgraph = "0.7.1"
 pretty_assertions = "1.4.1"
-pulldown-cmark = "0.12.2"
+pulldown-cmark = "0.13.0"
 rand = "0.9.0"
 rayon = "1.10.0"
 regex = "1.11.1"
-reqwest = { version = "0.12.12", default-features = false, features = ["rustls-tls", "http2", "charset"] }
+reqwest = { version = "0.12.14", default-features = false, features = ["rustls-tls", "http2", "charset"] }
 rowan = "0.16.1"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.138"
+serde_json = "1.0.140"
 serde_with = "3.12.0"
 strsim = "0.11.1"
 sysinfo = "0.33.1"
-tempfile = "3.16.0"
-tokio = { version = "1.43.0", features = ["full"] }
-tokio-util = "0.7.13"
+tempfile = "3.18.0"
+tokio = { version = "1.44.1", features = ["full"] }
+tokio-util = "0.7.14"
 toml = "0.8.20"
+toml_edit = { version = "0.22.24", features = ["serde"] }
 tower-lsp = "0.20.0"
 tracing = "0.1.41"
 tracing-indicatif = "0.3.9"
@@ -75,7 +77,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = "2.5.4"
 urlencoding = "2.1.3"
-uuid = "1.13.1"
+uuid = "1.15.1"
 walkdir = "2.5.0"
 
 [workspace.lints.rust]
@@ -83,27 +85,7 @@ missing_docs = "warn"
 nonstandard-style = "warn"
 rust-2018-idioms = "warn"
 rust-2021-compatibility = "warn"
-
-# Re-enable this lint and remove the group expansion lints after auditing remaining diagnostics as we get closer to the 2024 release
-# rust-2024-compatibility = "warn"
-# <expansion>
-boxed-slice-into-iter = "warn"
-dependency-on-unit-never-type-fallback = "warn"
-deprecated-safe-2024 = "warn"
-edition-2024-expr-fragment-specifier = "allow"  # Reason: the few macros where we use the `expr` fragment will not break with the new expressions
-if-let-rescope = "allow"                        # Reason: lint is too noisy and we are unlikely to have drop order dependencies
-impl-trait-overcaptures = "warn"
-keyword-idents-2024 = "warn"
-missing-unsafe-on-extern = "warn"
-never-type-fallback-flowing-into-unsafe = "warn"
-rust-2024-guarded-string-incompatible-syntax = "warn"
-rust-2024-incompatible-pat = "warn"
-rust-2024-prelude-collisions = "warn"
-static-mut-refs = "warn"
-tail-expr-drop-order = "allow"                  # Reason: lint is too noisy and we are unlikely to have drop order dependencies
-unsafe-attr-outside-unsafe = "warn"
-unsafe-op-in-unsafe-fn  = "warn"
-# </expansion>
+rust-2024-compatibility = "warn"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "warn"

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -10,12 +10,12 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-chrono = "0.4.39"
+chrono.workspace = true
 tokio.workspace = true
 clap.workspace = true
 reqwest.workspace = true
 toml.workspace = true
-toml_edit = { version = "0.22.23", features = ["serde"] }
+toml_edit.workspace = true
 
 [lints]
 workspace = true

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * `Document` is now trivially cloned ([#320](https://github.com/stjude-rust-labs/wdl/pull/320)).
 * The task evaluation graph now forms implicit edges between the command and
   other nodes in the graph; the command now always depends on an input even if

--- a/wdl-analysis/src/graph.rs
+++ b/wdl-analysis/src/graph.rs
@@ -422,14 +422,15 @@ pub struct DocumentGraph {
 impl DocumentGraph {
     /// Add a node to the document graph.
     pub fn add_node(&mut self, uri: Url, rooted: bool) -> NodeIndex {
-        let index = if let Some(index) = self.indexes.get(&uri) {
-            *index
-        } else {
-            debug!("inserting `{uri}` into the document graph");
-            let uri = Arc::new(uri);
-            let index = self.inner.add_node(DocumentGraphNode::new(uri.clone()));
-            self.indexes.insert(uri, index);
-            index
+        let index = match self.indexes.get(&uri) {
+            Some(index) => *index,
+            _ => {
+                debug!("inserting `{uri}` into the document graph");
+                let uri = Arc::new(uri);
+                let index = self.inner.add_node(DocumentGraphNode::new(uri.clone()));
+                self.indexes.insert(uri, index);
+                index
+            }
         };
 
         if rooted {

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * Refactored whitespace counting out of `strip_whitespace` into `count_whitespace` method ([#317](https://github.com/stjude-rust-labs/wdl/pull/317)).
 
 ## 0.10.0 - 01-17-2025

--- a/wdl-doc/CHANGELOG.md
+++ b/wdl-doc/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * `wdl-doc` crate is now implemented using a `DocsTree` struct which simplifies
   the API of doc generation ([#262](https://github.com/stjude-rust-labs/wdl/pull/262)).
 

--- a/wdl-doc/src/callable/task.rs
+++ b/wdl-doc/src/callable/task.rs
@@ -37,25 +37,21 @@ impl Task {
         output_section: Option<OutputSection>,
         runtime_section: Option<RuntimeSection>,
     ) -> Self {
-        let meta = if let Some(mds) = meta_section {
-            parse_meta(&mds)
-        } else {
-            MetaMap::default()
+        let meta = match meta_section {
+            Some(mds) => parse_meta(&mds),
+            _ => MetaMap::default(),
         };
-        let parameter_meta = if let Some(pmds) = parameter_meta {
-            parse_parameter_meta(&pmds)
-        } else {
-            MetaMap::default()
+        let parameter_meta = match parameter_meta {
+            Some(pmds) => parse_parameter_meta(&pmds),
+            _ => MetaMap::default(),
         };
-        let inputs = if let Some(is) = input_section {
-            parse_inputs(&is, &parameter_meta)
-        } else {
-            Vec::new()
+        let inputs = match input_section {
+            Some(is) => parse_inputs(&is, &parameter_meta),
+            _ => Vec::new(),
         };
-        let outputs = if let Some(os) = output_section {
-            parse_outputs(&os, &meta, &parameter_meta)
-        } else {
-            Vec::new()
+        let outputs = match output_section {
+            Some(os) => parse_outputs(&os, &meta, &parameter_meta),
+            _ => Vec::new(),
         };
 
         Self {
@@ -91,26 +87,29 @@ impl Task {
 
     /// Render the rutime section of the task as HTML.
     pub fn render_runtime_section(&self) -> Markup {
-        if let Some(runtime_section) = &self.runtime_section {
-            html! {
-                h2 { "Default Runtime Attributes" }
-                table class="border" {
-                    thead class="border" { tr {
-                        th { "Attribute" }
-                        th { "Value" }
-                    }}
-                    tbody class="border" {
-                        @for entry in runtime_section.items() {
-                            tr class="border" {
-                                td class="border" { code { (entry.name().as_str()) } }
-                                td class="border" { code { (entry.expr().syntax().to_string()) } }
+        match &self.runtime_section {
+            Some(runtime_section) => {
+                html! {
+                    h2 { "Default Runtime Attributes" }
+                    table class="border" {
+                        thead class="border" { tr {
+                            th { "Attribute" }
+                            th { "Value" }
+                        }}
+                        tbody class="border" {
+                            @for entry in runtime_section.items() {
+                                tr class="border" {
+                                    td class="border" { code { (entry.name().as_str()) } }
+                                    td class="border" { code { (entry.expr().syntax().to_string()) } }
+                                }
                             }
                         }
                     }
                 }
             }
-        } else {
-            html! {}
+            _ => {
+                html! {}
+            }
         }
     }
 

--- a/wdl-doc/src/callable/workflow.rs
+++ b/wdl-doc/src/callable/workflow.rs
@@ -34,25 +34,21 @@ impl Workflow {
         input_section: Option<InputSection>,
         output_section: Option<OutputSection>,
     ) -> Self {
-        let meta = if let Some(mds) = meta_section {
-            parse_meta(&mds)
-        } else {
-            MetaMap::default()
+        let meta = match meta_section {
+            Some(mds) => parse_meta(&mds),
+            _ => MetaMap::default(),
         };
-        let parameter_meta = if let Some(pmds) = parameter_meta {
-            parse_parameter_meta(&pmds)
-        } else {
-            MetaMap::default()
+        let parameter_meta = match parameter_meta {
+            Some(pmds) => parse_parameter_meta(&pmds),
+            _ => MetaMap::default(),
         };
-        let inputs = if let Some(is) = input_section {
-            parse_inputs(&is, &parameter_meta)
-        } else {
-            Vec::new()
+        let inputs = match input_section {
+            Some(is) => parse_inputs(&is, &parameter_meta),
+            _ => Vec::new(),
         };
-        let outputs = if let Some(os) = output_section {
-            parse_outputs(&os, &meta, &parameter_meta)
-        } else {
-            Vec::new()
+        let outputs = match output_section {
+            Some(os) => parse_outputs(&os, &meta, &parameter_meta),
+            _ => Vec::new(),
         };
 
         Self {

--- a/wdl-doc/src/docs_tree.rs
+++ b/wdl-doc/src/docs_tree.rs
@@ -257,17 +257,20 @@ impl DocsTree {
             div class="top-0 left-0 h-full w-1/6 dark:bg-slate-950 dark:text-white" {
                 h1 class="text-2xl text-center" { "Sidebar" }
                 @for node in nodes {
-                    @if let Some(page) = node.page() {
-                        @match page.page_type() {
-                            PageType::Index(_) => {
-                                p { a href=(diff_paths(node.path().join("index.html"), base).unwrap().to_string_lossy()) { (page.name()) } }
-                            }
-                            _ => {
-                                p { a href=(diff_paths(node.path(), base).unwrap().to_string_lossy()) { (page.name()) } }
+                    @match node.page() {
+                        Some(page) => {
+                            @match page.page_type() {
+                                PageType::Index(_) => {
+                                    p { a href=(diff_paths(node.path().join("index.html"), base).unwrap().to_string_lossy()) { (page.name()) } }
+                                }
+                                _ => {
+                                    p { a href=(diff_paths(node.path(), base).unwrap().to_string_lossy()) { (page.name()) } }
+                                }
                             }
                         }
-                    } @else {
-                        p class="" { (node.name()) }
+                        None => {
+                            p class="" { (node.name()) }
+                        }
                     }
                 }
             }

--- a/wdl-doc/src/parameter.rs
+++ b/wdl-doc/src/parameter.rs
@@ -63,13 +63,10 @@ impl Parameter {
     /// Returns `None` for outputs.
     pub fn required(&self) -> Option<bool> {
         match self.io {
-            InputOutput::Input => {
-                if let Some(d) = self.decl.as_unbound_decl() {
-                    Some(!d.ty().is_optional())
-                } else {
-                    Some(false)
-                }
-            }
+            InputOutput::Input => match self.decl.as_unbound_decl() {
+                Some(d) => Some(!d.ty().is_optional()),
+                _ => Some(false),
+            },
             InputOutput::Output => None,
         }
     }

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * Docker backend is now the default backend (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Refactored a common task management implementation to use in task execution
   backends (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).

--- a/wdl-engine/src/eval/v1/expr.rs
+++ b/wdl-engine/src/eval/v1/expr.rs
@@ -313,10 +313,11 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                 }
                 Value::Primitive(PrimitiveValue::File(path))
                 | Value::Primitive(PrimitiveValue::Directory(path)) => {
-                    if let Some(path) = evaluator.context.translate_path(Path::new(path.as_str())) {
-                        write!(buffer, "{path}", path = path.display()).unwrap()
-                    } else {
-                        write!(buffer, "{path}").unwrap();
+                    match evaluator.context.translate_path(Path::new(path.as_str())) {
+                        Some(path) => write!(buffer, "{path}", path = path.display()).unwrap(),
+                        _ => {
+                            write!(buffer, "{path}").unwrap();
+                        }
                     }
                 }
                 Value::Primitive(v) => write!(buffer, "{v}", v = v.raw()).unwrap(),
@@ -386,25 +387,28 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
         }
 
         let mut s = String::new();
-        if let Some(parts) = expr.strip_whitespace() {
-            for part in parts {
-                match part {
-                    StrippedStringPart::Text(t) => {
-                        s.push_str(&t);
-                    }
-                    StrippedStringPart::Placeholder(placeholder) => {
-                        self.evaluate_placeholder(&placeholder, &mut s)?;
+        match expr.strip_whitespace() {
+            Some(parts) => {
+                for part in parts {
+                    match part {
+                        StrippedStringPart::Text(t) => {
+                            s.push_str(&t);
+                        }
+                        StrippedStringPart::Placeholder(placeholder) => {
+                            self.evaluate_placeholder(&placeholder, &mut s)?;
+                        }
                     }
                 }
             }
-        } else {
-            for part in expr.parts() {
-                match part {
-                    StringPart::Text(t) => {
-                        t.unescape_to(&mut s);
-                    }
-                    StringPart::Placeholder(placeholder) => {
-                        self.evaluate_placeholder(&placeholder, &mut s)?;
+            _ => {
+                for part in expr.parts() {
+                    match part {
+                        StringPart::Text(t) => {
+                            t.unescape_to(&mut s);
+                        }
+                        StringPart::Placeholder(placeholder) => {
+                            self.evaluate_placeholder(&placeholder, &mut s)?;
+                        }
                     }
                 }
             }
@@ -431,16 +435,19 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                     let value = self.evaluate_expr(&expr)?;
                     let actual = value.ty();
 
-                    if let Some(ty) = expected.common_type(&actual) {
-                        expected = ty;
-                        expected_span = expr.span();
-                    } else {
-                        return Err(no_common_type(
-                            &expected,
-                            expected_span,
-                            &actual,
-                            expr.span(),
-                        ));
+                    match expected.common_type(&actual) {
+                        Some(ty) => {
+                            expected = ty;
+                            expected_span = expr.span();
+                        }
+                        _ => {
+                            return Err(no_common_type(
+                                &expected,
+                                expected_span,
+                                &actual,
+                                expr.span(),
+                            ));
+                        }
                     }
 
                     values.push(value);
@@ -501,30 +508,36 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                     let actual_value = self.evaluate_expr(&value)?;
                     let actual_value_ty = actual_value.ty();
 
-                    if let Some(ty) = expected_key_ty.common_type(&actual_key_ty) {
-                        expected_key_ty = ty;
-                        expected_key_span = key.span();
-                    } else {
-                        // No common key type
-                        return Err(no_common_type(
-                            &expected_key_ty,
-                            expected_key_span,
-                            &actual_key_ty,
-                            key.span(),
-                        ));
+                    match expected_key_ty.common_type(&actual_key_ty) {
+                        Some(ty) => {
+                            expected_key_ty = ty;
+                            expected_key_span = key.span();
+                        }
+                        _ => {
+                            // No common key type
+                            return Err(no_common_type(
+                                &expected_key_ty,
+                                expected_key_span,
+                                &actual_key_ty,
+                                key.span(),
+                            ));
+                        }
                     }
 
-                    if let Some(ty) = expected_value_ty.common_type(&actual_value_ty) {
-                        expected_value_ty = ty;
-                        expected_value_span = value.span();
-                    } else {
-                        // No common value type
-                        return Err(no_common_type(
-                            &expected_value_ty,
-                            expected_value_span,
-                            &actual_value_ty,
-                            value.span(),
-                        ));
+                    match expected_value_ty.common_type(&actual_value_ty) {
+                        Some(ty) => {
+                            expected_value_ty = ty;
+                            expected_value_span = value.span();
+                        }
+                        _ => {
+                            // No common value type
+                            return Err(no_common_type(
+                                &expected_value_ty,
+                                expected_value_span,
+                                &actual_value_ty,
+                                value.span(),
+                            ));
+                        }
                     }
 
                     let key = match actual_key {
@@ -569,16 +582,19 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
         let mut members = IndexMap::with_capacity(struct_ty.members().len());
         for item in expr.items() {
             let (n, v) = item.name_value();
-            if let Some(expected) = struct_ty.members().get(n.as_str()) {
-                let value = self.evaluate_expr(&v)?;
-                let value = value.coerce(expected).map_err(|e| {
-                    runtime_type_mismatch(e, expected, n.span(), &value.ty(), v.span())
-                })?;
+            match struct_ty.members().get(n.as_str()) {
+                Some(expected) => {
+                    let value = self.evaluate_expr(&v)?;
+                    let value = value.coerce(expected).map_err(|e| {
+                        runtime_type_mismatch(e, expected, n.span(), &value.ty(), v.span())
+                    })?;
 
-                members.insert(n.as_str().to_string(), value);
-            } else {
-                // Not a struct member
-                return Err(not_a_struct_member(name.as_str(), &n));
+                    members.insert(n.as_str().to_string(), value);
+                }
+                _ => {
+                    // Not a struct member
+                    return Err(not_a_struct_member(name.as_str(), &n));
+                }
             }
         }
 
@@ -651,15 +667,18 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
     ) -> Result<Value, Diagnostic> {
         let value = self.evaluate_expr(expr)?;
         if let Some(expected) = task_hint_types(self.context.version(), name.as_str(), true) {
-            if let Some(value) = expected.iter().find_map(|ty| value.coerce(ty).ok()) {
-                return Ok(value);
-            } else {
-                return Err(multiple_type_mismatch(
-                    expected,
-                    name.span(),
-                    &value.ty(),
-                    expr.span(),
-                ));
+            match expected.iter().find_map(|ty| value.coerce(ty).ok()) {
+                Some(value) => {
+                    return Ok(value);
+                }
+                _ => {
+                    return Err(multiple_type_mismatch(
+                        expected,
+                        name.span(),
+                        &value.ty(),
+                        expr.span(),
+                    ));
+                }
             }
         }
 

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -35,10 +35,11 @@ fn join_paths(
     ty: impl Fn(&str) -> Option<Type>,
 ) -> Result<()> {
     for (name, value) in inputs.iter_mut() {
-        let ty = if let Some(ty) = ty(name) {
-            ty
-        } else {
-            continue;
+        let ty = match ty(name) {
+            Some(ty) => ty,
+            _ => {
+                continue;
+            }
         };
 
         // Replace the value with `None` temporarily

--- a/wdl-engine/src/stdlib.rs
+++ b/wdl-engine/src/stdlib.rs
@@ -314,10 +314,9 @@ mod test {
                             1,
                             "signature count mismatch for function `{name}`"
                         );
+                        let params = TypeParameters::new(f.signature().type_parameters());
                         assert_eq!(
-                            f.signature()
-                                .display(&TypeParameters::new(f.signature().type_parameters()))
-                                .to_string(),
+                            f.signature().display(&params).to_string(),
                             imp.signatures[0].display,
                             "signature mismatch for function `{name}`"
                         );
@@ -329,9 +328,9 @@ mod test {
                             "signature count mismatch for function `{name}`"
                         );
                         for (i, sig) in f.signatures().iter().enumerate() {
+                            let params = TypeParameters::new(sig.type_parameters());
                             assert_eq!(
-                                sig.display(&TypeParameters::new(sig.type_parameters()))
-                                    .to_string(),
+                                sig.display(&params).to_string(),
                                 imp.signatures[i].display,
                                 "signature mismatch for function `{name}` (index {i})"
                             );

--- a/wdl-engine/src/value.rs
+++ b/wdl-engine/src/value.rs
@@ -1126,10 +1126,9 @@ impl PrimitiveValue {
     ) -> Result<bool> {
         match self {
             PrimitiveValue::File(p) => {
-                let path = if let Some(p) = translate(Path::new(p.as_str()))? {
-                    path.join(p)
-                } else {
-                    path.join(p.as_str())
+                let path = match translate(Path::new(p.as_str()))? {
+                    Some(p) => path.join(p),
+                    _ => path.join(p.as_str()),
                 };
 
                 if let Ok(path) = path.into_os_string().into_string() {
@@ -1145,10 +1144,9 @@ impl PrimitiveValue {
                 }
             }
             PrimitiveValue::Directory(p) => {
-                let path = if let Some(p) = translate(Path::new(p.as_str()))? {
-                    path.join(p)
-                } else {
-                    path.join(p.as_str())
+                let path = match translate(Path::new(p.as_str()))? {
+                    Some(p) => path.join(p),
+                    _ => path.join(p.as_str()),
                 };
 
                 if let Ok(path) = path.into_os_string().into_string() {

--- a/wdl-format/CHANGELOG.md
+++ b/wdl-format/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
+
 ## 0.4.0 - 01-17-2025
 
 ### Added

--- a/wdl-format/src/lib.rs
+++ b/wdl-format/src/lib.rs
@@ -31,7 +31,7 @@ pub const TAB: &str = "\t";
 /// [`Vec`]).
 #[macro_export]
 macro_rules! exactly_one {
-    ($entities:expr, $name:expr) => {
+    ($entities:expr_2021, $name:expr_2021) => {
         match $entities.len() {
             0 => unreachable!("we should never have zero {}", $name),
             // SAFETY: we just checked to ensure that exactly

--- a/wdl-format/src/v1/task.rs
+++ b/wdl-format/src/v1/task.rs
@@ -118,12 +118,17 @@ pub fn format_task_definition(element: &FormatElement, stream: &mut TokenStream<
         stream.blank_line();
     }
 
-    if let Some(requirements) = requirements {
-        (&requirements).write(stream);
-        stream.blank_line();
-    } else if let Some(runtime) = runtime {
-        (&runtime).write(stream);
-        stream.blank_line();
+    match requirements {
+        Some(requirements) => {
+            (&requirements).write(stream);
+            stream.blank_line();
+        }
+        _ => {
+            if let Some(runtime) = runtime {
+                (&runtime).write(stream);
+                stream.blank_line();
+            }
+        }
     }
 
     if let Some(hints) = hints {

--- a/wdl-format/src/v1/workflow.rs
+++ b/wdl-format/src/v1/workflow.rs
@@ -230,10 +230,13 @@ pub fn format_workflow_hints_array(element: &FormatElement, stream: &mut TokenSt
     let mut commas = commas.into_iter();
     for item in items {
         (&item).write(stream);
-        if let Some(comma) = commas.next() {
-            (&comma).write(stream);
-        } else {
-            stream.push_literal(",".to_string(), SyntaxKind::Comma);
+        match commas.next() {
+            Some(comma) => {
+                (&comma).write(stream);
+            }
+            _ => {
+                stream.push_literal(",".to_string(), SyntaxKind::Comma);
+            }
         }
         stream.end_line();
     }

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
+
 ## 0.11.0 - 01-17-2025
 
 ### Added

--- a/wdl-grammar/Cargo.toml
+++ b/wdl-grammar/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/wdl-grammar"
 itertools = { workspace = true }
 logos = { workspace = true }
 rowan = { workspace = true }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 codespan-reporting = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/wdl-grammar/src/grammar.rs
+++ b/wdl-grammar/src/grammar.rs
@@ -18,12 +18,12 @@ mod macros {
     ///
     /// Returns a diagnostic if the token is not the specified token.
     macro_rules! expected {
-        ($parser:ident, $marker:ident, $token:expr) => {
+        ($parser:ident, $marker:ident, $token:expr_2021) => {
             if let Err(e) = $parser.expect($token) {
                 return Err(($marker, e));
             }
         };
-        ($parser:ident, $marker:ident, $token:expr, $name:literal) => {
+        ($parser:ident, $marker:ident, $token:expr_2021, $name:literal) => {
             if let Err(e) = $parser.expect_with_name($token, $name) {
                 return Err(($marker, e));
             }

--- a/wdl-grammar/src/grammar/v1.rs
+++ b/wdl-grammar/src/grammar/v1.rs
@@ -351,7 +351,7 @@ const ANY_IDENT: TokenSet = TokenSet::new(&[
 /// Parses matching braces given a callback to parse the interior delimited
 /// items.
 macro_rules! braced_items {
-    ($parser:ident, $marker:ident, $delimiter:expr, $recovery:expr, $cb:expr) => {
+    ($parser:ident, $marker:ident, $delimiter:expr_2021, $recovery:expr_2021, $cb:expr_2021) => {
         if let Err(e) = $parser.matching_delimited(
             Token::OpenBrace,
             Token::CloseBrace,
@@ -367,7 +367,7 @@ macro_rules! braced_items {
 /// Parses matching brackets given a callback to parse the interior delimited
 /// items.
 macro_rules! bracketed_items {
-    ($parser:ident, $marker:ident, $delimiter:expr, $recovery:expr, $cb:expr) => {
+    ($parser:ident, $marker:ident, $delimiter:expr_2021, $recovery:expr_2021, $cb:expr_2021) => {
         if let Err(e) = $parser.matching_delimited(
             Token::OpenBracket,
             Token::CloseBracket,
@@ -383,7 +383,7 @@ macro_rules! bracketed_items {
 /// Parses matching parens given a callback to parse the interior delimited
 /// items.
 macro_rules! paren_items {
-    ($parser:ident, $marker:ident, $delimiter:expr, $recovery:expr, $cb:expr) => {
+    ($parser:ident, $marker:ident, $delimiter:expr_2021, $recovery:expr_2021, $cb:expr_2021) => {
         if let Err(e) = $parser.matching_delimited(
             Token::OpenParen,
             Token::CloseParen,
@@ -398,7 +398,7 @@ macro_rules! paren_items {
 
 /// Parses matching brackets given a callback to parse the interior.
 macro_rules! bracketed {
-    ($parser:ident, $marker:ident, $cb:expr) => {
+    ($parser:ident, $marker:ident, $cb:expr_2021) => {
         if let Err(e) = $parser.matching(Token::OpenBracket, Token::CloseBracket, false, $cb) {
             return Err(($marker, e));
         }
@@ -407,7 +407,7 @@ macro_rules! bracketed {
 
 /// Parses matching parenthesis given a callback to parse the interior.
 macro_rules! paren {
-    ($parser:ident, $marker:ident, $cb:expr) => {
+    ($parser:ident, $marker:ident, $cb:expr_2021) => {
         if let Err(e) = $parser.matching(Token::OpenParen, Token::CloseParen, false, $cb) {
             return Err(($marker, e));
         }

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,22 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-
 ### Added
 
 * Added suggestion for similar rule names when encountering unknown lint rules ([#334](https://github.com/stjude-rust-labs/wdl/pull/334)).
 
 ### Changed
 
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
+* Relaxed `CommentWhitespace` rule so that it doesn't fire when a comment has extra spaces before it ([#314](https://github.com/stjude-rust-labs/wdl/pull/314)).
 * `fix` messages suggest the correct order of imports to the user in `ImportSort` rule ([#332](https://github.com/stjude-rust-labs/wdl/pull/332)).
 
 ### Fixed
 
 * Fixed misplacement of highlighted spans for some ShellCheck lints ([#317](https://github.com/stjude-rust-labs/wdl/pull/317)).
-
-### Changed
-
-* Relaxed `CommentWhitespace` rule so that it doesn't fire when a comment has extra spaces before it ([#314](https://github.com/stjude-rust-labs/wdl/pull/314)).
 
 ## 0.9.0 - 01-17-2025
 

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -266,14 +266,17 @@ impl Visitor for ExpressionSpacingRule {
                 let mut prev = expr.syntax().prev_sibling_or_token();
                 if prev.is_none() {
                     // No prior elements, so we need to go up a level.
-                    if let Some(parent) = expr.syntax().parent() {
-                        if let Some(parent_prev) = parent.prev_sibling_or_token() {
-                            prev = Some(parent_prev);
+                    match expr.syntax().parent() {
+                        Some(parent) => {
+                            if let Some(parent_prev) = parent.prev_sibling_or_token() {
+                                prev = Some(parent_prev);
+                            }
                         }
-                    } else {
-                        unreachable!(
-                            "parenthesized expression should have a prior sibling or a parent"
-                        );
+                        _ => {
+                            unreachable!(
+                                "parenthesized expression should have a prior sibling or a parent"
+                            );
+                        }
                     }
                 }
 

--- a/wdl-lint/src/rules/key_value_pairs.rs
+++ b/wdl-lint/src/rules/key_value_pairs.rs
@@ -178,10 +178,9 @@ impl Visitor for KeyValuePairsRule {
             if next_newline.is_none() {
                 // No newline found, report missing
                 let s = child.span();
-                let end = if let Some(next) = find_next_comma(child.syntax()).0 {
-                    next.text_range().end()
-                } else {
-                    close_delim.text_range().start()
+                let end = match find_next_comma(child.syntax()).0 {
+                    Some(next) => next.text_range().end(),
+                    _ => close_delim.text_range().start(),
                 };
                 state.exceptable_add(
                     missing_trailing_newline(Span::new(s.start(), usize::from(end) - s.start())),
@@ -299,10 +298,9 @@ impl Visitor for KeyValuePairsRule {
             if next_newline.is_none() {
                 // No newline found, report missing
                 let s = child.span();
-                let end = if let Some(next) = find_next_comma(child.syntax()).0 {
-                    next.text_range().end()
-                } else {
-                    close_delim.text_range().start()
+                let end = match find_next_comma(child.syntax()).0 {
+                    Some(next) => next.text_range().end(),
+                    _ => close_delim.text_range().start(),
                 };
                 state.exceptable_add(
                     missing_trailing_newline(Span::new(s.start(), usize::from(end) - s.start())),

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -104,28 +104,33 @@ impl Visitor for MissingRequirementsRule {
         // version, the `runtime` section was recommended.
         if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here") {
             if minor_version >= V1::Two {
-                if let Some(runtime) = task.runtime() {
-                    let name = task.name();
-                    state.exceptable_add(
-                        deprecated_runtime_section(
-                            name.as_str(),
-                            runtime
-                                .syntax()
-                                .first_token()
-                                .expect("runtime section should have tokens")
-                                .text_range()
-                                .to_span(),
-                        ),
-                        SyntaxElement::from(runtime.syntax().clone()),
-                        &self.exceptable_nodes(),
-                    );
-                } else if task.requirements().is_none() {
-                    let name = task.name();
-                    state.exceptable_add(
-                        missing_requirements_section(name.as_str(), name.span()),
-                        SyntaxElement::from(task.syntax().clone()),
-                        &self.exceptable_nodes(),
-                    );
+                match task.runtime() {
+                    Some(runtime) => {
+                        let name = task.name();
+                        state.exceptable_add(
+                            deprecated_runtime_section(
+                                name.as_str(),
+                                runtime
+                                    .syntax()
+                                    .first_token()
+                                    .expect("runtime section should have tokens")
+                                    .text_range()
+                                    .to_span(),
+                            ),
+                            SyntaxElement::from(runtime.syntax().clone()),
+                            &self.exceptable_nodes(),
+                        );
+                    }
+                    _ => {
+                        if task.requirements().is_none() {
+                            let name = task.name();
+                            state.exceptable_add(
+                                missing_requirements_section(name.as_str(), name.span()),
+                                SyntaxElement::from(task.syntax().clone()),
+                                &self.exceptable_nodes(),
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -241,7 +241,7 @@ impl Visitor for PreambleFormattingRule {
                         return;
                     }
                     (_, _, false, false) => {
-                        // anything followed by invalid comment
+                        // Anything followed by invalid comment
                         // Handled by comment visitor
                         return;
                     }

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -198,110 +198,113 @@ impl Visitor for PreambleFormattingRule {
 
         let s = whitespace.as_str();
         // If there is a previous token, it must be a comment
-        if let Some(prev_comment) = whitespace.syntax().prev_token() {
-            let prev_text = prev_comment.text();
-            let prev_is_lint_directive = is_lint_directive(prev_text);
-            let prev_is_preamble_comment = is_preamble_comment(prev_text);
+        match whitespace.syntax().prev_token() {
+            Some(prev_comment) => {
+                let prev_text = prev_comment.text();
+                let prev_is_lint_directive = is_lint_directive(prev_text);
+                let prev_is_preamble_comment = is_preamble_comment(prev_text);
 
-            let next_token = whitespace
-                .syntax()
-                .next_token()
-                .expect("should have a next token");
-            assert!(
-                next_token.kind() == SyntaxKind::Comment,
-                "next token should be a comment"
-            );
+                let next_token = whitespace
+                    .syntax()
+                    .next_token()
+                    .expect("should have a next token");
+                assert!(
+                    next_token.kind() == SyntaxKind::Comment,
+                    "next token should be a comment"
+                );
 
-            let next_text = next_token.text();
-            let next_is_lint_directive = is_lint_directive(next_text);
-            let next_is_preamble_comment = is_preamble_comment(next_text);
+                let next_text = next_token.text();
+                let next_is_lint_directive = is_lint_directive(next_text);
+                let next_is_preamble_comment = is_preamble_comment(next_text);
 
-            let expect_single_blank = match (
-                prev_is_lint_directive,
-                prev_is_preamble_comment,
-                next_is_lint_directive,
-                next_is_preamble_comment,
-            ) {
-                (true, false, true, false) => {
-                    // Lint directive followed by lint directive
-                    false
-                }
-                (true, false, false, true) => {
-                    // Lint directive followed by preamble comment
-                    true
-                }
-                (false, true, false, true) => {
-                    // Preamble comment followed by preamble comment
-                    false
-                }
-                (false, true, true, false) => {
-                    // Preamble comment followed by lint directive
-                    // Handled by comment visitor
-                    return;
-                }
-                (_, _, false, false) => {
-                    // anything followed by invalid comment
-                    // Handled by comment visitor
-                    return;
-                }
-                (false, false, ..) => {
-                    // Invalid comment followed by anything
-                    // Handled by comment visitor
-                    return;
-                }
-                _ => {
-                    unreachable!()
-                }
-            };
-
-            let span = whitespace.span();
-            if expect_single_blank {
-                if s != "\r\n\r\n" && s != "\n\n" {
-                    // There's a special case where the blank line has extra whitespace
-                    // but that doesn't appear in the printed diagnostic.
-                    let mut diagnostic = expected_blank_line_before_preamble_comment(span);
-
-                    if s.chars().filter(|&c| c == '\n').count() == 2 {
-                        for (line, start, end) in lines_with_offset(s) {
-                            if !line.is_empty() {
-                                let end_offset = if s.ends_with("\r\n") {
-                                    2
-                                } else if s.ends_with('\n') {
-                                    1
-                                } else {
-                                    0
-                                };
-
-                                diagnostic = diagnostic.with_highlight(Span::new(
-                                    span.start() + start,
-                                    end - start - end_offset,
-                                ));
-                            }
-                        }
+                let expect_single_blank = match (
+                    prev_is_lint_directive,
+                    prev_is_preamble_comment,
+                    next_is_lint_directive,
+                    next_is_preamble_comment,
+                ) {
+                    (true, false, true, false) => {
+                        // Lint directive followed by lint directive
+                        false
                     }
-                    state.add(diagnostic);
-                }
-            } else if s != "\r\n" && s != "\n" {
-                // Don't include the newline separating the previous comment from the
-                // leading whitespace
-                let offset = if s.starts_with("\r\n") {
-                    2
-                } else if s.starts_with('\n') {
-                    1
-                } else {
-                    0
+                    (true, false, false, true) => {
+                        // Lint directive followed by preamble comment
+                        true
+                    }
+                    (false, true, false, true) => {
+                        // Preamble comment followed by preamble comment
+                        false
+                    }
+                    (false, true, true, false) => {
+                        // Preamble comment followed by lint directive
+                        // Handled by comment visitor
+                        return;
+                    }
+                    (_, _, false, false) => {
+                        // anything followed by invalid comment
+                        // Handled by comment visitor
+                        return;
+                    }
+                    (false, false, ..) => {
+                        // Invalid comment followed by anything
+                        // Handled by comment visitor
+                        return;
+                    }
+                    _ => {
+                        unreachable!()
+                    }
                 };
 
-                state.add(leading_whitespace(Span::new(
-                    span.start() + offset,
-                    span.len() - offset,
-                )));
-            } else {
-                return;
+                let span = whitespace.span();
+                if expect_single_blank {
+                    if s != "\r\n\r\n" && s != "\n\n" {
+                        // There's a special case where the blank line has extra whitespace
+                        // but that doesn't appear in the printed diagnostic.
+                        let mut diagnostic = expected_blank_line_before_preamble_comment(span);
+
+                        if s.chars().filter(|&c| c == '\n').count() == 2 {
+                            for (line, start, end) in lines_with_offset(s) {
+                                if !line.is_empty() {
+                                    let end_offset = if s.ends_with("\r\n") {
+                                        2
+                                    } else if s.ends_with('\n') {
+                                        1
+                                    } else {
+                                        0
+                                    };
+
+                                    diagnostic = diagnostic.with_highlight(Span::new(
+                                        span.start() + start,
+                                        end - start - end_offset,
+                                    ));
+                                }
+                            }
+                        }
+                        state.add(diagnostic);
+                    }
+                } else if s != "\r\n" && s != "\n" {
+                    // Don't include the newline separating the previous comment from the
+                    // leading whitespace
+                    let offset = if s.starts_with("\r\n") {
+                        2
+                    } else if s.starts_with('\n') {
+                        1
+                    } else {
+                        0
+                    };
+
+                    state.add(leading_whitespace(Span::new(
+                        span.start() + offset,
+                        span.len() - offset,
+                    )));
+                } else {
+                    return;
+                }
             }
-        } else {
-            // Whitespace is not allowed to start the document.
-            state.add(leading_whitespace(whitespace.span()));
+            _ => {
+                // Whitespace is not allowed to start the document.
+                state.add(leading_whitespace(whitespace.span()));
+            }
         }
     }
 

--- a/wdl-lint/src/rules/trailing_comma.rs
+++ b/wdl-lint/src/rules/trailing_comma.rs
@@ -115,34 +115,37 @@ impl Visitor for TrailingCommaRule {
             let last_child = item.items().last();
             if let Some(last_child) = last_child {
                 let (next_comma, comma_is_next) = find_next_comma(last_child.syntax());
-                if let Some(comma) = next_comma {
-                    if !comma_is_next {
-                        // Comma found, but not next, extraneous trivia
+                match next_comma {
+                    Some(comma) => {
+                        if !comma_is_next {
+                            // Comma found, but not next, extraneous trivia
+                            state.exceptable_add(
+                                extraneous_content(Span::new(
+                                    last_child.syntax().text_range().end().into(),
+                                    (comma.text_range().start()
+                                        - last_child.syntax().text_range().end())
+                                    .into(),
+                                )),
+                                SyntaxElement::from(item.syntax().clone()),
+                                &self.exceptable_nodes(),
+                            );
+                        }
+                    }
+                    _ => {
+                        // No comma found, report missing
                         state.exceptable_add(
-                            extraneous_content(Span::new(
-                                last_child.syntax().text_range().end().into(),
-                                (comma.text_range().start()
-                                    - last_child.syntax().text_range().end())
-                                .into(),
-                            )),
+                            missing_trailing_comma(
+                                last_child
+                                    .syntax()
+                                    .last_token()
+                                    .expect("object should have tokens")
+                                    .text_range()
+                                    .to_span(),
+                            ),
                             SyntaxElement::from(item.syntax().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
-                } else {
-                    // No comma found, report missing
-                    state.exceptable_add(
-                        missing_trailing_comma(
-                            last_child
-                                .syntax()
-                                .last_token()
-                                .expect("object should have tokens")
-                                .text_range()
-                                .to_span(),
-                        ),
-                        SyntaxElement::from(item.syntax().clone()),
-                        &self.exceptable_nodes(),
-                    );
                 }
             }
         }
@@ -163,34 +166,37 @@ impl Visitor for TrailingCommaRule {
             let last_child = item.elements().last();
             if let Some(last_child) = last_child {
                 let (next_comma, comma_is_next) = find_next_comma(last_child.syntax());
-                if let Some(comma) = next_comma {
-                    if !comma_is_next {
-                        // Comma found, but not next, extraneous trivia
+                match next_comma {
+                    Some(comma) => {
+                        if !comma_is_next {
+                            // Comma found, but not next, extraneous trivia
+                            state.exceptable_add(
+                                extraneous_content(Span::new(
+                                    last_child.syntax().text_range().end().into(),
+                                    (comma.text_range().start()
+                                        - last_child.syntax().text_range().end())
+                                    .into(),
+                                )),
+                                SyntaxElement::from(item.syntax().clone()),
+                                &self.exceptable_nodes(),
+                            );
+                        }
+                    }
+                    _ => {
+                        // No comma found, report missing
                         state.exceptable_add(
-                            extraneous_content(Span::new(
-                                last_child.syntax().text_range().end().into(),
-                                (comma.text_range().start()
-                                    - last_child.syntax().text_range().end())
-                                .into(),
-                            )),
+                            missing_trailing_comma(
+                                last_child
+                                    .syntax()
+                                    .last_token()
+                                    .expect("array should have tokens")
+                                    .text_range()
+                                    .to_span(),
+                            ),
                             SyntaxElement::from(item.syntax().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
-                } else {
-                    // No comma found, report missing
-                    state.exceptable_add(
-                        missing_trailing_comma(
-                            last_child
-                                .syntax()
-                                .last_token()
-                                .expect("array should have tokens")
-                                .text_range()
-                                .to_span(),
-                        ),
-                        SyntaxElement::from(item.syntax().clone()),
-                        &self.exceptable_nodes(),
-                    );
                 }
             }
         }
@@ -215,30 +221,34 @@ impl Visitor for TrailingCommaRule {
         call.inputs().for_each(|input| {
             // check each input for trailing comma
             let (next_comma, comma_is_next) = find_next_comma(input.syntax());
-            if let Some(nc) = next_comma {
-                if !comma_is_next {
+            match next_comma {
+                Some(nc) => {
+                    if !comma_is_next {
+                        state.exceptable_add(
+                            extraneous_content(Span::new(
+                                input.syntax().text_range().end().into(),
+                                (nc.text_range().start() - input.syntax().text_range().end())
+                                    .into(),
+                            )),
+                            SyntaxElement::from(call.syntax().clone()),
+                            &self.exceptable_nodes(),
+                        );
+                    }
+                }
+                _ => {
                     state.exceptable_add(
-                        extraneous_content(Span::new(
-                            input.syntax().text_range().end().into(),
-                            (nc.text_range().start() - input.syntax().text_range().end()).into(),
-                        )),
+                        missing_trailing_comma(
+                            input
+                                .syntax()
+                                .last_token()
+                                .expect("input should have tokens")
+                                .text_range()
+                                .to_span(),
+                        ),
                         SyntaxElement::from(call.syntax().clone()),
                         &self.exceptable_nodes(),
                     );
                 }
-            } else {
-                state.exceptable_add(
-                    missing_trailing_comma(
-                        input
-                            .syntax()
-                            .last_token()
-                            .expect("input should have tokens")
-                            .text_range()
-                            .to_span(),
-                    ),
-                    SyntaxElement::from(call.syntax().clone()),
-                    &self.exceptable_nodes(),
-                );
             }
         });
     }
@@ -260,33 +270,36 @@ impl Visitor for TrailingCommaRule {
                         let last_child = l.syntax().children().last();
                         if let Some(last_child) = last_child {
                             let (next_comma, comma_is_next) = find_next_comma(&last_child);
-                            if let Some(comma) = next_comma {
-                                if !comma_is_next {
-                                    // Comma found, but not next, extraneous trivia
+                            match next_comma {
+                                Some(comma) => {
+                                    if !comma_is_next {
+                                        // Comma found, but not next, extraneous trivia
+                                        state.exceptable_add(
+                                            extraneous_content(Span::new(
+                                                last_child.text_range().end().into(),
+                                                (comma.text_range().start()
+                                                    - last_child.text_range().end())
+                                                .into(),
+                                            )),
+                                            SyntaxElement::from(l.syntax().clone()),
+                                            &self.exceptable_nodes(),
+                                        );
+                                    }
+                                }
+                                _ => {
+                                    // No comma found, report missing
                                     state.exceptable_add(
-                                        extraneous_content(Span::new(
-                                            last_child.text_range().end().into(),
-                                            (comma.text_range().start()
-                                                - last_child.text_range().end())
-                                            .into(),
-                                        )),
+                                        missing_trailing_comma(
+                                            last_child
+                                                .last_token()
+                                                .expect("item should have tokens")
+                                                .text_range()
+                                                .to_span(),
+                                        ),
                                         SyntaxElement::from(l.syntax().clone()),
                                         &self.exceptable_nodes(),
                                     );
                                 }
-                            } else {
-                                // No comma found, report missing
-                                state.exceptable_add(
-                                    missing_trailing_comma(
-                                        last_child
-                                            .last_token()
-                                            .expect("item should have tokens")
-                                            .text_range()
-                                            .to_span(),
-                                    ),
-                                    SyntaxElement::from(l.syntax().clone()),
-                                    &self.exceptable_nodes(),
-                                );
                             }
                         }
                     }

--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
+
 ## 0.6.0 - 01-17-2025
 
 ## 0.5.0 - 10-22-2024

--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * `wdl` run now prefers running the workflow in a document containing a single
   workflow and a single task ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).
 * Changed the default log level of the `wdl` binary from `error` to `warn` ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).

--- a/wdl/examples/parse.rs
+++ b/wdl/examples/parse.rs
@@ -63,10 +63,13 @@ pub fn main() -> Result<()> {
     }
 
     let mut validator = Validator::default();
-    if let Err(diagnostics) = validator.validate(&document) {
-        emit_diagnostics(&args.path, &source, &diagnostics)?;
-    } else {
-        println!("{document:#?}");
+    match validator.validate(&document) {
+        Err(diagnostics) => {
+            emit_diagnostics(&args.path, &source, &diagnostics)?;
+        }
+        _ => {
+            println!("{document:#?}");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Now that Rust 2024 edition is out and that we're only two releases behind on MSRV, I thought we should probably just bump the repository to be `edition = "2024"`.

This PR accomplishes the following:

* Updates all dependencies to their latest version.
* Migrates the repository to Rust 2024 and bumps the MSRV to 1.85.0 from 1.83.0.
* Fixes clippy warnings relating to changes in 2024 edition.

Note that most of the changes come from indentation level changes when migrating an `if let` to a `match` (changes made via `--fix`).

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
