### PR TITLE
refactor: refactor `wdl-ast` to allow for alternative tree representation.

### DIFF
--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -42,6 +42,7 @@ pub use repository::Repository;
 use wdl::analysis::Analyzer;
 use wdl::analysis::DiagnosticsConfig;
 use wdl::analysis::rules;
+use wdl::ast::AstNode;
 use wdl::ast::Diagnostic;
 use wdl::lint::LintVisitor;
 use wdl::lint::ast::Validator;
@@ -228,7 +229,7 @@ pub async fn gauntlet(args: Args) -> Result<()> {
 
             let mut actual = IndexSet::new();
             if !diagnostics.is_empty() {
-                let source = result.document().node().syntax().text().to_string();
+                let source = result.document().root().text().to_string();
 
                 let file: SimpleFile<_, _> = SimpleFile::new(
                     Path::new(document_identifier.path())

--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Refactored analysis API to support different syntax tree element
+  representations ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * `Document` is now trivially cloned ([#320](https://github.com/stjude-rust-labs/wdl/pull/320)).
 * The task evaluation graph now forms implicit edges between the command and

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -498,13 +498,13 @@ impl Document {
 
         let root = node.root().expect("node should have been parsed");
         let (version, config) = match root.version_statement() {
-            Some(stmt) => (stmt.version(), config.excepted_for_node(stmt.syntax())),
+            Some(stmt) => (stmt.version(), config.excepted_for_node(stmt.inner())),
             None => {
                 // Don't process a document with a missing version
                 return Self {
                     data: Arc::new(DocumentData::new(
                         node.uri().clone(),
-                        Some(root.syntax().green().into()),
+                        Some(root.inner().green().into()),
                         None,
                         diagnostics,
                     )),
@@ -514,8 +514,8 @@ impl Document {
 
         let mut data = DocumentData::new(
             node.uri().clone(),
-            Some(root.syntax().green().into()),
-            SupportedVersion::from_str(version.as_str()).ok(),
+            Some(root.inner().green().into()),
+            SupportedVersion::from_str(version.text()).ok(),
             diagnostics,
         );
         match root.ast() {
@@ -554,7 +554,11 @@ impl Document {
     }
 
     /// Gets the root AST document node.
-    pub fn node(&self) -> wdl_ast::Document {
+    ///
+    /// # Panics
+    ///
+    /// Panics if the document was not be parsed.
+    pub fn root(&self) -> wdl_ast::Document {
         wdl_ast::Document::cast(SyntaxNode::new_root(
             self.data.root.clone().expect("should have a root"),
         ))

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -557,7 +557,7 @@ impl Document {
     ///
     /// # Panics
     ///
-    /// Panics if the document was not be parsed.
+    /// Panics if the document was not parsed.
     pub fn root(&self) -> wdl_ast::Document {
         wdl_ast::Document::cast(SyntaxNode::new_root(
             self.data.root.clone().expect("should have a root"),

--- a/wdl-analysis/src/graph.rs
+++ b/wdl-analysis/src/graph.rs
@@ -26,6 +26,7 @@ use tokio::runtime::Handle;
 use tracing::debug;
 use tracing::info;
 use url::Url;
+use wdl_ast::AstNode;
 use wdl_ast::Diagnostic;
 use wdl_ast::SyntaxNode;
 use wdl_ast::Validator;
@@ -357,7 +358,7 @@ impl DocumentGraphNode {
 
         Ok(ParseState::Parsed {
             version,
-            root: document.syntax().green().into(),
+            root: document.inner().green().into(),
             lines,
             diagnostics,
         })

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -620,7 +620,7 @@ where
                             None => continue,
                         };
 
-                        let import_uri = match graph.get(index).uri().join(text.as_str()) {
+                        let import_uri = match graph.get(index).uri().join(text.text()) {
                             Ok(uri) => uri,
                             Err(_) => continue,
                         };

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 use wdl_ast::Diagnostic;
-use wdl_ast::Ident;
+use wdl_ast::Span;
 
 use crate::document::Input;
 use crate::document::Output;
@@ -46,7 +46,7 @@ pub fn display_types(slice: &[Type]) -> impl fmt::Display + use<'_> {
 /// A trait implemented on type name resolvers.
 pub trait TypeNameResolver {
     /// Resolves the given type name to a type.
-    fn resolve(&mut self, name: &Ident) -> Result<Type, Diagnostic>;
+    fn resolve(&mut self, name: &str, span: Span) -> Result<Type, Diagnostic>;
 }
 
 /// A trait implemented on types that may be optional.

--- a/wdl-analysis/tests/analysis.rs
+++ b/wdl-analysis/tests/analysis.rs
@@ -36,6 +36,7 @@ use wdl_analysis::Analyzer;
 use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::path_to_uri;
 use wdl_analysis::rules;
+use wdl_ast::AstNode;
 use wdl_ast::Diagnostic;
 
 /// Finds tests to run as part of the analysis test suite.
@@ -124,7 +125,7 @@ fn compare_results(test: &Path, results: Vec<AnalysisResult>) -> Result<()> {
         };
 
         if !diagnostics.is_empty() {
-            let source = result.document().node().syntax().text().to_string();
+            let source = result.document().root().text().to_string();
             let file = SimpleFile::new(path, &source);
             for diagnostic in diagnostics.as_ref() {
                 term::emit(

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Refactored AST API to support different syntax tree element representations ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * Refactored whitespace counting out of `strip_whitespace` into `count_whitespace` method ([#317](https://github.com/stjude-rust-labs/wdl/pull/317)).
+
+### Fixed
+
+* AST validation now checks for duplicate `hints` sections in 1.2 documents ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 
 ## 0.10.0 - 01-17-2025
 

--- a/wdl-ast/src/element.rs
+++ b/wdl-ast/src/element.rs
@@ -23,8 +23,8 @@ macro_rules! ast_element_impl {
         $name:ident,
         // The improper name of the impl to be displayed (e.g., `node`).
         $display:ident,
-        // The abstract trait name (either `AbstractNode` or `AbstractToken`).
-        $abstract:ty,
+        // The implementation trait name (either `TreeNode` or `TreeToken`).
+        $trait_name:ty,
         // A mapping of all of the elements to map from syntax elements to ast
         // elements.
         //
@@ -32,7 +32,7 @@ macro_rules! ast_element_impl {
         [$($suffix:ident(): $syntax_kind:ty => $inner:ty => $variant:ty),*]
     ) => {
         paste::paste! {
-            impl<T: $abstract> $name<T> {
+            impl<T: $trait_name> $name<T> {
                 #[doc = "Attempts to cast an element to a [`" $name "`]."]
                 pub fn cast(element: T) -> Option<Self> {
                     match element.kind() {
@@ -118,7 +118,7 @@ macro_rules! ast_element_impl {
 
 /// An abstract syntax tree node.
 ///
-/// This enum has a variant for each node type.
+/// This enum has a variant for each struct implementing the [`AstNode`] trait.
 #[derive(Clone, Debug)]
 pub enum Node<N: TreeNode = SyntaxNode> {
     /// An access expression.
@@ -394,7 +394,7 @@ ast_element_impl!(
 
 /// An abstract syntax tree token.
 ///
-/// This enum has a variant for each token type.
+/// This enum has a variant for each struct implementing the [`AstToken`] trait.
 #[derive(Clone, Debug)]
 pub enum Token<T: TreeToken = SyntaxToken> {
     /// The `after` keyword.

--- a/wdl-ast/src/element.rs
+++ b/wdl-ast/src/element.rs
@@ -6,10 +6,11 @@ use crate::AstNode;
 use crate::AstToken;
 use crate::Comment;
 use crate::Ident;
-use crate::SyntaxElement;
 use crate::SyntaxKind;
 use crate::SyntaxNode;
 use crate::SyntaxToken;
+use crate::TreeNode;
+use crate::TreeToken;
 use crate::Version;
 use crate::VersionStatement;
 use crate::Whitespace;
@@ -22,8 +23,8 @@ macro_rules! ast_element_impl {
         $name:ident,
         // The improper name of the impl to be displayed (e.g., `node`).
         $display:ident,
-        // The prefix of the syntax element (e.g., `SyntaxNode`).
-        $syntax_prefix:ty,
+        // The abstract trait name (either `AbstractNode` or `AbstractToken`).
+        $abstract:ty,
         // A mapping of all of the elements to map from syntax elements to ast
         // elements.
         //
@@ -31,21 +32,13 @@ macro_rules! ast_element_impl {
         [$($suffix:ident(): $syntax_kind:ty => $inner:ty => $variant:ty),*]
     ) => {
         paste::paste! {
-            impl $name {
-                #[doc = "Attempts to cast a [`SyntaxElement`] to a [`" $name "`]."]
-                pub fn cast(element: SyntaxElement) -> Option<Self> {
+            impl<T: $abstract> $name<T> {
+                #[doc = "Attempts to cast an element to a [`" $name "`]."]
+                pub fn cast(element: T) -> Option<Self> {
                     match element.kind() {
                         $(
                             SyntaxKind::$syntax_kind => {
-                                let $display = element
-                                    .[<into_ $display>]()
-                                    .expect(
-                                        "`SyntaxElement` with kind \
-                                        `SyntaxKind::${stringify!($syntax_kind)}` could not \
-                                        be turned into a `${stringify!($syntax_prefix)}`"
-                                    );
-
-                                let inner = $inner::cast($display)
+                                let inner = $inner::<T>::cast(element)
                                     .expect(
                                         "couldn't cast ${stringify!($display)} to \
                                         `${stringify!($inner)}`
@@ -68,12 +61,11 @@ macro_rules! ast_element_impl {
                     }
                 }
 
-
-                #[doc = "Gets the inner [`" $syntax_prefix "`] from the [`" $name "`]."]
-                pub fn syntax(&self) -> &$syntax_prefix {
+                #[doc = "Gets the inner type from the [`" $name "`]."]
+                pub fn inner(&self) -> &T {
                     match self {
                         $(
-                            $name::$variant(inner) => inner.syntax(),
+                            $name::$variant(e) => e.inner(),
                         )*
                         // NOTE: a wildcard pattern (`_`) should not be required
                         // here. If one is suggested by the compiler, that means
@@ -88,7 +80,7 @@ macro_rules! ast_element_impl {
                     /// * If `self` is a [`${stringify!($variant)}`], then a reference to the
                     ///   inner [`${stringify!($inner)}`] wrapped in [`Some`] is returned.
                     /// * Else, [`None`] is returned.
-                    pub fn [<as_ $suffix>](&self) -> Option<&$inner> {
+                    pub fn [<as_ $suffix>](&self) -> Option<&$inner<T>> {
                         match self {
                             $name::$variant($suffix) => Some($suffix),
                             _ => None,
@@ -101,7 +93,7 @@ macro_rules! ast_element_impl {
                     /// * If `self` is a [`${stringify!($variant)}`], then the inner
                     ///   [`${stringify!($inner)}`] wrapped in [`Some`] is returned.
                     /// * Else, [`None`] is returned.
-                    pub fn [<into_ $suffix>](self) -> Option<$inner> {
+                    pub fn [<into_ $suffix>](self) -> Option<$inner<T>> {
                         match self {
                             $name::$variant($suffix) => Some($suffix),
                             _ => None,
@@ -113,7 +105,7 @@ macro_rules! ast_element_impl {
                     /// # Panics
                     ///
                     /// If `self` is not a [`${stringify!($variant)}`].
-                    pub fn [<unwrap_ $suffix>](self) -> $inner {
+                    pub fn [<unwrap_ $suffix>](self) -> $inner<T> {
                         self.[<into_ $suffix>]().expect(
                             "expected `${stringify!($variant)}` but got a different variant"
                         )
@@ -126,189 +118,189 @@ macro_rules! ast_element_impl {
 
 /// An abstract syntax tree node.
 ///
-/// This enum has a variant for each struct implementing the [`AstNode`] trait.
+/// This enum has a variant for each node type.
 #[derive(Clone, Debug)]
-pub enum Node {
+pub enum Node<N: TreeNode = SyntaxNode> {
     /// An access expression.
-    AccessExpr(AccessExpr),
+    AccessExpr(AccessExpr<N>),
     /// An addition expression.
-    AdditionExpr(AdditionExpr),
+    AdditionExpr(AdditionExpr<N>),
     /// An array type.
-    ArrayType(ArrayType),
+    ArrayType(ArrayType<N>),
     /// A V1 abstract syntax tree.
-    Ast(Ast),
+    Ast(Ast<N>),
     /// A bound declaration.
-    BoundDecl(BoundDecl),
+    BoundDecl(BoundDecl<N>),
     /// An after clause in a call statement.
-    CallAfter(CallAfter),
+    CallAfter(CallAfter<N>),
     /// An alias clause in a call statement.
-    CallAlias(CallAlias),
+    CallAlias(CallAlias<N>),
     /// A call expression.
-    CallExpr(CallExpr),
+    CallExpr(CallExpr<N>),
     /// A call input item.
-    CallInputItem(CallInputItem),
+    CallInputItem(CallInputItem<N>),
     /// A call statement.
-    CallStatement(CallStatement),
+    CallStatement(CallStatement<N>),
     /// A target within a call statement.
-    CallTarget(CallTarget),
+    CallTarget(CallTarget<N>),
     /// A command section.
-    CommandSection(CommandSection),
+    CommandSection(CommandSection<N>),
     /// A conditional statement.
-    ConditionalStatement(ConditionalStatement),
+    ConditionalStatement(ConditionalStatement<N>),
     /// The `default` placeholder option.
-    DefaultOption(DefaultOption),
+    DefaultOption(DefaultOption<N>),
     /// A division expression.
-    DivisionExpr(DivisionExpr),
+    DivisionExpr(DivisionExpr<N>),
     /// An equality expression.
-    EqualityExpr(EqualityExpr),
+    EqualityExpr(EqualityExpr<N>),
     /// An exponentiation expression.
-    ExponentiationExpr(ExponentiationExpr),
+    ExponentiationExpr(ExponentiationExpr<N>),
     /// A greater than or equal to expression.
-    GreaterEqualExpr(GreaterEqualExpr),
+    GreaterEqualExpr(GreaterEqualExpr<N>),
     /// A greater than expression.
-    GreaterExpr(GreaterExpr),
+    GreaterExpr(GreaterExpr<N>),
     /// An if expression.
-    IfExpr(IfExpr),
+    IfExpr(IfExpr<N>),
     /// An import alias.
-    ImportAlias(ImportAlias),
+    ImportAlias(ImportAlias<N>),
     /// An import statement.
-    ImportStatement(ImportStatement),
+    ImportStatement(ImportStatement<N>),
     /// An index expression.
-    IndexExpr(IndexExpr),
+    IndexExpr(IndexExpr<N>),
     /// An inequality expression.
-    InequalityExpr(InequalityExpr),
+    InequalityExpr(InequalityExpr<N>),
     /// An input section.
-    InputSection(InputSection),
+    InputSection(InputSection<N>),
     /// A less than or equal to expression.
-    LessEqualExpr(LessEqualExpr),
+    LessEqualExpr(LessEqualExpr<N>),
     /// A less than expression.
-    LessExpr(LessExpr),
+    LessExpr(LessExpr<N>),
     /// A literal array.
-    LiteralArray(LiteralArray),
+    LiteralArray(LiteralArray<N>),
     /// A literal boolean.
-    LiteralBoolean(LiteralBoolean),
+    LiteralBoolean(LiteralBoolean<N>),
     /// A literal float.
-    LiteralFloat(LiteralFloat),
+    LiteralFloat(LiteralFloat<N>),
     /// A literal hints.
-    LiteralHints(LiteralHints),
+    LiteralHints(LiteralHints<N>),
     /// A literal hints item.
-    LiteralHintsItem(LiteralHintsItem),
+    LiteralHintsItem(LiteralHintsItem<N>),
     /// A literal input.
-    LiteralInput(LiteralInput),
+    LiteralInput(LiteralInput<N>),
     /// A literal input item.
-    LiteralInputItem(LiteralInputItem),
+    LiteralInputItem(LiteralInputItem<N>),
     /// A literal integer.
-    LiteralInteger(LiteralInteger),
+    LiteralInteger(LiteralInteger<N>),
     /// A literal map.
-    LiteralMap(LiteralMap),
+    LiteralMap(LiteralMap<N>),
     /// A literal map item.
-    LiteralMapItem(LiteralMapItem),
+    LiteralMapItem(LiteralMapItem<N>),
     /// A literal none.
-    LiteralNone(LiteralNone),
+    LiteralNone(LiteralNone<N>),
     /// A literal null.
-    LiteralNull(LiteralNull),
+    LiteralNull(LiteralNull<N>),
     /// A literal object.
-    LiteralObject(LiteralObject),
+    LiteralObject(LiteralObject<N>),
     /// A literal object item.
-    LiteralObjectItem(LiteralObjectItem),
+    LiteralObjectItem(LiteralObjectItem<N>),
     /// A literal output.
-    LiteralOutput(LiteralOutput),
+    LiteralOutput(LiteralOutput<N>),
     /// A literal output item.
-    LiteralOutputItem(LiteralOutputItem),
+    LiteralOutputItem(LiteralOutputItem<N>),
     /// A literal pair.
-    LiteralPair(LiteralPair),
+    LiteralPair(LiteralPair<N>),
     /// A literal string.
-    LiteralString(LiteralString),
+    LiteralString(LiteralString<N>),
     /// A literal struct.
-    LiteralStruct(LiteralStruct),
+    LiteralStruct(LiteralStruct<N>),
     /// A literal struct item.
-    LiteralStructItem(LiteralStructItem),
+    LiteralStructItem(LiteralStructItem<N>),
     /// A logical and expression.
-    LogicalAndExpr(LogicalAndExpr),
+    LogicalAndExpr(LogicalAndExpr<N>),
     /// A logical not expression.
-    LogicalNotExpr(LogicalNotExpr),
+    LogicalNotExpr(LogicalNotExpr<N>),
     /// A logical or expression.
-    LogicalOrExpr(LogicalOrExpr),
+    LogicalOrExpr(LogicalOrExpr<N>),
     /// A map type.
-    MapType(MapType),
+    MapType(MapType<N>),
     /// A metadata array.
-    MetadataArray(MetadataArray),
+    MetadataArray(MetadataArray<N>),
     /// A metadata object.
-    MetadataObject(MetadataObject),
+    MetadataObject(MetadataObject<N>),
     /// A metadata object item.
-    MetadataObjectItem(MetadataObjectItem),
+    MetadataObjectItem(MetadataObjectItem<N>),
     /// A metadata section.
-    MetadataSection(MetadataSection),
+    MetadataSection(MetadataSection<N>),
     /// A modulo expression.
-    ModuloExpr(ModuloExpr),
+    ModuloExpr(ModuloExpr<N>),
     /// A multiplication expression.
-    MultiplicationExpr(MultiplicationExpr),
+    MultiplicationExpr(MultiplicationExpr<N>),
     /// A reference to a name.
-    NameRef(NameRef),
+    NameRefExpr(NameRefExpr<N>),
     /// A negation expression.
-    NegationExpr(NegationExpr),
+    NegationExpr(NegationExpr<N>),
     /// An output section.
-    OutputSection(OutputSection),
+    OutputSection(OutputSection<N>),
     /// A pair type.
-    PairType(PairType),
+    PairType(PairType<N>),
     /// An object type.
-    ObjectType(ObjectType),
+    ObjectType(ObjectType<N>),
     /// A parameter metadata section.
-    ParameterMetadataSection(ParameterMetadataSection),
+    ParameterMetadataSection(ParameterMetadataSection<N>),
     /// A parenthesized expression.
-    ParenthesizedExpr(ParenthesizedExpr),
+    ParenthesizedExpr(ParenthesizedExpr<N>),
     /// A placeholder.
-    Placeholder(Placeholder),
+    Placeholder(Placeholder<N>),
     /// A primitive type.
-    PrimitiveType(PrimitiveType),
+    PrimitiveType(PrimitiveType<N>),
     /// A requirements item.
-    RequirementsItem(RequirementsItem),
+    RequirementsItem(RequirementsItem<N>),
     /// A requirements section.
-    RequirementsSection(RequirementsSection),
+    RequirementsSection(RequirementsSection<N>),
     /// A runtime item.
-    RuntimeItem(RuntimeItem),
+    RuntimeItem(RuntimeItem<N>),
     /// A runtime section.
-    RuntimeSection(RuntimeSection),
+    RuntimeSection(RuntimeSection<N>),
     /// A scatter statement.
-    ScatterStatement(ScatterStatement),
+    ScatterStatement(ScatterStatement<N>),
     /// The `sep` placeholder option.
-    SepOption(SepOption),
+    SepOption(SepOption<N>),
     /// A struct definition.
-    StructDefinition(StructDefinition),
+    StructDefinition(StructDefinition<N>),
     /// A subtraction expression.
-    SubtractionExpr(SubtractionExpr),
+    SubtractionExpr(SubtractionExpr<N>),
     /// A task definition.
-    TaskDefinition(TaskDefinition),
+    TaskDefinition(TaskDefinition<N>),
     /// A task item within a hints section.
-    TaskHintsItem(TaskHintsItem),
+    TaskHintsItem(TaskHintsItem<N>),
     /// A hints section within a task.
-    TaskHintsSection(TaskHintsSection),
+    TaskHintsSection(TaskHintsSection<N>),
     /// A `true`/`false` placeholder option.
-    TrueFalseOption(TrueFalseOption),
+    TrueFalseOption(TrueFalseOption<N>),
     /// A reference to a type.
-    TypeRef(TypeRef),
+    TypeRef(TypeRef<N>),
     /// An unbound declaration.
-    UnboundDecl(UnboundDecl),
+    UnboundDecl(UnboundDecl<N>),
     /// A version statement.
-    VersionStatement(VersionStatement),
+    VersionStatement(VersionStatement<N>),
     /// A workflow definition.
-    WorkflowDefinition(WorkflowDefinition),
+    WorkflowDefinition(WorkflowDefinition<N>),
     /// An array within a workflow hints section.
-    WorkflowHintsArray(WorkflowHintsArray),
+    WorkflowHintsArray(WorkflowHintsArray<N>),
     /// A hints item within a workflow hints section.
-    WorkflowHintsItem(WorkflowHintsItem),
+    WorkflowHintsItem(WorkflowHintsItem<N>),
     /// An object within a workflow hints section.
-    WorkflowHintsObject(WorkflowHintsObject),
+    WorkflowHintsObject(WorkflowHintsObject<N>),
     /// An item within an object within a workflow hints section.
-    WorkflowHintsObjectItem(WorkflowHintsObjectItem),
+    WorkflowHintsObjectItem(WorkflowHintsObjectItem<N>),
     /// A hints section within a workflow.
-    WorkflowHintsSection(WorkflowHintsSection),
+    WorkflowHintsSection(WorkflowHintsSection<N>),
 }
 
 ast_element_impl!(
     Node,
     node,
-    SyntaxNode,
+    TreeNode,
     [
         access_expr(): AccessExprNode => AccessExpr => AccessExpr,
         addition_expr(): AdditionExprNode => AdditionExpr => AdditionExpr,
@@ -367,7 +359,7 @@ ast_element_impl!(
         metadata_section(): MetadataSectionNode => MetadataSection => MetadataSection,
         modulo_expr(): ModuloExprNode => ModuloExpr => ModuloExpr,
         multiplication_expr(): MultiplicationExprNode => MultiplicationExpr => MultiplicationExpr,
-        name_ref(): NameRefNode => NameRef => NameRef,
+        name_ref_expr(): NameRefExprNode => NameRefExpr => NameRefExpr,
         negation_expr(): NegationExprNode => NegationExpr => NegationExpr,
         object_type(): ObjectTypeNode => ObjectType => ObjectType,
         output_section(): OutputSectionNode => OutputSection => OutputSection,
@@ -402,169 +394,169 @@ ast_element_impl!(
 
 /// An abstract syntax tree token.
 ///
-/// This enum has a variant for each struct implementing the [`AstToken`] trait.
+/// This enum has a variant for each token type.
 #[derive(Clone, Debug)]
-pub enum Token {
+pub enum Token<T: TreeToken = SyntaxToken> {
     /// The `after` keyword.
-    AfterKeyword(AfterKeyword),
+    AfterKeyword(AfterKeyword<T>),
     /// The `alias` keyword.
-    AliasKeyword(AliasKeyword),
+    AliasKeyword(AliasKeyword<T>),
     /// The `Array` type keyword.
-    ArrayTypeKeyword(ArrayTypeKeyword),
+    ArrayTypeKeyword(ArrayTypeKeyword<T>),
     /// The `as` keyword.
-    AsKeyword(AsKeyword),
+    AsKeyword(AsKeyword<T>),
     /// The `=` symbol.
-    Assignment(Assignment),
+    Assignment(Assignment<T>),
     /// The `*` symbol.
-    Asterisk(Asterisk),
+    Asterisk(Asterisk<T>),
     /// The `Boolean` type keyword.
-    BooleanTypeKeyword(BooleanTypeKeyword),
+    BooleanTypeKeyword(BooleanTypeKeyword<T>),
     /// The `call` keyword.
-    CallKeyword(CallKeyword),
+    CallKeyword(CallKeyword<T>),
     /// The `}` symbol.
-    CloseBrace(CloseBrace),
+    CloseBrace(CloseBrace<T>),
     /// The `]` symbol.
-    CloseBracket(CloseBracket),
+    CloseBracket(CloseBracket<T>),
     /// The `>>>` symbol.
-    CloseHeredoc(CloseHeredoc),
+    CloseHeredoc(CloseHeredoc<T>),
     /// The `)` symbol.
-    CloseParen(CloseParen),
+    CloseParen(CloseParen<T>),
     /// The `:` symbol.
-    Colon(Colon),
+    Colon(Colon<T>),
     /// The `,` symbol.
-    Comma(Comma),
+    Comma(Comma<T>),
     /// The `command` keyword.
-    CommandKeyword(CommandKeyword),
+    CommandKeyword(CommandKeyword<T>),
     /// The text within a command section.
-    CommandText(CommandText),
+    CommandText(CommandText<T>),
     /// A comment.
-    Comment(Comment),
+    Comment(Comment<T>),
     /// The `Directory` type keyword.
-    DirectoryTypeKeyword(DirectoryTypeKeyword),
+    DirectoryTypeKeyword(DirectoryTypeKeyword<T>),
     /// The `.` symbol.
-    Dot(Dot),
+    Dot(Dot<T>),
     /// The `"` symbol.
-    DoubleQuote(DoubleQuote),
+    DoubleQuote(DoubleQuote<T>),
     /// The `else` keyword.
-    ElseKeyword(ElseKeyword),
+    ElseKeyword(ElseKeyword<T>),
     /// The `env` keyword.
-    EnvKeyword(EnvKeyword),
+    EnvKeyword(EnvKeyword<T>),
     /// The `==` symbol.
-    Equal(Equal),
+    Equal(Equal<T>),
     /// The `!` symbol.
-    Exclamation(Exclamation),
+    Exclamation(Exclamation<T>),
     /// The `**` symbol.
-    Exponentiation(Exponentiation),
+    Exponentiation(Exponentiation<T>),
     /// The `false` keyword.
-    FalseKeyword(FalseKeyword),
+    FalseKeyword(FalseKeyword<T>),
     /// The `File` type keyword.
-    FileTypeKeyword(FileTypeKeyword),
+    FileTypeKeyword(FileTypeKeyword<T>),
     /// A float.
-    Float(Float),
+    Float(Float<T>),
     /// The `Float` type keyword.
-    FloatTypeKeyword(FloatTypeKeyword),
+    FloatTypeKeyword(FloatTypeKeyword<T>),
     /// The `>` symbol.
-    Greater(Greater),
+    Greater(Greater<T>),
     /// The `>=` symbol.
-    GreaterEqual(GreaterEqual),
+    GreaterEqual(GreaterEqual<T>),
     /// The `hints` keyword.
-    HintsKeyword(HintsKeyword),
+    HintsKeyword(HintsKeyword<T>),
     /// An identity.
-    Ident(Ident),
+    Ident(Ident<T>),
     /// The `if` keyword.
-    IfKeyword(IfKeyword),
+    IfKeyword(IfKeyword<T>),
     /// The `import` keyword.
-    ImportKeyword(ImportKeyword),
+    ImportKeyword(ImportKeyword<T>),
     /// The `in` keyword.
-    InKeyword(InKeyword),
+    InKeyword(InKeyword<T>),
     /// The `input` keyword.
-    InputKeyword(InputKeyword),
+    InputKeyword(InputKeyword<T>),
     /// An integer.
-    Integer(Integer),
+    Integer(Integer<T>),
     /// The `Int` type keyword.
-    IntTypeKeyword(IntTypeKeyword),
+    IntTypeKeyword(IntTypeKeyword<T>),
     /// The `<` symbol.
-    Less(Less),
+    Less(Less<T>),
     /// The `<=` symbol.
-    LessEqual(LessEqual),
+    LessEqual(LessEqual<T>),
     /// The `&&` symbol.
-    LogicalAnd(LogicalAnd),
+    LogicalAnd(LogicalAnd<T>),
     /// The `||` symbol.
-    LogicalOr(LogicalOr),
+    LogicalOr(LogicalOr<T>),
     /// The `Map` type keyword.
-    MapTypeKeyword(MapTypeKeyword),
+    MapTypeKeyword(MapTypeKeyword<T>),
     /// The `meta` keyword.
-    MetaKeyword(MetaKeyword),
+    MetaKeyword(MetaKeyword<T>),
     /// The `-` symbol.
-    Minus(Minus),
+    Minus(Minus<T>),
     /// The `None` keyword.
-    NoneKeyword(NoneKeyword),
+    NoneKeyword(NoneKeyword<T>),
     /// The `!=` symbol.
-    NotEqual(NotEqual),
+    NotEqual(NotEqual<T>),
     /// The `null` keyword.
-    NullKeyword(NullKeyword),
+    NullKeyword(NullKeyword<T>),
     /// The `object` keyword.
-    ObjectKeyword(ObjectKeyword),
+    ObjectKeyword(ObjectKeyword<T>),
     /// The `Object` type keyword.
-    ObjectTypeKeyword(ObjectTypeKeyword),
+    ObjectTypeKeyword(ObjectTypeKeyword<T>),
     /// The `{` symbol.
-    OpenBrace(OpenBrace),
+    OpenBrace(OpenBrace<T>),
     /// The `[` symbol.
-    OpenBracket(OpenBracket),
+    OpenBracket(OpenBracket<T>),
     /// The `<<<` symbol.
-    OpenHeredoc(OpenHeredoc),
+    OpenHeredoc(OpenHeredoc<T>),
     /// The `(` symbol.
-    OpenParen(OpenParen),
+    OpenParen(OpenParen<T>),
     /// The `output` keyword.
-    OutputKeyword(OutputKeyword),
+    OutputKeyword(OutputKeyword<T>),
     /// The `Pair` type keyword.
-    PairTypeKeyword(PairTypeKeyword),
+    PairTypeKeyword(PairTypeKeyword<T>),
     /// The `parameter_meta` keyword.
-    ParameterMetaKeyword(ParameterMetaKeyword),
+    ParameterMetaKeyword(ParameterMetaKeyword<T>),
     /// The `%` symbol.
-    Percent(Percent),
+    Percent(Percent<T>),
     /// One of the placeholder open symbols.
-    PlaceholderOpen(PlaceholderOpen),
+    PlaceholderOpen(PlaceholderOpen<T>),
     /// The `+` symbol.
-    Plus(Plus),
+    Plus(Plus<T>),
     /// The `?` symbol.
-    QuestionMark(QuestionMark),
+    QuestionMark(QuestionMark<T>),
     /// The `requirements` keyword.
-    RequirementsKeyword(RequirementsKeyword),
+    RequirementsKeyword(RequirementsKeyword<T>),
     /// The `runtime` keyword.
-    RuntimeKeyword(RuntimeKeyword),
+    RuntimeKeyword(RuntimeKeyword<T>),
     /// The `scatter` keyword.
-    ScatterKeyword(ScatterKeyword),
+    ScatterKeyword(ScatterKeyword<T>),
     /// The `'` symbol.
-    SingleQuote(SingleQuote),
+    SingleQuote(SingleQuote<T>),
     /// The `/` symbol.
-    Slash(Slash),
+    Slash(Slash<T>),
     /// The textual part of a string.
-    StringText(StringText),
+    StringText(StringText<T>),
     /// The `String` type keyword.
-    StringTypeKeyword(StringTypeKeyword),
+    StringTypeKeyword(StringTypeKeyword<T>),
     /// The `struct` keyword.
-    StructKeyword(StructKeyword),
+    StructKeyword(StructKeyword<T>),
     /// The `task` keyword.
-    TaskKeyword(TaskKeyword),
+    TaskKeyword(TaskKeyword<T>),
     /// The `then` keyword.
-    ThenKeyword(ThenKeyword),
+    ThenKeyword(ThenKeyword<T>),
     /// The `true` keyword.
-    TrueKeyword(TrueKeyword),
+    TrueKeyword(TrueKeyword<T>),
     /// A version.
-    Version(Version),
+    Version(Version<T>),
     /// The `version` keyword.
-    VersionKeyword(VersionKeyword),
+    VersionKeyword(VersionKeyword<T>),
     /// Whitespace.
-    Whitespace(Whitespace),
+    Whitespace(Whitespace<T>),
     /// The `workflow` keyword.
-    WorkflowKeyword(WorkflowKeyword),
+    WorkflowKeyword(WorkflowKeyword<T>),
 }
 
 ast_element_impl!(
     Token,
     token,
-    SyntaxToken,
+    TreeToken,
     [
         after_keyword(): AfterKeyword => AfterKeyword => AfterKeyword,
         alias_keyword(): AliasKeyword => AliasKeyword => AliasKeyword,
@@ -575,7 +567,7 @@ ast_element_impl!(
         boolean_type_keyword(): BooleanTypeKeyword => BooleanTypeKeyword => BooleanTypeKeyword,
         call_keyword(): CallKeyword => CallKeyword => CallKeyword,
         close_brace(): CloseBrace => CloseBrace => CloseBrace,
-        close_brack(): CloseBracket => CloseBracket => CloseBracket,
+        close_bracket(): CloseBracket => CloseBracket => CloseBracket,
         close_heredoc(): CloseHeredoc => CloseHeredoc => CloseHeredoc,
         close_paren(): CloseParen => CloseParen => CloseParen,
         colon(): Colon => Colon => Colon,
@@ -589,7 +581,7 @@ ast_element_impl!(
         else_keyword(): ElseKeyword => ElseKeyword => ElseKeyword,
         env_keyword(): EnvKeyword => EnvKeyword => EnvKeyword,
         equal(): Equal => Equal => Equal,
-        exclaimation(): Exclamation => Exclamation => Exclamation,
+        exclamation(): Exclamation => Exclamation => Exclamation,
         exponentiation(): Exponentiation => Exponentiation => Exponentiation,
         false_keyword(): FalseKeyword => FalseKeyword => FalseKeyword,
         file_type_keyword(): FileTypeKeyword => FileTypeKeyword => FileTypeKeyword,
@@ -648,21 +640,21 @@ ast_element_impl!(
 
 /// An abstract syntax tree element.
 #[derive(Clone, Debug)]
-pub enum Element {
+pub enum Element<N: TreeNode = SyntaxNode> {
     /// An abstract syntax tree node.
-    Node(Node),
+    Node(Node<N>),
 
     /// An abstract syntax tree token.
-    Token(Token),
+    Token(Token<N::Token>),
 }
 
-impl Element {
+impl<N: TreeNode> Element<N> {
     /// Attempts to get a reference to the inner [`Node`].
     ///
     /// * If `self` is a [`Element::Node`], then a reference to the inner
     ///   [`Node`] wrapped in [`Some`] is returned.
     /// * Else, [`None`] is returned.
-    pub fn as_node(&self) -> Option<&Node> {
+    pub fn as_node(&self) -> Option<&Node<N>> {
         match self {
             Self::Node(node) => Some(node),
             _ => None,
@@ -674,7 +666,7 @@ impl Element {
     /// * If `self` is a [`Element::Node`], then the inner [`Node`] wrapped in
     ///   [`Some`] is returned.
     /// * Else, [`None`] is returned.
-    pub fn into_node(self) -> Option<Node> {
+    pub fn into_node(self) -> Option<Node<N>> {
         match self {
             Self::Node(node) => Some(node),
             _ => None,
@@ -686,7 +678,7 @@ impl Element {
     /// # Panics
     ///
     /// If `self` is not a [`Element::Node`].
-    pub fn unwrap_node(self) -> Node {
+    pub fn unwrap_node(self) -> Node<N> {
         self.into_node()
             .expect("expected `Element::Node` but got a different variant")
     }
@@ -696,7 +688,7 @@ impl Element {
     /// * If `self` is a [`Element::Token`], then a reference to the inner
     ///   [`Token`] wrapped in [`Some`] is returned.
     /// * Else, [`None`] is returned.
-    pub fn as_token(&self) -> Option<&Token> {
+    pub fn as_token(&self) -> Option<&Token<N::Token>> {
         match self {
             Self::Token(token) => Some(token),
             _ => None,
@@ -708,7 +700,7 @@ impl Element {
     /// * If `self` is a [`Element::Token`], then the inner [`Token`] wrapped in
     ///   [`Some`] is returned.
     /// * Else, [`None`] is returned.
-    pub fn into_token(self) -> Option<Token> {
+    pub fn into_token(self) -> Option<Token<N::Token>> {
         match self {
             Self::Token(token) => Some(token),
             _ => None,
@@ -720,47 +712,43 @@ impl Element {
     /// # Panics
     ///
     /// If `self` is not a [`Element::Token`].
-    pub fn unwrap_token(self) -> Token {
+    pub fn unwrap_token(self) -> Token<N::Token> {
         self.into_token()
             .expect("expected `Element::Token` but got a different variant")
     }
 
     /// Gets the underlying [`SyntaxElement`] from the [`Element`].
-    pub fn syntax(&self) -> SyntaxElement {
+    pub fn inner(&self) -> NodeOrToken<N, N::Token> {
         match self {
-            Element::Node(node) => SyntaxElement::Node(node.syntax().clone()),
-            Element::Token(token) => SyntaxElement::Token(token.syntax().clone()),
+            Element::Node(node) => NodeOrToken::Node(node.inner().clone()),
+            Element::Token(token) => NodeOrToken::Token(token.inner().clone()),
         }
     }
 
     /// Gets the underlying [`SyntaxKind`] from the [`Element`].
     pub fn kind(&self) -> SyntaxKind {
         match self {
-            Element::Node(node) => node.syntax().kind(),
-            Element::Token(token) => token.syntax().kind(),
+            Element::Node(node) => node.inner().kind(),
+            Element::Token(token) => token.inner().kind(),
         }
     }
 
     /// Returns whether the [`SyntaxElement`] represents trivia.
     pub fn is_trivia(&self) -> bool {
         match self {
-            Element::Node(node) => node.syntax().kind().is_trivia(),
-            Element::Token(token) => token.syntax().kind().is_trivia(),
+            Element::Node(node) => node.inner().kind().is_trivia(),
+            Element::Token(token) => token.inner().kind().is_trivia(),
         }
     }
 
-    /// Casts a [`SyntaxElement`] to an [`Element`].
-    ///
-    /// This is expected to always succeed, as any [`SyntaxElement`] _should_
-    /// have a corresponding [`Element`] (and, if it doesn't, that's very
-    /// likely a bug).
-    pub fn cast(element: SyntaxElement) -> Self {
-        match &element {
-            NodeOrToken::Node(_) => {
-                Self::Node(Node::cast(element).expect("a syntax node should cast to a Node"))
+    /// Casts an element from a node or a token.
+    pub fn cast(element: NodeOrToken<N, N::Token>) -> Self {
+        match element {
+            NodeOrToken::Node(n) => {
+                Self::Node(Node::cast(n).expect("a syntax node should cast to a Node"))
             }
-            NodeOrToken::Token(_) => {
-                Self::Token(Token::cast(element).expect("a syntax token should cast to a Token"))
+            NodeOrToken::Token(t) => {
+                Self::Token(Token::cast(t).expect("a syntax token should cast to a Token"))
             }
         }
     }

--- a/wdl-ast/src/lib.rs
+++ b/wdl-ast/src/lib.rs
@@ -40,9 +40,11 @@ use std::collections::HashSet;
 use std::fmt;
 
 pub use rowan::Direction;
-pub use rowan::ast::AstChildren;
-pub use rowan::ast::AstNode;
-pub use rowan::ast::support;
+use rowan::NodeOrToken;
+use v1::CloseBrace;
+use v1::CloseHeredoc;
+use v1::OpenBrace;
+use v1::OpenHeredoc;
 pub use wdl_grammar::Diagnostic;
 pub use wdl_grammar::Label;
 pub use wdl_grammar::Severity;
@@ -55,7 +57,6 @@ pub use wdl_grammar::SyntaxNode;
 pub use wdl_grammar::SyntaxToken;
 pub use wdl_grammar::SyntaxTokenExt;
 pub use wdl_grammar::SyntaxTree;
-pub use wdl_grammar::ToSpan;
 pub use wdl_grammar::WorkflowDescriptionLanguage;
 pub use wdl_grammar::version;
 
@@ -69,12 +70,326 @@ pub use element::*;
 pub use validation::*;
 pub use visitor::*;
 
-/// Gets a token of a given parent that can cast to the given type.
-fn token<T: AstToken>(parent: &SyntaxNode) -> Option<T> {
-    parent
-        .children_with_tokens()
-        .filter_map(SyntaxElement::into_token)
-        .find_map(T::cast)
+/// A trait that abstracts the underlying representation of a syntax tree node.
+///
+/// The default node type is `SyntaxNode` for all AST nodes.
+pub trait TreeNode: Clone + fmt::Debug + PartialEq + Eq + std::hash::Hash {
+    /// The associated token type for the tree node.
+    type Token: TreeToken;
+
+    /// Gets the parent node of the node.
+    ///
+    /// Returns `None` if the node is a root.
+    fn parent(&self) -> Option<Self>;
+
+    /// Gets the syntax kind of the node.
+    fn kind(&self) -> SyntaxKind;
+
+    /// Gets the text of the node.
+    ///
+    /// Node text is not contiguous, so the returned value implements `Display`.
+    fn text(&self) -> impl fmt::Display;
+
+    /// Gets the span of the node.
+    fn span(&self) -> Span;
+
+    /// Gets the children nodes of the node.
+    fn children(&self) -> impl Iterator<Item = Self>;
+
+    /// Gets all the children of the node, including tokens.
+    fn children_with_tokens(&self) -> impl Iterator<Item = NodeOrToken<Self, Self::Token>>;
+
+    /// Gets the last token of the node.
+    fn last_token(&self) -> Option<Self::Token>;
+
+    /// Gets the node descendants of the node.
+    fn descendants(&self) -> impl Iterator<Item = Self>;
+
+    /// Gets the ancestors of the node.
+    fn ancestors(&self) -> impl Iterator<Item = Self>;
+
+    /// Determines if a given rule id is excepted for the node.
+    fn is_rule_excepted(&self, id: &str) -> bool;
+}
+
+/// A trait that abstracts the underlying representation of a syntax token.
+pub trait TreeToken: Clone + fmt::Debug + PartialEq + Eq + std::hash::Hash {
+    /// The associated node type for the token.
+    type Node: TreeNode;
+
+    /// Gets the parent node of the token.
+    fn parent(&self) -> Self::Node;
+
+    /// Gets the syntax kind for the token.
+    fn kind(&self) -> SyntaxKind;
+
+    /// Gets the text of the token.
+    fn text(&self) -> &str;
+
+    /// Gets the span of the token.
+    fn span(&self) -> Span;
+}
+
+/// A trait implemented by AST nodes.
+pub trait AstNode<N: TreeNode>: Sized {
+    /// Determines if the kind can be cast to this representation.
+    fn can_cast(kind: SyntaxKind) -> bool;
+
+    /// Casts the given inner type to the this representation.
+    fn cast(inner: N) -> Option<Self>;
+
+    /// Gets the inner type from this representation.
+    fn inner(&self) -> &N;
+
+    /// Gets the syntax kind of the node.
+    fn kind(&self) -> SyntaxKind {
+        self.inner().kind()
+    }
+
+    /// Gets the text of the node.
+    ///
+    /// As node text is not contiguous, this returns a type that implements
+    /// `Display`.
+    fn text<'a>(&'a self) -> impl fmt::Display
+    where
+        N: 'a,
+    {
+        self.inner().text()
+    }
+
+    /// Gets the span of the node.
+    fn span(&self) -> Span {
+        self.inner().span()
+    }
+
+    /// Gets the first token child that can cast to an expected type.
+    fn token<C>(&self) -> Option<C>
+    where
+        C: AstToken<N::Token>,
+    {
+        self.inner()
+            .children_with_tokens()
+            .filter_map(|e| e.into_token())
+            .find_map(|t| C::cast(t))
+    }
+
+    /// Gets all the token children that can cast to an expected type.
+    fn tokens<'a, C>(&'a self) -> impl Iterator<Item = C>
+    where
+        C: AstToken<N::Token>,
+        N: 'a,
+    {
+        self.inner()
+            .children_with_tokens()
+            .filter_map(|e| e.into_token().and_then(C::cast))
+    }
+
+    /// Gets the last token of the node and attempts to cast it to an expected
+    /// type.
+    ///
+    /// Returns `None` if there is no last token or if it cannot be casted to
+    /// the expected type.
+    fn last_token<C>(&self) -> Option<C>
+    where
+        C: AstToken<N::Token>,
+    {
+        self.inner().last_token().and_then(C::cast)
+    }
+
+    /// Gets the first node child that can cast to an expected type.
+    fn child<C>(&self) -> Option<C>
+    where
+        C: AstNode<N>,
+    {
+        self.inner().children().find_map(C::cast)
+    }
+
+    /// Gets all node children that can cast to an expected type.
+    fn children<'a, C>(&'a self) -> impl Iterator<Item = C>
+    where
+        C: AstNode<N>,
+        N: 'a,
+    {
+        self.inner().children().filter_map(C::cast)
+    }
+
+    /// Gets the parent of the node if the underlying tree node has a parent.
+    ///
+    /// Returns `None` if the node has no parent or if the parent node is not of
+    /// the expected type.
+    fn parent<'a, P>(&self) -> Option<P>
+    where
+        P: AstNode<N>,
+        N: 'a,
+    {
+        P::cast(self.inner().parent()?)
+    }
+
+    /// Calculates the span of a scope given the node where the scope is
+    /// visible.
+    ///
+    /// Returns `None` if the node does not contain the open and close tokens as
+    /// children.
+    fn scope_span<O, C>(&self) -> Option<Span>
+    where
+        O: AstToken<N::Token>,
+        C: AstToken<N::Token>,
+    {
+        let open = self.token::<O>()?.span();
+        let close = self.last_token::<C>()?.span();
+
+        // The span starts after the opening brace and before the closing brace
+        Some(Span::new(open.end(), close.start() - open.end()))
+    }
+
+    /// Gets the interior span of child opening and closing brace tokens for the
+    /// node.
+    ///
+    /// The span starts from immediately after the opening brace token and ends
+    /// immediately before the closing brace token.
+    ///
+    /// Returns `None` if the node does not contain child brace tokens.
+    fn braced_scope_span(&self) -> Option<Span> {
+        self.scope_span::<OpenBrace<N::Token>, CloseBrace<N::Token>>()
+    }
+
+    /// Gets the interior span of child opening and closing heredoc tokens for
+    /// the node.
+    ///
+    /// The span starts from immediately after the opening heredoc token and
+    /// ends immediately before the closing heredoc token.
+    ///
+    /// Returns `None` if the node does not contain child heredoc tokens.
+    fn heredoc_scope_span(&self) -> Option<Span> {
+        self.scope_span::<OpenHeredoc<N::Token>, CloseHeredoc<N::Token>>()
+    }
+
+    /// Gets the node descendants (including self) from this node that can be
+    /// cast to the expected type.
+    fn descendants<'a, D>(&'a self) -> impl Iterator<Item = D>
+    where
+        D: AstNode<N>,
+        N: 'a,
+    {
+        self.inner().descendants().filter_map(|d| D::cast(d))
+    }
+}
+
+/// A trait implemented by AST tokens.
+pub trait AstToken<T: TreeToken>: Sized {
+    /// Determines if the kind can be cast to this representation.
+    fn can_cast(kind: SyntaxKind) -> bool;
+
+    /// Casts the given inner type to the this representation.
+    fn cast(inner: T) -> Option<Self>;
+
+    /// Gets the inner type from this representation.
+    fn inner(&self) -> &T;
+
+    /// Gets the syntax kind of the token.
+    fn kind(&self) -> SyntaxKind {
+        self.inner().kind()
+    }
+
+    /// Gets the text of the token.
+    fn text<'a>(&'a self) -> &'a str
+    where
+        T: 'a,
+    {
+        self.inner().text()
+    }
+
+    /// Gets the span of the token.
+    fn span(&self) -> Span {
+        self.inner().span()
+    }
+
+    /// Gets the parent of the token.
+    ///
+    /// Returns `None` if the parent node cannot be cast to the expected type.
+    fn parent<'a, P>(&self) -> Option<P>
+    where
+        P: AstNode<T::Node>,
+        T: 'a,
+    {
+        P::cast(self.inner().parent())
+    }
+}
+
+/// Implemented by nodes that can create a new root from a different tree node
+/// type.
+pub trait NewRoot<N: TreeNode>: Sized {
+    /// Constructs a new root node from the give root node of a different tree
+    /// node type.
+    fn new_root(root: N) -> Self;
+}
+
+impl TreeNode for SyntaxNode {
+    type Token = SyntaxToken;
+
+    fn parent(&self) -> Option<SyntaxNode> {
+        self.parent()
+    }
+
+    fn kind(&self) -> SyntaxKind {
+        self.kind()
+    }
+
+    fn children(&self) -> impl Iterator<Item = Self> {
+        self.children()
+    }
+
+    fn children_with_tokens(&self) -> impl Iterator<Item = NodeOrToken<Self, Self::Token>> {
+        self.children_with_tokens()
+    }
+
+    fn text(&self) -> impl fmt::Display {
+        self.text()
+    }
+
+    fn span(&self) -> Span {
+        let range = self.text_range();
+        let start = usize::from(range.start());
+        Span::new(start, usize::from(range.end()) - start)
+    }
+
+    fn last_token(&self) -> Option<Self::Token> {
+        self.last_token()
+    }
+
+    fn descendants(&self) -> impl Iterator<Item = Self> {
+        self.descendants()
+    }
+
+    fn ancestors(&self) -> impl Iterator<Item = Self> {
+        self.ancestors()
+    }
+
+    fn is_rule_excepted(&self, id: &str) -> bool {
+        <Self as SyntaxNodeExt>::is_rule_excepted(self, id)
+    }
+}
+
+impl TreeToken for SyntaxToken {
+    type Node = SyntaxNode;
+
+    fn parent(&self) -> SyntaxNode {
+        self.parent().expect("token should have a parent")
+    }
+
+    fn kind(&self) -> SyntaxKind {
+        self.kind()
+    }
+
+    fn text(&self) -> &str {
+        self.text()
+    }
+
+    fn span(&self) -> Span {
+        let range = self.text_range();
+        let start = usize::from(range.start());
+        Span::new(start, usize::from(range.end()) - start)
+    }
 }
 
 /// Represents the reason an AST node has been visited.
@@ -87,69 +402,6 @@ pub enum VisitReason {
     Enter,
     /// The visit has exited the node.
     Exit,
-}
-
-/// Calculates the span of a scope given the node where the scope is visible.
-fn scope_span(parent: &crate::SyntaxNode, open: SyntaxKind, close: SyntaxKind) -> Option<Span> {
-    let open = rowan::ast::support::token(parent, open)?
-        .text_range()
-        .to_span();
-    let close = parent
-        .last_child_or_token()
-        .and_then(|c| {
-            if c.kind() == close {
-                c.into_token()
-            } else {
-                None
-            }
-        })?
-        .text_range()
-        .to_span();
-
-    // The span starts after the opening brace and before the closing brace
-    Some(Span::new(open.end(), close.start() - open.end()))
-}
-
-/// An extension trait for AST nodes.
-pub trait AstNodeExt {
-    /// Gets the source span of the node.
-    fn span(&self) -> Span;
-
-    /// Gets the interior span of child opening and closing brace tokens for the
-    /// node.
-    ///
-    /// The span starts from immediately after the opening brace token and ends
-    /// immediately before the closing brace token.
-    ///
-    /// Returns `None` if the node does not contain child brace tokens.
-    fn braced_scope_span(&self) -> Option<Span>;
-
-    /// Gets the interior span of child opening and closing heredoc tokens for
-    /// the node.
-    ///
-    /// The span starts from immediately after the opening heredoc token and
-    /// ends immediately before the closing heredoc token.
-    ///
-    /// Returns `None` if the node does not contain child heredoc tokens.
-    fn heredoc_scope_span(&self) -> Option<Span>;
-}
-
-impl<T: AstNode<Language = WorkflowDescriptionLanguage>> AstNodeExt for T {
-    fn span(&self) -> Span {
-        self.syntax().text_range().to_span()
-    }
-
-    fn braced_scope_span(&self) -> Option<Span> {
-        scope_span(self.syntax(), SyntaxKind::OpenBrace, SyntaxKind::CloseBrace)
-    }
-
-    fn heredoc_scope_span(&self) -> Option<Span> {
-        scope_span(
-            self.syntax(),
-            SyntaxKind::OpenHeredoc,
-            SyntaxKind::CloseHeredoc,
-        )
-    }
 }
 
 /// An extension trait for syntax nodes.
@@ -208,66 +460,22 @@ impl SyntaxNodeExt for SyntaxNode {
     }
 }
 
-/// The trait implemented on AST tokens to go from untyped `SyntaxToken`
-/// to a typed representation.
-///
-/// The design of `AstToken` is directly inspired by `rust-analyzer`.
-pub trait AstToken {
-    /// Determines if the kind can be cast to this type representation.
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized;
-
-    /// Casts the untyped `SyntaxToken` to the typed representation.
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized;
-
-    /// Gets the untyped `SyntaxToken` of this AST token.
-    fn syntax(&self) -> &SyntaxToken;
-
-    /// Gets the text of the token.
-    fn as_str(&self) -> &str {
-        self.syntax().text()
-    }
-
-    /// Gets the source span of the token.
-    fn span(&self) -> Span {
-        self.syntax().text_range().to_span()
-    }
-}
-
-/// Finds the first child that casts to a particular [`AstToken`].
-pub fn token_child<T: AstToken>(parent: &SyntaxNode) -> Option<T> {
-    parent
-        .children_with_tokens()
-        .filter_map(|c| c.into_token())
-        .find_map(T::cast)
-}
-
-/// Finds all children that cast to a particular [`AstToken`].
-pub fn token_children<T: AstToken>(parent: &SyntaxNode) -> impl Iterator<Item = T> + use<T> {
-    parent
-        .children_with_tokens()
-        .filter_map(|c| c.into_token().and_then(T::cast))
-}
-
 /// Represents the AST of a [Document].
 ///
 /// See [Document::ast].
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Ast {
+pub enum Ast<N: TreeNode = SyntaxNode> {
     /// The WDL document specifies an unsupported version.
     Unsupported,
     /// The WDL document is V1.
-    V1(v1::Ast),
+    V1(v1::Ast<N>),
 }
 
-impl Ast {
+impl<N: TreeNode> Ast<N> {
     /// Gets the AST as a V1 AST.
     ///
     /// Returns `None` if the AST is not a V1 AST.
-    pub fn as_v1(&self) -> Option<&v1::Ast> {
+    pub fn as_v1(&self) -> Option<&v1::Ast<N>> {
         match self {
             Self::V1(ast) => Some(ast),
             _ => None,
@@ -275,7 +483,7 @@ impl Ast {
     }
 
     /// Consumes `self` and attempts to return the V1 AST.
-    pub fn into_v1(self) -> Option<v1::Ast> {
+    pub fn into_v1(self) -> Option<v1::Ast<N>> {
         match self {
             Self::V1(ast) => Some(ast),
             _ => None,
@@ -287,7 +495,7 @@ impl Ast {
     /// # Panics
     ///
     /// Panics if the AST is not a V1 AST.
-    pub fn unwrap_v1(self) -> v1::Ast {
+    pub fn unwrap_v1(self) -> v1::Ast<N> {
         self.into_v1().expect("the AST is not a V1 AST")
     }
 }
@@ -297,30 +505,27 @@ impl Ast {
 /// See [Document::ast] for getting a version-specific Abstract
 /// Syntax Tree.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Document(SyntaxNode);
+pub struct Document<N: TreeNode = SyntaxNode>(N);
 
-impl Document {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`Document`].
-    pub fn can_cast(kind: SyntaxKind) -> bool {
+impl<N: TreeNode> AstNode<N> for Document<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::RootNode
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`Document`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if Self::can_cast(syntax.kind()) {
-            Some(Self(syntax))
+    fn cast(inner: N) -> Option<Self> {
+        if Self::can_cast(inner.kind()) {
+            Some(Self(inner))
         } else {
             None
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
+}
 
+impl Document {
     /// Parses a document from the given source.
     ///
     /// A document and its AST elements are trivially cloned.
@@ -337,7 +542,7 @@ impl Document {
     ///         .version_statement()
     ///         .expect("should have version statement")
     ///         .version()
-    ///         .as_str(),
+    ///         .text(),
     ///     "1.1"
     /// );
     ///
@@ -355,26 +560,39 @@ impl Document {
             diagnostics,
         )
     }
+}
 
+impl<N: TreeNode> Document<N> {
     /// Gets the version statement of the document.
     ///
     /// This can be used to determine the version of the document that was
     /// parsed.
     ///
     /// A return value of `None` signifies a missing version statement.
-    pub fn version_statement(&self) -> Option<VersionStatement> {
-        support::child(&self.0)
+    pub fn version_statement(&self) -> Option<VersionStatement<N>> {
+        self.child()
     }
 
     /// Gets the AST representation of the document.
-    pub fn ast(&self) -> Ast {
+    pub fn ast(&self) -> Ast<N> {
         self.version_statement()
             .as_ref()
-            .and_then(|s| s.version().as_str().parse::<SupportedVersion>().ok())
-            .map(|_| Ast::V1(v1::Ast::cast(self.0.clone()).expect("root should cast")))
+            .and_then(|s| s.version().text().parse::<SupportedVersion>().ok())
+            .map(|v| match v {
+                SupportedVersion::V1(_) => Ast::V1(v1::Ast(self.0.clone())),
+                _ => Ast::Unsupported,
+            })
             .unwrap_or(Ast::Unsupported)
     }
 
+    /// Morphs a document of one node type to a document of a different node
+    /// type.
+    pub fn morph<U: TreeNode + NewRoot<N>>(self) -> Document<U> {
+        Document(U::new_root(self.0))
+    }
+}
+
+impl Document<SyntaxNode> {
     /// Visits the document with a pre-order traversal using the provided
     /// visitor to visit each element in the document.
     pub fn visit<V: Visitor>(&self, state: &mut V::State, visitor: &mut V) {
@@ -390,190 +608,169 @@ impl fmt::Debug for Document {
 
 /// Represents a whitespace token in the AST.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Whitespace(SyntaxToken);
+pub struct Whitespace<T: TreeToken = SyntaxToken>(T);
 
-impl AstToken for Whitespace {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> AstToken<T> for Whitespace<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::Whitespace
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::Whitespace => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::Whitespace => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
 /// Represents a comment token in the AST.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Comment(SyntaxToken);
+pub struct Comment<T: TreeToken = SyntaxToken>(T);
 
-impl AstToken for Comment {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> AstToken<T> for Comment<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::Comment
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::Comment => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::Comment => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
 /// Represents a version statement in a WDL AST.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct VersionStatement(SyntaxNode);
+pub struct VersionStatement<N: TreeNode = SyntaxNode>(N);
 
-impl VersionStatement {
+impl<N: TreeNode> VersionStatement<N> {
     /// Gets the version of the version statement.
-    pub fn version(&self) -> Version {
-        token(&self.0).expect("version statement must have a version token")
+    pub fn version(&self) -> Version<N::Token> {
+        self.token()
+            .expect("version statement must have a version token")
     }
 
     /// Gets the version keyword of the version statement.
-    pub fn keyword(&self) -> v1::VersionKeyword {
-        token(&self.0).expect("version statement must have a version keyword")
+    pub fn keyword(&self) -> v1::VersionKeyword<N::Token> {
+        self.token()
+            .expect("version statement must have a version keyword")
     }
 }
 
-impl AstNode for VersionStatement {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for VersionStatement<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::VersionStatementNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::VersionStatementNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::VersionStatementNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a version in the AST.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Version(SyntaxToken);
+pub struct Version<T: TreeToken = SyntaxToken>(T);
 
-impl AstToken for Version {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> AstToken<T> for Version<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::Version
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::Version => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::Version => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
 /// Represents an identifier token.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Ident(SyntaxToken);
+pub struct Ident<T: TreeToken = SyntaxToken>(T);
 
-impl AstToken for Ident {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> Ident<T> {
+    /// Gets a hashable representation of the identifier.
+    pub fn hashable(&self) -> TokenText<T> {
+        TokenText(self.0.clone())
+    }
+}
+
+impl<T: TreeToken> AstToken<T> for Ident<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::Ident
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::Ident => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::Ident => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
-/// Helper for hashing any AST token on string representation alone.
+/// Helper for hashing tokens by their text.
 ///
-/// Normally an AST token's equality and hash implementation work by comparing
-/// the token's element in the AST; thus, two `Ident` tokens with the same name
+/// Normally a token's equality and hash implementation work by comparing
+/// the token's element in the tree; thus, two tokens with the same text
 /// but different positions in the tree will compare and hash differently.
+///
+/// With this hash implementation, two tokens compare and hash identically if
+/// their text is the identical.
 #[derive(Debug, Clone)]
-pub struct TokenStrHash<T>(T);
+pub struct TokenText<T: TreeToken = SyntaxToken>(T);
 
-impl<T: AstToken> TokenStrHash<T> {
-    /// Constructs a new token hash for the given token.
-    pub fn new(token: T) -> Self {
-        Self(token)
+impl TokenText {
+    /// Gets the text of the underlying token.
+    pub fn text(&self) -> &str {
+        self.0.text()
+    }
+
+    /// Gets the span of the underlying token.
+    pub fn span(&self) -> Span {
+        self.0.span()
     }
 }
 
-impl<T: AstToken> PartialEq for TokenStrHash<T> {
+impl<T: TreeToken> PartialEq for TokenText<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.0.as_str() == other.0.as_str()
+        self.0.text() == other.0.text()
     }
 }
 
-impl<T: AstToken> Eq for TokenStrHash<T> {}
+impl<T: TreeToken> Eq for TokenText<T> {}
 
-impl<T: AstToken> std::hash::Hash for TokenStrHash<T> {
+impl<T: TreeToken> std::hash::Hash for TokenText<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.as_str().hash(state);
+        self.0.text().hash(state);
     }
 }
 
-impl<T: AstToken> std::borrow::Borrow<str> for TokenStrHash<T> {
+impl<T: TreeToken> std::borrow::Borrow<str> for TokenText<T> {
     fn borrow(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl<T: AstToken> AsRef<T> for TokenStrHash<T> {
-    fn as_ref(&self) -> &T {
-        &self.0
+        self.0.text()
     }
 }

--- a/wdl-ast/src/lib.rs
+++ b/wdl-ast/src/lib.rs
@@ -739,7 +739,7 @@ impl<T: TreeToken> AstToken<T> for Ident<T> {
 /// but different positions in the tree will compare and hash differently.
 ///
 /// With this hash implementation, two tokens compare and hash identically if
-/// their text is the identical.
+/// their text is identical.
 #[derive(Debug, Clone)]
 pub struct TokenText<T: TreeToken = SyntaxToken>(T);
 

--- a/wdl-ast/src/v1.rs
+++ b/wdl-ast/src/v1.rs
@@ -131,6 +131,16 @@ impl<N: TreeNode> DocumentItem<N> {
         }
     }
 
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
+        match self {
+            Self::Import(e) => e.inner(),
+            Self::Struct(e) => e.inner(),
+            Self::Task(e) => e.inner(),
+            Self::Workflow(e) => e.inner(),
+        }
+    }
+
     /// Attempts to get a reference to the inner [`ImportStatement`].
     ///
     /// * If `self` is a [`DocumentItem::Import`], then a reference to the inner

--- a/wdl-ast/src/v1.rs
+++ b/wdl-ast/src/v1.rs
@@ -1,11 +1,9 @@
 //! AST representation for a 1.x WDL document.
 
-use crate::AstChildren;
 use crate::AstNode;
 use crate::SyntaxKind;
 use crate::SyntaxNode;
-use crate::WorkflowDescriptionLanguage;
-use crate::support::children;
+use crate::TreeNode;
 
 mod decls;
 mod expr;
@@ -37,76 +35,68 @@ pub use workflow::*;
 ///
 /// [1]: crate::SyntaxTree
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Ast(SyntaxNode);
+pub struct Ast<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl Ast {
+impl<N: TreeNode> Ast<N> {
     /// Gets all of the document items in the AST.
-    pub fn items(&self) -> impl Iterator<Item = DocumentItem> + use<> {
+    pub fn items(&self) -> impl Iterator<Item = DocumentItem<N>> + use<'_, N> {
         DocumentItem::children(&self.0)
     }
 
     /// Gets the import statements in the AST.
-    pub fn imports(&self) -> AstChildren<ImportStatement> {
-        children(&self.0)
+    pub fn imports(&self) -> impl Iterator<Item = ImportStatement<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the struct definitions in the AST.
-    pub fn structs(&self) -> AstChildren<StructDefinition> {
-        children(&self.0)
+    pub fn structs(&self) -> impl Iterator<Item = StructDefinition<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the task definitions in the AST.
-    pub fn tasks(&self) -> AstChildren<TaskDefinition> {
-        children(&self.0)
+    pub fn tasks(&self) -> impl Iterator<Item = TaskDefinition<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the workflow definitions in the AST.
-    pub fn workflows(&self) -> AstChildren<WorkflowDefinition> {
-        children(&self.0)
+    pub fn workflows(&self) -> impl Iterator<Item = WorkflowDefinition<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for Ast {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for Ast<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::RootNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::RootNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::RootNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a document item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum DocumentItem {
+pub enum DocumentItem<N: TreeNode = SyntaxNode> {
     /// The item is an import statement.
-    Import(ImportStatement),
+    Import(ImportStatement<N>),
     /// The item is a struct definition.
-    Struct(StructDefinition),
+    Struct(StructDefinition<N>),
     /// The item is a task definition.
-    Task(TaskDefinition),
+    Task(TaskDefinition<N>),
     /// The item is a workflow definition.
-    Workflow(WorkflowDefinition),
+    Workflow(WorkflowDefinition<N>),
 }
 
-impl DocumentItem {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`DocumentItem`].
+impl<N: TreeNode> DocumentItem<N> {
+    // Returns whether or not the given syntax kind can be cast to
+    /// [`DocumentItem`].
     pub fn can_cast(kind: SyntaxKind) -> bool
     where
         Self: Sized,
@@ -120,36 +110,24 @@ impl DocumentItem {
         )
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`DocumentItem`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
+    /// Casts the given node to [`DocumentItem`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
             SyntaxKind::ImportStatementNode => Some(Self::Import(
-                ImportStatement::cast(syntax).expect("import statement to cast"),
+                ImportStatement::cast(inner).expect("import statement to cast"),
             )),
             SyntaxKind::StructDefinitionNode => Some(Self::Struct(
-                StructDefinition::cast(syntax).expect("struct definition to cast"),
+                StructDefinition::cast(inner).expect("struct definition to cast"),
             )),
             SyntaxKind::TaskDefinitionNode => Some(Self::Task(
-                TaskDefinition::cast(syntax).expect("task definition to cast"),
+                TaskDefinition::cast(inner).expect("task definition to cast"),
             )),
             SyntaxKind::WorkflowDefinitionNode => Some(Self::Workflow(
-                WorkflowDefinition::cast(syntax).expect("workflow definition to cast"),
+                WorkflowDefinition::cast(inner).expect("workflow definition to cast"),
             )),
             _ => None,
-        }
-    }
-
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
-        match self {
-            Self::Import(element) => element.syntax(),
-            Self::Struct(element) => element.syntax(),
-            Self::Task(element) => element.syntax(),
-            Self::Workflow(element) => element.syntax(),
         }
     }
 
@@ -158,9 +136,9 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Import`], then a reference to the inner
     ///   [`ImportStatement`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_import_statement(&self) -> Option<&ImportStatement> {
+    pub fn as_import_statement(&self) -> Option<&ImportStatement<N>> {
         match self {
-            DocumentItem::Import(import) => Some(import),
+            Self::Import(i) => Some(i),
             _ => None,
         }
     }
@@ -170,9 +148,9 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Import`], then the inner
     ///   [`ImportStatement`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_import_statement(self) -> Option<ImportStatement> {
+    pub fn into_import_statement(self) -> Option<ImportStatement<N>> {
         match self {
-            DocumentItem::Import(import) => Some(import),
+            Self::Import(i) => Some(i),
             _ => None,
         }
     }
@@ -182,9 +160,9 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Struct`], then a reference to the inner
     ///   [`StructDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_struct_definition(&self) -> Option<&StructDefinition> {
+    pub fn as_struct_definition(&self) -> Option<&StructDefinition<N>> {
         match self {
-            DocumentItem::Struct(r#struct) => Some(r#struct),
+            Self::Struct(i) => Some(i),
             _ => None,
         }
     }
@@ -194,9 +172,9 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Struct`], then the inner
     ///   [`StructDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_struct_definition(self) -> Option<StructDefinition> {
+    pub fn into_struct_definition(self) -> Option<StructDefinition<N>> {
         match self {
-            DocumentItem::Struct(r#struct) => Some(r#struct),
+            Self::Struct(i) => Some(i),
             _ => None,
         }
     }
@@ -206,9 +184,9 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Task`], then a reference to the inner
     ///   [`TaskDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_task_definition(&self) -> Option<&TaskDefinition> {
+    pub fn as_task_definition(&self) -> Option<&TaskDefinition<N>> {
         match self {
-            DocumentItem::Task(task) => Some(task),
+            Self::Task(i) => Some(i),
             _ => None,
         }
     }
@@ -218,9 +196,9 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Task`], then the inner
     ///   [`TaskDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_task_definition(self) -> Option<TaskDefinition> {
+    pub fn into_task_definition(self) -> Option<TaskDefinition<N>> {
         match self {
-            DocumentItem::Task(task) => Some(task),
+            Self::Task(i) => Some(i),
             _ => None,
         }
     }
@@ -230,9 +208,9 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Workflow`], then a reference to the
     ///   inner [`WorkflowDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_workflow_definition(&self) -> Option<&WorkflowDefinition> {
+    pub fn as_workflow_definition(&self) -> Option<&WorkflowDefinition<N>> {
         match self {
-            DocumentItem::Workflow(workflow) => Some(workflow),
+            Self::Workflow(i) => Some(i),
             _ => None,
         }
     }
@@ -242,28 +220,20 @@ impl DocumentItem {
     /// * If `self` is a [`DocumentItem::Workflow`], then the inner
     ///   [`WorkflowDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_workflow_definition(self) -> Option<WorkflowDefinition> {
+    pub fn into_workflow_definition(self) -> Option<WorkflowDefinition<N>> {
         match self {
-            DocumentItem::Workflow(workflow) => Some(workflow),
+            Self::Workflow(i) => Some(i),
             _ => None,
         }
     }
 
-    /// Finds the first child that can be cast to an [`DocumentItem`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`DocumentItem`] to
-    /// implement the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    /// Finds the first child that can be cast to a [`DocumentItem`].
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
-    /// Finds all children that can be cast to an [`DocumentItem`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring [`DocumentItem`] to
-    /// implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = DocumentItem> + use<> {
-        syntax.children().filter_map(Self::cast)
+    /// Finds all children that can be cast to a [`DocumentItem`].
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
     }
 }

--- a/wdl-ast/src/v1/decls.rs
+++ b/wdl-ast/src/v1/decls.rs
@@ -818,7 +818,7 @@ impl<N: TreeNode> Decl<N> {
         kind == SyntaxKind::BoundDeclNode || kind == SyntaxKind::UnboundDeclNode
     }
 
-    /// Casts the given node to [`StructItem`].
+    /// Casts the given node to [`Decl`].
     ///
     /// Returns `None` if the node cannot be cast.
     pub fn cast(inner: N) -> Option<Self> {

--- a/wdl-ast/src/v1/decls.rs
+++ b/wdl-ast/src/v1/decls.rs
@@ -4,22 +4,23 @@ use std::fmt;
 
 use super::EnvKeyword;
 use super::Expr;
+use super::Plus;
+use super::QuestionMark;
 use crate::AstNode;
 use crate::AstToken;
 use crate::Ident;
 use crate::SyntaxKind;
 use crate::SyntaxNode;
-use crate::WorkflowDescriptionLanguage;
-use crate::support;
-use crate::token;
+use crate::TreeNode;
+use crate::TreeToken;
 
 /// Represents a `Map` type.
 #[derive(Clone, Debug, Eq)]
-pub struct MapType(SyntaxNode);
+pub struct MapType<N: TreeNode = SyntaxNode>(N);
 
-impl MapType {
+impl<N: TreeNode> MapType<N> {
     /// Gets the key and value types of the `Map`.
-    pub fn types(&self) -> (PrimitiveType, Type) {
+    pub fn types(&self) -> (PrimitiveType<N>, Type<N>) {
         let mut children = self.0.children().filter_map(Type::cast);
         let key = children
             .next()
@@ -38,33 +39,25 @@ impl MapType {
     }
 }
 
-impl PartialEq for MapType {
+impl<N: TreeNode> PartialEq for MapType<N> {
     fn eq(&self, other: &Self) -> bool {
         self.is_optional() == other.is_optional() && self.types() == other.types()
     }
 }
 
-impl AstNode for MapType {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for MapType<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::MapTypeNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::MapTypeNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::MapTypeNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -82,29 +75,26 @@ impl fmt::Display for MapType {
 
 /// Represents an `Array` type.
 #[derive(Clone, Debug, Eq)]
-pub struct ArrayType(SyntaxNode);
+pub struct ArrayType<N: TreeNode = SyntaxNode>(N);
 
-impl ArrayType {
+impl<N: TreeNode> ArrayType<N> {
     /// Gets the element type of the array.
-    pub fn element_type(&self) -> Type {
+    pub fn element_type(&self) -> Type<N> {
         Type::child(&self.0).expect("array should have an element type")
     }
 
     /// Determines if the type has the "non-empty" qualifier.
     pub fn is_non_empty(&self) -> bool {
-        support::token(&self.0, SyntaxKind::Plus).is_some()
+        self.token::<Plus<N::Token>>().is_some()
     }
 
     /// Determines if the type is optional.
     pub fn is_optional(&self) -> bool {
-        matches!(
-            self.0.last_token().map(|t| t.kind()),
-            Some(SyntaxKind::QuestionMark)
-        )
+        self.last_token::<QuestionMark<N::Token>>().is_some()
     }
 }
 
-impl PartialEq for ArrayType {
+impl<N: TreeNode> PartialEq for ArrayType<N> {
     fn eq(&self, other: &Self) -> bool {
         self.is_optional() == other.is_optional()
             && self.is_non_empty() == other.is_non_empty()
@@ -112,27 +102,19 @@ impl PartialEq for ArrayType {
     }
 }
 
-impl AstNode for ArrayType {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for ArrayType<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::ArrayTypeNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::ArrayTypeNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::ArrayTypeNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -151,11 +133,11 @@ impl fmt::Display for ArrayType {
 
 /// Represents a `Pair` type.
 #[derive(Clone, Debug, Eq)]
-pub struct PairType(SyntaxNode);
+pub struct PairType<N: TreeNode = SyntaxNode>(N);
 
-impl PairType {
+impl<N: TreeNode> PairType<N> {
     /// Gets the first and second types of the `Pair`.
-    pub fn types(&self) -> (Type, Type) {
+    pub fn types(&self) -> (Type<N>, Type<N>) {
         let mut children = self.0.children().filter_map(Type::cast);
         let left = children.next().expect("pair should have a left type");
         let right = children.next().expect("pair should have a right type");
@@ -171,33 +153,25 @@ impl PairType {
     }
 }
 
-impl PartialEq for PairType {
+impl<N: TreeNode> PartialEq for PairType<N> {
     fn eq(&self, other: &Self) -> bool {
         self.is_optional() == other.is_optional() && self.types() == other.types()
     }
 }
 
-impl AstNode for PairType {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for PairType<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::PairTypeNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::PairTypeNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::PairTypeNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -215,9 +189,9 @@ impl fmt::Display for PairType {
 
 /// Represents a `Object` type.
 #[derive(Clone, Debug, Eq)]
-pub struct ObjectType(SyntaxNode);
+pub struct ObjectType<N: TreeNode = SyntaxNode>(N);
 
-impl ObjectType {
+impl<N: TreeNode> ObjectType<N> {
     /// Determines if the type is optional.
     pub fn is_optional(&self) -> bool {
         matches!(
@@ -227,33 +201,25 @@ impl ObjectType {
     }
 }
 
-impl PartialEq for ObjectType {
+impl<N: TreeNode> PartialEq for ObjectType<N> {
     fn eq(&self, other: &Self) -> bool {
         self.is_optional() == other.is_optional()
     }
 }
 
-impl AstNode for ObjectType {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for ObjectType<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::ObjectTypeNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::ObjectTypeNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::ObjectTypeNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -270,12 +236,12 @@ impl fmt::Display for ObjectType {
 
 /// Represents a reference to a type.
 #[derive(Clone, Debug, Eq)]
-pub struct TypeRef(SyntaxNode);
+pub struct TypeRef<N: TreeNode = SyntaxNode>(N);
 
-impl TypeRef {
+impl<N: TreeNode> TypeRef<N> {
     /// Gets the name of the type reference.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("type reference should have a name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("type reference should have a name")
     }
 
     /// Determines if the type is optional.
@@ -287,33 +253,25 @@ impl TypeRef {
     }
 }
 
-impl PartialEq for TypeRef {
+impl<N: TreeNode> PartialEq for TypeRef<N> {
     fn eq(&self, other: &Self) -> bool {
-        self.is_optional() == other.is_optional() && self.name().as_str() == other.name().as_str()
+        self.is_optional() == other.is_optional() && self.name().text() == other.name().text()
     }
 }
 
-impl AstNode for TypeRef {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for TypeRef<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::TypeRefNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::TypeRefNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::TypeRefNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -323,7 +281,7 @@ impl fmt::Display for TypeRef {
         write!(
             f,
             "{n}{o}",
-            n = self.name().as_str(),
+            n = self.name().text(),
             o = if self.is_optional() { "?" } else { "" }
         )
     }
@@ -348,21 +306,23 @@ pub enum PrimitiveTypeKind {
 
 /// Represents a primitive type.
 #[derive(Clone, Debug, Eq)]
-pub struct PrimitiveType(SyntaxNode);
+pub struct PrimitiveType<N: TreeNode = SyntaxNode>(N);
 
-impl PrimitiveType {
+impl<N: TreeNode> PrimitiveType<N> {
     /// Gets the kind of the primitive type.
     pub fn kind(&self) -> PrimitiveTypeKind {
         self.0
             .children_with_tokens()
-            .find_map(|t| match t.kind() {
-                SyntaxKind::BooleanTypeKeyword => Some(PrimitiveTypeKind::Boolean),
-                SyntaxKind::IntTypeKeyword => Some(PrimitiveTypeKind::Integer),
-                SyntaxKind::FloatTypeKeyword => Some(PrimitiveTypeKind::Float),
-                SyntaxKind::StringTypeKeyword => Some(PrimitiveTypeKind::String),
-                SyntaxKind::FileTypeKeyword => Some(PrimitiveTypeKind::File),
-                SyntaxKind::DirectoryTypeKeyword => Some(PrimitiveTypeKind::Directory),
-                _ => None,
+            .find_map(|c| {
+                c.into_token().and_then(|t| match t.kind() {
+                    SyntaxKind::BooleanTypeKeyword => Some(PrimitiveTypeKind::Boolean),
+                    SyntaxKind::IntTypeKeyword => Some(PrimitiveTypeKind::Integer),
+                    SyntaxKind::FloatTypeKeyword => Some(PrimitiveTypeKind::Float),
+                    SyntaxKind::StringTypeKeyword => Some(PrimitiveTypeKind::String),
+                    SyntaxKind::FileTypeKeyword => Some(PrimitiveTypeKind::File),
+                    SyntaxKind::DirectoryTypeKeyword => Some(PrimitiveTypeKind::Directory),
+                    _ => None,
+                })
             })
             .expect("type should have a kind")
     }
@@ -376,33 +336,25 @@ impl PrimitiveType {
     }
 }
 
-impl PartialEq for PrimitiveType {
+impl<N: TreeNode> PartialEq for PrimitiveType<N> {
     fn eq(&self, other: &Self) -> bool {
         self.kind() == other.kind()
     }
 }
 
-impl AstNode for PrimitiveType {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for PrimitiveType<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::PrimitiveTypeNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::PrimitiveTypeNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::PrimitiveTypeNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -427,29 +379,26 @@ impl fmt::Display for PrimitiveType {
 }
 
 /// Represents a type.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Type {
+#[derive(Clone, Debug, Eq)]
+pub enum Type<N: TreeNode = SyntaxNode> {
     /// The type is a map.
-    Map(MapType),
+    Map(MapType<N>),
     /// The type is an array.
-    Array(ArrayType),
+    Array(ArrayType<N>),
     /// The type is a pair.
-    Pair(PairType),
+    Pair(PairType<N>),
     /// The type is an object.
-    Object(ObjectType),
+    Object(ObjectType<N>),
     /// The type is a reference to custom type.
-    Ref(TypeRef),
+    Ref(TypeRef<N>),
     /// The type is a primitive.
-    Primitive(PrimitiveType),
+    Primitive(PrimitiveType<N>),
 }
 
-impl Type {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`Type`].
-    pub fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> Type<N> {
+    //// Returns whether or not the given syntax kind can be cast to
+    /// [`Type`].
+    pub fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
             SyntaxKind::MapTypeNode
@@ -461,41 +410,42 @@ impl Type {
         )
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`Type`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self> {
-        match syntax.kind() {
+    /// Casts the given node to [`Type`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
             SyntaxKind::MapTypeNode => {
-                Some(Self::Map(MapType::cast(syntax).expect("map type to cast")))
+                Some(Self::Map(MapType::cast(inner).expect("map type to cast")))
             }
             SyntaxKind::ArrayTypeNode => Some(Self::Array(
-                ArrayType::cast(syntax).expect("array type to cast"),
+                ArrayType::cast(inner).expect("array type to cast"),
             )),
             SyntaxKind::PairTypeNode => Some(Self::Pair(
-                PairType::cast(syntax).expect("pair type to cast"),
+                PairType::cast(inner).expect("pair type to cast"),
             )),
             SyntaxKind::ObjectTypeNode => Some(Self::Object(
-                ObjectType::cast(syntax).expect("object type to cast"),
+                ObjectType::cast(inner).expect("object type to cast"),
             )),
             SyntaxKind::TypeRefNode => {
-                Some(Self::Ref(TypeRef::cast(syntax).expect("type ref to cast")))
+                Some(Self::Ref(TypeRef::cast(inner).expect("type ref to cast")))
             }
             SyntaxKind::PrimitiveTypeNode => Some(Self::Primitive(
-                PrimitiveType::cast(syntax).expect("primitive type to cast"),
+                PrimitiveType::cast(inner).expect("primitive type to cast"),
             )),
             _ => None,
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
         match self {
-            Type::Map(element) => element.syntax(),
-            Type::Array(element) => element.syntax(),
-            Type::Pair(element) => element.syntax(),
-            Type::Object(element) => element.syntax(),
-            Type::Ref(element) => element.syntax(),
-            Type::Primitive(element) => element.syntax(),
+            Self::Map(ty) => ty.inner(),
+            Self::Array(ty) => ty.inner(),
+            Self::Pair(ty) => ty.inner(),
+            Self::Object(ty) => ty.inner(),
+            Self::Ref(ty) => ty.inner(),
+            Self::Primitive(ty) => ty.inner(),
         }
     }
 
@@ -516,9 +466,9 @@ impl Type {
     /// * If `self` is a [`Type::Map`], then a reference to the inner
     ///   [`MapType`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_map_type(&self) -> Option<&MapType> {
+    pub fn as_map_type(&self) -> Option<&MapType<N>> {
         match self {
-            Self::Map(map) => Some(map),
+            Self::Map(ty) => Some(ty),
             _ => None,
         }
     }
@@ -528,9 +478,9 @@ impl Type {
     /// * If `self` is a [`Type::Map`], then the inner [`MapType`] is returned
     ///   wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_map_type(self) -> Option<MapType> {
+    pub fn into_map_type(self) -> Option<MapType<N>> {
         match self {
-            Self::Map(map) => Some(map),
+            Self::Map(ty) => Some(ty),
             _ => None,
         }
     }
@@ -540,7 +490,7 @@ impl Type {
     /// # Panics
     ///
     /// Panics if the type is not a map type.
-    pub fn unwrap_map_type(self) -> MapType {
+    pub fn unwrap_map_type(self) -> MapType<N> {
         match self {
             Self::Map(ty) => ty,
             _ => panic!("not a map type"),
@@ -552,9 +502,9 @@ impl Type {
     /// * If `self` is a [`Type::Array`], then a reference to the inner
     ///   [`ArrayType`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_array_type(&self) -> Option<&ArrayType> {
+    pub fn as_array_type(&self) -> Option<&ArrayType<N>> {
         match self {
-            Self::Array(array) => Some(array),
+            Self::Array(ty) => Some(ty),
             _ => None,
         }
     }
@@ -564,9 +514,9 @@ impl Type {
     /// * If `self` is a [`Type::Array`], then the inner [`ArrayType`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_array_type(self) -> Option<ArrayType> {
+    pub fn into_array_type(self) -> Option<ArrayType<N>> {
         match self {
-            Self::Array(array) => Some(array),
+            Self::Array(ty) => Some(ty),
             _ => None,
         }
     }
@@ -576,7 +526,7 @@ impl Type {
     /// # Panics
     ///
     /// Panics if the type is not an array type.
-    pub fn unwrap_array_type(self) -> ArrayType {
+    pub fn unwrap_array_type(self) -> ArrayType<N> {
         match self {
             Self::Array(ty) => ty,
             _ => panic!("not an array type"),
@@ -588,9 +538,9 @@ impl Type {
     /// * If `self` is a [`Type::Pair`], then a reference to the inner
     ///   [`PairType`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_pair_type(&self) -> Option<&PairType> {
+    pub fn as_pair_type(&self) -> Option<&PairType<N>> {
         match self {
-            Self::Pair(pair) => Some(pair),
+            Self::Pair(ty) => Some(ty),
             _ => None,
         }
     }
@@ -600,9 +550,9 @@ impl Type {
     /// * If `self` is a [`Type::Pair`], then the inner [`PairType`] is returned
     ///   wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_pair_type(self) -> Option<PairType> {
+    pub fn into_pair_type(self) -> Option<PairType<N>> {
         match self {
-            Self::Pair(pair) => Some(pair),
+            Self::Pair(ty) => Some(ty),
             _ => None,
         }
     }
@@ -612,7 +562,7 @@ impl Type {
     /// # Panics
     ///
     /// Panics if the type is not a pair type.
-    pub fn unwrap_pair_type(self) -> PairType {
+    pub fn unwrap_pair_type(self) -> PairType<N> {
         match self {
             Self::Pair(ty) => ty,
             _ => panic!("not a pair type"),
@@ -624,9 +574,9 @@ impl Type {
     /// * If `self` is a [`Type::Object`], then a reference to the inner
     ///   [`ObjectType`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_object_type(&self) -> Option<&ObjectType> {
+    pub fn as_object_type(&self) -> Option<&ObjectType<N>> {
         match self {
-            Self::Object(object) => Some(object),
+            Self::Object(ty) => Some(ty),
             _ => None,
         }
     }
@@ -636,9 +586,9 @@ impl Type {
     /// * If `self` is a [`Type::Object`], then the inner [`ObjectType`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_object_type(self) -> Option<ObjectType> {
+    pub fn into_object_type(self) -> Option<ObjectType<N>> {
         match self {
-            Self::Object(object) => Some(object),
+            Self::Object(ty) => Some(ty),
             _ => None,
         }
     }
@@ -648,7 +598,7 @@ impl Type {
     /// # Panics
     ///
     /// Panics if the type is not an object type.
-    pub fn unwrap_object_type(self) -> ObjectType {
+    pub fn unwrap_object_type(self) -> ObjectType<N> {
         match self {
             Self::Object(ty) => ty,
             _ => panic!("not an object type"),
@@ -660,9 +610,9 @@ impl Type {
     /// * If `self` is a [`Type::Ref`], then a reference to the inner
     ///   [`TypeRef`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_type_ref(&self) -> Option<&TypeRef> {
+    pub fn as_type_ref(&self) -> Option<&TypeRef<N>> {
         match self {
-            Self::Ref(type_ref) => Some(type_ref),
+            Self::Ref(ty) => Some(ty),
             _ => None,
         }
     }
@@ -672,9 +622,9 @@ impl Type {
     /// * If `self` is a [`Type::Ref`], then the inner [`TypeRef`] is returned
     ///   wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_type_ref(self) -> Option<TypeRef> {
+    pub fn into_type_ref(self) -> Option<TypeRef<N>> {
         match self {
-            Self::Ref(type_ref) => Some(type_ref),
+            Self::Ref(ty) => Some(ty),
             _ => None,
         }
     }
@@ -684,9 +634,9 @@ impl Type {
     /// # Panics
     ///
     /// Panics if the type is not a type reference.
-    pub fn unwrap_type_ref(self) -> TypeRef {
+    pub fn unwrap_type_ref(self) -> TypeRef<N> {
         match self {
-            Self::Ref(r) => r,
+            Self::Ref(ty) => ty,
             _ => panic!("not a type reference"),
         }
     }
@@ -696,9 +646,9 @@ impl Type {
     /// * If `self` is a [`Type::Primitive`], then a reference to the inner
     ///   [`PrimitiveType`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_primitive_type(&self) -> Option<&PrimitiveType> {
+    pub fn as_primitive_type(&self) -> Option<&PrimitiveType<N>> {
         match self {
-            Self::Primitive(primitive) => Some(primitive),
+            Self::Primitive(ty) => Some(ty),
             _ => None,
         }
     }
@@ -708,9 +658,9 @@ impl Type {
     /// * If `self` is a [`Type::Primitive`], then the inner [`PrimitiveType`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_primitive_type(self) -> Option<PrimitiveType> {
+    pub fn into_primitive_type(self) -> Option<PrimitiveType<N>> {
         match self {
-            Self::Primitive(primitive) => Some(primitive),
+            Self::Primitive(ty) => Some(ty),
             _ => None,
         }
     }
@@ -720,7 +670,7 @@ impl Type {
     /// # Panics
     ///
     /// Panics if the type is not a primitive type.
-    pub fn unwrap_primitive_type(self) -> PrimitiveType {
+    pub fn unwrap_primitive_type(self) -> PrimitiveType<N> {
         match self {
             Self::Primitive(ty) => ty,
             _ => panic!("not a primitive type"),
@@ -728,21 +678,27 @@ impl Type {
     }
 
     /// Finds the first child that can be cast to a [`Type`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`Type`] to implement
-    /// the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
     /// Finds all children that can be cast to a [`Type`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring [`Type`] to
-    /// implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = Type> + use<> {
-        syntax.children().filter_map(Self::cast)
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
+    }
+}
+
+impl<N: TreeNode> PartialEq for Type<N> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Map(l), Self::Map(r)) => l == r,
+            (Self::Array(l), Self::Array(r)) => l == r,
+            (Self::Pair(l), Self::Pair(r)) => l == r,
+            (Self::Object(l), Self::Object(r)) => l == r,
+            (Self::Ref(l), Self::Ref(r)) => l == r,
+            (Self::Primitive(l), Self::Primitive(r)) => l == r,
+            _ => false,
+        }
     }
 }
 
@@ -761,147 +717,127 @@ impl fmt::Display for Type {
 
 /// Represents an unbound declaration.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UnboundDecl(pub(crate) SyntaxNode);
+pub struct UnboundDecl<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl UnboundDecl {
+impl<N: TreeNode> UnboundDecl<N> {
     /// Gets the `env` token, if present.
     ///
     /// This may only return a token for task inputs (WDL 1.2+).
-    pub fn env(&self) -> Option<EnvKeyword> {
-        token(&self.0)
+    pub fn env(&self) -> Option<EnvKeyword<N::Token>> {
+        self.token()
     }
 
     /// Gets the type of the declaration.
-    pub fn ty(&self) -> Type {
+    pub fn ty(&self) -> Type<N> {
         Type::child(&self.0).expect("unbound declaration should have a type")
     }
 
     /// Gets the name of the declaration.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("unbound declaration should have a name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token()
+            .expect("unbound declaration should have a name")
     }
 }
 
-impl AstNode for UnboundDecl {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for UnboundDecl<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::UnboundDeclNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::UnboundDeclNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::UnboundDeclNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a bound declaration in a task or workflow definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BoundDecl(pub(crate) SyntaxNode);
+pub struct BoundDecl<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl BoundDecl {
+impl<N: TreeNode> BoundDecl<N> {
     /// Gets the `env` token, if present.
     ///
     /// This may only return a token for task inputs and private declarations
     /// (WDL 1.2+).
-    pub fn env(&self) -> Option<EnvKeyword> {
-        token(&self.0)
+    pub fn env(&self) -> Option<EnvKeyword<N::Token>> {
+        self.token()
     }
 
     /// Gets the type of the declaration.
-    pub fn ty(&self) -> Type {
+    pub fn ty(&self) -> Type<N> {
         Type::child(&self.0).expect("bound declaration should have a type")
     }
 
     /// Gets the name of the declaration.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("bound declaration should have a name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("bound declaration should have a name")
     }
 
     /// Gets the expression the declaration is bound to.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("bound declaration should have an expression")
     }
 }
 
-impl AstNode for BoundDecl {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for BoundDecl<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::BoundDeclNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::BoundDeclNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::BoundDeclNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a declaration in an input section.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Decl {
+pub enum Decl<N: TreeNode = SyntaxNode> {
     /// The declaration is bound.
-    Bound(BoundDecl),
+    Bound(BoundDecl<N>),
     /// The declaration is unbound.
-    Unbound(UnboundDecl),
+    Unbound(UnboundDecl<N>),
 }
 
-impl Decl {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`Decl`].
-    pub fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> Decl<N> {
+    /// Returns whether or not the given syntax kind can be cast to
+    /// [`Decl`].
+    pub fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::BoundDeclNode || kind == SyntaxKind::UnboundDeclNode
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`Decl`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
+    /// Casts the given node to [`StructItem`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
             SyntaxKind::BoundDeclNode => Some(Self::Bound(
-                BoundDecl::cast(syntax).expect("bound decl to cast"),
+                BoundDecl::cast(inner).expect("bound decl to cast"),
             )),
             SyntaxKind::UnboundDeclNode => Some(Self::Unbound(
-                UnboundDecl::cast(syntax).expect("unbound decl to cast"),
+                UnboundDecl::cast(inner).expect("unbound decl to cast"),
             )),
             _ => None,
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
         match self {
-            Self::Bound(element) => element.syntax(),
-            Self::Unbound(element) => element.syntax(),
+            Self::Bound(d) => d.inner(),
+            Self::Unbound(d) => d.inner(),
         }
     }
 
@@ -909,7 +845,7 @@ impl Decl {
     ///
     /// This may only return a token for task inputs and private declarations
     /// (WDL 1.2+).
-    pub fn env(&self) -> Option<EnvKeyword> {
+    pub fn env(&self) -> Option<EnvKeyword<N::Token>> {
         match self {
             Self::Bound(d) => d.env(),
             Self::Unbound(d) => d.env(),
@@ -917,7 +853,7 @@ impl Decl {
     }
 
     /// Gets the type of the declaration.
-    pub fn ty(&self) -> Type {
+    pub fn ty(&self) -> Type<N> {
         match self {
             Self::Bound(d) => d.ty(),
             Self::Unbound(d) => d.ty(),
@@ -925,7 +861,7 @@ impl Decl {
     }
 
     /// Gets the name of the declaration.
-    pub fn name(&self) -> Ident {
+    pub fn name(&self) -> Ident<N::Token> {
         match self {
             Self::Bound(d) => d.name(),
             Self::Unbound(d) => d.name(),
@@ -935,7 +871,7 @@ impl Decl {
     /// Gets the expression of the declaration.
     ///
     /// Returns `None` for unbound declarations.
-    pub fn expr(&self) -> Option<Expr> {
+    pub fn expr(&self) -> Option<Expr<N>> {
         match self {
             Self::Bound(d) => Some(d.expr()),
             Self::Unbound(_) => None,
@@ -947,9 +883,9 @@ impl Decl {
     /// * If `self` is a [`Decl::Bound`], then a reference to the inner
     ///   [`BoundDecl`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_bound_decl(&self) -> Option<&BoundDecl> {
+    pub fn as_bound_decl(&self) -> Option<&BoundDecl<N>> {
         match self {
-            Self::Bound(bound_decl) => Some(bound_decl),
+            Self::Bound(d) => Some(d),
             _ => None,
         }
     }
@@ -959,9 +895,9 @@ impl Decl {
     /// * If `self` is a [`Decl::Bound`], then the inner [`BoundDecl`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_bound_decl(self) -> Option<BoundDecl> {
+    pub fn into_bound_decl(self) -> Option<BoundDecl<N>> {
         match self {
-            Self::Bound(bound_decl) => Some(bound_decl),
+            Self::Bound(d) => Some(d),
             _ => None,
         }
     }
@@ -971,9 +907,9 @@ impl Decl {
     /// # Panics
     ///
     /// Panics if the declaration is not a bound declaration.
-    pub fn unwrap_bound_decl(self) -> BoundDecl {
+    pub fn unwrap_bound_decl(self) -> BoundDecl<N> {
         match self {
-            Self::Bound(decl) => decl,
+            Self::Bound(d) => d,
             _ => panic!("not a bound declaration"),
         }
     }
@@ -983,9 +919,9 @@ impl Decl {
     /// * If `self` is a [`Decl::Unbound`], then a reference to the inner
     ///   [`UnboundDecl`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_unbound_decl(&self) -> Option<&UnboundDecl> {
+    pub fn as_unbound_decl(&self) -> Option<&UnboundDecl<N>> {
         match self {
-            Self::Unbound(unbound_decl) => Some(unbound_decl),
+            Self::Unbound(d) => Some(d),
             _ => None,
         }
     }
@@ -995,9 +931,9 @@ impl Decl {
     /// * If `self` is a [`Decl::Unbound`], then the inner [`UnboundDecl`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_unbound_decl(self) -> Option<UnboundDecl> {
+    pub fn into_unbound_decl(self) -> Option<UnboundDecl<N>> {
         match self {
-            Self::Unbound(unbound_decl) => Some(unbound_decl),
+            Self::Unbound(d) => Some(d),
             _ => None,
         }
     }
@@ -1007,29 +943,21 @@ impl Decl {
     /// # Panics
     ///
     /// Panics if the declaration is not an unbound declaration.
-    pub fn unwrap_unbound_decl(self) -> UnboundDecl {
+    pub fn unwrap_unbound_decl(self) -> UnboundDecl<N> {
         match self {
-            Self::Unbound(decl) => decl,
+            Self::Unbound(d) => d,
             _ => panic!("not an unbound declaration"),
         }
     }
 
     /// Finds the first child that can be cast to a [`Decl`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`Decl`] to implement
-    /// the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
     /// Finds all children that can be cast to a [`Decl`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring [`Decl`] to
-    /// implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = Decl> + use<> {
-        syntax.children().filter_map(Self::cast)
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
     }
 }
 
@@ -1070,7 +998,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Inputs
         let input = tasks[0].input().expect("task should have an input section");
@@ -1080,12 +1008,12 @@ task test {
         // First input declaration
         let decl = decls[0].clone().unwrap_unbound_decl();
         assert_eq!(decl.ty().to_string(), "Boolean");
-        assert_eq!(decl.name().as_str(), "a");
+        assert_eq!(decl.name().text(), "a");
 
         // Second input declaration
         let decl = decls[1].clone().unwrap_bound_decl();
         assert_eq!(decl.ty().to_string(), "Int");
-        assert_eq!(decl.name().as_str(), "b");
+        assert_eq!(decl.name().text(), "b");
         assert_eq!(
             decl.expr()
                 .unwrap_literal()
@@ -1098,37 +1026,37 @@ task test {
         // Third input declaration
         let decl = decls[2].clone().unwrap_bound_decl();
         assert_eq!(decl.ty().to_string(), "Float?");
-        assert_eq!(decl.name().as_str(), "c");
+        assert_eq!(decl.name().text(), "c");
         decl.expr().unwrap_literal().unwrap_none();
 
         // Fourth input declaration
         let decl = decls[3].clone().unwrap_unbound_decl();
         assert_eq!(decl.ty().to_string(), "String");
-        assert_eq!(decl.name().as_str(), "d");
+        assert_eq!(decl.name().text(), "d");
 
         // Fifth input declaration
         let decl = decls[4].clone().unwrap_bound_decl();
         assert_eq!(decl.ty().to_string(), "File");
-        assert_eq!(decl.name().as_str(), "e");
+        assert_eq!(decl.name().text(), "e");
         assert_eq!(
             decl.expr()
                 .unwrap_literal()
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "foo.wdl"
         );
 
         // Sixth input declaration
         let decl = decls[5].clone().unwrap_unbound_decl();
         assert_eq!(decl.ty().to_string(), "Map[Int, Int]");
-        assert_eq!(decl.name().as_str(), "f");
+        assert_eq!(decl.name().text(), "f");
 
         // Seventh input declaration
         let decl = decls[6].clone().unwrap_bound_decl();
         assert_eq!(decl.ty().to_string(), "Array[String]");
-        assert_eq!(decl.name().as_str(), "g");
+        assert_eq!(decl.name().text(), "g");
         assert_eq!(
             decl.expr()
                 .unwrap_literal()
@@ -1141,12 +1069,12 @@ task test {
         // Eighth input declaration
         let decl = decls[7].clone().unwrap_unbound_decl();
         assert_eq!(decl.ty().to_string(), "Pair[Boolean, Int]");
-        assert_eq!(decl.name().as_str(), "h");
+        assert_eq!(decl.name().text(), "h");
 
         // Ninth input declaration
         let decl = decls[8].clone().unwrap_bound_decl();
         assert_eq!(decl.ty().to_string(), "Object");
-        assert_eq!(decl.name().as_str(), "i");
+        assert_eq!(decl.name().text(), "i");
         assert_eq!(
             decl.expr().unwrap_literal().unwrap_object().items().count(),
             0
@@ -1155,19 +1083,19 @@ task test {
         // Tenth input declaration
         let decl = decls[9].clone().unwrap_unbound_decl();
         assert_eq!(decl.ty().to_string(), "MyStruct");
-        assert_eq!(decl.name().as_str(), "j");
+        assert_eq!(decl.name().text(), "j");
 
         // Eleventh input declaration
         let decl = decls[10].clone().unwrap_bound_decl();
         assert_eq!(decl.ty().to_string(), "Directory");
-        assert_eq!(decl.name().as_str(), "k");
+        assert_eq!(decl.name().text(), "k");
         assert_eq!(
             decl.expr()
                 .unwrap_literal()
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "foo"
         );
 

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -1,88 +1,81 @@
 //! V1 AST representation for expressions.
 
+use rowan::NodeOrToken;
 use wdl_grammar::lexer::v1::EscapeToken;
 use wdl_grammar::lexer::v1::Logos;
 
-use crate::AstChildren;
+use super::Minus;
 use crate::AstNode;
 use crate::AstToken;
 use crate::Ident;
-use crate::SyntaxElement;
 use crate::SyntaxKind;
 use crate::SyntaxNode;
 use crate::SyntaxToken;
-use crate::WorkflowDescriptionLanguage;
-use crate::support;
-use crate::support::child;
-use crate::support::children;
-use crate::token;
-use crate::token_child;
+use crate::TreeNode;
+use crate::TreeToken;
 
 /// Represents an expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Expr {
+pub enum Expr<N: TreeNode = SyntaxNode> {
     /// The expression is a literal.
-    Literal(LiteralExpr),
+    Literal(LiteralExpr<N>),
     /// The expression is a name reference.
-    Name(NameRef),
+    NameRef(NameRefExpr<N>),
     /// The expression is a parenthesized expression.
-    Parenthesized(ParenthesizedExpr),
+    Parenthesized(ParenthesizedExpr<N>),
     /// The expression is an `if` expression.
-    If(IfExpr),
+    If(IfExpr<N>),
     /// The expression is a "logical not" expression.
-    LogicalNot(LogicalNotExpr),
+    LogicalNot(LogicalNotExpr<N>),
     /// The expression is a negation expression.
-    Negation(NegationExpr),
+    Negation(NegationExpr<N>),
     /// The expression is a "logical or" expression.
-    LogicalOr(LogicalOrExpr),
+    LogicalOr(LogicalOrExpr<N>),
     /// The expression is a "logical and" expression.
-    LogicalAnd(LogicalAndExpr),
+    LogicalAnd(LogicalAndExpr<N>),
     /// The expression is an equality expression.
-    Equality(EqualityExpr),
+    Equality(EqualityExpr<N>),
     /// The expression is an inequality expression.
-    Inequality(InequalityExpr),
+    Inequality(InequalityExpr<N>),
     /// The expression is a "less than" expression.
-    Less(LessExpr),
+    Less(LessExpr<N>),
     /// The expression is a "less than or equal to" expression.
-    LessEqual(LessEqualExpr),
+    LessEqual(LessEqualExpr<N>),
     /// The expression is a "greater" expression.
-    Greater(GreaterExpr),
+    Greater(GreaterExpr<N>),
     /// The expression is a "greater than or equal to" expression.
-    GreaterEqual(GreaterEqualExpr),
+    GreaterEqual(GreaterEqualExpr<N>),
     /// The expression is an addition expression.
-    Addition(AdditionExpr),
+    Addition(AdditionExpr<N>),
     /// The expression is a subtraction expression.
-    Subtraction(SubtractionExpr),
+    Subtraction(SubtractionExpr<N>),
     /// The expression is a multiplication expression.
-    Multiplication(MultiplicationExpr),
+    Multiplication(MultiplicationExpr<N>),
     /// The expression is a division expression.
-    Division(DivisionExpr),
+    Division(DivisionExpr<N>),
     /// The expression is a modulo expression.
-    Modulo(ModuloExpr),
+    Modulo(ModuloExpr<N>),
     /// The expression is an exponentiation expression.
-    Exponentiation(ExponentiationExpr),
+    Exponentiation(ExponentiationExpr<N>),
     /// The expression is a call expression.
-    Call(CallExpr),
+    Call(CallExpr<N>),
     /// The expression is an index expression.
-    Index(IndexExpr),
+    Index(IndexExpr<N>),
     /// The expression is a member access expression.
-    Access(AccessExpr),
+    Access(AccessExpr<N>),
 }
 
-impl Expr {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`Expr`].
-    pub fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
-        if LiteralExpr::can_cast(kind) {
+impl<N: TreeNode> Expr<N> {
+    /// Returns whether or not the given syntax kind can be cast to
+    /// [`Expr`].
+    pub fn can_cast(kind: SyntaxKind) -> bool {
+        if LiteralExpr::<N>::can_cast(kind) {
             return true;
         }
 
         matches!(
             kind,
-            SyntaxKind::NameRefNode
+            SyntaxKind::NameRefExprNode
                 | SyntaxKind::ParenthesizedExprNode
                 | SyntaxKind::IfExprNode
                 | SyntaxKind::LogicalNotExprNode
@@ -107,112 +100,113 @@ impl Expr {
         )
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`Expr`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if LiteralExpr::can_cast(syntax.kind()) {
+    /// Casts the given node to [`StructItem`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        if LiteralExpr::<N>::can_cast(inner.kind()) {
             return Some(Self::Literal(
-                LiteralExpr::cast(syntax).expect("literal expr should cast"),
+                LiteralExpr::cast(inner).expect("literal expr should cast"),
             ));
         }
 
-        match syntax.kind() {
-            SyntaxKind::NameRefNode => Some(Self::Name(
-                NameRef::cast(syntax).expect("name ref should cast"),
+        match inner.kind() {
+            SyntaxKind::NameRefExprNode => Some(Self::NameRef(
+                NameRefExpr::cast(inner).expect("name ref should cast"),
             )),
             SyntaxKind::ParenthesizedExprNode => Some(Self::Parenthesized(
-                ParenthesizedExpr::cast(syntax).expect("parenthesized expr should cast"),
+                ParenthesizedExpr::cast(inner).expect("parenthesized expr should cast"),
             )),
             SyntaxKind::IfExprNode => {
-                Some(Self::If(IfExpr::cast(syntax).expect("if expr should cast")))
+                Some(Self::If(IfExpr::cast(inner).expect("if expr should cast")))
             }
             SyntaxKind::LogicalNotExprNode => Some(Self::LogicalNot(
-                LogicalNotExpr::cast(syntax).expect("logical not expr should cast"),
+                LogicalNotExpr::cast(inner).expect("logical not expr should cast"),
             )),
             SyntaxKind::NegationExprNode => Some(Self::Negation(
-                NegationExpr::cast(syntax).expect("negation expr should cast"),
+                NegationExpr::cast(inner).expect("negation expr should cast"),
             )),
             SyntaxKind::LogicalOrExprNode => Some(Self::LogicalOr(
-                LogicalOrExpr::cast(syntax).expect("logical or expr should cast"),
+                LogicalOrExpr::cast(inner).expect("logical or expr should cast"),
             )),
             SyntaxKind::LogicalAndExprNode => Some(Self::LogicalAnd(
-                LogicalAndExpr::cast(syntax).expect("logical and expr should cast"),
+                LogicalAndExpr::cast(inner).expect("logical and expr should cast"),
             )),
             SyntaxKind::EqualityExprNode => Some(Self::Equality(
-                EqualityExpr::cast(syntax).expect("equality expr should cast"),
+                EqualityExpr::cast(inner).expect("equality expr should cast"),
             )),
             SyntaxKind::InequalityExprNode => Some(Self::Inequality(
-                InequalityExpr::cast(syntax).expect("inequality expr should cast"),
+                InequalityExpr::cast(inner).expect("inequality expr should cast"),
             )),
             SyntaxKind::LessExprNode => Some(Self::Less(
-                LessExpr::cast(syntax).expect("less expr should cast"),
+                LessExpr::cast(inner).expect("less expr should cast"),
             )),
             SyntaxKind::LessEqualExprNode => Some(Self::LessEqual(
-                LessEqualExpr::cast(syntax).expect("less equal expr should cast"),
+                LessEqualExpr::cast(inner).expect("less equal expr should cast"),
             )),
             SyntaxKind::GreaterExprNode => Some(Self::Greater(
-                GreaterExpr::cast(syntax).expect("greater expr should cast"),
+                GreaterExpr::cast(inner).expect("greater expr should cast"),
             )),
             SyntaxKind::GreaterEqualExprNode => Some(Self::GreaterEqual(
-                GreaterEqualExpr::cast(syntax).expect("greater equal expr should cast"),
+                GreaterEqualExpr::cast(inner).expect("greater equal expr should cast"),
             )),
             SyntaxKind::AdditionExprNode => Some(Self::Addition(
-                AdditionExpr::cast(syntax).expect("addition expr should cast"),
+                AdditionExpr::cast(inner).expect("addition expr should cast"),
             )),
             SyntaxKind::SubtractionExprNode => Some(Self::Subtraction(
-                SubtractionExpr::cast(syntax).expect("subtraction expr should cast"),
+                SubtractionExpr::cast(inner).expect("subtraction expr should cast"),
             )),
             SyntaxKind::MultiplicationExprNode => Some(Self::Multiplication(
-                MultiplicationExpr::cast(syntax).expect("multiplication expr should cast"),
+                MultiplicationExpr::cast(inner).expect("multiplication expr should cast"),
             )),
             SyntaxKind::DivisionExprNode => Some(Self::Division(
-                DivisionExpr::cast(syntax).expect("division expr should cast"),
+                DivisionExpr::cast(inner).expect("division expr should cast"),
             )),
             SyntaxKind::ModuloExprNode => Some(Self::Modulo(
-                ModuloExpr::cast(syntax).expect("modulo expr should cast"),
+                ModuloExpr::cast(inner).expect("modulo expr should cast"),
             )),
             SyntaxKind::ExponentiationExprNode => Some(Self::Exponentiation(
-                ExponentiationExpr::cast(syntax).expect("exponentiation expr should cast"),
+                ExponentiationExpr::cast(inner).expect("exponentiation expr should cast"),
             )),
             SyntaxKind::CallExprNode => Some(Self::Call(
-                CallExpr::cast(syntax).expect("call expr should cast"),
+                CallExpr::cast(inner).expect("call expr should cast"),
             )),
             SyntaxKind::IndexExprNode => Some(Self::Index(
-                IndexExpr::cast(syntax).expect("index expr should cast"),
+                IndexExpr::cast(inner).expect("index expr should cast"),
             )),
             SyntaxKind::AccessExprNode => Some(Self::Access(
-                AccessExpr::cast(syntax).expect("access expr should cast"),
+                AccessExpr::cast(inner).expect("access expr should cast"),
             )),
             _ => None,
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
         match self {
-            Expr::Literal(element) => element.syntax(),
-            Expr::Name(element) => element.syntax(),
-            Expr::Parenthesized(element) => element.syntax(),
-            Expr::If(element) => element.syntax(),
-            Expr::LogicalNot(element) => element.syntax(),
-            Expr::Negation(element) => element.syntax(),
-            Expr::LogicalOr(element) => element.syntax(),
-            Expr::LogicalAnd(element) => element.syntax(),
-            Expr::Equality(element) => element.syntax(),
-            Expr::Inequality(element) => element.syntax(),
-            Expr::Less(element) => element.syntax(),
-            Expr::LessEqual(element) => element.syntax(),
-            Expr::Greater(element) => element.syntax(),
-            Expr::GreaterEqual(element) => element.syntax(),
-            Expr::Addition(element) => element.syntax(),
-            Expr::Subtraction(element) => element.syntax(),
-            Expr::Multiplication(element) => element.syntax(),
-            Expr::Division(element) => element.syntax(),
-            Expr::Modulo(element) => element.syntax(),
-            Expr::Exponentiation(element) => element.syntax(),
-            Expr::Call(element) => element.syntax(),
-            Expr::Index(element) => element.syntax(),
-            Expr::Access(element) => element.syntax(),
+            Self::Literal(e) => e.inner(),
+            Self::NameRef(e) => e.inner(),
+            Self::Parenthesized(e) => e.inner(),
+            Self::If(e) => e.inner(),
+            Self::LogicalNot(e) => e.inner(),
+            Self::Negation(e) => e.inner(),
+            Self::LogicalOr(e) => e.inner(),
+            Self::LogicalAnd(e) => e.inner(),
+            Self::Equality(e) => e.inner(),
+            Self::Inequality(e) => e.inner(),
+            Self::Less(e) => e.inner(),
+            Self::LessEqual(e) => e.inner(),
+            Self::Greater(e) => e.inner(),
+            Self::GreaterEqual(e) => e.inner(),
+            Self::Addition(e) => e.inner(),
+            Self::Subtraction(e) => e.inner(),
+            Self::Multiplication(e) => e.inner(),
+            Self::Division(e) => e.inner(),
+            Self::Modulo(e) => e.inner(),
+            Self::Exponentiation(e) => e.inner(),
+            Self::Call(e) => e.inner(),
+            Self::Index(e) => e.inner(),
+            Self::Access(e) => e.inner(),
         }
     }
 
@@ -221,9 +215,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Literal`], then a reference to the inner
     ///   [`LiteralExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_literal(&self) -> Option<&LiteralExpr> {
+    pub fn as_literal(&self) -> Option<&LiteralExpr<N>> {
         match self {
-            Self::Literal(literal) => Some(literal),
+            Self::Literal(e) => Some(e),
             _ => None,
         }
     }
@@ -233,9 +227,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Literal`], then the inner [`LiteralExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_literal(self) -> Option<LiteralExpr> {
+    pub fn into_literal(self) -> Option<LiteralExpr<N>> {
         match self {
-            Self::Literal(literal) => Some(literal),
+            Self::Literal(e) => Some(e),
             _ => None,
         }
     }
@@ -245,9 +239,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal expression.
-    pub fn unwrap_literal(self) -> LiteralExpr {
+    pub fn unwrap_literal(self) -> LiteralExpr<N> {
         match self {
-            Self::Literal(expr) => expr,
+            Self::Literal(e) => e,
             _ => panic!("not a literal expression"),
         }
     }
@@ -257,9 +251,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Name`], then a reference to the inner
     ///   [`NameRef`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_name_ref(&self) -> Option<&NameRef> {
+    pub fn as_name_ref(&self) -> Option<&NameRefExpr<N>> {
         match self {
-            Self::Name(name_ref) => Some(name_ref),
+            Self::NameRef(e) => Some(e),
             _ => None,
         }
     }
@@ -269,9 +263,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Name`], then the inner [`NameRef`] is returned
     ///   wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_name_ref(self) -> Option<NameRef> {
+    pub fn into_name_ref(self) -> Option<NameRefExpr<N>> {
         match self {
-            Self::Name(name_ref) => Some(name_ref),
+            Self::NameRef(e) => Some(e),
             _ => None,
         }
     }
@@ -281,9 +275,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a name reference.
-    pub fn unwrap_name_ref(self) -> NameRef {
+    pub fn unwrap_name_ref(self) -> NameRefExpr<N> {
         match self {
-            Self::Name(expr) => expr,
+            Self::NameRef(e) => e,
             _ => panic!("not a name reference"),
         }
     }
@@ -293,9 +287,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Parenthesized`], then a reference to the inner
     ///   [`ParenthesizedExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_parenthesized(&self) -> Option<&ParenthesizedExpr> {
+    pub fn as_parenthesized(&self) -> Option<&ParenthesizedExpr<N>> {
         match self {
-            Self::Parenthesized(parenthesized) => Some(parenthesized),
+            Self::Parenthesized(e) => Some(e),
             _ => None,
         }
     }
@@ -305,9 +299,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Parenthesized`], then the inner
     ///   [`ParenthesizedExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_parenthesized(self) -> Option<ParenthesizedExpr> {
+    pub fn into_parenthesized(self) -> Option<ParenthesizedExpr<N>> {
         match self {
-            Self::Parenthesized(parenthesized) => Some(parenthesized),
+            Self::Parenthesized(e) => Some(e),
             _ => None,
         }
     }
@@ -317,9 +311,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a parenthesized expression.
-    pub fn unwrap_parenthesized(self) -> ParenthesizedExpr {
+    pub fn unwrap_parenthesized(self) -> ParenthesizedExpr<N> {
         match self {
-            Self::Parenthesized(expr) => expr,
+            Self::Parenthesized(e) => e,
             _ => panic!("not a parenthesized expression"),
         }
     }
@@ -329,9 +323,9 @@ impl Expr {
     /// * If `self` is a [`Expr::If`], then a reference to the inner [`IfExpr`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_if(&self) -> Option<&IfExpr> {
+    pub fn as_if(&self) -> Option<&IfExpr<N>> {
         match self {
-            Self::If(r#if) => Some(r#if),
+            Self::If(e) => Some(e),
             _ => None,
         }
     }
@@ -341,9 +335,9 @@ impl Expr {
     /// * If `self` is a [`Expr::If`], then the inner [`IfExpr`] is returned
     ///   wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_if(self) -> Option<IfExpr> {
+    pub fn into_if(self) -> Option<IfExpr<N>> {
         match self {
-            Self::If(r#if) => Some(r#if),
+            Self::If(e) => Some(e),
             _ => None,
         }
     }
@@ -353,9 +347,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not an `if` expression.
-    pub fn unwrap_if(self) -> IfExpr {
+    pub fn unwrap_if(self) -> IfExpr<N> {
         match self {
-            Self::If(expr) => expr,
+            Self::If(e) => e,
             _ => panic!("not an `if` expression"),
         }
     }
@@ -365,9 +359,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LogicalNot`], then a reference to the inner
     ///   [`LogicalNotExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_logical_not(&self) -> Option<&LogicalNotExpr> {
+    pub fn as_logical_not(&self) -> Option<&LogicalNotExpr<N>> {
         match self {
-            Self::LogicalNot(logical_not) => Some(logical_not),
+            Self::LogicalNot(e) => Some(e),
             _ => None,
         }
     }
@@ -377,9 +371,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LogicalNot`], then the inner [`LogicalNotExpr`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_logical_not(self) -> Option<LogicalNotExpr> {
+    pub fn into_logical_not(self) -> Option<LogicalNotExpr<N>> {
         match self {
-            Self::LogicalNot(logical_not) => Some(logical_not),
+            Self::LogicalNot(e) => Some(e),
             _ => None,
         }
     }
@@ -389,9 +383,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a logical `not` expression.
-    pub fn unwrap_logical_not(self) -> LogicalNotExpr {
+    pub fn unwrap_logical_not(self) -> LogicalNotExpr<N> {
         match self {
-            Self::LogicalNot(expr) => expr,
+            Self::LogicalNot(e) => e,
             _ => panic!("not a logical `not` expression"),
         }
     }
@@ -401,9 +395,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Negation`], then a reference to the inner
     ///   [`NegationExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_negation(&self) -> Option<&NegationExpr> {
+    pub fn as_negation(&self) -> Option<&NegationExpr<N>> {
         match self {
-            Self::Negation(negation) => Some(negation),
+            Self::Negation(e) => Some(e),
             _ => None,
         }
     }
@@ -413,9 +407,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Negation`], then the inner [`NegationExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_negation(self) -> Option<NegationExpr> {
+    pub fn into_negation(self) -> Option<NegationExpr<N>> {
         match self {
-            Self::Negation(negation) => Some(negation),
+            Self::Negation(e) => Some(e),
             _ => None,
         }
     }
@@ -425,9 +419,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a negation expression.
-    pub fn unwrap_negation(self) -> NegationExpr {
+    pub fn unwrap_negation(self) -> NegationExpr<N> {
         match self {
-            Self::Negation(expr) => expr,
+            Self::Negation(e) => e,
             _ => panic!("not a negation expression"),
         }
     }
@@ -437,9 +431,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LogicalOr`], then a reference to the inner
     ///   [`LogicalOrExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_logical_or(&self) -> Option<&LogicalOrExpr> {
+    pub fn as_logical_or(&self) -> Option<&LogicalOrExpr<N>> {
         match self {
-            Self::LogicalOr(logical_or) => Some(logical_or),
+            Self::LogicalOr(e) => Some(e),
             _ => None,
         }
     }
@@ -449,9 +443,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LogicalOr`], then the inner [`LogicalOrExpr`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_logical_or(self) -> Option<LogicalOrExpr> {
+    pub fn into_logical_or(self) -> Option<LogicalOrExpr<N>> {
         match self {
-            Self::LogicalOr(logical_or) => Some(logical_or),
+            Self::LogicalOr(e) => Some(e),
             _ => None,
         }
     }
@@ -461,9 +455,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a logical `or` expression.
-    pub fn unwrap_logical_or(self) -> LogicalOrExpr {
+    pub fn unwrap_logical_or(self) -> LogicalOrExpr<N> {
         match self {
-            Self::LogicalOr(expr) => expr,
+            Self::LogicalOr(e) => e,
             _ => panic!("not a logical `or` expression"),
         }
     }
@@ -473,9 +467,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LogicalAnd`], then a reference to the inner
     ///   [`LogicalAndExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_logical_and(&self) -> Option<&LogicalAndExpr> {
+    pub fn as_logical_and(&self) -> Option<&LogicalAndExpr<N>> {
         match self {
-            Self::LogicalAnd(logical_and) => Some(logical_and),
+            Self::LogicalAnd(e) => Some(e),
             _ => None,
         }
     }
@@ -485,9 +479,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LogicalAnd`], then the inner [`LogicalAndExpr`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_logical_and(self) -> Option<LogicalAndExpr> {
+    pub fn into_logical_and(self) -> Option<LogicalAndExpr<N>> {
         match self {
-            Self::LogicalAnd(logical_and) => Some(logical_and),
+            Self::LogicalAnd(e) => Some(e),
             _ => None,
         }
     }
@@ -497,9 +491,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a logical `and` expression.
-    pub fn unwrap_logical_and(self) -> LogicalAndExpr {
+    pub fn unwrap_logical_and(self) -> LogicalAndExpr<N> {
         match self {
-            Self::LogicalAnd(expr) => expr,
+            Self::LogicalAnd(e) => e,
             _ => panic!("not a logical `and` expression"),
         }
     }
@@ -509,9 +503,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Equality`], then a reference to the inner
     ///   [`EqualityExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_equality(&self) -> Option<&EqualityExpr> {
+    pub fn as_equality(&self) -> Option<&EqualityExpr<N>> {
         match self {
-            Self::Equality(equality) => Some(equality),
+            Self::Equality(e) => Some(e),
             _ => None,
         }
     }
@@ -521,9 +515,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Equality`], then the inner [`EqualityExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_equality(self) -> Option<EqualityExpr> {
+    pub fn into_equality(self) -> Option<EqualityExpr<N>> {
         match self {
-            Self::Equality(equality) => Some(equality),
+            Self::Equality(e) => Some(e),
             _ => None,
         }
     }
@@ -533,9 +527,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not an equality expression.
-    pub fn unwrap_equality(self) -> EqualityExpr {
+    pub fn unwrap_equality(self) -> EqualityExpr<N> {
         match self {
-            Self::Equality(expr) => expr,
+            Self::Equality(e) => e,
             _ => panic!("not an equality expression"),
         }
     }
@@ -545,9 +539,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Inequality`], then a reference to the inner
     ///   [`InequalityExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_inequality(&self) -> Option<&InequalityExpr> {
+    pub fn as_inequality(&self) -> Option<&InequalityExpr<N>> {
         match self {
-            Self::Inequality(inequality) => Some(inequality),
+            Self::Inequality(e) => Some(e),
             _ => None,
         }
     }
@@ -557,9 +551,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Inequality`], then the inner [`InequalityExpr`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_inequality(self) -> Option<InequalityExpr> {
+    pub fn into_inequality(self) -> Option<InequalityExpr<N>> {
         match self {
-            Self::Inequality(inequality) => Some(inequality),
+            Self::Inequality(e) => Some(e),
             _ => None,
         }
     }
@@ -569,9 +563,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not an inequality expression.
-    pub fn unwrap_inequality(self) -> InequalityExpr {
+    pub fn unwrap_inequality(self) -> InequalityExpr<N> {
         match self {
-            Self::Inequality(expr) => expr,
+            Self::Inequality(e) => e,
             _ => panic!("not an inequality expression"),
         }
     }
@@ -581,9 +575,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Less`], then a reference to the inner
     ///   [`LessExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_less(&self) -> Option<&LessExpr> {
+    pub fn as_less(&self) -> Option<&LessExpr<N>> {
         match self {
-            Self::Less(less) => Some(less),
+            Self::Less(e) => Some(e),
             _ => None,
         }
     }
@@ -593,9 +587,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Less`], then the inner [`LessExpr`] is returned
     ///   wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_less(self) -> Option<LessExpr> {
+    pub fn into_less(self) -> Option<LessExpr<N>> {
         match self {
-            Self::Less(less) => Some(less),
+            Self::Less(e) => Some(e),
             _ => None,
         }
     }
@@ -605,9 +599,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a "less than" expression.
-    pub fn unwrap_less(self) -> LessExpr {
+    pub fn unwrap_less(self) -> LessExpr<N> {
         match self {
-            Self::Less(expr) => expr,
+            Self::Less(e) => e,
             _ => panic!("not a \"less than\" expression"),
         }
     }
@@ -617,9 +611,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LessEqual`], then a reference to the inner
     ///   [`LessEqualExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_less_equal(&self) -> Option<&LessEqualExpr> {
+    pub fn as_less_equal(&self) -> Option<&LessEqualExpr<N>> {
         match self {
-            Self::LessEqual(less_equal) => Some(less_equal),
+            Self::LessEqual(e) => Some(e),
             _ => None,
         }
     }
@@ -629,9 +623,9 @@ impl Expr {
     /// * If `self` is a [`Expr::LessEqual`], then the inner [`LessEqualExpr`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_less_equal(self) -> Option<LessEqualExpr> {
+    pub fn into_less_equal(self) -> Option<LessEqualExpr<N>> {
         match self {
-            Self::LessEqual(less_equal) => Some(less_equal),
+            Self::LessEqual(e) => Some(e),
             _ => None,
         }
     }
@@ -641,9 +635,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a "less than or equal to" expression.
-    pub fn unwrap_less_equal(self) -> LessEqualExpr {
+    pub fn unwrap_less_equal(self) -> LessEqualExpr<N> {
         match self {
-            Self::LessEqual(expr) => expr,
+            Self::LessEqual(e) => e,
             _ => panic!("not a \"less than or equal to\" expression"),
         }
     }
@@ -653,9 +647,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Greater`], then a reference to the inner
     ///   [`GreaterExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_greater(&self) -> Option<&GreaterExpr> {
+    pub fn as_greater(&self) -> Option<&GreaterExpr<N>> {
         match self {
-            Self::Greater(greater) => Some(greater),
+            Self::Greater(e) => Some(e),
             _ => None,
         }
     }
@@ -665,9 +659,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Greater`], then the inner [`GreaterExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_greater(self) -> Option<GreaterExpr> {
+    pub fn into_greater(self) -> Option<GreaterExpr<N>> {
         match self {
-            Self::Greater(greater) => Some(greater),
+            Self::Greater(e) => Some(e),
             _ => None,
         }
     }
@@ -677,9 +671,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a "greater than" expression.
-    pub fn unwrap_greater(self) -> GreaterExpr {
+    pub fn unwrap_greater(self) -> GreaterExpr<N> {
         match self {
-            Self::Greater(expr) => expr,
+            Self::Greater(e) => e,
             _ => panic!("not a \"greater than\" expression"),
         }
     }
@@ -689,9 +683,9 @@ impl Expr {
     /// * If `self` is a [`Expr::GreaterEqual`], then a reference to the inner
     ///   [`GreaterEqualExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_greater_equal(&self) -> Option<&GreaterEqualExpr> {
+    pub fn as_greater_equal(&self) -> Option<&GreaterEqualExpr<N>> {
         match self {
-            Self::GreaterEqual(greater_equal) => Some(greater_equal),
+            Self::GreaterEqual(e) => Some(e),
             _ => None,
         }
     }
@@ -701,9 +695,9 @@ impl Expr {
     /// * If `self` is a [`Expr::GreaterEqual`], then the inner
     ///   [`GreaterEqualExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_greater_equal(self) -> Option<GreaterEqualExpr> {
+    pub fn into_greater_equal(self) -> Option<GreaterEqualExpr<N>> {
         match self {
-            Self::GreaterEqual(greater_equal) => Some(greater_equal),
+            Self::GreaterEqual(e) => Some(e),
             _ => None,
         }
     }
@@ -713,9 +707,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a "greater than or equal to" expression.
-    pub fn unwrap_greater_equal(self) -> GreaterEqualExpr {
+    pub fn unwrap_greater_equal(self) -> GreaterEqualExpr<N> {
         match self {
-            Self::GreaterEqual(expr) => expr,
+            Self::GreaterEqual(e) => e,
             _ => panic!("not a \"greater than or equal to\" expression"),
         }
     }
@@ -725,9 +719,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Addition`], then a reference to the inner
     ///   [`AdditionExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_addition(&self) -> Option<&AdditionExpr> {
+    pub fn as_addition(&self) -> Option<&AdditionExpr<N>> {
         match self {
-            Self::Addition(addition) => Some(addition),
+            Self::Addition(e) => Some(e),
             _ => None,
         }
     }
@@ -737,9 +731,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Addition`], then the inner [`AdditionExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_addition(self) -> Option<AdditionExpr> {
+    pub fn into_addition(self) -> Option<AdditionExpr<N>> {
         match self {
-            Self::Addition(addition) => Some(addition),
+            Self::Addition(e) => Some(e),
             _ => None,
         }
     }
@@ -749,9 +743,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not an addition expression.
-    pub fn unwrap_addition(self) -> AdditionExpr {
+    pub fn unwrap_addition(self) -> AdditionExpr<N> {
         match self {
-            Self::Addition(expr) => expr,
+            Self::Addition(e) => e,
             _ => panic!("not an addition expression"),
         }
     }
@@ -761,9 +755,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Subtraction`], then a reference to the inner
     ///   [`SubtractionExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_subtraction(&self) -> Option<&SubtractionExpr> {
+    pub fn as_subtraction(&self) -> Option<&SubtractionExpr<N>> {
         match self {
-            Self::Subtraction(subtraction) => Some(subtraction),
+            Self::Subtraction(e) => Some(e),
             _ => None,
         }
     }
@@ -773,9 +767,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Subtraction`], then the inner
     ///   [`SubtractionExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_subtraction(self) -> Option<SubtractionExpr> {
+    pub fn into_subtraction(self) -> Option<SubtractionExpr<N>> {
         match self {
-            Self::Subtraction(subtraction) => Some(subtraction),
+            Self::Subtraction(e) => Some(e),
             _ => None,
         }
     }
@@ -785,9 +779,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a subtraction expression.
-    pub fn unwrap_subtraction(self) -> SubtractionExpr {
+    pub fn unwrap_subtraction(self) -> SubtractionExpr<N> {
         match self {
-            Self::Subtraction(expr) => expr,
+            Self::Subtraction(e) => e,
             _ => panic!("not a subtraction expression"),
         }
     }
@@ -797,9 +791,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Multiplication`], then a reference to the inner
     ///   [`MultiplicationExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_multiplication(&self) -> Option<&MultiplicationExpr> {
+    pub fn as_multiplication(&self) -> Option<&MultiplicationExpr<N>> {
         match self {
-            Self::Multiplication(multiplication) => Some(multiplication),
+            Self::Multiplication(e) => Some(e),
             _ => None,
         }
     }
@@ -809,9 +803,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Multiplication`], then the inner
     ///   [`MultiplicationExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_multiplication(self) -> Option<MultiplicationExpr> {
+    pub fn into_multiplication(self) -> Option<MultiplicationExpr<N>> {
         match self {
-            Self::Multiplication(multiplication) => Some(multiplication),
+            Self::Multiplication(e) => Some(e),
             _ => None,
         }
     }
@@ -821,9 +815,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a multiplication expression.
-    pub fn unwrap_multiplication(self) -> MultiplicationExpr {
+    pub fn unwrap_multiplication(self) -> MultiplicationExpr<N> {
         match self {
-            Self::Multiplication(expr) => expr,
+            Self::Multiplication(e) => e,
             _ => panic!("not a multiplication expression"),
         }
     }
@@ -833,9 +827,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Division`], then a reference to the inner
     ///   [`DivisionExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_division(&self) -> Option<&DivisionExpr> {
+    pub fn as_division(&self) -> Option<&DivisionExpr<N>> {
         match self {
-            Self::Division(division) => Some(division),
+            Self::Division(e) => Some(e),
             _ => None,
         }
     }
@@ -845,9 +839,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Division`], then the inner [`DivisionExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_division(self) -> Option<DivisionExpr> {
+    pub fn into_division(self) -> Option<DivisionExpr<N>> {
         match self {
-            Self::Division(division) => Some(division),
+            Self::Division(e) => Some(e),
             _ => None,
         }
     }
@@ -857,9 +851,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a division expression.
-    pub fn unwrap_division(self) -> DivisionExpr {
+    pub fn unwrap_division(self) -> DivisionExpr<N> {
         match self {
-            Self::Division(expr) => expr,
+            Self::Division(e) => e,
             _ => panic!("not a division expression"),
         }
     }
@@ -869,9 +863,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Modulo`], then a reference to the inner
     ///   [`ModuloExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_modulo(&self) -> Option<&ModuloExpr> {
+    pub fn as_modulo(&self) -> Option<&ModuloExpr<N>> {
         match self {
-            Self::Modulo(modulo) => Some(modulo),
+            Self::Modulo(e) => Some(e),
             _ => None,
         }
     }
@@ -881,9 +875,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Modulo`], then the inner [`ModuloExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_modulo(self) -> Option<ModuloExpr> {
+    pub fn into_modulo(self) -> Option<ModuloExpr<N>> {
         match self {
-            Self::Modulo(modulo) => Some(modulo),
+            Self::Modulo(e) => Some(e),
             _ => None,
         }
     }
@@ -893,9 +887,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a modulo expression.
-    pub fn unwrap_modulo(self) -> ModuloExpr {
+    pub fn unwrap_modulo(self) -> ModuloExpr<N> {
         match self {
-            Self::Modulo(expr) => expr,
+            Self::Modulo(e) => e,
             _ => panic!("not a modulo expression"),
         }
     }
@@ -905,9 +899,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Exponentiation`], then a reference to the inner
     ///   [`ExponentiationExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_exponentiation(&self) -> Option<&ExponentiationExpr> {
+    pub fn as_exponentiation(&self) -> Option<&ExponentiationExpr<N>> {
         match self {
-            Self::Exponentiation(exponentiation) => Some(exponentiation),
+            Self::Exponentiation(e) => Some(e),
             _ => None,
         }
     }
@@ -917,9 +911,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Exponentiation`], then the inner
     ///   [`ExponentiationExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_exponentiation(self) -> Option<ExponentiationExpr> {
+    pub fn into_exponentiation(self) -> Option<ExponentiationExpr<N>> {
         match self {
-            Self::Exponentiation(exponentiation) => Some(exponentiation),
+            Self::Exponentiation(e) => Some(e),
             _ => None,
         }
     }
@@ -929,9 +923,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not an exponentiation expression.
-    pub fn unwrap_exponentiation(self) -> ExponentiationExpr {
+    pub fn unwrap_exponentiation(self) -> ExponentiationExpr<N> {
         match self {
-            Self::Exponentiation(expr) => expr,
+            Self::Exponentiation(e) => e,
             _ => panic!("not an exponentiation expression"),
         }
     }
@@ -941,9 +935,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Call`], then a reference to the inner
     ///   [`CallExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_call(&self) -> Option<&CallExpr> {
+    pub fn as_call(&self) -> Option<&CallExpr<N>> {
         match self {
-            Self::Call(call) => Some(call),
+            Self::Call(e) => Some(e),
             _ => None,
         }
     }
@@ -953,9 +947,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Call`], then the inner [`CallExpr`] is returned
     ///   wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_call(self) -> Option<CallExpr> {
+    pub fn into_call(self) -> Option<CallExpr<N>> {
         match self {
-            Self::Call(call) => Some(call),
+            Self::Call(e) => Some(e),
             _ => None,
         }
     }
@@ -965,9 +959,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not a call expression.
-    pub fn unwrap_call(self) -> CallExpr {
+    pub fn unwrap_call(self) -> CallExpr<N> {
         match self {
-            Self::Call(expr) => expr,
+            Self::Call(e) => e,
             _ => panic!("not a call expression"),
         }
     }
@@ -977,9 +971,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Index`], then a reference to the inner
     ///   [`IndexExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_index(&self) -> Option<&IndexExpr> {
+    pub fn as_index(&self) -> Option<&IndexExpr<N>> {
         match self {
-            Self::Index(index) => Some(index),
+            Self::Index(e) => Some(e),
             _ => None,
         }
     }
@@ -989,9 +983,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Index`], then the inner [`IndexExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_index(self) -> Option<IndexExpr> {
+    pub fn into_index(self) -> Option<IndexExpr<N>> {
         match self {
-            Self::Index(index) => Some(index),
+            Self::Index(e) => Some(e),
             _ => None,
         }
     }
@@ -1001,9 +995,9 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not an index expression.
-    pub fn unwrap_index(self) -> IndexExpr {
+    pub fn unwrap_index(self) -> IndexExpr<N> {
         match self {
-            Self::Index(expr) => expr,
+            Self::Index(e) => e,
             _ => panic!("not an index expression"),
         }
     }
@@ -1013,9 +1007,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Access`], then a reference to the inner
     ///   [`AccessExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_access(&self) -> Option<&AccessExpr> {
+    pub fn as_access(&self) -> Option<&AccessExpr<N>> {
         match self {
-            Self::Access(access) => Some(access),
+            Self::Access(e) => Some(e),
             _ => None,
         }
     }
@@ -1025,9 +1019,9 @@ impl Expr {
     /// * If `self` is a [`Expr::Access`], then the inner [`AccessExpr`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_access(self) -> Option<AccessExpr> {
+    pub fn into_access(self) -> Option<AccessExpr<N>> {
         match self {
-            Self::Access(access) => Some(access),
+            Self::Access(e) => Some(e),
             _ => None,
         }
     }
@@ -1037,56 +1031,43 @@ impl Expr {
     /// # Panics
     ///
     /// Panics if the expression is not an access expression.
-    pub fn unwrap_access(self) -> AccessExpr {
+    pub fn unwrap_access(self) -> AccessExpr<N> {
         match self {
-            Self::Access(expr) => expr,
+            Self::Access(e) => e,
             _ => panic!("not an access expression"),
         }
     }
 
     /// Finds the first child that can be cast to an [`Expr`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`Expr`] to implement
-    /// the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
     /// Finds all children that can be cast to an [`Expr`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring [`Expr`] to
-    /// implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = Expr> + use<> {
-        syntax.children().filter_map(Self::cast)
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
     }
 
     /// Determines if the expression is an empty array literal or any number of
     /// parenthesized expressions that terminate with an empty array literal.
     pub fn is_empty_array_literal(&self) -> bool {
         match self {
-            Self::Parenthesized(expr) => expr.inner().is_empty_array_literal(),
+            Self::Parenthesized(expr) => expr.expr().is_empty_array_literal(),
             Self::Literal(LiteralExpr::Array(expr)) => expr.elements().next().is_none(),
             _ => false,
         }
     }
 }
 
-impl AstNode for Expr {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
-        if LiteralExpr::can_cast(kind) {
+impl<N: TreeNode> AstNode<N> for Expr<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        if LiteralExpr::<N>::can_cast(kind) {
             return true;
         }
 
         matches!(
             kind,
-            SyntaxKind::NameRefNode
+            SyntaxKind::NameRefExprNode
                 | SyntaxKind::ParenthesizedExprNode
                 | SyntaxKind::IfExprNode
                 | SyntaxKind::LogicalNotExprNode
@@ -1111,51 +1092,48 @@ impl AstNode for Expr {
         )
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        if LiteralExpr::can_cast(syntax.kind()) {
-            return LiteralExpr::cast(syntax).map(Self::Literal);
+    fn cast(inner: N) -> Option<Self> {
+        if LiteralExpr::<N>::can_cast(inner.kind()) {
+            return LiteralExpr::cast(inner).map(Self::Literal);
         }
 
-        match syntax.kind() {
-            SyntaxKind::NameRefNode => Some(Self::Name(NameRef(syntax))),
+        match inner.kind() {
+            SyntaxKind::NameRefExprNode => Some(Self::NameRef(NameRefExpr(inner))),
             SyntaxKind::ParenthesizedExprNode => {
-                Some(Self::Parenthesized(ParenthesizedExpr(syntax)))
+                Some(Self::Parenthesized(ParenthesizedExpr(inner)))
             }
-            SyntaxKind::IfExprNode => Some(Self::If(IfExpr(syntax))),
-            SyntaxKind::LogicalNotExprNode => Some(Self::LogicalNot(LogicalNotExpr(syntax))),
-            SyntaxKind::NegationExprNode => Some(Self::Negation(NegationExpr(syntax))),
-            SyntaxKind::LogicalOrExprNode => Some(Self::LogicalOr(LogicalOrExpr(syntax))),
-            SyntaxKind::LogicalAndExprNode => Some(Self::LogicalAnd(LogicalAndExpr(syntax))),
-            SyntaxKind::EqualityExprNode => Some(Self::Equality(EqualityExpr(syntax))),
-            SyntaxKind::InequalityExprNode => Some(Self::Inequality(InequalityExpr(syntax))),
-            SyntaxKind::LessExprNode => Some(Self::Less(LessExpr(syntax))),
-            SyntaxKind::LessEqualExprNode => Some(Self::LessEqual(LessEqualExpr(syntax))),
-            SyntaxKind::GreaterExprNode => Some(Self::Greater(GreaterExpr(syntax))),
-            SyntaxKind::GreaterEqualExprNode => Some(Self::GreaterEqual(GreaterEqualExpr(syntax))),
-            SyntaxKind::AdditionExprNode => Some(Self::Addition(AdditionExpr(syntax))),
-            SyntaxKind::SubtractionExprNode => Some(Self::Subtraction(SubtractionExpr(syntax))),
+            SyntaxKind::IfExprNode => Some(Self::If(IfExpr(inner))),
+            SyntaxKind::LogicalNotExprNode => Some(Self::LogicalNot(LogicalNotExpr(inner))),
+            SyntaxKind::NegationExprNode => Some(Self::Negation(NegationExpr(inner))),
+            SyntaxKind::LogicalOrExprNode => Some(Self::LogicalOr(LogicalOrExpr(inner))),
+            SyntaxKind::LogicalAndExprNode => Some(Self::LogicalAnd(LogicalAndExpr(inner))),
+            SyntaxKind::EqualityExprNode => Some(Self::Equality(EqualityExpr(inner))),
+            SyntaxKind::InequalityExprNode => Some(Self::Inequality(InequalityExpr(inner))),
+            SyntaxKind::LessExprNode => Some(Self::Less(LessExpr(inner))),
+            SyntaxKind::LessEqualExprNode => Some(Self::LessEqual(LessEqualExpr(inner))),
+            SyntaxKind::GreaterExprNode => Some(Self::Greater(GreaterExpr(inner))),
+            SyntaxKind::GreaterEqualExprNode => Some(Self::GreaterEqual(GreaterEqualExpr(inner))),
+            SyntaxKind::AdditionExprNode => Some(Self::Addition(AdditionExpr(inner))),
+            SyntaxKind::SubtractionExprNode => Some(Self::Subtraction(SubtractionExpr(inner))),
             SyntaxKind::MultiplicationExprNode => {
-                Some(Self::Multiplication(MultiplicationExpr(syntax)))
+                Some(Self::Multiplication(MultiplicationExpr(inner)))
             }
-            SyntaxKind::DivisionExprNode => Some(Self::Division(DivisionExpr(syntax))),
-            SyntaxKind::ModuloExprNode => Some(Self::Modulo(ModuloExpr(syntax))),
+            SyntaxKind::DivisionExprNode => Some(Self::Division(DivisionExpr(inner))),
+            SyntaxKind::ModuloExprNode => Some(Self::Modulo(ModuloExpr(inner))),
             SyntaxKind::ExponentiationExprNode => {
-                Some(Self::Exponentiation(ExponentiationExpr(syntax)))
+                Some(Self::Exponentiation(ExponentiationExpr(inner)))
             }
-            SyntaxKind::CallExprNode => Some(Self::Call(CallExpr(syntax))),
-            SyntaxKind::IndexExprNode => Some(Self::Index(IndexExpr(syntax))),
-            SyntaxKind::AccessExprNode => Some(Self::Access(AccessExpr(syntax))),
+            SyntaxKind::CallExprNode => Some(Self::Call(CallExpr(inner))),
+            SyntaxKind::IndexExprNode => Some(Self::Index(IndexExpr(inner))),
+            SyntaxKind::AccessExprNode => Some(Self::Access(AccessExpr(inner))),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         match self {
-            Self::Literal(l) => l.syntax(),
-            Self::Name(n) => &n.0,
+            Self::Literal(l) => l.inner(),
+            Self::NameRef(n) => &n.0,
             Self::Parenthesized(p) => &p.0,
             Self::If(i) => &i.0,
             Self::LogicalNot(n) => &n.0,
@@ -1183,42 +1161,39 @@ impl AstNode for Expr {
 
 /// Represents a literal expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum LiteralExpr {
+pub enum LiteralExpr<N: TreeNode = SyntaxNode> {
     /// The literal is a `Boolean`.
-    Boolean(LiteralBoolean),
+    Boolean(LiteralBoolean<N>),
     /// The literal is an `Int`.
-    Integer(LiteralInteger),
+    Integer(LiteralInteger<N>),
     /// The literal is a `Float`.
-    Float(LiteralFloat),
+    Float(LiteralFloat<N>),
     /// The literal is a `String`.
-    String(LiteralString),
+    String(LiteralString<N>),
     /// The literal is an `Array`.
-    Array(LiteralArray),
+    Array(LiteralArray<N>),
     /// The literal is a `Pair`.
-    Pair(LiteralPair),
+    Pair(LiteralPair<N>),
     /// The literal is a `Map`.
-    Map(LiteralMap),
+    Map(LiteralMap<N>),
     /// The literal is an `Object`.
-    Object(LiteralObject),
+    Object(LiteralObject<N>),
     /// The literal is a struct.
-    Struct(LiteralStruct),
+    Struct(LiteralStruct<N>),
     /// The literal is a `None`.
-    None(LiteralNone),
+    None(LiteralNone<N>),
     /// The literal is a `hints`.
-    Hints(LiteralHints),
+    Hints(LiteralHints<N>),
     /// The literal is an `input`.
-    Input(LiteralInput),
+    Input(LiteralInput<N>),
     /// The literal is an `output`.
-    Output(LiteralOutput),
+    Output(LiteralOutput<N>),
 }
 
-impl LiteralExpr {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast
-    /// to any of the underlying members within the [`Expr`].
-    pub fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> LiteralExpr<N> {
+    /// Returns whether or not the given syntax kind can be cast to
+    /// [`StructItem`].
+    pub fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
             SyntaxKind::LiteralBooleanNode
@@ -1237,69 +1212,70 @@ impl LiteralExpr {
         )
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`LiteralExpr`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self> {
-        match syntax.kind() {
+    /// Casts the given node to [`StructItem`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
             SyntaxKind::LiteralBooleanNode => Some(Self::Boolean(
-                LiteralBoolean::cast(syntax).expect("literal boolean to cast"),
+                LiteralBoolean::cast(inner).expect("literal boolean to cast"),
             )),
             SyntaxKind::LiteralIntegerNode => Some(Self::Integer(
-                LiteralInteger::cast(syntax).expect("literal integer to cast"),
+                LiteralInteger::cast(inner).expect("literal integer to cast"),
             )),
             SyntaxKind::LiteralFloatNode => Some(Self::Float(
-                LiteralFloat::cast(syntax).expect("literal float to cast"),
+                LiteralFloat::cast(inner).expect("literal float to cast"),
             )),
             SyntaxKind::LiteralStringNode => Some(Self::String(
-                LiteralString::cast(syntax).expect("literal string to cast"),
+                LiteralString::cast(inner).expect("literal string to cast"),
             )),
             SyntaxKind::LiteralArrayNode => Some(Self::Array(
-                LiteralArray::cast(syntax).expect("literal array to cast"),
+                LiteralArray::cast(inner).expect("literal array to cast"),
             )),
             SyntaxKind::LiteralPairNode => Some(Self::Pair(
-                LiteralPair::cast(syntax).expect("literal pair to cast"),
+                LiteralPair::cast(inner).expect("literal pair to cast"),
             )),
             SyntaxKind::LiteralMapNode => Some(Self::Map(
-                LiteralMap::cast(syntax).expect("literal map to case"),
+                LiteralMap::cast(inner).expect("literal map to case"),
             )),
             SyntaxKind::LiteralObjectNode => Some(Self::Object(
-                LiteralObject::cast(syntax).expect("literal object to cast"),
+                LiteralObject::cast(inner).expect("literal object to cast"),
             )),
             SyntaxKind::LiteralStructNode => Some(Self::Struct(
-                LiteralStruct::cast(syntax).expect("literal struct to cast"),
+                LiteralStruct::cast(inner).expect("literal struct to cast"),
             )),
             SyntaxKind::LiteralNoneNode => Some(Self::None(
-                LiteralNone::cast(syntax).expect("literal none to cast"),
+                LiteralNone::cast(inner).expect("literal none to cast"),
             )),
             SyntaxKind::LiteralHintsNode => Some(Self::Hints(
-                LiteralHints::cast(syntax).expect("literal hints to cast"),
+                LiteralHints::cast(inner).expect("literal hints to cast"),
             )),
             SyntaxKind::LiteralInputNode => Some(Self::Input(
-                LiteralInput::cast(syntax).expect("literal input to cast"),
+                LiteralInput::cast(inner).expect("literal input to cast"),
             )),
             SyntaxKind::LiteralOutputNode => Some(Self::Output(
-                LiteralOutput::cast(syntax).expect("literal output to cast"),
+                LiteralOutput::cast(inner).expect("literal output to cast"),
             )),
             _ => None,
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
         match self {
-            Self::Boolean(element) => element.syntax(),
-            Self::Integer(element) => element.syntax(),
-            Self::Float(element) => element.syntax(),
-            Self::String(element) => element.syntax(),
-            Self::Array(element) => element.syntax(),
-            Self::Pair(element) => element.syntax(),
-            Self::Map(element) => element.syntax(),
-            Self::Object(element) => element.syntax(),
-            Self::Struct(element) => element.syntax(),
-            Self::None(element) => element.syntax(),
-            Self::Hints(element) => element.syntax(),
-            Self::Input(element) => element.syntax(),
-            Self::Output(element) => element.syntax(),
+            Self::Boolean(e) => e.inner(),
+            Self::Integer(e) => e.inner(),
+            Self::Float(e) => e.inner(),
+            Self::String(e) => e.inner(),
+            Self::Array(e) => e.inner(),
+            Self::Pair(e) => e.inner(),
+            Self::Map(e) => e.inner(),
+            Self::Object(e) => e.inner(),
+            Self::Struct(e) => e.inner(),
+            Self::None(e) => e.inner(),
+            Self::Hints(e) => e.inner(),
+            Self::Input(e) => e.inner(),
+            Self::Output(e) => e.inner(),
         }
     }
 
@@ -1308,9 +1284,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Boolean`], then a reference to the inner
     ///   [`LiteralBoolean`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_boolean(&self) -> Option<&LiteralBoolean> {
+    pub fn as_boolean(&self) -> Option<&LiteralBoolean<N>> {
         match self {
-            Self::Boolean(boolean) => Some(boolean),
+            Self::Boolean(e) => Some(e),
             _ => None,
         }
     }
@@ -1320,9 +1296,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Boolean`], then the inner
     ///   [`LiteralBoolean`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_boolean(self) -> Option<LiteralBoolean> {
+    pub fn into_boolean(self) -> Option<LiteralBoolean<N>> {
         match self {
-            Self::Boolean(boolean) => Some(boolean),
+            Self::Boolean(e) => Some(e),
             _ => None,
         }
     }
@@ -1332,9 +1308,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal boolean.
-    pub fn unwrap_boolean(self) -> LiteralBoolean {
+    pub fn unwrap_boolean(self) -> LiteralBoolean<N> {
         match self {
-            Self::Boolean(literal) => literal,
+            Self::Boolean(e) => e,
             _ => panic!("not a literal boolean"),
         }
     }
@@ -1344,9 +1320,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Integer`], then a reference to the inner
     ///   [`LiteralInteger`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_integer(&self) -> Option<&LiteralInteger> {
+    pub fn as_integer(&self) -> Option<&LiteralInteger<N>> {
         match self {
-            Self::Integer(integer) => Some(integer),
+            Self::Integer(e) => Some(e),
             _ => None,
         }
     }
@@ -1356,9 +1332,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Integer`], then the inner
     ///   [`LiteralInteger`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_integer(self) -> Option<LiteralInteger> {
+    pub fn into_integer(self) -> Option<LiteralInteger<N>> {
         match self {
-            Self::Integer(integer) => Some(integer),
+            Self::Integer(e) => Some(e),
             _ => None,
         }
     }
@@ -1368,9 +1344,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal integer.
-    pub fn unwrap_integer(self) -> LiteralInteger {
+    pub fn unwrap_integer(self) -> LiteralInteger<N> {
         match self {
-            Self::Integer(literal) => literal,
+            Self::Integer(e) => e,
             _ => panic!("not a literal integer"),
         }
     }
@@ -1380,9 +1356,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Float`], then a reference to the inner
     ///   [`LiteralFloat`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_float(&self) -> Option<&LiteralFloat> {
+    pub fn as_float(&self) -> Option<&LiteralFloat<N>> {
         match self {
-            Self::Float(float) => Some(float),
+            Self::Float(e) => Some(e),
             _ => None,
         }
     }
@@ -1392,9 +1368,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Float`], then the inner [`LiteralFloat`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_float(self) -> Option<LiteralFloat> {
+    pub fn into_float(self) -> Option<LiteralFloat<N>> {
         match self {
-            Self::Float(float) => Some(float),
+            Self::Float(e) => Some(e),
             _ => None,
         }
     }
@@ -1404,9 +1380,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal float.
-    pub fn unwrap_float(self) -> LiteralFloat {
+    pub fn unwrap_float(self) -> LiteralFloat<N> {
         match self {
-            Self::Float(literal) => literal,
+            Self::Float(e) => e,
             _ => panic!("not a literal float"),
         }
     }
@@ -1416,9 +1392,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::String`], then a reference to the inner
     ///   [`LiteralString`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_string(&self) -> Option<&LiteralString> {
+    pub fn as_string(&self) -> Option<&LiteralString<N>> {
         match self {
-            Self::String(string) => Some(string),
+            Self::String(e) => Some(e),
             _ => None,
         }
     }
@@ -1428,9 +1404,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::String`], then the inner
     ///   [`LiteralString`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_string(self) -> Option<LiteralString> {
+    pub fn into_string(self) -> Option<LiteralString<N>> {
         match self {
-            Self::String(string) => Some(string),
+            Self::String(e) => Some(e),
             _ => None,
         }
     }
@@ -1440,9 +1416,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal string.
-    pub fn unwrap_string(self) -> LiteralString {
+    pub fn unwrap_string(self) -> LiteralString<N> {
         match self {
-            Self::String(literal) => literal,
+            Self::String(e) => e,
             _ => panic!("not a literal string"),
         }
     }
@@ -1452,9 +1428,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Array`], then a reference to the inner
     ///   [`LiteralArray`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_array(&self) -> Option<&LiteralArray> {
+    pub fn as_array(&self) -> Option<&LiteralArray<N>> {
         match self {
-            Self::Array(array) => Some(array),
+            Self::Array(e) => Some(e),
             _ => None,
         }
     }
@@ -1464,9 +1440,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Array`], then the inner [`LiteralArray`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_array(self) -> Option<LiteralArray> {
+    pub fn into_array(self) -> Option<LiteralArray<N>> {
         match self {
-            Self::Array(array) => Some(array),
+            Self::Array(e) => Some(e),
             _ => None,
         }
     }
@@ -1476,9 +1452,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal array.
-    pub fn unwrap_array(self) -> LiteralArray {
+    pub fn unwrap_array(self) -> LiteralArray<N> {
         match self {
-            Self::Array(literal) => literal,
+            Self::Array(e) => e,
             _ => panic!("not a literal array"),
         }
     }
@@ -1488,9 +1464,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Pair`], then a reference to the inner
     ///   [`LiteralPair`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_pair(&self) -> Option<&LiteralPair> {
+    pub fn as_pair(&self) -> Option<&LiteralPair<N>> {
         match self {
-            Self::Pair(pair) => Some(pair),
+            Self::Pair(e) => Some(e),
             _ => None,
         }
     }
@@ -1500,9 +1476,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Pair`], then the inner [`LiteralPair`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_pair(self) -> Option<LiteralPair> {
+    pub fn into_pair(self) -> Option<LiteralPair<N>> {
         match self {
-            Self::Pair(pair) => Some(pair),
+            Self::Pair(e) => Some(e),
             _ => None,
         }
     }
@@ -1512,9 +1488,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal pair.
-    pub fn unwrap_pair(self) -> LiteralPair {
+    pub fn unwrap_pair(self) -> LiteralPair<N> {
         match self {
-            Self::Pair(literal) => literal,
+            Self::Pair(e) => e,
             _ => panic!("not a literal pair"),
         }
     }
@@ -1524,9 +1500,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Map`], then a reference to the inner
     ///   [`LiteralMap`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_map(&self) -> Option<&LiteralMap> {
+    pub fn as_map(&self) -> Option<&LiteralMap<N>> {
         match self {
-            Self::Map(map) => Some(map),
+            Self::Map(e) => Some(e),
             _ => None,
         }
     }
@@ -1536,9 +1512,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Map`], then the inner [`LiteralMap`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_map(self) -> Option<LiteralMap> {
+    pub fn into_map(self) -> Option<LiteralMap<N>> {
         match self {
-            Self::Map(map) => Some(map),
+            Self::Map(e) => Some(e),
             _ => None,
         }
     }
@@ -1548,9 +1524,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal map.
-    pub fn unwrap_map(self) -> LiteralMap {
+    pub fn unwrap_map(self) -> LiteralMap<N> {
         match self {
-            Self::Map(literal) => literal,
+            Self::Map(e) => e,
             _ => panic!("not a literal map"),
         }
     }
@@ -1560,9 +1536,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Object`], then a reference to the inner
     ///   [`LiteralObject`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_object(&self) -> Option<&LiteralObject> {
+    pub fn as_object(&self) -> Option<&LiteralObject<N>> {
         match self {
-            Self::Object(object) => Some(object),
+            Self::Object(e) => Some(e),
             _ => None,
         }
     }
@@ -1572,9 +1548,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Object`], then the inner
     ///   [`LiteralObject`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_object(self) -> Option<LiteralObject> {
+    pub fn into_object(self) -> Option<LiteralObject<N>> {
         match self {
-            Self::Object(object) => Some(object),
+            Self::Object(e) => Some(e),
             _ => None,
         }
     }
@@ -1584,9 +1560,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal object.
-    pub fn unwrap_object(self) -> LiteralObject {
+    pub fn unwrap_object(self) -> LiteralObject<N> {
         match self {
-            Self::Object(literal) => literal,
+            Self::Object(e) => e,
             _ => panic!("not a literal object"),
         }
     }
@@ -1596,9 +1572,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Struct`], then a reference to the inner
     ///   [`LiteralStruct`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_struct(&self) -> Option<&LiteralStruct> {
+    pub fn as_struct(&self) -> Option<&LiteralStruct<N>> {
         match self {
-            Self::Struct(r#struct) => Some(r#struct),
+            Self::Struct(e) => Some(e),
             _ => None,
         }
     }
@@ -1608,9 +1584,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Struct`], then the inner
     ///   [`LiteralStruct`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_struct(self) -> Option<LiteralStruct> {
+    pub fn into_struct(self) -> Option<LiteralStruct<N>> {
         match self {
-            Self::Struct(r#struct) => Some(r#struct),
+            Self::Struct(e) => Some(e),
             _ => None,
         }
     }
@@ -1620,9 +1596,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal struct.
-    pub fn unwrap_struct(self) -> LiteralStruct {
+    pub fn unwrap_struct(self) -> LiteralStruct<N> {
         match self {
-            Self::Struct(literal) => literal,
+            Self::Struct(e) => e,
             _ => panic!("not a literal struct"),
         }
     }
@@ -1632,9 +1608,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::None`], then a reference to the inner
     ///   [`LiteralNone`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_none(&self) -> Option<&LiteralNone> {
+    pub fn as_none(&self) -> Option<&LiteralNone<N>> {
         match self {
-            Self::None(none) => Some(none),
+            Self::None(e) => Some(e),
             _ => None,
         }
     }
@@ -1644,9 +1620,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::None`], then the inner [`LiteralNone`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_none(self) -> Option<LiteralNone> {
+    pub fn into_none(self) -> Option<LiteralNone<N>> {
         match self {
-            Self::None(none) => Some(none),
+            Self::None(e) => Some(e),
             _ => None,
         }
     }
@@ -1656,9 +1632,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal `None`.
-    pub fn unwrap_none(self) -> LiteralNone {
+    pub fn unwrap_none(self) -> LiteralNone<N> {
         match self {
-            Self::None(literal) => literal,
+            Self::None(e) => e,
             _ => panic!("not a literal `None`"),
         }
     }
@@ -1668,9 +1644,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Hints`], then a reference to the inner
     ///   [`LiteralHints`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_hints(&self) -> Option<&LiteralHints> {
+    pub fn as_hints(&self) -> Option<&LiteralHints<N>> {
         match self {
-            Self::Hints(hints) => Some(hints),
+            Self::Hints(e) => Some(e),
             _ => None,
         }
     }
@@ -1680,9 +1656,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Hints`], then the inner [`LiteralHints`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_hints(self) -> Option<LiteralHints> {
+    pub fn into_hints(self) -> Option<LiteralHints<N>> {
         match self {
-            Self::Hints(hints) => Some(hints),
+            Self::Hints(e) => Some(e),
             _ => None,
         }
     }
@@ -1692,9 +1668,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal `hints`.
-    pub fn unwrap_hints(self) -> LiteralHints {
+    pub fn unwrap_hints(self) -> LiteralHints<N> {
         match self {
-            Self::Hints(literal) => literal,
+            Self::Hints(e) => e,
             _ => panic!("not a literal `hints`"),
         }
     }
@@ -1704,9 +1680,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Input`], then a reference to the inner
     ///   [`LiteralInput`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_input(&self) -> Option<&LiteralInput> {
+    pub fn as_input(&self) -> Option<&LiteralInput<N>> {
         match self {
-            Self::Input(input) => Some(input),
+            Self::Input(e) => Some(e),
             _ => None,
         }
     }
@@ -1716,9 +1692,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Input`], then the inner [`LiteralInput`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_input(self) -> Option<LiteralInput> {
+    pub fn into_input(self) -> Option<LiteralInput<N>> {
         match self {
-            Self::Input(input) => Some(input),
+            Self::Input(e) => Some(e),
             _ => None,
         }
     }
@@ -1728,9 +1704,9 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal `input`.
-    pub fn unwrap_input(self) -> LiteralInput {
+    pub fn unwrap_input(self) -> LiteralInput<N> {
         match self {
-            Self::Input(literal) => literal,
+            Self::Input(e) => e,
             _ => panic!("not a literal `input`"),
         }
     }
@@ -1740,9 +1716,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Output`], then a reference to the inner
     ///   [`LiteralOutput`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_output(&self) -> Option<&LiteralOutput> {
+    pub fn as_output(&self) -> Option<&LiteralOutput<N>> {
         match self {
-            Self::Output(output) => Some(output),
+            Self::Output(e) => Some(e),
             _ => None,
         }
     }
@@ -1752,9 +1728,9 @@ impl LiteralExpr {
     /// * If `self` is a [`LiteralExpr::Output`], then the inner
     ///   [`LiteralOutput`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_output(self) -> Option<LiteralOutput> {
+    pub fn into_output(self) -> Option<LiteralOutput<N>> {
         match self {
-            Self::Output(output) => Some(output),
+            Self::Output(e) => Some(e),
             _ => None,
         }
     }
@@ -1764,107 +1740,87 @@ impl LiteralExpr {
     /// # Panics
     ///
     /// Panics if the expression is not a literal `output`.
-    pub fn unwrap_output(self) -> LiteralOutput {
+    pub fn unwrap_output(self) -> LiteralOutput<N> {
         match self {
-            Self::Output(literal) => literal,
+            Self::Output(e) => e,
             _ => panic!("not a literal `output`"),
         }
     }
 
-    /// Finds the first child that can be cast to an [`Expr`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`LiteralExpr`] to
-    /// implement the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    /// Finds the first child that can be cast to a [`LiteralExpr`].
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
-    /// Finds all children that can be cast to an [`Expr`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring [`LiteralExpr`] to
-    /// implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = LiteralExpr> + use<> {
-        syntax.children().filter_map(Self::cast)
+    /// Finds all children that can be cast to a [`LiteralExpr`].
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
     }
 }
 
 /// Represents a literal boolean.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralBoolean(pub(super) SyntaxNode);
+pub struct LiteralBoolean<N: TreeNode = SyntaxNode>(pub(super) N);
 
-impl LiteralBoolean {
+impl<N: TreeNode> LiteralBoolean<N> {
     /// Gets the value of the literal boolean.
     pub fn value(&self) -> bool {
         self.0
             .children_with_tokens()
-            .find_map(|c| match c.kind() {
-                SyntaxKind::TrueKeyword => Some(true),
-                SyntaxKind::FalseKeyword => Some(false),
-                _ => None,
+            .find_map(|c| {
+                c.into_token().and_then(|t| match t.kind() {
+                    SyntaxKind::TrueKeyword => Some(true),
+                    SyntaxKind::FalseKeyword => Some(false),
+                    _ => None,
+                })
             })
             .expect("`true` or `false` keyword should be present")
     }
 }
 
-impl AstNode for LiteralBoolean {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralBoolean<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralBooleanNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralBooleanNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralBooleanNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an integer token.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Integer(SyntaxToken);
+pub struct Integer<T: TreeToken = SyntaxToken>(T);
 
-impl AstToken for Integer {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> AstToken<T> for Integer<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::Integer
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::Integer => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::Integer => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
 /// Represents a literal integer.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralInteger(pub(super) SyntaxNode);
+pub struct LiteralInteger<N: TreeNode = SyntaxNode>(pub(super) N);
 
-impl LiteralInteger {
+impl<N: TreeNode> LiteralInteger<N> {
     /// Gets the minus token for the literal integer.
     ///
     /// A minus token *only* occurs in metadata sections, where
@@ -1873,13 +1829,13 @@ impl LiteralInteger {
     ///
     /// Otherwise, a prefix `-` would be a negation expression and not
     /// part of the literal integer.
-    pub fn minus(&self) -> Option<SyntaxToken> {
-        support::token(&self.0, SyntaxKind::Minus)
+    pub fn minus(&self) -> Option<Minus<N::Token>> {
+        self.token()
     }
 
     /// Gets the integer token for the literal.
-    pub fn token(&self) -> Integer {
-        token(&self.0).expect("should have integer token")
+    pub fn integer(&self) -> Integer<N::Token> {
+        self.token().expect("should have integer token")
     }
 
     /// Gets the value of the literal integer.
@@ -1890,7 +1846,7 @@ impl LiteralInteger {
 
         // If there's a minus sign present, negate the value; this may
         // only occur in metadata sections
-        if support::token(&self.0, SyntaxKind::Minus).is_some() {
+        if self.minus().is_some() {
             if value == (i64::MAX as u64) + 1 {
                 return Some(i64::MIN);
             }
@@ -1914,7 +1870,7 @@ impl LiteralInteger {
         let value = self.as_u64()?;
 
         // Check for "double" negation
-        if support::token(&self.0, SyntaxKind::Minus).is_some() {
+        if self.minus().is_some() {
             // Can't negate i64::MIN as that would overflow
             if value == (i64::MAX as u64) + 1 {
                 return None;
@@ -1935,8 +1891,8 @@ impl LiteralInteger {
     /// This returns `None` if the integer is out of range for a 64-bit signed
     /// integer, excluding `i64::MAX + 1` to allow for negation.
     fn as_u64(&self) -> Option<u64> {
-        let token = self.token();
-        let text = token.as_str();
+        let token = self.integer();
+        let text = token.text();
         let i = if text == "0" {
             0
         } else if text.starts_with("0x") || text.starts_with("0X") {
@@ -1956,63 +1912,49 @@ impl LiteralInteger {
     }
 }
 
-impl AstNode for LiteralInteger {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralInteger<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralIntegerNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralIntegerNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralIntegerNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a float token.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Float(SyntaxToken);
+pub struct Float<T: TreeToken = SyntaxToken>(T);
 
-impl AstToken for Float {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> AstToken<T> for Float<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::Float
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::Float => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::Float => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
 /// Represents a literal float.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralFloat(pub(crate) SyntaxNode);
+pub struct LiteralFloat<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl LiteralFloat {
+impl<N: TreeNode> LiteralFloat<N> {
     /// Gets the minus token for the literal float.
     ///
     /// A minus token *only* occurs in metadata sections, where
@@ -2021,48 +1963,40 @@ impl LiteralFloat {
     ///
     /// Otherwise, a prefix `-` would be a negation expression and not
     /// part of the literal float.
-    pub fn minus(&self) -> Option<SyntaxToken> {
-        support::token(&self.0, SyntaxKind::Minus)
+    pub fn minus(&self) -> Option<Minus<N::Token>> {
+        self.token()
     }
 
     /// Gets the float token for the literal.
-    pub fn token(&self) -> Float {
-        token(&self.0).expect("should have float token")
+    pub fn float(&self) -> Float<N::Token> {
+        self.token().expect("should have float token")
     }
 
     /// Gets the value of the literal float.
     ///
     /// Returns `None` if the literal value is not in range.
     pub fn value(&self) -> Option<f64> {
-        self.token()
-            .as_str()
+        self.float()
+            .text()
             .parse()
             .ok()
             .and_then(|f: f64| if f.is_infinite() { None } else { Some(f) })
     }
 }
 
-impl AstNode for LiteralFloat {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralFloat<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralFloatNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralFloatNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralFloatNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -2082,11 +2016,11 @@ pub enum LiteralStringKind {
 /// and it's line continuations parsed. Placeholders are not changed and are
 /// copied as-is.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum StrippedStringPart {
+pub enum StrippedStringPart<N: TreeNode = SyntaxNode> {
     /// A textual part of the string.
     Text(String),
     /// A placeholder encountered in the string.
-    Placeholder(Placeholder),
+    Placeholder(Placeholder<N>),
 }
 
 /// Unescapes a multiline string.
@@ -2142,18 +2076,20 @@ fn unescape_multiline_string(s: &str) -> String {
 
 /// Represents a literal string.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralString(pub(super) SyntaxNode);
+pub struct LiteralString<N: TreeNode = SyntaxNode>(pub(super) N);
 
-impl LiteralString {
+impl<N: TreeNode> LiteralString<N> {
     /// Gets the kind of the string literal.
     pub fn kind(&self) -> LiteralStringKind {
         self.0
             .children_with_tokens()
-            .find_map(|c| match c.kind() {
-                SyntaxKind::SingleQuote => Some(LiteralStringKind::SingleQuoted),
-                SyntaxKind::DoubleQuote => Some(LiteralStringKind::DoubleQuoted),
-                SyntaxKind::OpenHeredoc => Some(LiteralStringKind::Multiline),
-                _ => None,
+            .find_map(|c| {
+                c.into_token().and_then(|t| match t.kind() {
+                    SyntaxKind::SingleQuote => Some(LiteralStringKind::SingleQuoted),
+                    SyntaxKind::DoubleQuote => Some(LiteralStringKind::DoubleQuoted),
+                    SyntaxKind::OpenHeredoc => Some(LiteralStringKind::Multiline),
+                    _ => None,
+                })
             })
             .expect("string is missing opening token")
     }
@@ -2170,7 +2106,7 @@ impl LiteralString {
     /// Gets the parts of the string.
     ///
     /// A part may be literal text or an interpolated expression.
-    pub fn parts(&self) -> impl Iterator<Item = StringPart> + use<> {
+    pub fn parts(&self) -> impl Iterator<Item = StringPart<N>> + use<'_, N> {
         self.0.children_with_tokens().filter_map(StringPart::cast)
     }
 
@@ -2180,7 +2116,7 @@ impl LiteralString {
     /// Returns `None` if the string is interpolated, as
     /// interpolated strings cannot be represented as a single
     /// span of text.
-    pub fn text(&self) -> Option<StringText> {
+    pub fn text(&self) -> Option<StringText<N::Token>> {
         let mut parts = self.parts();
         if let Some(StringPart::Text(text)) = parts.next() {
             if parts.next().is_none() {
@@ -2197,7 +2133,7 @@ impl LiteralString {
     /// unescaping the string.
     ///
     /// Returns `None` if not a multi-line string.
-    pub fn strip_whitespace(&self) -> Option<Vec<StrippedStringPart>> {
+    pub fn strip_whitespace(&self) -> Option<Vec<StrippedStringPart<N>>> {
         if self.kind() != LiteralStringKind::Multiline {
             return None;
         }
@@ -2208,7 +2144,7 @@ impl LiteralString {
             match part {
                 StringPart::Text(text) => {
                     result.push(StrippedStringPart::Text(unescape_multiline_string(
-                        text.as_str(),
+                        text.text(),
                     )));
                 }
                 StringPart::Placeholder(placeholder) => {
@@ -2332,47 +2268,39 @@ impl LiteralString {
     }
 }
 
-impl AstNode for LiteralString {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralString<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralStringNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralStringNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralStringNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a part of a string.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum StringPart {
+pub enum StringPart<N: TreeNode = SyntaxNode> {
     /// A textual part of the string.
-    Text(StringText),
+    Text(StringText<N::Token>),
     /// A placeholder encountered in the string.
-    Placeholder(Placeholder),
+    Placeholder(Placeholder<N>),
 }
 
-impl StringPart {
+impl<N: TreeNode> StringPart<N> {
     /// Unwraps the string part into text.
     ///
     /// # Panics
     ///
     /// Panics if the string part is not text.
-    pub fn unwrap_text(self) -> StringText {
+    pub fn unwrap_text(self) -> StringText<N::Token> {
         match self {
             Self::Text(text) => text,
             _ => panic!("not string text"),
@@ -2384,7 +2312,7 @@ impl StringPart {
     /// # Panics
     ///
     /// Panics if the string part is not a placeholder.
-    pub fn unwrap_placeholder(self) -> Placeholder {
+    pub fn unwrap_placeholder(self) -> Placeholder<N> {
         match self {
             Self::Placeholder(p) => p,
             _ => panic!("not a placeholder"),
@@ -2392,19 +2320,19 @@ impl StringPart {
     }
 
     /// Casts the given syntax element to a string part.
-    fn cast(syntax: SyntaxElement) -> Option<Self> {
-        match syntax {
-            SyntaxElement::Node(n) => Some(Self::Placeholder(Placeholder::cast(n)?)),
-            SyntaxElement::Token(t) => Some(Self::Text(StringText::cast(t)?)),
+    fn cast(element: NodeOrToken<N, N::Token>) -> Option<Self> {
+        match element {
+            NodeOrToken::Node(n) => Some(Self::Placeholder(Placeholder::cast(n)?)),
+            NodeOrToken::Token(t) => Some(Self::Text(StringText::cast(t)?)),
         }
     }
 }
 
 /// Represents a textual part of a string.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StringText(pub(crate) SyntaxToken);
+pub struct StringText<T: TreeToken = SyntaxToken>(pub(crate) T);
 
-impl StringText {
+impl<T: TreeToken> StringText<T> {
     /// Unescapes the string text to the given buffer.
     ///
     /// If the string text contains invalid escape sequences, they are left
@@ -2463,108 +2391,88 @@ impl StringText {
     }
 }
 
-impl AstToken for StringText {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> AstToken<T> for StringText<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralStringText
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralStringText => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralStringText => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
 /// Represents a placeholder in a string or command.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Placeholder(pub(crate) SyntaxNode);
+pub struct Placeholder<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl Placeholder {
+impl<N: TreeNode> Placeholder<N> {
     /// Returns whether or not placeholder has a tilde (`~`) opening.
     ///
     /// If this method returns false, the opening was a dollar sign (`$`).
     pub fn has_tilde(&self) -> bool {
         self.0
             .children_with_tokens()
-            .find_map(|c| match c.kind() {
-                SyntaxKind::PlaceholderOpen => Some(
-                    c.as_token()
-                        .expect("should be token")
-                        .text()
-                        .starts_with('~'),
-                ),
-                _ => None,
+            .find_map(|c| {
+                c.into_token().and_then(|t| match t.kind() {
+                    SyntaxKind::PlaceholderOpen => Some(t.text().starts_with('~')),
+                    _ => None,
+                })
             })
             .expect("should have a placeholder open token")
     }
 
     /// Gets the option for the placeholder.
-    pub fn option(&self) -> Option<PlaceholderOption> {
-        child(&self.0)
+    pub fn option(&self) -> Option<PlaceholderOption<N>> {
+        self.child()
     }
 
     /// Gets the placeholder expression.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("placeholder should have an expression")
     }
 }
 
-impl AstNode for Placeholder {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for Placeholder<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::PlaceholderNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::PlaceholderNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::PlaceholderNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a placeholder option.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum PlaceholderOption {
+pub enum PlaceholderOption<N: TreeNode = SyntaxNode> {
     /// A `sep` option for specifying a delimiter for formatting arrays.
-    Sep(SepOption),
+    Sep(SepOption<N>),
     /// A `default` option for substituting a default value for an undefined
     /// expression.
-    Default(DefaultOption),
+    Default(DefaultOption<N>),
     /// A `true/false` option for substituting a value depending on whether a
     /// boolean expression is true or false.
-    TrueFalse(TrueFalseOption),
+    TrueFalse(TrueFalseOption<N>),
 }
 
-impl PlaceholderOption {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`PlaceholderOption`].
-    pub fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> PlaceholderOption<N> {
+    /// Returns whether or not the given syntax kind can be cast to
+    /// [`PlaceholderOption`].
+    pub fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
             SyntaxKind::PlaceholderSepOptionNode
@@ -2573,32 +2481,30 @@ impl PlaceholderOption {
         )
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`PlaceholderOption`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
+    /// Casts the given node to [`PlaceholderOption`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
             SyntaxKind::PlaceholderSepOptionNode => Some(Self::Sep(
-                SepOption::cast(syntax).expect("separator option to cast"),
+                SepOption::cast(inner).expect("separator option to cast"),
             )),
             SyntaxKind::PlaceholderDefaultOptionNode => Some(Self::Default(
-                DefaultOption::cast(syntax).expect("default option to cast"),
+                DefaultOption::cast(inner).expect("default option to cast"),
             )),
             SyntaxKind::PlaceholderTrueFalseOptionNode => Some(Self::TrueFalse(
-                TrueFalseOption::cast(syntax).expect("true false option to cast"),
+                TrueFalseOption::cast(inner).expect("true false option to cast"),
             )),
             _ => None,
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
         match self {
-            Self::Sep(element) => element.syntax(),
-            Self::Default(element) => element.syntax(),
-            Self::TrueFalse(element) => element.syntax(),
+            Self::Sep(element) => element.inner(),
+            Self::Default(element) => element.inner(),
+            Self::TrueFalse(element) => element.inner(),
         }
     }
 
@@ -2607,9 +2513,9 @@ impl PlaceholderOption {
     /// * If `self` is a [`PlaceholderOption::Sep`], then a reference to the
     ///   inner [`SepOption`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_sep(&self) -> Option<&SepOption> {
+    pub fn as_sep(&self) -> Option<&SepOption<N>> {
         match self {
-            Self::Sep(sep) => Some(sep),
+            Self::Sep(o) => Some(o),
             _ => None,
         }
     }
@@ -2619,9 +2525,9 @@ impl PlaceholderOption {
     /// * If `self` is a [`PlaceholderOption::Sep`], then the inner
     ///   [`SepOption`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_sep(self) -> Option<SepOption> {
+    pub fn into_sep(self) -> Option<SepOption<N>> {
         match self {
-            Self::Sep(sep) => Some(sep),
+            Self::Sep(o) => Some(o),
             _ => None,
         }
     }
@@ -2631,9 +2537,9 @@ impl PlaceholderOption {
     /// # Panics
     ///
     /// Panics if the option is not a separator option.
-    pub fn unwrap_sep(self) -> SepOption {
+    pub fn unwrap_sep(self) -> SepOption<N> {
         match self {
-            Self::Sep(opt) => opt,
+            Self::Sep(o) => o,
             _ => panic!("not a separator option"),
         }
     }
@@ -2643,9 +2549,9 @@ impl PlaceholderOption {
     /// * If `self` is a [`PlaceholderOption::Default`], then a reference to the
     ///   inner [`DefaultOption`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_default(&self) -> Option<&DefaultOption> {
+    pub fn as_default(&self) -> Option<&DefaultOption<N>> {
         match self {
-            Self::Default(default) => Some(default),
+            Self::Default(o) => Some(o),
             _ => None,
         }
     }
@@ -2655,9 +2561,9 @@ impl PlaceholderOption {
     /// * If `self` is a [`PlaceholderOption::Default`], then the inner
     ///   [`DefaultOption`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_default(self) -> Option<DefaultOption> {
+    pub fn into_default(self) -> Option<DefaultOption<N>> {
         match self {
-            Self::Default(default) => Some(default),
+            Self::Default(o) => Some(o),
             _ => None,
         }
     }
@@ -2667,9 +2573,9 @@ impl PlaceholderOption {
     /// # Panics
     ///
     /// Panics if the option is not a default option.
-    pub fn unwrap_default(self) -> DefaultOption {
+    pub fn unwrap_default(self) -> DefaultOption<N> {
         match self {
-            Self::Default(opt) => opt,
+            Self::Default(o) => o,
             _ => panic!("not a default option"),
         }
     }
@@ -2679,9 +2585,9 @@ impl PlaceholderOption {
     /// * If `self` is a [`PlaceholderOption::TrueFalse`], then a reference to
     ///   the inner [`TrueFalseOption`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_true_false(&self) -> Option<&TrueFalseOption> {
+    pub fn as_true_false(&self) -> Option<&TrueFalseOption<N>> {
         match self {
-            Self::TrueFalse(true_false) => Some(true_false),
+            Self::TrueFalse(o) => Some(o),
             _ => None,
         }
     }
@@ -2691,9 +2597,9 @@ impl PlaceholderOption {
     /// * If `self` is a [`PlaceholderOption::TrueFalse`], then the inner
     ///   [`TrueFalseOption`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_true_false(self) -> Option<TrueFalseOption> {
+    pub fn into_true_false(self) -> Option<TrueFalseOption<N>> {
         match self {
-            Self::TrueFalse(true_false) => Some(true_false),
+            Self::TrueFalse(o) => Some(o),
             _ => None,
         }
     }
@@ -2703,39 +2609,26 @@ impl PlaceholderOption {
     /// # Panics
     ///
     /// Panics if the option is not a true/false option.
-    pub fn unwrap_true_false(self) -> TrueFalseOption {
+    pub fn unwrap_true_false(self) -> TrueFalseOption<N> {
         match self {
-            Self::TrueFalse(opt) => opt,
+            Self::TrueFalse(o) => o,
             _ => panic!("not a true/false option"),
         }
     }
 
-    /// Finds the first child that can be cast to an [`PlaceholderOption`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`PlaceholderOption`]
-    /// to implement the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    /// Finds the first child that can be cast to a [`PlaceholderOption`].
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
-    /// Finds all children that can be cast to an [`PlaceholderOption`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring
-    /// [`PlaceholderOption`] to implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = PlaceholderOption> + use<> {
-        syntax.children().filter_map(Self::cast)
+    /// Finds all children that can be cast to a [`PlaceholderOption`].
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
     }
 }
 
-impl AstNode for PlaceholderOption {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for PlaceholderOption<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
             SyntaxKind::PlaceholderSepOptionNode
@@ -2744,21 +2637,18 @@ impl AstNode for PlaceholderOption {
         )
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::PlaceholderSepOptionNode => Some(Self::Sep(SepOption(syntax))),
-            SyntaxKind::PlaceholderDefaultOptionNode => Some(Self::Default(DefaultOption(syntax))),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::PlaceholderSepOptionNode => Some(Self::Sep(SepOption(inner))),
+            SyntaxKind::PlaceholderDefaultOptionNode => Some(Self::Default(DefaultOption(inner))),
             SyntaxKind::PlaceholderTrueFalseOptionNode => {
-                Some(Self::TrueFalse(TrueFalseOption(syntax)))
+                Some(Self::TrueFalse(TrueFalseOption(inner)))
             }
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         match self {
             Self::Sep(s) => &s.0,
             Self::Default(d) => &d.0,
@@ -2769,107 +2659,92 @@ impl AstNode for PlaceholderOption {
 
 /// Represents a `sep` option for a placeholder.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SepOption(SyntaxNode);
+pub struct SepOption<N: TreeNode = SyntaxNode>(N);
 
-impl SepOption {
+impl<N: TreeNode> SepOption<N> {
     /// Gets the separator to use for formatting an array.
-    pub fn separator(&self) -> LiteralString {
-        child(&self.0).expect("sep option should have a string literal")
+    pub fn separator(&self) -> LiteralString<N> {
+        self.child()
+            .expect("sep option should have a string literal")
     }
 }
 
-impl AstNode for SepOption {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for SepOption<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::PlaceholderSepOptionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::PlaceholderSepOptionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::PlaceholderSepOptionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a `default` option for a placeholder.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DefaultOption(SyntaxNode);
+pub struct DefaultOption<N: TreeNode = SyntaxNode>(N);
 
-impl DefaultOption {
+impl<N: TreeNode> DefaultOption<N> {
     /// Gets the value to use for an undefined expression.
-    pub fn value(&self) -> LiteralString {
-        child(&self.0).expect("default option should have a string literal")
+    pub fn value(&self) -> LiteralString<N> {
+        self.child()
+            .expect("default option should have a string literal")
     }
 }
 
-impl AstNode for DefaultOption {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for DefaultOption<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::PlaceholderDefaultOptionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::PlaceholderDefaultOptionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::PlaceholderDefaultOptionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a `true/false` option for a placeholder.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TrueFalseOption(SyntaxNode);
+pub struct TrueFalseOption<N: TreeNode = SyntaxNode>(N);
 
-impl TrueFalseOption {
+impl<N: TreeNode> TrueFalseOption<N> {
     /// Gets the `true` and `false`` values to use for a placeholder
     /// expression that evaluates to a boolean.
     ///
     /// The first value returned is the `true` value and the second
     /// value is the `false` value.
-    pub fn values(&self) -> (LiteralString, LiteralString) {
+    pub fn values(&self) -> (LiteralString<N>, LiteralString<N>) {
         let mut true_value = None;
         let mut false_value = None;
         let mut found = None;
         let mut children = self.0.children_with_tokens();
         for child in children.by_ref() {
-            match child.kind() {
-                SyntaxKind::TrueKeyword => {
+            match child {
+                NodeOrToken::Token(t) if t.kind() == SyntaxKind::TrueKeyword => {
                     found = Some(true);
                 }
-                SyntaxKind::FalseKeyword => {
+                NodeOrToken::Token(t) if t.kind() == SyntaxKind::FalseKeyword => {
                     found = Some(false);
                 }
-                k if LiteralString::can_cast(k) => {
-                    let child = child.into_node().expect("should be a node");
+                NodeOrToken::Node(n) if LiteralString::<N>::can_cast(n.kind()) => {
                     if found.expect("should have found true or false") {
                         assert!(true_value.is_none(), "multiple true values present");
-                        true_value = Some(LiteralString(child));
+                        true_value = Some(LiteralString(n));
                     } else {
                         assert!(false_value.is_none(), "multiple false values present");
-                        false_value = Some(LiteralString(child));
+                        false_value = Some(LiteralString(n));
                     }
 
                     if true_value.is_some() && false_value.is_some() {
@@ -2887,74 +2762,58 @@ impl TrueFalseOption {
     }
 }
 
-impl AstNode for TrueFalseOption {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for TrueFalseOption<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::PlaceholderTrueFalseOptionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::PlaceholderTrueFalseOptionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::PlaceholderTrueFalseOptionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal array.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralArray(SyntaxNode);
+pub struct LiteralArray<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralArray {
+impl<N: TreeNode> LiteralArray<N> {
     /// Gets the elements of the literal array.
-    pub fn elements(&self) -> impl Iterator<Item = Expr> + use<> {
+    pub fn elements(&self) -> impl Iterator<Item = Expr<N>> + use<'_, N> {
         Expr::children(&self.0)
     }
 }
 
-impl AstNode for LiteralArray {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralArray<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralArrayNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralArrayNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralArrayNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal pair.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralPair(SyntaxNode);
+pub struct LiteralPair<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralPair {
+impl<N: TreeNode> LiteralPair<N> {
     /// Gets the first and second expressions in the literal pair.
-    pub fn exprs(&self) -> (Expr, Expr) {
+    pub fn exprs(&self) -> (Expr<N>, Expr<N>) {
         let mut children = self.0.children().filter_map(Expr::cast);
         let left = children.next().expect("pair should have a left expression");
         let right = children
@@ -2964,74 +2823,58 @@ impl LiteralPair {
     }
 }
 
-impl AstNode for LiteralPair {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralPair<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralPairNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralPairNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralPairNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal map.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralMap(SyntaxNode);
+pub struct LiteralMap<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralMap {
+impl<N: TreeNode> LiteralMap<N> {
     /// Gets the items of the literal map.
-    pub fn items(&self) -> AstChildren<LiteralMapItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = LiteralMapItem<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for LiteralMap {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralMap<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralMapNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralMapNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralMapNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal map item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralMapItem(SyntaxNode);
+pub struct LiteralMapItem<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralMapItem {
+impl<N: TreeNode> LiteralMapItem<N> {
     /// Gets the key and the value of the item.
-    pub fn key_value(&self) -> (Expr, Expr) {
+    pub fn key_value(&self) -> (Expr<N>, Expr<N>) {
         let mut children = Expr::children(&self.0);
         let key = children.next().expect("expected a key expression");
         let value = children.next().expect("expected a value expression");
@@ -3039,541 +2882,428 @@ impl LiteralMapItem {
     }
 }
 
-impl AstNode for LiteralMapItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralMapItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralMapItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralMapItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralMapItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal object.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralObject(SyntaxNode);
+pub struct LiteralObject<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralObject {
+impl<N: TreeNode> LiteralObject<N> {
     /// Gets the items of the literal object.
-    pub fn items(&self) -> AstChildren<LiteralObjectItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = LiteralObjectItem<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for LiteralObject {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralObject<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralObjectNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralObjectNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralObjectNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Gets the name and value of a object or struct literal item.
-fn name_value(parent: &SyntaxNode) -> (Ident, Expr) {
-    let key = token_child::<Ident>(parent).expect("expected a key token");
-    let value = Expr::child(parent).expect("expected a value expression");
-
+fn name_value<N: TreeNode, T: AstNode<N>>(parent: &T) -> (Ident<N::Token>, Expr<N>) {
+    let key = parent.token().expect("expected a key token");
+    let value = Expr::child(parent.inner()).expect("expected a value expression");
     (key, value)
 }
 
 /// Represents a literal object item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralObjectItem(SyntaxNode);
+pub struct LiteralObjectItem<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralObjectItem {
+impl<N: TreeNode> LiteralObjectItem<N> {
     /// Gets the name and the value of the item.
-    pub fn name_value(&self) -> (Ident, Expr) {
-        name_value(&self.0)
+    pub fn name_value(&self) -> (Ident<N::Token>, Expr<N>) {
+        name_value(self)
     }
 }
 
-impl AstNode for LiteralObjectItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralObjectItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralObjectItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralObjectItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralObjectItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal struct.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralStruct(SyntaxNode);
+pub struct LiteralStruct<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralStruct {
+impl<N: TreeNode> LiteralStruct<N> {
     /// Gets the name of the struct.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("expected the struct to have a name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("expected the struct to have a name")
     }
 
     /// Gets the items of the literal struct.
-    pub fn items(&self) -> AstChildren<LiteralStructItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = LiteralStructItem<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for LiteralStruct {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralStruct<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralStructNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralStructNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralStructNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal struct item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralStructItem(SyntaxNode);
+pub struct LiteralStructItem<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralStructItem {
+impl<N: TreeNode> LiteralStructItem<N> {
     /// Gets the name and the value of the item.
-    pub fn name_value(&self) -> (Ident, Expr) {
-        name_value(&self.0)
+    pub fn name_value(&self) -> (Ident<N::Token>, Expr<N>) {
+        name_value(self)
     }
 }
 
-impl AstNode for LiteralStructItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralStructItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralStructItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralStructItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralStructItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal `None`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralNone(SyntaxNode);
+pub struct LiteralNone<N: TreeNode = SyntaxNode>(N);
 
-impl AstNode for LiteralNone {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralNone<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralNoneNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralNoneNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralNoneNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal `hints`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralHints(SyntaxNode);
+pub struct LiteralHints<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralHints {
+impl<N: TreeNode> LiteralHints<N> {
     /// Gets the items of the literal hints.
-    pub fn items(&self) -> AstChildren<LiteralHintsItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = LiteralHintsItem<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for LiteralHints {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralHints<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralHintsNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralHintsNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralHintsNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal hints item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralHintsItem(SyntaxNode);
+pub struct LiteralHintsItem<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralHintsItem {
+impl<N: TreeNode> LiteralHintsItem<N> {
     /// Gets the name of the hints item.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("expected an item name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("expected an item name")
     }
 
     /// Gets the expression of the hints item.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("expected an item expression")
     }
 }
 
-impl AstNode for LiteralHintsItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralHintsItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralHintsItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralHintsItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralHintsItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal `input`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralInput(SyntaxNode);
+pub struct LiteralInput<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralInput {
+impl<N: TreeNode> LiteralInput<N> {
     /// Gets the items of the literal input.
-    pub fn items(&self) -> AstChildren<LiteralInputItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = LiteralInputItem<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for LiteralInput {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralInput<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralInputNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralInputNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralInputNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal input item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralInputItem(SyntaxNode);
+pub struct LiteralInputItem<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralInputItem {
+impl<N: TreeNode> LiteralInputItem<N> {
     /// Gets the names of the input item.
     ///
     /// More than one name indicates a struct member path.
-    pub fn names(&self) -> impl Iterator<Item = Ident> + use<> {
+    pub fn names(&self) -> impl Iterator<Item = Ident<N::Token>> + use<'_, N> {
         self.0
             .children_with_tokens()
-            .filter_map(SyntaxElement::into_token)
+            .filter_map(NodeOrToken::into_token)
             .filter_map(Ident::cast)
     }
 
     /// Gets the expression of the input item.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("expected an item expression")
     }
 }
 
-impl AstNode for LiteralInputItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralInputItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralInputItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralInputItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralInputItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal `output`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralOutput(SyntaxNode);
+pub struct LiteralOutput<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralOutput {
+impl<N: TreeNode> LiteralOutput<N> {
     /// Gets the items of the literal output.
-    pub fn items(&self) -> AstChildren<LiteralOutputItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = LiteralOutputItem<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for LiteralOutput {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralOutput<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralOutputNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralOutputNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralOutputNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a literal output item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralOutputItem(SyntaxNode);
+pub struct LiteralOutputItem<N: TreeNode = SyntaxNode>(N);
 
-impl LiteralOutputItem {
+impl<N: TreeNode> LiteralOutputItem<N> {
     /// Gets the names of the output item.
     ///
     /// More than one name indicates a struct member path.
-    pub fn names(&self) -> impl Iterator<Item = Ident> + use<> {
+    pub fn names(&self) -> impl Iterator<Item = Ident<N::Token>> + use<'_, N> {
         self.0
             .children_with_tokens()
-            .filter_map(SyntaxElement::into_token)
+            .filter_map(NodeOrToken::into_token)
             .filter_map(Ident::cast)
     }
 
     /// Gets the expression of the output item.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("expected an item expression")
     }
 }
 
-impl AstNode for LiteralOutputItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralOutputItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralOutputItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralOutputItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralOutputItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
-/// Represents a reference to a name.
+/// Represents a name reference expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct NameRef(SyntaxNode);
+pub struct NameRefExpr<N: TreeNode = SyntaxNode>(N);
 
-impl NameRef {
+impl<N: TreeNode> NameRefExpr<N> {
     /// Gets the name being referenced.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("expected a name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("expected a name")
     }
 }
 
-impl AstNode for NameRef {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
-        kind == SyntaxKind::NameRefNode
+impl<N: TreeNode> AstNode<N> for NameRefExpr<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == SyntaxKind::NameRefExprNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::NameRefNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::NameRefExprNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a parenthesized expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ParenthesizedExpr(SyntaxNode);
+pub struct ParenthesizedExpr<N: TreeNode = SyntaxNode>(N);
 
-impl ParenthesizedExpr {
+impl<N: TreeNode> ParenthesizedExpr<N> {
     /// Gets the inner expression.
-    pub fn inner(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("expected an inner expression")
     }
 }
 
-impl AstNode for ParenthesizedExpr {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for ParenthesizedExpr<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::ParenthesizedExprNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::ParenthesizedExprNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::ParenthesizedExprNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an `if` expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct IfExpr(SyntaxNode);
+pub struct IfExpr<N: TreeNode = SyntaxNode>(N);
 
-impl IfExpr {
+impl<N: TreeNode> IfExpr<N> {
     /// Gets the three expressions of the `if` expression
     ///
     /// The first expression is the conditional.
     /// The second expression is the `true` expression.
     /// The third expression is the `false` expression.
-    pub fn exprs(&self) -> (Expr, Expr, Expr) {
+    pub fn exprs(&self) -> (Expr<N>, Expr<N>, Expr<N>) {
         let mut children = Expr::children(&self.0);
         let conditional = children
             .next()
@@ -3584,27 +3314,19 @@ impl IfExpr {
     }
 }
 
-impl AstNode for IfExpr {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for IfExpr<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::IfExprNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::IfExprNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::IfExprNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -3614,36 +3336,28 @@ macro_rules! prefix_expression {
     ($name:ident, $kind:ident, $desc:literal) => {
         #[doc = concat!("Represents a ", $desc, " expression.")]
         #[derive(Clone, Debug, PartialEq, Eq)]
-        pub struct $name(SyntaxNode);
+        pub struct $name<N: TreeNode = SyntaxNode>(N);
 
-        impl $name {
+        impl<N: TreeNode> $name<N> {
             /// Gets the operand expression.
-            pub fn operand(&self) -> Expr {
+            pub fn operand(&self) -> Expr<N> {
                 Expr::child(&self.0).expect("expected an operand expression")
             }
         }
 
-        impl AstNode for $name {
-            type Language = WorkflowDescriptionLanguage;
-
-            fn can_cast(kind: SyntaxKind) -> bool
-            where
-                Self: Sized,
-            {
+        impl<N: TreeNode> AstNode<N> for $name<N> {
+            fn can_cast(kind: SyntaxKind) -> bool {
                 kind == SyntaxKind::$kind
             }
 
-            fn cast(syntax: SyntaxNode) -> Option<Self>
-            where
-                Self: Sized,
-            {
-                match syntax.kind() {
-                    SyntaxKind::$kind => Some(Self(syntax)),
+            fn cast(inner: N) -> Option<Self> {
+                match inner.kind() {
+                    SyntaxKind::$kind => Some(Self(inner)),
                     _ => None,
                 }
             }
 
-            fn syntax(&self) -> &SyntaxNode {
+            fn inner(&self) -> &N {
                 &self.0
             }
         }
@@ -3655,11 +3369,11 @@ macro_rules! infix_expression {
     ($name:ident, $kind:ident, $desc:literal) => {
         #[doc = concat!("Represents a ", $desc, " expression.")]
         #[derive(Clone, Debug, PartialEq, Eq)]
-        pub struct $name(SyntaxNode);
+        pub struct $name<N: TreeNode = SyntaxNode>(N);
 
-        impl $name {
+        impl<N: TreeNode> $name<N> {
             /// Gets the operands of the expression.
-            pub fn operands(&self) -> (Expr, Expr) {
+            pub fn operands(&self) -> (Expr<N>, Expr<N>) {
                 let mut children = Expr::children(&self.0);
                 let lhs = children.next().expect("expected a lhs expression");
                 let rhs = children.next().expect("expected a rhs expression");
@@ -3667,27 +3381,19 @@ macro_rules! infix_expression {
             }
         }
 
-        impl AstNode for $name {
-            type Language = WorkflowDescriptionLanguage;
-
-            fn can_cast(kind: SyntaxKind) -> bool
-            where
-                Self: Sized,
-            {
+        impl<N: TreeNode> AstNode<N> for $name<N> {
+            fn can_cast(kind: SyntaxKind) -> bool {
                 kind == SyntaxKind::$kind
             }
 
-            fn cast(syntax: SyntaxNode) -> Option<Self>
-            where
-                Self: Sized,
-            {
-                match syntax.kind() {
-                    SyntaxKind::$kind => Some(Self(syntax)),
+            fn cast(inner: N) -> Option<Self> {
+                match inner.kind() {
+                    SyntaxKind::$kind => Some(Self(inner)),
                     _ => None,
                 }
             }
 
-            fn syntax(&self) -> &SyntaxNode {
+            fn inner(&self) -> &N {
                 &self.0
             }
         }
@@ -3717,55 +3423,47 @@ infix_expression!(ExponentiationExpr, ExponentiationExprNode, "exponentiation");
 
 /// Represents a call expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CallExpr(SyntaxNode);
+pub struct CallExpr<N: TreeNode = SyntaxNode>(N);
 
-impl CallExpr {
+impl<N: TreeNode> CallExpr<N> {
     /// Gets the call target expression.
-    pub fn target(&self) -> Ident {
-        token(&self.0).expect("expected a target identifier")
+    pub fn target(&self) -> Ident<N::Token> {
+        self.token().expect("expected a target identifier")
     }
 
     /// Gets the call arguments.
-    pub fn arguments(&self) -> impl Iterator<Item = Expr> + use<> {
+    pub fn arguments(&self) -> impl Iterator<Item = Expr<N>> + use<'_, N> {
         Expr::children(&self.0)
     }
 }
 
-impl AstNode for CallExpr {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for CallExpr<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::CallExprNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::CallExprNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::CallExprNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an index expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct IndexExpr(SyntaxNode);
+pub struct IndexExpr<N: TreeNode = SyntaxNode>(N);
 
-impl IndexExpr {
+impl<N: TreeNode> IndexExpr<N> {
     /// Gets the operand and the index expressions.
     ///
     /// The first is the operand expression.
     /// The second is the index expression.
-    pub fn operands(&self) -> (Expr, Expr) {
+    pub fn operands(&self) -> (Expr<N>, Expr<N>) {
         let mut children = Expr::children(&self.0);
         let operand = children.next().expect("expected an operand expression");
         let index = children.next().expect("expected an index expression");
@@ -3773,41 +3471,33 @@ impl IndexExpr {
     }
 }
 
-impl AstNode for IndexExpr {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for IndexExpr<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::IndexExprNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::IndexExprNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::IndexExprNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an access expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AccessExpr(SyntaxNode);
+pub struct AccessExpr<N: TreeNode = SyntaxNode>(N);
 
-impl AccessExpr {
+impl<N: TreeNode> AccessExpr<N> {
     /// Gets the operand and the name of the access.
     ///
     /// The first is the operand expression.
     /// The second is the member name.
-    pub fn operands(&self) -> (Expr, Ident) {
+    pub fn operands(&self) -> (Expr<N>, Ident<N::Token>) {
         let operand = Expr::child(&self.0).expect("expected an operand expression");
         let name = Ident::cast(self.0.last_token().expect("expected a last token"))
             .expect("expected an ident token");
@@ -3815,27 +3505,19 @@ impl AccessExpr {
     }
 }
 
-impl AstNode for AccessExpr {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for AccessExpr<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::AccessExprNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::AccessExprNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::AccessExprNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -3872,7 +3554,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -3880,12 +3562,12 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Boolean");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert!(decls[0].expr().unwrap_literal().unwrap_boolean().value());
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Boolean");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert!(!decls[1].expr().unwrap_literal().unwrap_boolean().value());
 
         // Visit the literal boolean values in the tree
@@ -3943,7 +3625,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -3951,7 +3633,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -3964,7 +3646,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -3977,7 +3659,7 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Int");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         assert_eq!(
             decls[2]
                 .expr()
@@ -3990,7 +3672,7 @@ task test {
 
         // Fourth declaration
         assert_eq!(decls[3].ty().to_string(), "Int");
-        assert_eq!(decls[3].name().as_str(), "d");
+        assert_eq!(decls[3].name().text(), "d");
         assert_eq!(
             decls[3]
                 .expr()
@@ -4003,7 +3685,7 @@ task test {
 
         // Fifth declaration
         assert_eq!(decls[4].ty().to_string(), "Int");
-        assert_eq!(decls[4].name().as_str(), "e");
+        assert_eq!(decls[4].name().text(), "e");
         assert_eq!(
             decls[4]
                 .expr()
@@ -4016,7 +3698,7 @@ task test {
 
         // Sixth declaration
         assert_eq!(decls[5].ty().to_string(), "Int");
-        assert_eq!(decls[5].name().as_str(), "f");
+        assert_eq!(decls[5].name().text(), "f");
         assert_eq!(
             decls[5]
                 .expr()
@@ -4029,7 +3711,7 @@ task test {
 
         // Seventh declaration
         assert_eq!(decls[6].ty().to_string(), "Int");
-        assert_eq!(decls[6].name().as_str(), "g");
+        assert_eq!(decls[6].name().text(), "g");
         assert!(
             decls[6]
                 .expr()
@@ -4041,7 +3723,7 @@ task test {
 
         // Eighth declaration
         assert_eq!(decls[7].ty().to_string(), "Int");
-        assert_eq!(decls[7].name().as_str(), "h");
+        assert_eq!(decls[7].name().text(), "h");
         assert!(
             decls[7]
                 .expr()
@@ -4118,7 +3800,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -4126,7 +3808,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Float");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_relative_eq!(
             decls[0]
                 .expr()
@@ -4139,7 +3821,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Float");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_relative_eq!(
             decls[1]
                 .expr()
@@ -4152,7 +3834,7 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Float");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         assert_relative_eq!(
             decls[2]
                 .expr()
@@ -4165,7 +3847,7 @@ task test {
 
         // Fourth declaration
         assert_eq!(decls[3].ty().to_string(), "Float");
-        assert_eq!(decls[3].name().as_str(), "d");
+        assert_eq!(decls[3].name().text(), "d");
         assert_relative_eq!(
             decls[3]
                 .expr()
@@ -4178,7 +3860,7 @@ task test {
 
         // Fifth declaration
         assert_eq!(decls[4].ty().to_string(), "Float");
-        assert_eq!(decls[4].name().as_str(), "e");
+        assert_eq!(decls[4].name().text(), "e");
         assert_relative_eq!(
             decls[4]
                 .expr()
@@ -4191,7 +3873,7 @@ task test {
 
         // Sixth declaration
         assert_eq!(decls[5].ty().to_string(), "Float");
-        assert_eq!(decls[5].name().as_str(), "f");
+        assert_eq!(decls[5].name().text(), "f");
         assert_relative_eq!(
             decls[5]
                 .expr()
@@ -4204,7 +3886,7 @@ task test {
 
         // Seventh declaration
         assert_eq!(decls[6].ty().to_string(), "Float");
-        assert_eq!(decls[6].name().as_str(), "g");
+        assert_eq!(decls[6].name().text(), "g");
         assert_relative_eq!(
             decls[6]
                 .expr()
@@ -4217,7 +3899,7 @@ task test {
 
         // Eighth declaration
         assert_eq!(decls[7].ty().to_string(), "Float");
-        assert_eq!(decls[7].name().as_str(), "h");
+        assert_eq!(decls[7].name().text(), "h");
         assert!(
             decls[7]
                 .expr()
@@ -4289,7 +3971,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -4297,39 +3979,39 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "String");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let s = decls[0].expr().unwrap_literal().unwrap_string();
         assert_eq!(s.kind(), LiteralStringKind::DoubleQuoted);
-        assert_eq!(s.text().unwrap().as_str(), "hello");
+        assert_eq!(s.text().unwrap().text(), "hello");
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "String");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let s = decls[1].expr().unwrap_literal().unwrap_string();
         assert_eq!(s.kind(), LiteralStringKind::SingleQuoted);
-        assert_eq!(s.text().unwrap().as_str(), "world");
+        assert_eq!(s.text().unwrap().text(), "world");
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "String");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let s = decls[2].expr().unwrap_literal().unwrap_string();
         assert_eq!(s.kind(), LiteralStringKind::DoubleQuoted);
         let parts: Vec<_> = s.parts().collect();
         assert_eq!(parts.len(), 3);
-        assert_eq!(parts[0].clone().unwrap_text().as_str(), "Hello, ");
+        assert_eq!(parts[0].clone().unwrap_text().text(), "Hello, ");
         let placeholder = parts[1].clone().unwrap_placeholder();
         assert!(!placeholder.has_tilde());
-        assert_eq!(placeholder.expr().unwrap_name_ref().name().as_str(), "name");
-        assert_eq!(parts[2].clone().unwrap_text().as_str(), "!");
+        assert_eq!(placeholder.expr().unwrap_name_ref().name().text(), "name");
+        assert_eq!(parts[2].clone().unwrap_text().text(), "!");
 
         // Fourth declaration
         assert_eq!(decls[3].ty().to_string(), "String");
-        assert_eq!(decls[3].name().as_str(), "d");
+        assert_eq!(decls[3].name().text(), "d");
         let s = decls[3].expr().unwrap_literal().unwrap_string();
         assert_eq!(s.kind(), LiteralStringKind::SingleQuoted);
         let parts: Vec<_> = s.parts().collect();
         assert_eq!(parts.len(), 3);
-        assert_eq!(parts[0].clone().unwrap_text().as_str(), "String");
+        assert_eq!(parts[0].clone().unwrap_text().text(), "String");
         let placeholder = parts[1].clone().unwrap_placeholder();
         assert!(placeholder.has_tilde());
         assert_eq!(
@@ -4339,36 +4021,30 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "ception"
         );
-        assert_eq!(parts[2].clone().unwrap_text().as_str(), "!");
+        assert_eq!(parts[2].clone().unwrap_text().text(), "!");
 
         // Fifth declaration
         assert_eq!(decls[4].ty().to_string(), "String");
-        assert_eq!(decls[4].name().as_str(), "e");
+        assert_eq!(decls[4].name().text(), "e");
         let s = decls[4].expr().unwrap_literal().unwrap_string();
         assert_eq!(s.kind(), LiteralStringKind::Multiline);
         let parts: Vec<_> = s.parts().collect();
         assert_eq!(parts.len(), 5);
         assert_eq!(
-            parts[0].clone().unwrap_text().as_str(),
+            parts[0].clone().unwrap_text().text(),
             " this is\n    a multiline \\\n    string!\n    "
         );
         let placeholder = parts[1].clone().unwrap_placeholder();
         assert!(!placeholder.has_tilde());
-        assert_eq!(
-            placeholder.expr().unwrap_name_ref().name().as_str(),
-            "first"
-        );
-        assert_eq!(parts[2].clone().unwrap_text().as_str(), "\n    ");
+        assert_eq!(placeholder.expr().unwrap_name_ref().name().text(), "first");
+        assert_eq!(parts[2].clone().unwrap_text().text(), "\n    ");
         let placeholder = parts[3].clone().unwrap_placeholder();
         assert!(!placeholder.has_tilde());
-        assert_eq!(
-            placeholder.expr().unwrap_name_ref().name().as_str(),
-            "second"
-        );
-        assert_eq!(parts[4].clone().unwrap_text().as_str(), "\n    ");
+        assert_eq!(placeholder.expr().unwrap_name_ref().name().text(), "second");
+        assert_eq!(parts[4].clone().unwrap_text().text(), "\n    ");
 
         // Use a visitor to visit all the string literals without placeholders
         struct MyVisitor(Vec<String>);
@@ -4393,7 +4069,7 @@ task test {
                 // Collect only the non-interpolated strings in the source
                 if let Expr::Literal(LiteralExpr::String(s)) = expr {
                     if let Some(s) = s.text() {
-                        self.0.push(s.as_str().to_string());
+                        self.0.push(s.text().to_string());
                     }
                 }
             }
@@ -4423,7 +4099,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -4431,7 +4107,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Array[Int]");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let a = decls[0].expr().unwrap_literal().unwrap_array();
         let elements: Vec<_> = a.elements().collect();
         assert_eq!(elements.len(), 3);
@@ -4465,7 +4141,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Array[String]");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let a = decls[1].expr().unwrap_literal().unwrap_array();
         let elements: Vec<_> = a.elements().collect();
         assert_eq!(elements.len(), 3);
@@ -4476,7 +4152,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "hello"
         );
         assert_eq!(
@@ -4486,7 +4162,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "world"
         );
         assert_eq!(
@@ -4496,13 +4172,13 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "!"
         );
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Array[Array[Int]]");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let a = decls[2].expr().unwrap_literal().unwrap_array();
         let elements: Vec<_> = a.elements().collect();
         assert_eq!(elements.len(), 3);
@@ -4638,7 +4314,7 @@ task test {
                                 elements.push(i.value().unwrap().to_string())
                             }
                             Expr::Literal(LiteralExpr::String(s)) => {
-                                elements.push(s.text().unwrap().as_str().to_string())
+                                elements.push(s.text().unwrap().text().to_string())
                             }
                             Expr::Literal(LiteralExpr::Array(a)) => {
                                 for element in a.elements().map(|e| {
@@ -4690,7 +4366,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -4698,7 +4374,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Pair[Int, Int]");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let p = decls[0].expr().unwrap_literal().unwrap_pair();
         let (left, right) = p.exprs();
         assert_eq!(
@@ -4721,7 +4397,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Pair[String, Int]");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let p = decls[1].expr().unwrap_literal().unwrap_pair();
         let (left, right) = p.exprs();
         assert_eq!(
@@ -4730,7 +4406,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "0x1000"
         );
         assert_eq!(
@@ -4745,7 +4421,7 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Array[Pair[Int, String]]");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let a = decls[2].expr().unwrap_literal().unwrap_array();
         let elements: Vec<_> = a.elements().collect();
         assert_eq!(elements.len(), 3);
@@ -4766,7 +4442,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "hello"
         );
         let p = elements[1].clone().unwrap_literal().unwrap_pair();
@@ -4786,7 +4462,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "world"
         );
         let p = elements[2].clone().unwrap_literal().unwrap_pair();
@@ -4806,7 +4482,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "!"
         );
 
@@ -4835,7 +4511,7 @@ task test {
 
                     let left = match left {
                         Expr::Literal(LiteralExpr::String(s)) => {
-                            s.text().unwrap().as_str().to_string()
+                            s.text().unwrap().text().to_string()
                         }
                         Expr::Literal(LiteralExpr::Integer(i)) => i.value().unwrap().to_string(),
                         _ => panic!("expected a string or integer"),
@@ -4843,7 +4519,7 @@ task test {
 
                     let right = match right {
                         Expr::Literal(LiteralExpr::String(s)) => {
-                            s.text().unwrap().as_str().to_string()
+                            s.text().unwrap().text().to_string()
                         }
                         Expr::Literal(LiteralExpr::Integer(i)) => i.value().unwrap().to_string(),
                         _ => panic!("expected a string or integer"),
@@ -4890,7 +4566,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -4898,24 +4574,20 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Map[Int, Int]");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let m = decls[0].expr().unwrap_literal().unwrap_map();
         let items: Vec<_> = m.items().collect();
         assert_eq!(items.len(), 0);
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Map[String, String]");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let m = decls[1].expr().unwrap_literal().unwrap_map();
         let items: Vec<_> = m.items().collect();
         assert_eq!(items.len(), 2);
         let (key, value) = items[0].key_value();
         assert_eq!(
-            key.unwrap_literal()
-                .unwrap_string()
-                .text()
-                .unwrap()
-                .as_str(),
+            key.unwrap_literal().unwrap_string().text().unwrap().text(),
             "foo"
         );
         assert_eq!(
@@ -4924,16 +4596,12 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
         let (key, value) = items[1].key_value();
         assert_eq!(
-            key.unwrap_literal()
-                .unwrap_string()
-                .text()
-                .unwrap()
-                .as_str(),
+            key.unwrap_literal().unwrap_string().text().unwrap().text(),
             "bar"
         );
         assert_eq!(
@@ -4942,7 +4610,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "baz"
         );
 
@@ -4975,14 +4643,14 @@ task test {
                                 .unwrap_string()
                                 .text()
                                 .unwrap()
-                                .as_str()
+                                .text()
                                 .to_string(),
                             value
                                 .unwrap_literal()
                                 .unwrap_string()
                                 .text()
                                 .unwrap()
-                                .as_str()
+                                .text()
                                 .to_string(),
                         );
                     }
@@ -5019,7 +4687,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -5027,33 +4695,33 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Object");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let o = decls[0].expr().unwrap_literal().unwrap_object();
         let items: Vec<_> = o.items().collect();
         assert_eq!(items.len(), 0);
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Object");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let o = decls[1].expr().unwrap_literal().unwrap_object();
         let items: Vec<_> = o.items().collect();
         assert_eq!(items.len(), 3);
         let (name, value) = items[0].name_value();
-        assert_eq!(name.as_str(), "foo");
+        assert_eq!(name.text(), "foo");
         assert_eq!(
             value
                 .unwrap_literal()
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
         let (name, value) = items[1].name_value();
-        assert_eq!(name.as_str(), "bar");
+        assert_eq!(name.text(), "bar");
         assert_eq!(value.unwrap_literal().unwrap_integer().value().unwrap(), 1);
         let (name, value) = items[2].name_value();
-        assert_eq!(name.as_str(), "baz");
+        assert_eq!(name.text(), "baz");
         let elements: Vec<_> = value.unwrap_literal().unwrap_array().elements().collect();
         assert_eq!(elements.len(), 3);
         assert_eq!(
@@ -5111,19 +4779,19 @@ task test {
                         match value {
                             Expr::Literal(LiteralExpr::Integer(i)) => {
                                 items.insert(
-                                    name.as_str().to_string(),
+                                    name.text().to_string(),
                                     i.value().unwrap().to_string(),
                                 );
                             }
                             Expr::Literal(LiteralExpr::String(s)) => {
                                 items.insert(
-                                    name.as_str().to_string(),
-                                    s.text().unwrap().as_str().to_string(),
+                                    name.text().to_string(),
+                                    s.text().unwrap().text().to_string(),
                                 );
                             }
                             Expr::Literal(LiteralExpr::Array(a)) => {
                                 items.insert(
-                                    name.as_str().to_string(),
+                                    name.text().to_string(),
                                     a.elements()
                                         .map(|e| {
                                             e.unwrap_literal().unwrap_integer().value().unwrap()
@@ -5174,7 +4842,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -5182,35 +4850,35 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Foo");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let s = decls[0].expr().unwrap_literal().unwrap_struct();
-        assert_eq!(s.name().as_str(), "Foo");
+        assert_eq!(s.name().text(), "Foo");
         let items: Vec<_> = s.items().collect();
         assert_eq!(items.len(), 1);
         let (name, value) = items[0].name_value();
-        assert_eq!(name.as_str(), "foo");
+        assert_eq!(name.text(), "foo");
         assert_eq!(
             value
                 .unwrap_literal()
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Bar");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let s = decls[1].expr().unwrap_literal().unwrap_struct();
-        assert_eq!(s.name().as_str(), "Bar");
+        assert_eq!(s.name().text(), "Bar");
         let items: Vec<_> = s.items().collect();
         assert_eq!(items.len(), 2);
         let (name, value) = items[0].name_value();
-        assert_eq!(name.as_str(), "bar");
+        assert_eq!(name.text(), "bar");
         assert_eq!(value.unwrap_literal().unwrap_integer().value().unwrap(), 1);
         let (name, value) = items[1].name_value();
-        assert_eq!(name.as_str(), "baz");
+        assert_eq!(name.text(), "baz");
         let elements: Vec<_> = value.unwrap_literal().unwrap_array().elements().collect();
         assert_eq!(elements.len(), 3);
         assert_eq!(
@@ -5268,19 +4936,19 @@ task test {
                         match value {
                             Expr::Literal(LiteralExpr::Integer(i)) => {
                                 items.insert(
-                                    name.as_str().to_string(),
+                                    name.text().to_string(),
                                     i.value().unwrap().to_string(),
                                 );
                             }
                             Expr::Literal(LiteralExpr::String(s)) => {
                                 items.insert(
-                                    name.as_str().to_string(),
-                                    s.text().unwrap().as_str().to_string(),
+                                    name.text().to_string(),
+                                    s.text().unwrap().text().to_string(),
                                 );
                             }
                             Expr::Literal(LiteralExpr::Array(a)) => {
                                 items.insert(
-                                    name.as_str().to_string(),
+                                    name.text().to_string(),
                                     a.elements()
                                         .map(|e| {
                                             e.unwrap_literal().unwrap_integer().value().unwrap()
@@ -5331,7 +4999,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -5339,14 +5007,14 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int?");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         decls[0].expr().unwrap_literal().unwrap_none();
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Boolean");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let (lhs, rhs) = decls[1].expr().unwrap_equality().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
         rhs.unwrap_literal().unwrap_none();
 
         // Use a visitor to count the number of literal `None` in the tree
@@ -5408,7 +5076,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task hints
         let hints = tasks[0].hints().expect("should have a hints section");
@@ -5416,7 +5084,7 @@ task test {
         assert_eq!(items.len(), 3);
 
         // First hints item
-        assert_eq!(items[0].name().as_str(), "foo");
+        assert_eq!(items[0].name().text(), "foo");
         let inner: Vec<_> = items[0]
             .expr()
             .unwrap_literal()
@@ -5424,7 +5092,7 @@ task test {
             .items()
             .collect();
         assert_eq!(inner.len(), 2);
-        assert_eq!(inner[0].name().as_str(), "bar");
+        assert_eq!(inner[0].name().text(), "bar");
         assert_eq!(
             inner[0]
                 .expr()
@@ -5432,10 +5100,10 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
-        assert_eq!(inner[1].name().as_str(), "baz");
+        assert_eq!(inner[1].name().text(), "baz");
         assert_eq!(
             inner[1]
                 .expr()
@@ -5443,12 +5111,12 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "baz"
         );
 
         // Second hints item
-        assert_eq!(items[1].name().as_str(), "bar");
+        assert_eq!(items[1].name().text(), "bar");
         assert_eq!(
             items[1]
                 .expr()
@@ -5456,12 +5124,12 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
 
         // Third hints item
-        assert_eq!(items[2].name().as_str(), "baz");
+        assert_eq!(items[2].name().text(), "baz");
         let inner: Vec<_> = items[2]
             .expr()
             .unwrap_literal()
@@ -5469,7 +5137,7 @@ task test {
             .items()
             .collect();
         assert_eq!(inner.len(), 3);
-        assert_eq!(inner[0].name().as_str(), "a");
+        assert_eq!(inner[0].name().text(), "a");
         assert_eq!(
             inner[0]
                 .expr()
@@ -5479,7 +5147,7 @@ task test {
                 .unwrap(),
             1
         );
-        assert_eq!(inner[1].name().as_str(), "b");
+        assert_eq!(inner[1].name().text(), "b");
         assert_relative_eq!(
             inner[1]
                 .expr()
@@ -5489,7 +5157,7 @@ task test {
                 .unwrap(),
             10.0
         );
-        assert_eq!(inner[2].name().as_str(), "c");
+        assert_eq!(inner[2].name().text(), "c");
         let map: Vec<_> = inner[2]
             .expr()
             .unwrap_literal()
@@ -5499,11 +5167,11 @@ task test {
         assert_eq!(map.len(), 1);
         let (k, v) = map[0].key_value();
         assert_eq!(
-            k.unwrap_literal().unwrap_string().text().unwrap().as_str(),
+            k.unwrap_literal().unwrap_string().text().unwrap().text(),
             "foo"
         );
         assert_eq!(
-            v.unwrap_literal().unwrap_string().text().unwrap().as_str(),
+            v.unwrap_literal().unwrap_string().text().unwrap().text(),
             "bar"
         );
 
@@ -5562,7 +5230,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task hints
         let hints = tasks[0].hints().expect("task should have hints section");
@@ -5570,7 +5238,7 @@ task test {
         assert_eq!(items.len(), 1);
 
         // First hints item
-        assert_eq!(items[0].name().as_str(), "inputs");
+        assert_eq!(items[0].name().text(), "inputs");
         let input: Vec<_> = items[0]
             .expr()
             .unwrap_literal()
@@ -5581,7 +5249,7 @@ task test {
         assert_eq!(
             input[0]
                 .names()
-                .map(|i| i.as_str().to_string())
+                .map(|i| i.text().to_string())
                 .collect::<Vec<_>>(),
             ["a"]
         );
@@ -5592,7 +5260,7 @@ task test {
             .items()
             .collect();
         assert_eq!(inner.len(), 1);
-        assert_eq!(inner[0].name().as_str(), "foo");
+        assert_eq!(inner[0].name().text(), "foo");
         assert_eq!(
             inner[0]
                 .expr()
@@ -5600,13 +5268,13 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
         assert_eq!(
             input[1]
                 .names()
-                .map(|i| i.as_str().to_string())
+                .map(|i| i.text().to_string())
                 .collect::<Vec<_>>(),
             ["b", "c", "d"]
         );
@@ -5617,7 +5285,7 @@ task test {
             .items()
             .collect();
         assert_eq!(inner.len(), 1);
-        assert_eq!(inner[0].name().as_str(), "bar");
+        assert_eq!(inner[0].name().text(), "bar");
         assert_eq!(
             inner[0]
                 .expr()
@@ -5625,7 +5293,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "baz"
         );
 
@@ -5684,7 +5352,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task hints
         let hints = tasks[0].hints().expect("task should have a hints section");
@@ -5692,7 +5360,7 @@ task test {
         assert_eq!(items.len(), 1);
 
         // First hints item
-        assert_eq!(items[0].name().as_str(), "outputs");
+        assert_eq!(items[0].name().text(), "outputs");
         let output: Vec<_> = items[0]
             .expr()
             .unwrap_literal()
@@ -5703,7 +5371,7 @@ task test {
         assert_eq!(
             output[0]
                 .names()
-                .map(|i| i.as_str().to_string())
+                .map(|i| i.text().to_string())
                 .collect::<Vec<_>>(),
             ["a"]
         );
@@ -5714,7 +5382,7 @@ task test {
             .items()
             .collect();
         assert_eq!(inner.len(), 1);
-        assert_eq!(inner[0].name().as_str(), "foo");
+        assert_eq!(inner[0].name().text(), "foo");
         assert_eq!(
             inner[0]
                 .expr()
@@ -5722,13 +5390,13 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
         assert_eq!(
             output[1]
                 .names()
-                .map(|i| i.as_str().to_string())
+                .map(|i| i.text().to_string())
                 .collect::<Vec<_>>(),
             ["b", "c", "d"]
         );
@@ -5739,7 +5407,7 @@ task test {
             .items()
             .collect();
         assert_eq!(inner.len(), 1);
-        assert_eq!(inner[0].name().as_str(), "bar");
+        assert_eq!(inner[0].name().text(), "bar");
         assert_eq!(
             inner[0]
                 .expr()
@@ -5747,7 +5415,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "baz"
         );
 
@@ -5798,7 +5466,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -5806,7 +5474,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -5819,8 +5487,8 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
-        assert_eq!(decls[1].expr().unwrap_name_ref().name().as_str(), "a");
+        assert_eq!(decls[1].name().text(), "b");
+        assert_eq!(decls[1].expr().unwrap_name_ref().name().text(), "a");
 
         // Use a visitor to visit every name reference in the tree
         struct MyVisitor(Vec<String>);
@@ -5842,8 +5510,8 @@ task test {
                     return;
                 }
 
-                if let Expr::Name(n) = expr {
-                    self.0.push(n.name().as_str().to_string());
+                if let Expr::NameRef(n) = expr {
+                    self.0.push(n.name().text().to_string());
                 }
             }
         }
@@ -5871,7 +5539,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -5879,12 +5547,12 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
                 .unwrap_parenthesized()
-                .inner()
+                .expr()
                 .unwrap_literal()
                 .unwrap_integer()
                 .value()
@@ -5894,17 +5562,17 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let (lhs, rhs) = decls[1]
             .expr()
             .unwrap_parenthesized()
-            .inner()
+            .expr()
             .unwrap_subtraction()
             .operands();
         assert_eq!(lhs.unwrap_literal().unwrap_integer().value().unwrap(), 10);
         let (lhs, rhs) = rhs
             .unwrap_parenthesized()
-            .inner()
+            .expr()
             .unwrap_addition()
             .operands();
         assert_eq!(lhs.unwrap_literal().unwrap_integer().value().unwrap(), 5);
@@ -5957,7 +5625,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -5965,7 +5633,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let (c, t, f) = decls[0].expr().unwrap_if().exprs();
         assert!(c.unwrap_literal().unwrap_boolean().value());
         assert_eq!(t.unwrap_literal().unwrap_integer().value().unwrap(), 1);
@@ -5973,17 +5641,17 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "String");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let (c, t, f) = decls[1].expr().unwrap_if().exprs();
         let (lhs, rhs) = c.unwrap_greater().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
         assert_eq!(rhs.unwrap_literal().unwrap_integer().value().unwrap(), 0);
         assert_eq!(
-            t.unwrap_literal().unwrap_string().text().unwrap().as_str(),
+            t.unwrap_literal().unwrap_string().text().unwrap().text(),
             "yes"
         );
         assert_eq!(
-            f.unwrap_literal().unwrap_string().text().unwrap().as_str(),
+            f.unwrap_literal().unwrap_string().text().unwrap().text(),
             "no"
         );
 
@@ -6034,7 +5702,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6042,7 +5710,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Boolean");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert!(
             decls[0]
                 .expr()
@@ -6055,7 +5723,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Boolean");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6067,7 +5735,7 @@ task test {
                 .operand()
                 .unwrap_name_ref()
                 .name()
-                .as_str(),
+                .text(),
             "a"
         );
 
@@ -6118,7 +5786,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6126,7 +5794,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -6141,7 +5809,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6153,7 +5821,7 @@ task test {
                 .operand()
                 .unwrap_name_ref()
                 .name()
-                .as_str(),
+                .text(),
             "a"
         );
 
@@ -6205,7 +5873,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6213,20 +5881,20 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Boolean");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert!(!decls[0].expr().unwrap_literal().unwrap_boolean().value());
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Boolean");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert!(decls[1].expr().unwrap_literal().unwrap_boolean().value());
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_logical_or().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of logical `or` expressions in the tree
         struct MyVisitor(usize);
@@ -6276,7 +5944,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6284,20 +5952,20 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Boolean");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert!(decls[0].expr().unwrap_literal().unwrap_boolean().value());
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Boolean");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert!(decls[1].expr().unwrap_literal().unwrap_boolean().value());
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_logical_and().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of logical `and` expressions in the tree
         struct MyVisitor(usize);
@@ -6347,7 +6015,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6355,20 +6023,20 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Boolean");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert!(decls[0].expr().unwrap_literal().unwrap_boolean().value());
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Boolean");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert!(!decls[1].expr().unwrap_literal().unwrap_boolean().value());
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_equality().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of equality expressions in the tree
         struct MyVisitor(usize);
@@ -6418,7 +6086,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6426,20 +6094,20 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Boolean");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert!(decls[0].expr().unwrap_literal().unwrap_boolean().value());
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Boolean");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert!(!decls[1].expr().unwrap_literal().unwrap_boolean().value());
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_inequality().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of inequality expressions in the tree.
         struct MyVisitor(usize);
@@ -6489,7 +6157,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6497,7 +6165,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -6510,7 +6178,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6523,10 +6191,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_less().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to visit the number of `<` expressions in the tree.
         struct MyVisitor(usize);
@@ -6576,7 +6244,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6584,7 +6252,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -6597,7 +6265,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6610,10 +6278,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_less_equal().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of `<=` expressions in the tree.
         struct MyVisitor(usize);
@@ -6663,7 +6331,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6671,7 +6339,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -6684,7 +6352,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6697,10 +6365,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_greater().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of `>` expressions in the tree
         struct MyVisitor(usize);
@@ -6750,7 +6418,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6758,7 +6426,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -6771,7 +6439,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6784,10 +6452,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Boolean");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_greater_equal().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of `>=` expressions in the tree.
         struct MyVisitor(usize);
@@ -6837,7 +6505,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6845,7 +6513,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -6858,7 +6526,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6871,10 +6539,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Int");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_addition().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of addition expressions in the tree
         struct MyVisitor(usize);
@@ -6924,7 +6592,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -6932,7 +6600,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -6945,7 +6613,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -6958,10 +6626,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Int");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_subtraction().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of subtraction expressions in the tree
         struct MyVisitor(usize);
@@ -7011,7 +6679,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -7019,7 +6687,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -7032,7 +6700,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -7045,10 +6713,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Int");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_multiplication().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of multiplication expressions in the tree
         struct MyVisitor(usize);
@@ -7098,7 +6766,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -7106,7 +6774,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -7119,7 +6787,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -7132,10 +6800,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Int");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_division().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of division expressions in the tree
         struct MyVisitor(usize);
@@ -7185,7 +6853,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -7193,7 +6861,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -7206,7 +6874,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -7219,10 +6887,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Int");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_modulo().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of modulo expressions in the tree
         struct MyVisitor(usize);
@@ -7272,7 +6940,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -7280,7 +6948,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Int");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         assert_eq!(
             decls[0]
                 .expr()
@@ -7293,7 +6961,7 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         assert_eq!(
             decls[1]
                 .expr()
@@ -7306,10 +6974,10 @@ task test {
 
         // Third declaration
         assert_eq!(decls[2].ty().to_string(), "Int");
-        assert_eq!(decls[2].name().as_str(), "c");
+        assert_eq!(decls[2].name().text(), "c");
         let (lhs, rhs) = decls[2].expr().unwrap_exponentiation().operands();
-        assert_eq!(lhs.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(rhs.unwrap_name_ref().name().as_str(), "b");
+        assert_eq!(lhs.unwrap_name_ref().name().text(), "a");
+        assert_eq!(rhs.unwrap_name_ref().name().text(), "b");
 
         // Use a visitor to count the number of exponentiation expressions in the tree
         struct MyVisitor(usize);
@@ -7358,7 +7026,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -7366,7 +7034,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Array[Int]");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let elements: Vec<_> = decls[0]
             .expr()
             .unwrap_literal()
@@ -7404,9 +7072,9 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "String");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let call = decls[1].expr().unwrap_call();
-        assert_eq!(call.target().as_str(), "sep");
+        assert_eq!(call.target().text(), "sep");
         let args: Vec<_> = call.arguments().collect();
         assert_eq!(args.len(), 2);
         assert_eq!(
@@ -7416,10 +7084,10 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             " "
         );
-        assert_eq!(args[1].clone().unwrap_name_ref().name().as_str(), "a");
+        assert_eq!(args[1].clone().unwrap_name_ref().name().text(), "a");
 
         // Use a visitor to count the number of call expressions in the tree
         struct MyVisitor(usize);
@@ -7468,7 +7136,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -7476,7 +7144,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Array[Int]");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let elements: Vec<_> = decls[0]
             .expr()
             .unwrap_literal()
@@ -7514,9 +7182,9 @@ task test {
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "Int");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let (expr, index) = decls[1].expr().unwrap_index().operands();
-        assert_eq!(expr.unwrap_name_ref().name().as_str(), "a");
+        assert_eq!(expr.unwrap_name_ref().name().text(), "a");
         assert_eq!(index.unwrap_literal().unwrap_integer().value().unwrap(), 1);
 
         // Use a visitor to count the number of index expressions in the tree
@@ -7566,7 +7234,7 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task declarations
         let decls: Vec<_> = tasks[0].declarations().collect();
@@ -7574,7 +7242,7 @@ task test {
 
         // First declaration
         assert_eq!(decls[0].ty().to_string(), "Object");
-        assert_eq!(decls[0].name().as_str(), "a");
+        assert_eq!(decls[0].name().text(), "a");
         let items: Vec<_> = decls[0]
             .expr()
             .unwrap_literal()
@@ -7583,23 +7251,23 @@ task test {
             .collect();
         assert_eq!(items.len(), 1);
         let (name, value) = items[0].name_value();
-        assert_eq!(name.as_str(), "foo");
+        assert_eq!(name.text(), "foo");
         assert_eq!(
             value
                 .unwrap_literal()
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
 
         // Second declaration
         assert_eq!(decls[1].ty().to_string(), "String");
-        assert_eq!(decls[1].name().as_str(), "b");
+        assert_eq!(decls[1].name().text(), "b");
         let (expr, index) = decls[1].expr().unwrap_access().operands();
-        assert_eq!(expr.unwrap_name_ref().name().as_str(), "a");
-        assert_eq!(index.as_str(), "foo");
+        assert_eq!(expr.unwrap_name_ref().name().text(), "a");
+        assert_eq!(index.text(), "foo");
 
         // Use a visitor to count the number of access expressions in the tree
         struct MyVisitor(usize);
@@ -7652,7 +7320,7 @@ task test {
         assert_eq!(decls.len(), 1);
 
         let expr = decls[0].expr().unwrap_literal().unwrap_string();
-        assert_eq!(expr.text().unwrap().as_str(), "  foo  ");
+        assert_eq!(expr.text().unwrap().text(), "  foo  ");
 
         let stripped = expr.strip_whitespace();
         assert!(stripped.is_none());

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -100,7 +100,7 @@ impl<N: TreeNode> Expr<N> {
         )
     }
 
-    /// Casts the given node to [`StructItem`].
+    /// Casts the given node to [`Expr`].
     ///
     /// Returns `None` if the node cannot be cast.
     pub fn cast(inner: N) -> Option<Self> {
@@ -1192,7 +1192,7 @@ pub enum LiteralExpr<N: TreeNode = SyntaxNode> {
 
 impl<N: TreeNode> LiteralExpr<N> {
     /// Returns whether or not the given syntax kind can be cast to
-    /// [`StructItem`].
+    /// [`LiteralExpr`].
     pub fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -1212,7 +1212,7 @@ impl<N: TreeNode> LiteralExpr<N> {
         )
     }
 
-    /// Casts the given node to [`StructItem`].
+    /// Casts the given node to [`LiteralExpr`].
     ///
     /// Returns `None` if the node cannot be cast.
     pub fn cast(inner: N) -> Option<Self> {

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -251,7 +251,7 @@ impl<N: TreeNode> TaskItem<N> {
         )
     }
 
-    /// Casts the given node to [`StructItem`].
+    /// Casts the given node to [`TaskItem`].
     ///
     /// Returns `None` if the node cannot be cast.
     pub fn cast(inner: N) -> Option<Self> {
@@ -555,7 +555,7 @@ impl<N: TreeNode> SectionParent<N> {
         )
     }
 
-    /// Casts the given node to [`StructItem`].
+    /// Casts the given node to [`SectionParent`].
     ///
     /// Returns `None` if the node cannot be cast.
     pub fn cast(inner: N) -> Option<Self> {

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -1,5 +1,7 @@
 //! V1 AST representation for task definitions.
 
+use rowan::NodeOrToken;
+
 use super::BoundDecl;
 use super::Decl;
 use super::Expr;
@@ -7,22 +9,18 @@ use super::LiteralBoolean;
 use super::LiteralFloat;
 use super::LiteralInteger;
 use super::LiteralString;
+use super::OpenHeredoc;
 use super::Placeholder;
 use super::StructDefinition;
 use super::WorkflowDefinition;
-use crate::AstChildren;
 use crate::AstNode;
 use crate::AstToken;
 use crate::Ident;
-use crate::SyntaxElement;
 use crate::SyntaxKind;
 use crate::SyntaxNode;
 use crate::SyntaxToken;
-use crate::WorkflowDescriptionLanguage;
-use crate::support;
-use crate::support::child;
-use crate::support::children;
-use crate::token;
+use crate::TreeNode;
+use crate::TreeToken;
 
 pub mod common;
 pub mod requirements;
@@ -136,120 +134,109 @@ fn unescape_command_text(s: &str, heredoc: bool, buffer: &mut String) {
 
 /// Represents a task definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TaskDefinition(pub(crate) SyntaxNode);
+pub struct TaskDefinition<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl TaskDefinition {
+impl<N: TreeNode> TaskDefinition<N> {
     /// Gets the name of the task.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("task should have a name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("task should have a name")
     }
 
     /// Gets the items of the task.
-    pub fn items(&self) -> impl Iterator<Item = TaskItem> + use<> {
+    pub fn items(&self) -> impl Iterator<Item = TaskItem<N>> + use<'_, N> {
         TaskItem::children(&self.0)
     }
 
     /// Gets the input section of the task.
-    pub fn input(&self) -> Option<InputSection> {
-        child(&self.0)
+    pub fn input(&self) -> Option<InputSection<N>> {
+        self.child()
     }
 
     /// Gets the output section of the task.
-    pub fn output(&self) -> Option<OutputSection> {
-        child(&self.0)
+    pub fn output(&self) -> Option<OutputSection<N>> {
+        self.child()
     }
 
     /// Gets the command section of the task.
-    pub fn command(&self) -> Option<CommandSection> {
-        child(&self.0)
+    pub fn command(&self) -> Option<CommandSection<N>> {
+        self.child()
     }
 
     /// Gets the requirements sections of the task.
-    pub fn requirements(&self) -> Option<RequirementsSection> {
-        child(&self.0)
+    pub fn requirements(&self) -> Option<RequirementsSection<N>> {
+        self.child()
     }
 
     /// Gets the hints section of the task.
-    pub fn hints(&self) -> Option<TaskHintsSection> {
-        child(&self.0)
+    pub fn hints(&self) -> Option<TaskHintsSection<N>> {
+        self.child()
     }
 
     /// Gets the runtime section of the task.
-    pub fn runtime(&self) -> Option<RuntimeSection> {
-        child(&self.0)
+    pub fn runtime(&self) -> Option<RuntimeSection<N>> {
+        self.child()
     }
 
     /// Gets the metadata section of the task.
-    pub fn metadata(&self) -> Option<MetadataSection> {
-        child(&self.0)
+    pub fn metadata(&self) -> Option<MetadataSection<N>> {
+        self.child()
     }
 
     /// Gets the parameter section of the task.
-    pub fn parameter_metadata(&self) -> Option<ParameterMetadataSection> {
-        child(&self.0)
+    pub fn parameter_metadata(&self) -> Option<ParameterMetadataSection<N>> {
+        self.child()
     }
 
     /// Gets the private declarations of the task.
-    pub fn declarations(&self) -> AstChildren<BoundDecl> {
-        children(&self.0)
+    pub fn declarations(&self) -> impl Iterator<Item = BoundDecl<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for TaskDefinition {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for TaskDefinition<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::TaskDefinitionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::TaskDefinitionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::TaskDefinitionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an item in a task definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TaskItem {
+pub enum TaskItem<N: TreeNode = SyntaxNode> {
     /// The item is an input section.
-    Input(InputSection),
+    Input(InputSection<N>),
     /// The item is an output section.
-    Output(OutputSection),
+    Output(OutputSection<N>),
     /// The item is a command section.
-    Command(CommandSection),
+    Command(CommandSection<N>),
     /// The item is a requirements section.
-    Requirements(RequirementsSection),
+    Requirements(RequirementsSection<N>),
     /// The item is a task hints section.
-    Hints(TaskHintsSection),
+    Hints(TaskHintsSection<N>),
     /// The item is a runtime section.
-    Runtime(RuntimeSection),
+    Runtime(RuntimeSection<N>),
     /// The item is a metadata section.
-    Metadata(MetadataSection),
+    Metadata(MetadataSection<N>),
     /// The item is a parameter meta section.
-    ParameterMetadata(ParameterMetadataSection),
+    ParameterMetadata(ParameterMetadataSection<N>),
     /// The item is a private bound declaration.
-    Declaration(BoundDecl),
+    Declaration(BoundDecl<N>),
 }
 
-impl TaskItem {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`TaskItem`].
-    pub fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> TaskItem<N> {
+    /// Returns whether or not the given syntax kind can be cast to
+    /// [`TaskItem`].
+    pub fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
             SyntaxKind::InputSectionNode
@@ -264,56 +251,54 @@ impl TaskItem {
         )
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`TaskItem`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
+    /// Casts the given node to [`StructItem`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
             SyntaxKind::InputSectionNode => Some(Self::Input(
-                InputSection::cast(syntax).expect("input section to cast"),
+                InputSection::cast(inner).expect("input section to cast"),
             )),
             SyntaxKind::OutputSectionNode => Some(Self::Output(
-                OutputSection::cast(syntax).expect("output section to cast"),
+                OutputSection::cast(inner).expect("output section to cast"),
             )),
             SyntaxKind::CommandSectionNode => Some(Self::Command(
-                CommandSection::cast(syntax).expect("command section to cast"),
+                CommandSection::cast(inner).expect("command section to cast"),
             )),
             SyntaxKind::RequirementsSectionNode => Some(Self::Requirements(
-                RequirementsSection::cast(syntax).expect("requirements section to cast"),
+                RequirementsSection::cast(inner).expect("requirements section to cast"),
             )),
             SyntaxKind::RuntimeSectionNode => Some(Self::Runtime(
-                RuntimeSection::cast(syntax).expect("runtime section to cast"),
+                RuntimeSection::cast(inner).expect("runtime section to cast"),
             )),
             SyntaxKind::MetadataSectionNode => Some(Self::Metadata(
-                MetadataSection::cast(syntax).expect("metadata section to cast"),
+                MetadataSection::cast(inner).expect("metadata section to cast"),
             )),
             SyntaxKind::ParameterMetadataSectionNode => Some(Self::ParameterMetadata(
-                ParameterMetadataSection::cast(syntax).expect("parameter metadata section to cast"),
+                ParameterMetadataSection::cast(inner).expect("parameter metadata section to cast"),
             )),
             SyntaxKind::TaskHintsSectionNode => Some(Self::Hints(
-                TaskHintsSection::cast(syntax).expect("task hints section to cast"),
+                TaskHintsSection::cast(inner).expect("task hints section to cast"),
             )),
             SyntaxKind::BoundDeclNode => Some(Self::Declaration(
-                BoundDecl::cast(syntax).expect("bound decl to cast"),
+                BoundDecl::cast(inner).expect("bound decl to cast"),
             )),
             _ => None,
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
         match self {
-            Self::Input(element) => element.syntax(),
-            Self::Output(element) => element.syntax(),
-            Self::Command(element) => element.syntax(),
-            Self::Requirements(element) => element.syntax(),
-            Self::Hints(element) => element.syntax(),
-            Self::Runtime(element) => element.syntax(),
-            Self::Metadata(element) => element.syntax(),
-            Self::ParameterMetadata(element) => element.syntax(),
-            Self::Declaration(element) => element.syntax(),
+            Self::Input(element) => element.inner(),
+            Self::Output(element) => element.inner(),
+            Self::Command(element) => element.inner(),
+            Self::Requirements(element) => element.inner(),
+            Self::Hints(element) => element.inner(),
+            Self::Runtime(element) => element.inner(),
+            Self::Metadata(element) => element.inner(),
+            Self::ParameterMetadata(element) => element.inner(),
+            Self::Declaration(element) => element.inner(),
         }
     }
 
@@ -322,9 +307,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Input`], then a reference to the inner
     ///   [`InputSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_input_section(&self) -> Option<&InputSection> {
+    pub fn as_input_section(&self) -> Option<&InputSection<N>> {
         match self {
-            Self::Input(input_section) => Some(input_section),
+            Self::Input(s) => Some(s),
             _ => None,
         }
     }
@@ -334,9 +319,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Input`], then the inner [`InputSection`] is
     ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_input_section(self) -> Option<InputSection> {
+    pub fn into_input_section(self) -> Option<InputSection<N>> {
         match self {
-            Self::Input(input_section) => Some(input_section),
+            Self::Input(s) => Some(s),
             _ => None,
         }
     }
@@ -346,9 +331,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Output`], then a reference to the inner
     ///   [`OutputSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_output_section(&self) -> Option<&OutputSection> {
+    pub fn as_output_section(&self) -> Option<&OutputSection<N>> {
         match self {
-            Self::Output(output_section) => Some(output_section),
+            Self::Output(s) => Some(s),
             _ => None,
         }
     }
@@ -358,9 +343,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Output`], then the inner [`OutputSection`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_output_section(self) -> Option<OutputSection> {
+    pub fn into_output_section(self) -> Option<OutputSection<N>> {
         match self {
-            Self::Output(output_section) => Some(output_section),
+            Self::Output(s) => Some(s),
             _ => None,
         }
     }
@@ -370,9 +355,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Command`], then a reference to the inner
     ///   [`CommandSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_command_section(&self) -> Option<&CommandSection> {
+    pub fn as_command_section(&self) -> Option<&CommandSection<N>> {
         match self {
-            Self::Command(command_section) => Some(command_section),
+            Self::Command(s) => Some(s),
             _ => None,
         }
     }
@@ -382,9 +367,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Command`], then the inner
     ///   [`CommandSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_command_section(self) -> Option<CommandSection> {
+    pub fn into_command_section(self) -> Option<CommandSection<N>> {
         match self {
-            Self::Command(command_section) => Some(command_section),
+            Self::Command(s) => Some(s),
             _ => None,
         }
     }
@@ -394,9 +379,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Requirements`], then a reference to the
     ///   inner [`RequirementsSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_requirements_section(&self) -> Option<&RequirementsSection> {
+    pub fn as_requirements_section(&self) -> Option<&RequirementsSection<N>> {
         match self {
-            Self::Requirements(requirements_section) => Some(requirements_section),
+            Self::Requirements(s) => Some(s),
             _ => None,
         }
     }
@@ -407,9 +392,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Requirements`], then the inner
     ///   [`RequirementsSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_requirements_section(self) -> Option<RequirementsSection> {
+    pub fn into_requirements_section(self) -> Option<RequirementsSection<N>> {
         match self {
-            Self::Requirements(requirements_section) => Some(requirements_section),
+            Self::Requirements(s) => Some(s),
             _ => None,
         }
     }
@@ -419,9 +404,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Hints`], then a reference to the inner
     ///   [`TaskHintsSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_hints_section(&self) -> Option<&TaskHintsSection> {
+    pub fn as_hints_section(&self) -> Option<&TaskHintsSection<N>> {
         match self {
-            Self::Hints(hints_section) => Some(hints_section),
+            Self::Hints(s) => Some(s),
             _ => None,
         }
     }
@@ -431,9 +416,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Hints`], then the inner
     ///   [`TaskHintsSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_hints_section(self) -> Option<TaskHintsSection> {
+    pub fn into_hints_section(self) -> Option<TaskHintsSection<N>> {
         match self {
-            Self::Hints(hints_section) => Some(hints_section),
+            Self::Hints(s) => Some(s),
             _ => None,
         }
     }
@@ -443,9 +428,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Runtime`], then a reference to the inner
     ///   [`RuntimeSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_runtime_section(&self) -> Option<&RuntimeSection> {
+    pub fn as_runtime_section(&self) -> Option<&RuntimeSection<N>> {
         match self {
-            Self::Runtime(runtime_section) => Some(runtime_section),
+            Self::Runtime(s) => Some(s),
             _ => None,
         }
     }
@@ -455,9 +440,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Runtime`], then the inner
     ///   [`RuntimeSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_runtime_section(self) -> Option<RuntimeSection> {
+    pub fn into_runtime_section(self) -> Option<RuntimeSection<N>> {
         match self {
-            Self::Runtime(runtime_section) => Some(runtime_section),
+            Self::Runtime(s) => Some(s),
             _ => None,
         }
     }
@@ -467,9 +452,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Metadata`], then a reference to the inner
     ///   [`MetadataSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_metadata_section(&self) -> Option<&MetadataSection> {
+    pub fn as_metadata_section(&self) -> Option<&MetadataSection<N>> {
         match self {
-            Self::Metadata(metadata_section) => Some(metadata_section),
+            Self::Metadata(s) => Some(s),
             _ => None,
         }
     }
@@ -479,9 +464,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Metadata`], then the inner
     ///   [`MetadataSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_metadata_section(self) -> Option<MetadataSection> {
+    pub fn into_metadata_section(self) -> Option<MetadataSection<N>> {
         match self {
-            Self::Metadata(metadata_section) => Some(metadata_section),
+            Self::Metadata(s) => Some(s),
             _ => None,
         }
     }
@@ -492,9 +477,9 @@ impl TaskItem {
     ///   the inner [`ParameterMetadataSection`] is returned wrapped in
     ///   [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_parameter_metadata_section(&self) -> Option<&ParameterMetadataSection> {
+    pub fn as_parameter_metadata_section(&self) -> Option<&ParameterMetadataSection<N>> {
         match self {
-            Self::ParameterMetadata(parameter_metadata_section) => Some(parameter_metadata_section),
+            Self::ParameterMetadata(s) => Some(s),
             _ => None,
         }
     }
@@ -505,9 +490,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::ParameterMetadata`], then the inner
     ///   [`ParameterMetadataSection`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_parameter_metadata_section(self) -> Option<ParameterMetadataSection> {
+    pub fn into_parameter_metadata_section(self) -> Option<ParameterMetadataSection<N>> {
         match self {
-            Self::ParameterMetadata(parameter_metadata_section) => Some(parameter_metadata_section),
+            Self::ParameterMetadata(s) => Some(s),
             _ => None,
         }
     }
@@ -517,9 +502,9 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Declaration`], then a reference to the
     ///   inner [`BoundDecl`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_declaration(&self) -> Option<&BoundDecl> {
+    pub fn as_declaration(&self) -> Option<&BoundDecl<N>> {
         match self {
-            Self::Declaration(declaration) => Some(declaration),
+            Self::Declaration(d) => Some(d),
             _ => None,
         }
     }
@@ -529,50 +514,39 @@ impl TaskItem {
     /// * If `self` is a [`TaskItem::Declaration`], then the inner [`BoundDecl`]
     ///   is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_declaration(self) -> Option<BoundDecl> {
+    pub fn into_declaration(self) -> Option<BoundDecl<N>> {
         match self {
-            Self::Declaration(declaration) => Some(declaration),
+            Self::Declaration(d) => Some(d),
             _ => None,
         }
     }
 
-    /// Finds the first child that can be cast to an [`TaskItem`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`TaskItem`] to
-    /// implement the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    /// Finds the first child that can be cast to a [`TaskItem`].
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
-    /// Finds all children that can be cast to an [`TaskItem`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring [`TaskItem`] to
-    /// implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = TaskItem> + use<> {
-        syntax.children().filter_map(Self::cast)
+    /// Finds all children that can be cast to a [`TaskItem`].
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
     }
 }
 
 /// Represents the parent of a section.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SectionParent {
+pub enum SectionParent<N: TreeNode = SyntaxNode> {
     /// The parent is a task.
-    Task(TaskDefinition),
+    Task(TaskDefinition<N>),
     /// The parent is a workflow.
-    Workflow(WorkflowDefinition),
+    Workflow(WorkflowDefinition<N>),
     /// The parent is a struct.
-    Struct(StructDefinition),
+    Struct(StructDefinition<N>),
 }
 
-impl SectionParent {
-    /// Returns whether or not a [`SyntaxKind`] is able to be cast to any of the
-    /// underlying members within the [`SectionParent`].
-    pub fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> SectionParent<N> {
+    /// Returns whether or not the given syntax kind can be cast to
+    /// [`SectionParent`].
+    pub fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
             SyntaxKind::TaskDefinitionNode
@@ -581,37 +555,35 @@ impl SectionParent {
         )
     }
 
-    /// Attempts to cast the [`SyntaxNode`] to any of the underlying members
-    /// within the [`SectionParent`].
-    pub fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
+    /// Casts the given node to [`StructItem`].
+    ///
+    /// Returns `None` if the node cannot be cast.
+    pub fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
             SyntaxKind::TaskDefinitionNode => Some(Self::Task(
-                TaskDefinition::cast(syntax).expect("task definition to cast"),
+                TaskDefinition::cast(inner).expect("task definition to cast"),
             )),
             SyntaxKind::WorkflowDefinitionNode => Some(Self::Workflow(
-                WorkflowDefinition::cast(syntax).expect("workflow definition to cast"),
+                WorkflowDefinition::cast(inner).expect("workflow definition to cast"),
             )),
             SyntaxKind::StructDefinitionNode => Some(Self::Struct(
-                StructDefinition::cast(syntax).expect("struct definition to cast"),
+                StructDefinition::cast(inner).expect("struct definition to cast"),
             )),
             _ => None,
         }
     }
 
-    /// Gets a reference to the underlying [`SyntaxNode`].
-    pub fn syntax(&self) -> &SyntaxNode {
+    /// Gets a reference to the inner node.
+    pub fn inner(&self) -> &N {
         match self {
-            Self::Task(element) => element.syntax(),
-            Self::Workflow(element) => element.syntax(),
-            Self::Struct(element) => element.syntax(),
+            Self::Task(element) => element.inner(),
+            Self::Workflow(element) => element.inner(),
+            Self::Struct(element) => element.inner(),
         }
     }
 
     /// Gets the name of the section parent.
-    pub fn name(&self) -> Ident {
+    pub fn name(&self) -> Ident<N::Token> {
         match self {
             Self::Task(t) => t.name(),
             Self::Workflow(w) => w.name(),
@@ -624,7 +596,7 @@ impl SectionParent {
     /// * If `self` is a [`SectionParent::Task`], then a reference to the inner
     ///   [`TaskDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_task(&self) -> Option<&TaskDefinition> {
+    pub fn as_task(&self) -> Option<&TaskDefinition<N>> {
         match self {
             Self::Task(task) => Some(task),
             _ => None,
@@ -636,7 +608,7 @@ impl SectionParent {
     /// * If `self` is a [`SectionParent::Task`], then the inner
     ///   [`TaskDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_task(self) -> Option<TaskDefinition> {
+    pub fn into_task(self) -> Option<TaskDefinition<N>> {
         match self {
             Self::Task(task) => Some(task),
             _ => None,
@@ -648,7 +620,7 @@ impl SectionParent {
     /// # Panics
     ///
     /// Panics if it is not a task definition.
-    pub fn unwrap_task(self) -> TaskDefinition {
+    pub fn unwrap_task(self) -> TaskDefinition<N> {
         match self {
             Self::Task(task) => task,
             _ => panic!("not a task definition"),
@@ -660,7 +632,7 @@ impl SectionParent {
     /// * If `self` is a [`SectionParent::Workflow`], then a reference to the
     ///   inner [`WorkflowDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_workflow(&self) -> Option<&WorkflowDefinition> {
+    pub fn as_workflow(&self) -> Option<&WorkflowDefinition<N>> {
         match self {
             Self::Workflow(workflow) => Some(workflow),
             _ => None,
@@ -672,7 +644,7 @@ impl SectionParent {
     /// * If `self` is a [`SectionParent::Workflow`], then the inner
     ///   [`WorkflowDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_workflow(self) -> Option<WorkflowDefinition> {
+    pub fn into_workflow(self) -> Option<WorkflowDefinition<N>> {
         match self {
             Self::Workflow(workflow) => Some(workflow),
             _ => None,
@@ -684,7 +656,7 @@ impl SectionParent {
     /// # Panics
     ///
     /// Panics if it is not a workflow definition.
-    pub fn unwrap_workflow(self) -> WorkflowDefinition {
+    pub fn unwrap_workflow(self) -> WorkflowDefinition<N> {
         match self {
             Self::Workflow(workflow) => workflow,
             _ => panic!("not a workflow definition"),
@@ -696,7 +668,7 @@ impl SectionParent {
     /// * If `self` is a [`SectionParent::Struct`], then a reference to the
     ///   inner [`StructDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn as_struct(&self) -> Option<&StructDefinition> {
+    pub fn as_struct(&self) -> Option<&StructDefinition<N>> {
         match self {
             Self::Struct(r#struct) => Some(r#struct),
             _ => None,
@@ -708,7 +680,7 @@ impl SectionParent {
     /// * If `self` is a [`SectionParent::Struct`], then the inner
     ///   [`StructDefinition`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
-    pub fn into_struct(self) -> Option<StructDefinition> {
+    pub fn into_struct(self) -> Option<StructDefinition<N>> {
         match self {
             Self::Struct(r#struct) => Some(r#struct),
             _ => None,
@@ -720,112 +692,88 @@ impl SectionParent {
     /// # Panics
     ///
     /// Panics if it is not a struct definition.
-    pub fn unwrap_struct(self) -> StructDefinition {
+    pub fn unwrap_struct(self) -> StructDefinition<N> {
         match self {
             Self::Struct(def) => def,
             _ => panic!("not a struct definition"),
         }
     }
 
-    /// Finds the first child that can be cast to an [`SectionParent`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::child`] without requiring [`SectionParent`] to
-    /// implement the `AstNode` trait.
-    pub fn child(syntax: &SyntaxNode) -> Option<Self> {
-        syntax.children().find_map(Self::cast)
+    /// Finds the first child that can be cast to a [`SectionParent`].
+    pub fn child(node: &N) -> Option<Self> {
+        node.children().find_map(Self::cast)
     }
 
-    /// Finds all children that can be cast to an [`SectionParent`].
-    ///
-    /// This is meant to emulate the functionality of
-    /// [`rowan::ast::support::children`] without requiring [`SectionParent`] to
-    /// implement the `AstNode` trait.
-    pub fn children(syntax: &SyntaxNode) -> impl Iterator<Item = SectionParent> + use<> {
-        syntax.children().filter_map(Self::cast)
+    /// Finds all children that can be cast to a [`SectionParent`].
+    pub fn children(node: &N) -> impl Iterator<Item = Self> + use<'_, N> {
+        node.children().filter_map(Self::cast)
     }
 }
 
 /// Represents an input section in a task or workflow definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InputSection(pub(crate) SyntaxNode);
+pub struct InputSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl InputSection {
+impl<N: TreeNode> InputSection<N> {
     /// Gets the declarations of the input section.
-    pub fn declarations(&self) -> impl Iterator<Item = Decl> + use<> {
+    pub fn declarations(&self) -> impl Iterator<Item = Decl<N>> + use<'_, N> {
         Decl::children(&self.0)
     }
 
     /// Gets the parent of the input section.
-    pub fn parent(&self) -> SectionParent {
+    pub fn parent(&self) -> SectionParent<N> {
         SectionParent::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 }
 
-impl AstNode for InputSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for InputSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::InputSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::InputSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::InputSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an output section in a task or workflow definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct OutputSection(pub(crate) SyntaxNode);
+pub struct OutputSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl OutputSection {
+impl<N: TreeNode> OutputSection<N> {
     /// Gets the declarations of the output section.
-    pub fn declarations(&self) -> AstChildren<BoundDecl> {
-        children(&self.0)
+    pub fn declarations(&self) -> impl Iterator<Item = BoundDecl<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the parent of the output section.
-    pub fn parent(&self) -> SectionParent {
+    pub fn parent(&self) -> SectionParent<N> {
         SectionParent::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 }
 
-impl AstNode for OutputSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for OutputSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::OutputSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::OutputSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::OutputSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -834,25 +782,25 @@ impl AstNode for OutputSection {
 ///
 /// Placeholders are not changed and are copied as is.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum StrippedCommandPart {
+pub enum StrippedCommandPart<N: TreeNode = SyntaxNode> {
     /// A text part.
     Text(String),
     /// A placeholder part.
-    Placeholder(Placeholder),
+    Placeholder(Placeholder<N>),
 }
 
 /// Represents a command section in a task definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CommandSection(pub(crate) SyntaxNode);
+pub struct CommandSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl CommandSection {
+impl<N: TreeNode> CommandSection<N> {
     /// Gets whether or not the command section is a heredoc command.
     pub fn is_heredoc(&self) -> bool {
-        support::token(&self.0, SyntaxKind::OpenHeredoc).is_some()
+        self.token::<OpenHeredoc<N::Token>>().is_some()
     }
 
     /// Gets the parts of the command.
-    pub fn parts(&self) -> impl Iterator<Item = CommandPart> + use<> {
+    pub fn parts(&self) -> impl Iterator<Item = CommandPart<N>> + use<'_, N> {
         self.0.children_with_tokens().filter_map(CommandPart::cast)
     }
 
@@ -861,7 +809,7 @@ impl CommandSection {
     ///
     /// Returns `None` if the command is interpolated, as interpolated commands
     /// cannot be represented as a single span of text.
-    pub fn text(&self) -> Option<CommandText> {
+    pub fn text(&self) -> Option<CommandText<N::Token>> {
         let mut parts = self.parts();
         if let Some(CommandPart::Text(text)) = parts.next() {
             if parts.next().is_none() {
@@ -886,7 +834,7 @@ impl CommandSection {
                     let mut leading_spaces = 0;
                     let mut leading_tabs = 0;
 
-                    for c in text.as_str().chars() {
+                    for c in text.text().chars() {
                         match c {
                             ' ' if parsing_leading_whitespace => {
                                 leading_spaces += 1;
@@ -954,14 +902,14 @@ impl CommandSection {
     /// Strips leading whitespace from the command.
     ///
     /// If the command has mixed indentation, this will return `None`.
-    pub fn strip_whitespace(&self) -> Option<Vec<StrippedCommandPart>> {
+    pub fn strip_whitespace(&self) -> Option<Vec<StrippedCommandPart<N>>> {
         let mut result = Vec::new();
         let heredoc = self.is_heredoc();
         for part in self.parts() {
             match part {
                 CommandPart::Text(text) => {
                     let mut s = String::new();
-                    unescape_command_text(text.as_str(), heredoc, &mut s);
+                    unescape_command_text(text.text(), heredoc, &mut s);
                     result.push(StrippedCommandPart::Text(s));
                 }
                 CommandPart::Placeholder(p) => {
@@ -1049,91 +997,87 @@ impl CommandSection {
     }
 
     /// Gets the parent of the command section.
-    pub fn parent(&self) -> SectionParent {
+    pub fn parent(&self) -> SectionParent<N> {
         SectionParent::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 }
 
-impl AstNode for CommandSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for CommandSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::CommandSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::CommandSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::CommandSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a textual part of a command.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CommandText(pub(crate) SyntaxToken);
+pub struct CommandText<T: TreeToken = SyntaxToken>(pub(crate) T);
 
-impl CommandText {
+impl<T: TreeToken> CommandText<T> {
     /// Unescapes the command text to the given buffer.
     ///
     /// When `heredoc` is true, only heredoc escape sequences are allowed.
     ///
     /// Otherwise, brace command sequences are accepted.
     pub fn unescape_to(&self, heredoc: bool, buffer: &mut String) {
-        unescape_command_text(self.0.text(), heredoc, buffer);
+        unescape_command_text(self.text(), heredoc, buffer);
     }
 }
 
-impl AstToken for CommandText {
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<T: TreeToken> AstToken<T> for CommandText<T> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralCommandText
     }
 
-    fn cast(syntax: SyntaxToken) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralCommandText => Some(Self(syntax)),
+    fn cast(inner: T) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralCommandText => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxToken {
+    fn inner(&self) -> &T {
         &self.0
     }
 }
 
 /// Represents a part of a command.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum CommandPart {
+pub enum CommandPart<N: TreeNode = SyntaxNode> {
     /// A textual part of the command.
-    Text(CommandText),
+    Text(CommandText<N::Token>),
     /// A placeholder encountered in the command.
-    Placeholder(Placeholder),
+    Placeholder(Placeholder<N>),
 }
 
-impl CommandPart {
+impl<N: TreeNode> CommandPart<N> {
+    /// Casts the given [`NodeOrToken`] to [`CommandPart`].
+    ///
+    /// Returns `None` if it cannot case cannot be cast.
+    pub fn cast(element: NodeOrToken<N, N::Token>) -> Option<Self> {
+        match element {
+            NodeOrToken::Node(n) => Some(Self::Placeholder(Placeholder::cast(n)?)),
+            NodeOrToken::Token(t) => Some(Self::Text(CommandText::cast(t)?)),
+        }
+    }
+
     /// Unwraps the command part into text.
     ///
     /// # Panics
     ///
     /// Panics if the command part is not text.
-    pub fn unwrap_text(self) -> CommandText {
+    pub fn unwrap_text(self) -> CommandText<N::Token> {
         match self {
             Self::Text(text) => text,
             _ => panic!("not string text"),
@@ -1145,408 +1089,336 @@ impl CommandPart {
     /// # Panics
     ///
     /// Panics if the command part is not a placeholder.
-    pub fn unwrap_placeholder(self) -> Placeholder {
+    pub fn unwrap_placeholder(self) -> Placeholder<N> {
         match self {
             Self::Placeholder(p) => p,
             _ => panic!("not a placeholder"),
-        }
-    }
-
-    /// Casts the given syntax element to a command part.
-    fn cast(syntax: SyntaxElement) -> Option<Self> {
-        match syntax {
-            SyntaxElement::Node(n) => Some(Self::Placeholder(Placeholder::cast(n)?)),
-            SyntaxElement::Token(t) => Some(Self::Text(CommandText::cast(t)?)),
         }
     }
 }
 
 /// Represents a requirements section in a task definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RequirementsSection(pub(crate) SyntaxNode);
+pub struct RequirementsSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl RequirementsSection {
+impl<N: TreeNode> RequirementsSection<N> {
     /// Gets the items in the requirements section.
-    pub fn items(&self) -> AstChildren<RequirementsItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = RequirementsItem<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the parent of the requirements section.
-    pub fn parent(&self) -> SectionParent {
+    pub fn parent(&self) -> SectionParent<N> {
         SectionParent::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 
     /// Gets the `container` item as a
     /// [`Container`](requirements::item::Container) (if it exists).
-    pub fn container(&self) -> Option<requirements::item::Container> {
+    pub fn container(&self) -> Option<requirements::item::Container<N>> {
         // NOTE: validation should ensure that, at most, one `container` item exists in
         // the `requirements` section.
-        child::<requirements::item::Container>(&self.0)
+        self.child()
     }
 }
 
-impl AstNode for RequirementsSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for RequirementsSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::RequirementsSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::RequirementsSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::RequirementsSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an item in a requirements section.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RequirementsItem(SyntaxNode);
+pub struct RequirementsItem<N: TreeNode = SyntaxNode>(N);
 
-impl RequirementsItem {
+impl<N: TreeNode> RequirementsItem<N> {
     /// Gets the name of the requirements item.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("expected an item name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("expected an item name")
     }
 
     /// Gets the expression of the requirements item.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("expected an item expression")
     }
 
     /// Consumes `self` and attempts to cast the requirements item to a
     /// [`Container`](requirements::item::Container).
-    pub fn into_container(self) -> Option<requirements::item::Container> {
+    pub fn into_container(self) -> Option<requirements::item::Container<N>> {
         requirements::item::Container::try_from(self).ok()
     }
 }
 
-impl AstNode for RequirementsItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for RequirementsItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::RequirementsItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::RequirementsItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::RequirementsItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a hints section in a task definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TaskHintsSection(pub(crate) SyntaxNode);
+pub struct TaskHintsSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl TaskHintsSection {
+impl<N: TreeNode> TaskHintsSection<N> {
     /// Gets the items in the hints section.
-    pub fn items(&self) -> AstChildren<TaskHintsItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = TaskHintsItem<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the parent of the hints section.
-    pub fn parent(&self) -> TaskDefinition {
+    pub fn parent(&self) -> TaskDefinition<N> {
         TaskDefinition::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 }
 
-impl AstNode for TaskHintsSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for TaskHintsSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::TaskHintsSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::TaskHintsSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::TaskHintsSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an item in a task hints section.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TaskHintsItem(SyntaxNode);
+pub struct TaskHintsItem<N: TreeNode = SyntaxNode>(N);
 
-impl TaskHintsItem {
+impl<N: TreeNode> TaskHintsItem<N> {
     /// Gets the name of the hints item.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("expected an item name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("expected an item name")
     }
 
     /// Gets the expression of the hints item.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("expected an item expression")
     }
 }
 
-impl AstNode for TaskHintsItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for TaskHintsItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::TaskHintsItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::TaskHintsItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::TaskHintsItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a runtime section in a task definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RuntimeSection(pub(crate) SyntaxNode);
+pub struct RuntimeSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl RuntimeSection {
+impl<N: TreeNode> RuntimeSection<N> {
     /// Gets the items in the runtime section.
-    pub fn items(&self) -> AstChildren<RuntimeItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = RuntimeItem<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the parent of the runtime section.
-    pub fn parent(&self) -> SectionParent {
+    pub fn parent(&self) -> SectionParent<N> {
         SectionParent::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 
     /// Gets the `container` item as a [`Container`](runtime::item::Container)
     /// (if it exists).
-    pub fn container(&self) -> Option<runtime::item::Container> {
+    pub fn container(&self) -> Option<runtime::item::Container<N>> {
         // NOTE: validation should ensure that, at most, one `container`/`docker` item
         // exists in the `runtime` section.
-        child::<runtime::item::Container>(&self.0)
+        self.child()
     }
 }
 
-impl AstNode for RuntimeSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for RuntimeSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::RuntimeSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::RuntimeSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::RuntimeSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents an item in a runtime section.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RuntimeItem(pub(crate) SyntaxNode);
+pub struct RuntimeItem<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl RuntimeItem {
+impl<N: TreeNode> RuntimeItem<N> {
     /// Gets the name of the runtime item.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("expected an item name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("expected an item name")
     }
 
     /// Gets the expression of the runtime item.
-    pub fn expr(&self) -> Expr {
+    pub fn expr(&self) -> Expr<N> {
         Expr::child(&self.0).expect("expected an item expression")
     }
 
     /// Consumes `self` and attempts to cast the runtime item to a
     /// [`Container`](runtime::item::Container).
-    pub fn into_container(self) -> Option<runtime::item::Container> {
+    pub fn into_container(self) -> Option<runtime::item::Container<N>> {
         runtime::item::Container::try_from(self).ok()
     }
 }
 
-impl AstNode for RuntimeItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for RuntimeItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::RuntimeItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::RuntimeItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::RuntimeItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a metadata section in a task or workflow definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MetadataSection(pub(crate) SyntaxNode);
+pub struct MetadataSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl MetadataSection {
+impl<N: TreeNode> MetadataSection<N> {
     /// Gets the items of the metadata section.
-    pub fn items(&self) -> AstChildren<MetadataObjectItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = MetadataObjectItem<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the parent of the metadata section.
-    pub fn parent(&self) -> SectionParent {
+    pub fn parent(&self) -> SectionParent<N> {
         SectionParent::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 }
 
-impl AstNode for MetadataSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for MetadataSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::MetadataSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::MetadataSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::MetadataSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a metadata object item.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MetadataObjectItem(pub(crate) SyntaxNode);
+pub struct MetadataObjectItem<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl MetadataObjectItem {
+impl<N: TreeNode> MetadataObjectItem<N> {
     /// Gets the name of the item.
-    pub fn name(&self) -> Ident {
-        token(&self.0).expect("expected a name")
+    pub fn name(&self) -> Ident<N::Token> {
+        self.token().expect("expected a name")
     }
 
     /// Gets the value of the item.
-    pub fn value(&self) -> MetadataValue {
-        child(&self.0).expect("expected a value")
+    pub fn value(&self) -> MetadataValue<N> {
+        self.child().expect("expected a value")
     }
 }
 
-impl AstNode for MetadataObjectItem {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for MetadataObjectItem<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::MetadataObjectItemNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::MetadataObjectItemNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::MetadataObjectItemNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a metadata value.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum MetadataValue {
+pub enum MetadataValue<N: TreeNode = SyntaxNode> {
     /// The value is a literal boolean.
-    Boolean(LiteralBoolean),
+    Boolean(LiteralBoolean<N>),
     /// The value is a literal integer.
-    Integer(LiteralInteger),
+    Integer(LiteralInteger<N>),
     /// The value is a literal float.
-    Float(LiteralFloat),
+    Float(LiteralFloat<N>),
     /// The value is a literal string.
-    String(LiteralString),
+    String(LiteralString<N>),
     /// The value is a literal null.
-    Null(LiteralNull),
+    Null(LiteralNull<N>),
     /// The value is a metadata object.
-    Object(MetadataObject),
+    Object(MetadataObject<N>),
     /// The value is a metadata array.
-    Array(MetadataArray),
+    Array(MetadataArray<N>),
 }
 
-impl MetadataValue {
+impl<N: TreeNode> MetadataValue<N> {
     /// Unwraps the metadata value into a boolean.
     ///
     /// # Panics
     ///
     /// Panics if the metadata value is not a boolean.
-    pub fn unwrap_boolean(self) -> LiteralBoolean {
+    pub fn unwrap_boolean(self) -> LiteralBoolean<N> {
         match self {
             Self::Boolean(b) => b,
             _ => panic!("not a boolean"),
@@ -1558,7 +1430,7 @@ impl MetadataValue {
     /// # Panics
     ///
     /// Panics if the metadata value is not an integer.
-    pub fn unwrap_integer(self) -> LiteralInteger {
+    pub fn unwrap_integer(self) -> LiteralInteger<N> {
         match self {
             Self::Integer(i) => i,
             _ => panic!("not an integer"),
@@ -1570,7 +1442,7 @@ impl MetadataValue {
     /// # Panics
     ///
     /// Panics if the metadata value is not a float.
-    pub fn unwrap_float(self) -> LiteralFloat {
+    pub fn unwrap_float(self) -> LiteralFloat<N> {
         match self {
             Self::Float(f) => f,
             _ => panic!("not a float"),
@@ -1582,7 +1454,7 @@ impl MetadataValue {
     /// # Panics
     ///
     /// Panics if the metadata value is not a string.
-    pub fn unwrap_string(self) -> LiteralString {
+    pub fn unwrap_string(self) -> LiteralString<N> {
         match self {
             Self::String(s) => s,
             _ => panic!("not a string"),
@@ -1594,7 +1466,7 @@ impl MetadataValue {
     /// # Panics
     ///
     /// Panics if the metadata value is not a null.
-    pub fn unwrap_null(self) -> LiteralNull {
+    pub fn unwrap_null(self) -> LiteralNull<N> {
         match self {
             Self::Null(n) => n,
             _ => panic!("not a null"),
@@ -1606,7 +1478,7 @@ impl MetadataValue {
     /// # Panics
     ///
     /// Panics if the metadata value is not an object.
-    pub fn unwrap_object(self) -> MetadataObject {
+    pub fn unwrap_object(self) -> MetadataObject<N> {
         match self {
             Self::Object(o) => o,
             _ => panic!("not an object"),
@@ -1618,7 +1490,7 @@ impl MetadataValue {
     /// # Panics
     ///
     /// Panics if the metadata value is not an array.
-    pub fn unwrap_array(self) -> MetadataArray {
+    pub fn unwrap_array(self) -> MetadataArray<N> {
         match self {
             Self::Array(a) => a,
             _ => panic!("not an array"),
@@ -1626,13 +1498,8 @@ impl MetadataValue {
     }
 }
 
-impl AstNode for MetadataValue {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for MetadataValue<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
             SyntaxKind::LiteralBooleanNode
@@ -1645,23 +1512,20 @@ impl AstNode for MetadataValue {
         )
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralBooleanNode => Some(Self::Boolean(LiteralBoolean(syntax))),
-            SyntaxKind::LiteralIntegerNode => Some(Self::Integer(LiteralInteger(syntax))),
-            SyntaxKind::LiteralFloatNode => Some(Self::Float(LiteralFloat(syntax))),
-            SyntaxKind::LiteralStringNode => Some(Self::String(LiteralString(syntax))),
-            SyntaxKind::LiteralNullNode => Some(Self::Null(LiteralNull(syntax))),
-            SyntaxKind::MetadataObjectNode => Some(Self::Object(MetadataObject(syntax))),
-            SyntaxKind::MetadataArrayNode => Some(Self::Array(MetadataArray(syntax))),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralBooleanNode => Some(Self::Boolean(LiteralBoolean(inner))),
+            SyntaxKind::LiteralIntegerNode => Some(Self::Integer(LiteralInteger(inner))),
+            SyntaxKind::LiteralFloatNode => Some(Self::Float(LiteralFloat(inner))),
+            SyntaxKind::LiteralStringNode => Some(Self::String(LiteralString(inner))),
+            SyntaxKind::LiteralNullNode => Some(Self::Null(LiteralNull(inner))),
+            SyntaxKind::MetadataObjectNode => Some(Self::Object(MetadataObject(inner))),
+            SyntaxKind::MetadataArrayNode => Some(Self::Array(MetadataArray(inner))),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         match self {
             Self::Boolean(b) => &b.0,
             Self::Integer(i) => &i.0,
@@ -1676,143 +1540,111 @@ impl AstNode for MetadataValue {
 
 /// Represents a literal null.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LiteralNull(SyntaxNode);
+pub struct LiteralNull<N: TreeNode = SyntaxNode>(N);
 
-impl AstNode for LiteralNull {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for LiteralNull<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::LiteralNullNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::LiteralNullNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::LiteralNullNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a metadata object.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MetadataObject(pub(crate) SyntaxNode);
+pub struct MetadataObject<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl MetadataObject {
+impl<N: TreeNode> MetadataObject<N> {
     /// Gets the items of the metadata object.
-    pub fn items(&self) -> AstChildren<MetadataObjectItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = MetadataObjectItem<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for MetadataObject {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for MetadataObject<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::MetadataObjectNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::MetadataObjectNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::MetadataObjectNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a metadata array.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MetadataArray(pub(crate) SyntaxNode);
+pub struct MetadataArray<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl MetadataArray {
+impl<N: TreeNode> MetadataArray<N> {
     /// Gets the elements of the metadata array.
-    pub fn elements(&self) -> AstChildren<MetadataValue> {
-        children(&self.0)
+    pub fn elements(&self) -> impl Iterator<Item = MetadataValue<N>> + use<'_, N> {
+        self.children()
     }
 }
 
-impl AstNode for MetadataArray {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for MetadataArray<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::MetadataArrayNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::MetadataArrayNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::MetadataArrayNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
 
 /// Represents a parameter metadata section in a task or workflow definition.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ParameterMetadataSection(pub(crate) SyntaxNode);
+pub struct ParameterMetadataSection<N: TreeNode = SyntaxNode>(pub(crate) N);
 
-impl ParameterMetadataSection {
+impl<N: TreeNode> ParameterMetadataSection<N> {
     /// Gets the items of the parameter metadata section.
-    pub fn items(&self) -> AstChildren<MetadataObjectItem> {
-        children(&self.0)
+    pub fn items(&self) -> impl Iterator<Item = MetadataObjectItem<N>> + use<'_, N> {
+        self.children()
     }
 
     /// Gets the parent of the parameter metadata section.
-    pub fn parent(&self) -> SectionParent {
+    pub fn parent(&self) -> SectionParent<N> {
         SectionParent::cast(self.0.parent().expect("should have a parent"))
             .expect("parent should cast")
     }
 }
 
-impl AstNode for ParameterMetadataSection {
-    type Language = WorkflowDescriptionLanguage;
-
-    fn can_cast(kind: SyntaxKind) -> bool
-    where
-        Self: Sized,
-    {
+impl<N: TreeNode> AstNode<N> for ParameterMetadataSection<N> {
+    fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::ParameterMetadataSectionNode
     }
 
-    fn cast(syntax: SyntaxNode) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match syntax.kind() {
-            SyntaxKind::ParameterMetadataSectionNode => Some(Self(syntax)),
+    fn cast(inner: N) -> Option<Self> {
+        match inner.kind() {
+            SyntaxKind::ParameterMetadataSectionNode => Some(Self(inner)),
             _ => None,
         }
     }
 
-    fn syntax(&self) -> &SyntaxNode {
+    fn inner(&self) -> &N {
         &self.0
     }
 }
@@ -1880,39 +1712,36 @@ task test {
         let ast = ast.as_v1().expect("should be a V1 AST");
         let tasks: Vec<_> = ast.tasks().collect();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].name().as_str(), "test");
+        assert_eq!(tasks[0].name().text(), "test");
 
         // Task input
         let input = tasks[0].input().expect("should have an input section");
-        assert_eq!(input.parent().unwrap_task().name().as_str(), "test");
+        assert_eq!(input.parent().unwrap_task().name().text(), "test");
         let decls: Vec<_> = input.declarations().collect();
         assert_eq!(decls.len(), 1);
         assert_eq!(
             decls[0].clone().unwrap_unbound_decl().ty().to_string(),
             "String"
         );
-        assert_eq!(
-            decls[0].clone().unwrap_unbound_decl().name().as_str(),
-            "name"
-        );
+        assert_eq!(decls[0].clone().unwrap_unbound_decl().name().text(), "name");
 
         // Task output
         let output = tasks[0].output().expect("should have an output section");
-        assert_eq!(output.parent().unwrap_task().name().as_str(), "test");
+        assert_eq!(output.parent().unwrap_task().name().text(), "test");
         let decls: Vec<_> = output.declarations().collect();
         assert_eq!(decls.len(), 1);
         assert_eq!(decls[0].ty().to_string(), "String");
-        assert_eq!(decls[0].name().as_str(), "output");
-        assert_eq!(decls[0].expr().unwrap_call().target().as_str(), "stdout");
+        assert_eq!(decls[0].name().text(), "output");
+        assert_eq!(decls[0].expr().unwrap_call().target().text(), "stdout");
 
         // Task command
         let command = tasks[0].command().expect("should have a command section");
-        assert_eq!(command.parent().name().as_str(), "test");
+        assert_eq!(command.parent().name().text(), "test");
         assert!(command.is_heredoc());
         let parts: Vec<_> = command.parts().collect();
         assert_eq!(parts.len(), 3);
         assert_eq!(
-            parts[0].clone().unwrap_text().as_str(),
+            parts[0].clone().unwrap_text().text(),
             "\n        printf \"hello, "
         );
         assert_eq!(
@@ -1922,19 +1751,19 @@ task test {
                 .expr()
                 .unwrap_name_ref()
                 .name()
-                .as_str(),
+                .text(),
             "name"
         );
-        assert_eq!(parts[2].clone().unwrap_text().as_str(), "!\n    ");
+        assert_eq!(parts[2].clone().unwrap_text().text(), "!\n    ");
 
         // Task requirements
         let requirements = tasks[0]
             .requirements()
             .expect("should have a requirements section");
-        assert_eq!(requirements.parent().name().as_str(), "test");
+        assert_eq!(requirements.parent().name().text(), "test");
         let items: Vec<_> = requirements.items().collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name().as_str(), TASK_REQUIREMENT_CONTAINER);
+        assert_eq!(items[0].name().text(), TASK_REQUIREMENT_CONTAINER);
         assert_eq!(
             items[0]
                 .expr()
@@ -1942,16 +1771,16 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "baz/qux"
         );
 
         // Task hints
         let hints = tasks[0].hints().expect("should have a hints section");
-        assert_eq!(hints.parent().name().as_str(), "test");
+        assert_eq!(hints.parent().name().text(), "test");
         let items: Vec<_> = hints.items().collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name().as_str(), "foo");
+        assert_eq!(items[0].name().text(), "foo");
         assert_eq!(
             items[0]
                 .expr()
@@ -1959,16 +1788,16 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "bar"
         );
 
         // Task runtimes
         let runtime = tasks[0].runtime().expect("should have a runtime section");
-        assert_eq!(runtime.parent().name().as_str(), "test");
+        assert_eq!(runtime.parent().name().text(), "test");
         let items: Vec<_> = runtime.items().collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name().as_str(), TASK_REQUIREMENT_CONTAINER);
+        assert_eq!(items[0].name().text(), TASK_REQUIREMENT_CONTAINER);
         assert_eq!(
             items[0]
                 .expr()
@@ -1976,38 +1805,38 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "foo/bar"
         );
 
         // Task metadata
         let metadata = tasks[0].metadata().expect("should have a metadata section");
-        assert_eq!(metadata.parent().unwrap_task().name().as_str(), "test");
+        assert_eq!(metadata.parent().unwrap_task().name().text(), "test");
         let items: Vec<_> = metadata.items().collect();
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0].name().as_str(), "description");
+        assert_eq!(items[0].name().text(), "description");
         assert_eq!(
-            items[0].value().unwrap_string().text().unwrap().as_str(),
+            items[0].value().unwrap_string().text().unwrap().text(),
             "a test"
         );
 
         // Second metadata
-        assert_eq!(items[1].name().as_str(), "foo");
+        assert_eq!(items[1].name().text(), "foo");
         items[1].value().unwrap_null();
 
         // Task parameter metadata
         let param_meta = tasks[0]
             .parameter_metadata()
             .expect("should have a parameter metadata section");
-        assert_eq!(param_meta.parent().unwrap_task().name().as_str(), "test");
+        assert_eq!(param_meta.parent().unwrap_task().name().text(), "test");
         let items: Vec<_> = param_meta.items().collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name().as_str(), "name");
+        assert_eq!(items[0].name().text(), "name");
         let items: Vec<_> = items[0].value().unwrap_object().items().collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name().as_str(), "help");
+        assert_eq!(items[0].name().text(), "help");
         assert_eq!(
-            items[0].value().unwrap_string().text().unwrap().as_str(),
+            items[0].value().unwrap_string().text().unwrap().text(),
             "a name to greet"
         );
 
@@ -2017,7 +1846,7 @@ task test {
 
         // First task declaration
         assert_eq!(decls[0].ty().to_string(), "String");
-        assert_eq!(decls[0].name().as_str(), "x");
+        assert_eq!(decls[0].name().text(), "x");
         assert_eq!(
             decls[0]
                 .expr()
@@ -2025,7 +1854,7 @@ task test {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "private"
         );
 

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -1062,16 +1062,6 @@ pub enum CommandPart<N: TreeNode = SyntaxNode> {
 }
 
 impl<N: TreeNode> CommandPart<N> {
-    /// Casts the given [`NodeOrToken`] to [`CommandPart`].
-    ///
-    /// Returns `None` if it cannot case cannot be cast.
-    pub fn cast(element: NodeOrToken<N, N::Token>) -> Option<Self> {
-        match element {
-            NodeOrToken::Node(n) => Some(Self::Placeholder(Placeholder::cast(n)?)),
-            NodeOrToken::Token(t) => Some(Self::Text(CommandText::cast(t)?)),
-        }
-    }
-
     /// Unwraps the command part into text.
     ///
     /// # Panics
@@ -1093,6 +1083,16 @@ impl<N: TreeNode> CommandPart<N> {
         match self {
             Self::Placeholder(p) => p,
             _ => panic!("not a placeholder"),
+        }
+    }
+
+    /// Casts the given [`NodeOrToken`] to [`CommandPart`].
+    ///
+    /// Returns `None` if it cannot case cannot be cast.
+    fn cast(element: NodeOrToken<N, N::Token>) -> Option<Self> {
+        match element {
+            NodeOrToken::Node(n) => Some(Self::Placeholder(Placeholder::cast(n)?)),
+            NodeOrToken::Token(t) => Some(Self::Text(CommandText::cast(t)?)),
         }
     }
 }

--- a/wdl-ast/src/v1/tokens.rs
+++ b/wdl-ast/src/v1/tokens.rs
@@ -3,34 +3,29 @@
 use crate::AstToken;
 use crate::SyntaxKind;
 use crate::SyntaxToken;
+use crate::TreeToken;
 
 /// Defines an AST token struct.
 macro_rules! define_token_struct {
     ($name:ident, $doc:literal) => {
         #[derive(Clone, Debug)]
         #[doc = concat!("A token representing ", $doc, ".")]
-        pub struct $name(SyntaxToken);
+        pub struct $name<T: TreeToken = SyntaxToken>(T);
 
-        impl AstToken for $name {
-            fn can_cast(kind: SyntaxKind) -> bool
-            where
-                Self: Sized,
-            {
+        impl<T: TreeToken> AstToken<T> for $name<T> {
+            fn can_cast(kind: SyntaxKind) -> bool {
                 matches!(kind, SyntaxKind::$name)
             }
 
-            fn cast(syntax: SyntaxToken) -> Option<Self>
-            where
-                Self: Sized,
-            {
-                if Self::can_cast(syntax.kind()) {
-                    return Some(Self(syntax));
+            fn cast(inner: T) -> Option<Self> {
+                if Self::can_cast(inner.kind()) {
+                    return Some(Self(inner));
                 }
 
                 None
             }
 
-            fn syntax(&self) -> &SyntaxToken {
+            fn inner(&self) -> &T {
                 &self.0
             }
         }

--- a/wdl-ast/src/validation/env.rs
+++ b/wdl-ast/src/validation/env.rs
@@ -1,6 +1,6 @@
 //! Validation of `env` declarations.
 
-use crate::AstNodeExt;
+use crate::AstNode;
 use crate::AstToken;
 use crate::Diagnostic;
 use crate::Diagnostics;

--- a/wdl-ast/src/validation/exprs.rs
+++ b/wdl-ast/src/validation/exprs.rs
@@ -2,19 +2,19 @@
 
 use std::fmt;
 
-use rowan::ast::support::token;
-
 use crate::AstNode;
+use crate::AstToken;
 use crate::Diagnostic;
 use crate::Diagnostics;
 use crate::Document;
 use crate::Span;
 use crate::SupportedVersion;
-use crate::SyntaxKind;
-use crate::ToSpan;
 use crate::VisitReason;
 use crate::Visitor;
 use crate::v1;
+use crate::v1::HintsKeyword;
+use crate::v1::InputKeyword;
+use crate::v1::OutputKeyword;
 use crate::version::V1;
 
 /// Creates a "hints scope required" diagnostic.
@@ -126,22 +126,19 @@ impl Visitor for ScopedExprVisitor {
 
         let literal = match expr {
             v1::Expr::Literal(v1::LiteralExpr::Hints(l)) => Literal::Hints(
-                token(l.syntax(), SyntaxKind::HintsKeyword)
+                l.token::<HintsKeyword<_>>()
                     .expect("should have keyword")
-                    .text_range()
-                    .to_span(),
+                    .span(),
             ),
             v1::Expr::Literal(v1::LiteralExpr::Input(l)) => Literal::Input(
-                token(l.syntax(), SyntaxKind::InputKeyword)
+                l.token::<InputKeyword<_>>()
                     .expect("should have keyword")
-                    .text_range()
-                    .to_span(),
+                    .span(),
             ),
             v1::Expr::Literal(v1::LiteralExpr::Output(l)) => Literal::Output(
-                token(l.syntax(), SyntaxKind::OutputKeyword)
+                l.token::<OutputKeyword<_>>()
                     .expect("should have keyword")
-                    .text_range()
-                    .to_span(),
+                    .span(),
             ),
             _ => return,
         };

--- a/wdl-ast/src/validation/imports.rs
+++ b/wdl-ast/src/validation/imports.rs
@@ -1,6 +1,6 @@
 //! Validation of imports.
 
-use crate::AstNodeExt;
+use crate::AstNode;
 use crate::Diagnostic;
 use crate::Diagnostics;
 use crate::Document;

--- a/wdl-ast/src/validation/requirements.rs
+++ b/wdl-ast/src/validation/requirements.rs
@@ -25,7 +25,7 @@ use crate::v1::TASK_REQUIREMENT_RETURN_CODES_ALIAS;
 fn unsupported_requirements_key(name: &Ident) -> Diagnostic {
     Diagnostic::error(format!(
         "unsupported requirements key `{name}`",
-        name = name.as_str()
+        name = name.text()
     ))
     .with_highlight(name.span())
 }
@@ -80,7 +80,7 @@ impl Visitor for RequirementsVisitor {
 
         for item in section.items() {
             let name = item.name();
-            if !SUPPORTED_KEYS.contains(&name.as_str()) {
+            if !SUPPORTED_KEYS.contains(&name.text()) {
                 state.add(unsupported_requirements_key(&name))
             }
         }

--- a/wdl-ast/src/visitor.rs
+++ b/wdl-ast/src/visitor.rs
@@ -23,7 +23,7 @@
 
 use rowan::WalkEvent;
 
-use crate::AstToken as _;
+use crate::AstToken;
 use crate::Comment;
 use crate::Document;
 use crate::SupportedVersion;
@@ -312,7 +312,7 @@ pub(crate) fn visit<V: Visitor>(root: &SyntaxNode, state: &mut V::State, visitor
 
                 let version = document
                     .version_statement()
-                    .and_then(|s| s.version().as_str().parse::<SupportedVersion>().ok())
+                    .and_then(|s| s.version().text().parse::<SupportedVersion>().ok())
                     .expect("only WDL documents with supported versions can be visited");
 
                 visitor.document(state, reason, &document, version)
@@ -425,7 +425,7 @@ pub(crate) fn visit<V: Visitor>(root: &SyntaxNode, state: &mut V::State, visitor
             SyntaxKind::LiteralNullNode => {
                 // Skip these nodes as they're part of a metadata section
             }
-            k if Expr::can_cast(k) => {
+            k if Expr::<SyntaxNode>::can_cast(k) => {
                 visitor.expr(
                     state,
                     reason,
@@ -457,7 +457,7 @@ pub(crate) fn visit<V: Visitor>(root: &SyntaxNode, state: &mut V::State, visitor
             | SyntaxKind::LiteralInputNode
             | SyntaxKind::LiteralOutputNode
             | SyntaxKind::ParenthesizedExprNode
-            | SyntaxKind::NameRefNode
+            | SyntaxKind::NameRefExprNode
             | SyntaxKind::IfExprNode
             | SyntaxKind::LogicalNotExprNode
             | SyntaxKind::NegationExprNode

--- a/wdl-ast/tests/registry.rs
+++ b/wdl-ast/tests/registry.rs
@@ -23,12 +23,13 @@ use wdl_ast::AstToken;
 use wdl_ast::Comment;
 use wdl_ast::Ident;
 use wdl_ast::SyntaxKind;
+use wdl_ast::SyntaxNode;
+use wdl_ast::SyntaxToken;
 use wdl_ast::Version;
 use wdl_ast::VersionStatement;
 use wdl_ast::Whitespace;
 use wdl_ast::v1;
 use wdl_grammar::ALL_SYNTAX_KIND;
-use wdl_grammar::WorkflowDescriptionLanguage;
 
 /// A private module for sealed traits.
 ///
@@ -154,7 +155,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, Box<[SyntaxKind]>>> = LazyLock::
         v1::Minus::register(),
         v1::ModuloExpr::register(),
         v1::MultiplicationExpr::register(),
-        v1::NameRef::register(),
+        v1::NameRefExpr::register(),
         v1::NegationExpr::register(),
         v1::NoneKeyword::register(),
         v1::NotEqual::register(),
@@ -260,9 +261,9 @@ trait AstNodeRegistrant: private::SealedNode {
     fn register() -> (&'static str, Box<[SyntaxKind]>);
 }
 
-impl<T: AstNode<Language = WorkflowDescriptionLanguage> + 'static> private::SealedNode for T {}
+impl<T: AstNode<SyntaxNode> + 'static> private::SealedNode for T {}
 
-impl<T: AstNode<Language = WorkflowDescriptionLanguage> + 'static> AstNodeRegistrant for T {
+impl<T: AstNode<SyntaxNode> + 'static> AstNodeRegistrant for T {
     fn register() -> (&'static str, Box<[SyntaxKind]>) {
         (
             type_name::<T>(),
@@ -282,9 +283,9 @@ trait AstTokenRegistrant: private::SealedToken {
     fn register() -> (&'static str, Box<[SyntaxKind]>);
 }
 
-impl<T: AstToken + 'static> private::SealedToken for T {}
+impl<T: AstToken<SyntaxToken> + 'static> private::SealedToken for T {}
 
-impl<T: AstToken + 'static> AstTokenRegistrant for T {
+impl<T: AstToken<SyntaxToken> + 'static> AstTokenRegistrant for T {
     fn register() -> (&'static str, Box<[SyntaxKind]>) {
         (
             type_name::<T>(),

--- a/wdl-ast/tests/validation/duplicate-hints/source.errors
+++ b/wdl-ast/tests/validation/duplicate-hints/source.errors
@@ -1,0 +1,18 @@
+error: task `t` contains a duplicate hints section
+   ┌─ tests/validation/duplicate-hints/source.wdl:10:5
+   │
+ 6 │     hints {
+   │     ----- first hints section is defined here
+   ·
+10 │     hints {
+   │     ^^^^^ this hints section is a duplicate
+
+error: workflow `w` contains a duplicate hints section
+   ┌─ tests/validation/duplicate-hints/source.wdl:35:5
+   │
+31 │     hints {
+   │     ----- first hints section is defined here
+   ·
+35 │     hints {
+   │     ^^^^^ this hints section is a duplicate
+

--- a/wdl-ast/tests/validation/duplicate-hints/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-hints/source.wdl
@@ -1,0 +1,38 @@
+# This is a test of too many hints sections in a task or workflow.
+
+version 1.2
+
+task t {
+    hints {
+
+    }
+
+    hints {
+
+    }
+
+    command <<<>>>
+}
+
+# This duplicate task should be ignored.
+task t {
+    hints {
+
+    }
+
+    hints {
+
+    }
+
+    command <<<>>>
+}
+
+workflow w {
+    hints {
+
+    }
+
+    hints {
+
+    }
+}

--- a/wdl-ast/tests/validation/duplicate-requirements/source.errors
+++ b/wdl-ast/tests/validation/duplicate-requirements/source.errors
@@ -1,0 +1,9 @@
+error: task `t` contains a duplicate requirements section
+   ┌─ tests/validation/duplicate-requirements/source.wdl:10:5
+   │
+ 6 │     requirements {
+   │     ------------ first requirements section is defined here
+   ·
+10 │     requirements {
+   │     ^^^^^^^^^^^^ this requirements section is a duplicate
+

--- a/wdl-ast/tests/validation/duplicate-requirements/source.wdl
+++ b/wdl-ast/tests/validation/duplicate-requirements/source.wdl
@@ -1,0 +1,28 @@
+# This is a test of too many requirements sections in a task.
+
+version 1.2
+
+task t {
+    requirements {
+
+    }
+
+    requirements {
+
+    }
+
+    command <<<>>>
+}
+
+# This duplicate task should be ignored.
+task t {
+    requirements {
+
+    }
+
+    requirements {
+
+    }
+
+    command <<<>>>
+}

--- a/wdl-doc/CHANGELOG.md
+++ b/wdl-doc/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to use new `wdl-ast` API ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * `wdl-doc` crate is now implemented using a `DocsTree` struct which simplifies
   the API of doc generation ([#262](https://github.com/stjude-rust-labs/wdl/pull/262)).

--- a/wdl-doc/src/callable.rs
+++ b/wdl-doc/src/callable.rs
@@ -230,7 +230,7 @@ pub trait Callable {
 fn parse_meta(meta: &MetadataSection) -> MetaMap {
     meta.items()
         .map(|m| {
-            let name = m.name().as_str().to_owned();
+            let name = m.name().text().to_owned();
             let item = m.value();
             (name, item)
         })
@@ -242,7 +242,7 @@ fn parse_parameter_meta(parameter_meta: &ParameterMetadataSection) -> MetaMap {
     parameter_meta
         .items()
         .map(|m| {
-            let name = m.name().as_str().to_owned();
+            let name = m.name().text().to_owned();
             let item = m.value();
             (name, item)
         })
@@ -254,7 +254,7 @@ fn parse_inputs(input_section: &InputSection, parameter_meta: &MetaMap) -> Vec<P
     input_section
         .declarations()
         .map(|decl| {
-            let name = decl.name().as_str().to_owned();
+            let name = decl.name().text().to_owned();
             let meta = parameter_meta.get(&name);
             Parameter::new(decl.clone(), meta.cloned(), InputOutput::Input)
         })
@@ -275,7 +275,7 @@ fn parse_outputs(
         })
         .map(|o| {
             o.items()
-                .map(|i| (i.name().as_str().to_owned(), i.value().clone()))
+                .map(|i| (i.name().text().to_owned(), i.value().clone()))
                 .collect()
         })
         .unwrap_or_default();
@@ -283,7 +283,7 @@ fn parse_outputs(
     output_section
         .declarations()
         .map(|decl| {
-            let name = decl.name().as_str().to_owned();
+            let name = decl.name().text().to_owned();
             let meta = parameter_meta.get(&name).or_else(|| output_meta.get(&name));
             Parameter::new(
                 wdl_ast::v1::Decl::Bound(decl.clone()),
@@ -353,7 +353,7 @@ mod tests {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "Workflow"
         );
         assert_eq!(
@@ -364,7 +364,7 @@ mod tests {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "A workflow"
         );
     }
@@ -410,7 +410,7 @@ mod tests {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "An integer"
         );
     }

--- a/wdl-doc/src/callable/task.rs
+++ b/wdl-doc/src/callable/task.rs
@@ -2,6 +2,7 @@
 
 use maud::Markup;
 use maud::html;
+use wdl_ast::AstNode;
 use wdl_ast::AstToken;
 use wdl_ast::v1::InputSection;
 use wdl_ast::v1::MetadataSection;
@@ -85,7 +86,7 @@ impl Task {
         }
     }
 
-    /// Render the rutime section of the task as HTML.
+    /// Render the runtime section of the task as HTML.
     pub fn render_runtime_section(&self) -> Markup {
         match &self.runtime_section {
             Some(runtime_section) => {
@@ -99,8 +100,8 @@ impl Task {
                         tbody class="border" {
                             @for entry in runtime_section.items() {
                                 tr class="border" {
-                                    td class="border" { code { (entry.name().as_str()) } }
-                                    td class="border" { code { (entry.expr().syntax().to_string()) } }
+                                    td class="border" { code { (entry.name().text()) } }
+                                    td class="border" { code { ({let e = entry.expr(); e.text().to_string() }) } }
                                 }
                             }
                         }
@@ -179,7 +180,7 @@ mod tests {
         let ast_task = doc_item.into_task_definition().unwrap();
 
         let task = Task::new(
-            ast_task.name().as_str().to_owned(),
+            ast_task.name().text().to_owned(),
             ast_task.metadata(),
             ast_task.parameter_metadata(),
             ast_task.input(),
@@ -196,7 +197,7 @@ mod tests {
                 .unwrap_string()
                 .text()
                 .unwrap()
-                .as_str(),
+                .text(),
             "A simple task"
         );
         assert_eq!(task.inputs().len(), 1);

--- a/wdl-doc/src/callable/workflow.rs
+++ b/wdl-doc/src/callable/workflow.rs
@@ -67,7 +67,7 @@ impl Workflow {
     /// Returns the `category` entry from the meta section, if it exists.
     pub fn category(&self) -> Option<String> {
         self.meta.get("category").and_then(|v| match v {
-            MetadataValue::String(s) => Some(s.text().unwrap().as_str().to_string()),
+            MetadataValue::String(s) => Some(s.text().unwrap().text().to_string()),
             _ => None,
         })
     }
@@ -157,7 +157,7 @@ mod tests {
         let ast_workflow = doc_item.into_workflow_definition().unwrap();
 
         let workflow = Workflow::new(
-            ast_workflow.name().as_str().to_string(),
+            ast_workflow.name().text().to_string(),
             ast_workflow.metadata(),
             ast_workflow.parameter_metadata(),
             ast_workflow.input(),

--- a/wdl-doc/src/lib.rs
+++ b/wdl-doc/src/lib.rs
@@ -129,7 +129,7 @@ impl<T: AsRef<str>> Render for Markdown<T> {
 fn parse_preamble_comments(version: VersionStatement) -> String {
     let comments = version
         .keyword()
-        .syntax()
+        .inner()
         .preceding_trivia()
         .map(|t| match t.kind() {
             wdl_ast::SyntaxKind::Comment => match t.to_string().strip_prefix("## ") {
@@ -180,7 +180,7 @@ impl Document {
 
     /// Get the version of the document as text.
     pub fn version(&self) -> String {
-        self.version.version().as_str().to_string()
+        self.version.version().text().to_string()
     }
 
     /// Get the preamble comments of the document.
@@ -290,7 +290,7 @@ pub async fn document_workspace(
         if !cur_dir.exists() {
             std::fs::create_dir_all(&cur_dir)?;
         }
-        let ast_doc = result.document().node();
+        let ast_doc = result.document().root();
         let version = ast_doc
             .version_statement()
             .expect("document should have a version statement");
@@ -301,7 +301,7 @@ pub async fn document_workspace(
         for item in ast.items() {
             match item {
                 DocumentItem::Struct(s) => {
-                    let name = s.name().as_str().to_owned();
+                    let name = s.name().text().to_owned();
                     let path = cur_dir.join(format!("{}-struct.html", name));
 
                     let r#struct = r#struct::Struct::new(s.clone());
@@ -311,7 +311,7 @@ pub async fn document_workspace(
                     local_pages.push((diff_paths(path, &cur_dir).unwrap(), page));
                 }
                 DocumentItem::Task(t) => {
-                    let name = t.name().as_str().to_owned();
+                    let name = t.name().text().to_owned();
                     let path = cur_dir.join(format!("{}-task.html", name));
 
                     let task = task::Task::new(
@@ -328,7 +328,7 @@ pub async fn document_workspace(
                     local_pages.push((diff_paths(path, &cur_dir).unwrap(), page));
                 }
                 DocumentItem::Workflow(w) => {
-                    let name = w.name().as_str().to_owned();
+                    let name = w.name().text().to_owned();
                     let path = cur_dir.join(format!("{}-workflow.html", name));
 
                     let workflow = workflow::Workflow::new(
@@ -418,7 +418,7 @@ mod tests {
         let doc_item = document.ast().into_v1().unwrap().items().next().unwrap();
         let ast_workflow = doc_item.into_workflow_definition().unwrap();
         let workflow = workflow::Workflow::new(
-            ast_workflow.name().as_str().to_string(),
+            ast_workflow.name().text().to_string(),
             ast_workflow.metadata(),
             ast_workflow.parameter_metadata(),
             ast_workflow.input(),

--- a/wdl-doc/src/meta.rs
+++ b/wdl-doc/src/meta.rs
@@ -13,12 +13,12 @@ use crate::Render;
 pub(crate) fn render_value(value: &MetadataValue) -> Markup {
     match value {
         MetadataValue::String(s) => {
-            html! { (Markdown(s.text().map(|t| t.as_str().to_string()).unwrap_or_default()).render()) }
+            html! { (Markdown(s.text().map(|t| t.text().to_string()).unwrap_or_default()).render()) }
         }
-        MetadataValue::Boolean(b) => html! { code { (b.syntax().to_string()) } },
-        MetadataValue::Integer(i) => html! { code { (i.syntax().to_string()) } },
-        MetadataValue::Float(f) => html! { code { (f.syntax().to_string()) } },
-        MetadataValue::Null(n) => html! { code { (n.syntax().to_string()) } },
+        MetadataValue::Boolean(b) => html! { code { (b.text().to_string()) } },
+        MetadataValue::Integer(i) => html! { code { (i.text().to_string()) } },
+        MetadataValue::Float(f) => html! { code { (f.text().to_string()) } },
+        MetadataValue::Null(n) => html! { code { (n.text().to_string()) } },
         MetadataValue::Array(a) => {
             html! {
                 div {
@@ -31,7 +31,7 @@ pub(crate) fn render_value(value: &MetadataValue) -> Markup {
                                         (render_value(&item)) ","
                                     }
                                     _ => {
-                                        code { (item.syntax().to_string()) } ","
+                                        code { (item.text().to_string()) } ","
                                     }
                                 }
                             }
@@ -48,7 +48,7 @@ pub(crate) fn render_value(value: &MetadataValue) -> Markup {
                     ul {
                         @for item in o.items() {
                             li {
-                                b { (item.name().as_str()) ":" } " " (render_value(&item.value())) ","
+                                b { (item.name().text()) ":" } " " (render_value(&item.value())) ","
                             }
                         }
                     }

--- a/wdl-doc/src/parameter.rs
+++ b/wdl-doc/src/parameter.rs
@@ -2,6 +2,7 @@
 
 use maud::Markup;
 use maud::html;
+use wdl_ast::AstNode;
 use wdl_ast::AstToken;
 use wdl_ast::v1::Decl;
 use wdl_ast::v1::MetadataValue;
@@ -37,7 +38,7 @@ impl Parameter {
 
     /// Get the name of the parameter.
     pub fn name(&self) -> String {
-        self.decl.name().as_str().to_owned()
+        self.decl.name().text().to_owned()
     }
 
     /// Get the type of the parameter.
@@ -54,7 +55,7 @@ impl Parameter {
     pub fn expr(&self) -> String {
         self.decl
             .expr()
-            .map(|expr| expr.syntax().to_string())
+            .map(|expr| expr.text().to_string())
             .unwrap_or("None".to_string())
     }
 
@@ -75,9 +76,9 @@ impl Parameter {
     pub fn group(&self) -> Option<Group> {
         if let Some(MetadataValue::Object(o)) = &self.meta {
             for item in o.items() {
-                if item.name().as_str() == "group" {
+                if item.name().text() == "group" {
                     if let MetadataValue::String(s) = item.value() {
-                        return s.text().map(|t| t.as_str().to_string()).map(Group);
+                        return s.text().map(|t| t.text().to_string()).map(Group);
                     }
                 }
             }
@@ -92,7 +93,7 @@ impl Parameter {
                 return render_value(meta);
             } else if let MetadataValue::Object(o) = meta {
                 for item in o.items() {
-                    if item.name().as_str() == "description" {
+                    if item.name().text() == "description" {
                         if let MetadataValue::String(_) = item.value() {
                             return render_value(&item.value());
                         }
@@ -109,13 +110,13 @@ impl Parameter {
     pub fn render_remaining_meta(&self) -> Markup {
         if let Some(MetadataValue::Object(o)) = &self.meta {
             let filtered_items = o.items().filter(|item| {
-                item.name().as_str() != "description" && item.name().as_str() != "group"
+                item.name().text() != "description" && item.name().text() != "group"
             });
             return html! {
                 ul {
                     @for item in filtered_items {
                         li {
-                            b { (item.name().as_str()) ":" } " " (render_value(&item.value()))
+                            b { (item.name().text()) ":" } " " (render_value(&item.value()))
                         }
                     }
                 }

--- a/wdl-doc/src/struct.rs
+++ b/wdl-doc/src/struct.rs
@@ -20,13 +20,13 @@ impl Struct {
 
     /// Get the name of the struct.
     pub fn name(&self) -> String {
-        self.def.name().as_str().to_string()
+        self.def.name().text().to_string()
     }
 
     /// Get the members of the struct.
     pub fn members(&self) -> impl Iterator<Item = (String, String)> + '_ {
         self.def.members().map(|decl| {
-            let name = decl.name().as_str().to_owned();
+            let name = decl.name().text().to_owned();
             let ty = decl.ty().to_string();
             (name, ty)
         })

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated for refactored `wdl-ast` API so that evaluation can now operate
+  directly on AST nodes in `async` context ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * Docker backend is now the default backend (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Refactored a common task management implementation to use in task execution

--- a/wdl-engine/src/diagnostics.rs
+++ b/wdl-engine/src/diagnostics.rs
@@ -8,6 +8,7 @@ use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
 use wdl_ast::Ident;
 use wdl_ast::Span;
+use wdl_ast::TreeToken;
 
 /// Creates an "integer not in range" diagnostic.
 pub fn integer_not_in_range(span: Span) -> Diagnostic {
@@ -64,10 +65,10 @@ pub fn exponent_not_in_range(span: Span) -> Diagnostic {
 }
 
 /// Creates a "cannot call" diagnostic.
-pub fn cannot_call(target: &Ident) -> Diagnostic {
+pub fn cannot_call<T: TreeToken>(target: &Ident<T>) -> Diagnostic {
     Diagnostic::error(format!(
         "function `{target}` can only be called from task outputs",
-        target = target.as_str()
+        target = target.text()
     ))
     .with_highlight(target.span())
 }
@@ -141,10 +142,10 @@ pub fn map_key_not_found(span: Span) -> Diagnostic {
 }
 
 /// Creates a "not an object member" diagnostic.
-pub fn not_an_object_member(member: &Ident) -> Diagnostic {
+pub fn not_an_object_member<T: TreeToken>(member: &Ident<T>) -> Diagnostic {
     Diagnostic::error(format!(
         "object does not have a member named `{member}`",
-        member = member.as_str()
+        member = member.text()
     ))
     .with_highlight(member.span())
 }

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -16,7 +16,7 @@ use indexmap::IndexMap;
 use wdl_analysis::document::Task;
 use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
-use wdl_ast::Ident;
+use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::v1::TASK_REQUIREMENT_RETURN_CODES;
 use wdl_ast::v1::TASK_REQUIREMENT_RETURN_CODES_ALIAS;
@@ -59,10 +59,10 @@ pub trait EvaluationContext {
     fn version(&self) -> SupportedVersion;
 
     /// Gets the value of the given name in scope.
-    fn resolve_name(&self, name: &Ident) -> Result<Value, Diagnostic>;
+    fn resolve_name(&self, name: &str, span: Span) -> Result<Value, Diagnostic>;
 
     /// Resolves a type name to a type.
-    fn resolve_type_name(&mut self, name: &Ident) -> Result<Type, Diagnostic>;
+    fn resolve_type_name(&self, name: &str, span: Span) -> Result<Type, Diagnostic>;
 
     /// Gets the working directory for the evaluation.
     fn work_dir(&self) -> &Path;

--- a/wdl-engine/src/eval/v1.rs
+++ b/wdl-engine/src/eval/v1.rs
@@ -6,47 +6,12 @@ mod workflow;
 
 use anyhow::Result;
 pub use expr::*;
-use rowan::ast::AstPtr;
 pub use task::*;
-use wdl_analysis::document::Document;
-use wdl_ast::v1::BoundDecl;
-use wdl_ast::v1::Decl;
-use wdl_ast::v1::UnboundDecl;
 pub use workflow::*;
 
 use super::EvaluatedTask;
 use super::EvaluationResult;
 use crate::Outputs;
-
-/// Represents a pointer to a declaration node.
-///
-/// This type is cheaply cloned.
-#[derive(Debug, Clone)]
-enum DeclPtr {
-    /// The declaration is bound.
-    Bound(AstPtr<BoundDecl>),
-    /// The declaration is unbound.
-    Unbound(AstPtr<UnboundDecl>),
-}
-
-impl DeclPtr {
-    /// Constructs a new pointer to a declaration node given the declaration
-    /// node.
-    fn new(decl: &Decl) -> Self {
-        match decl {
-            Decl::Bound(decl) => Self::Bound(AstPtr::new(decl)),
-            Decl::Unbound(decl) => Self::Unbound(AstPtr::new(decl)),
-        }
-    }
-
-    /// Converts the pointer back to the declaration node.
-    fn to_node(&self, document: &Document) -> Decl {
-        match self {
-            Self::Bound(decl) => Decl::Bound(decl.to_node(document.node().syntax())),
-            Self::Unbound(decl) => Decl::Unbound(decl.to_node(document.node().syntax())),
-        }
-    }
-}
 
 /// Represents the kind of progress made during evaluation.
 #[derive(Debug, Clone, Copy)]

--- a/wdl-engine/src/lib.rs
+++ b/wdl-engine/src/lib.rs
@@ -7,6 +7,7 @@ mod eval;
 mod inputs;
 mod outputs;
 mod stdlib;
+pub(crate) mod tree;
 mod units;
 mod value;
 
@@ -26,9 +27,9 @@ use wdl_analysis::document::Document;
 use wdl_analysis::types::Type;
 use wdl_analysis::types::TypeNameResolver;
 use wdl_analysis::types::v1::AstTypeConverter;
-use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
-use wdl_ast::Ident;
+use wdl_ast::Span;
+use wdl_ast::TreeNode;
 
 /// One gibibyte (GiB) as a float.
 ///
@@ -39,28 +40,28 @@ const ONE_GIBIBYTE: f64 = 1024.0 * 1024.0 * 1024.0;
 ///
 /// This function will import the type into the type cache if not already
 /// cached.
-fn resolve_type_name(document: &Document, name: &Ident) -> Result<Type, Diagnostic> {
+fn resolve_type_name(document: &Document, name: &str, span: Span) -> Result<Type, Diagnostic> {
     document
-        .struct_by_name(name.as_str())
+        .struct_by_name(name)
         .map(|s| s.ty().expect("struct should have type").clone())
-        .ok_or_else(|| unknown_type(name.as_str(), name.span()))
+        .ok_or_else(|| unknown_type(name, span))
 }
 
 /// Converts a V1 AST type to an analysis type.
-fn convert_ast_type_v1(document: &Document, ty: &wdl_ast::v1::Type) -> Result<Type, Diagnostic> {
+fn convert_ast_type_v1<N: TreeNode>(
+    document: &Document,
+    ty: &wdl_ast::v1::Type<N>,
+) -> Result<Type, Diagnostic> {
     /// Used to resolve a type name from a document.
-    struct Resolver<'a> {
-        /// The document containing the type name to resolve.
-        document: &'a Document,
-    }
+    struct Resolver<'a>(&'a Document);
 
     impl TypeNameResolver for Resolver<'_> {
-        fn resolve(&mut self, name: &Ident) -> Result<Type, Diagnostic> {
-            resolve_type_name(self.document, name)
+        fn resolve(&mut self, name: &str, span: Span) -> Result<Type, Diagnostic> {
+            resolve_type_name(self.0, name, span)
         }
     }
 
-    AstTypeConverter::new(Resolver { document }).convert_type(ty)
+    AstTypeConverter::new(Resolver(document)).convert_type(ty)
 }
 
 /// Cached information about the host system.

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -1,4 +1,4 @@
-//! Implementation of syntax tree elements that are `Send`+`Sync`.
+//! Implementation of syntax tree elements that are `Send + Sync`.
 //!
 //! This is used by the engine instead of the corresponding types from `rowan`
 //! because that implementation is inherently not `Send`.

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -132,7 +132,7 @@ impl SyntaxNode {
     ///
     /// Returns `None` if there is no sibling node or token.
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
-        // This should also be a constant-time access rather than having to iterate
+        // This should also be a constant-time access rather than having to iterate.
         // We need the offset relative to the start of the parent from the green node to
         // do that; currently that information is private in `rowan`
 

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -226,7 +226,7 @@ impl TreeNode for SyntaxNode {
     }
 
     fn last_token(&self) -> Option<Self::Token> {
-        // Unfortunately `rowan` does not expose the relative offset of each green child
+        // Unfortunately `rowan` does not expose the relative offset of each green child.
         // If it did, we could easily just look at the last child here instead of
         // iterating to find the last child's start
         let mut last: Option<(usize, NodeOrToken<&GreenNodeData, &GreenTokenData>)> = None;

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -114,7 +114,7 @@ impl SyntaxNode {
     pub fn next_sibling(&self) -> Option<SyntaxNode> {
         // This should also be a constant-time access rather than having to iterate.
         // We need the offset relative to the start of the parent from the green node to
-        // do that; currently that information is private in `rowan`
+        // do that; currently that information is private in `rowan`.
 
         let parent = self.parent()?;
         let mut children = parent.children();

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -313,7 +313,7 @@ impl From<SyntaxNode> for SyntaxElement {
     }
 }
 
-/// Represents a syntax token that is `Send`+`Sync`.
+/// Represents a syntax token that is `Send + Sync`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SyntaxToken(Arc<ElementData>);
 

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -112,7 +112,7 @@ impl SyntaxNode {
     ///
     /// Returns `None` if there is no sibling node.
     pub fn next_sibling(&self) -> Option<SyntaxNode> {
-        // This should also be a constant-time access rather than having to iterate
+        // This should also be a constant-time access rather than having to iterate.
         // We need the offset relative to the start of the parent from the green node to
         // do that; currently that information is private in `rowan`
 

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -322,9 +322,9 @@ impl SyntaxToken {
     ///
     /// Returns `None` if there is no next sibling node or token.
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
-        // This should also be a constant-time access rather than having to iterate
+        // This should also be a constant-time access rather than having to iterate.
         // We need the offset relative to the start of the parent from the green node to
-        // do that
+        // do that.
 
         let parent = self.parent();
         let mut children = parent.children_with_tokens();

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -134,7 +134,7 @@ impl SyntaxNode {
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
         // This should also be a constant-time access rather than having to iterate.
         // We need the offset relative to the start of the parent from the green node to
-        // do that; currently that information is private in `rowan`
+        // do that; currently that information is private in `rowan`.
 
         let parent = self.parent()?;
         let mut children = parent.children_with_tokens();

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -68,7 +68,7 @@ impl ElementData {
 /// Represents an element in a syntax tree.
 pub type SyntaxElement = NodeOrToken<SyntaxNode, SyntaxToken>;
 
-/// Represents a syntax node that is `Send`+`Sync`.
+/// Represents a syntax node that is `Send + Sync`.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SyntaxNode(Arc<ElementData>);
 

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -228,7 +228,7 @@ impl TreeNode for SyntaxNode {
     fn last_token(&self) -> Option<Self::Token> {
         // Unfortunately `rowan` does not expose the relative offset of each green child.
         // If it did, we could easily just look at the last child here instead of
-        // iterating to find the last child's start
+        // iterating to find the last child's start.
         let mut last: Option<(usize, NodeOrToken<&GreenNodeData, &GreenTokenData>)> = None;
         let mut start = self.0.offset;
 

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -1,0 +1,544 @@
+//! Implementation of a syntax tree elements that are `Send`+`Sync`.
+//!
+//! This is used by the engine instead of the corresponding types from `rowan`
+//! because their implementation is inherently not `Send`.
+//!
+//! The engine performs evaluation in an asynchronous fashion, so the AST nodes
+//! need to be `Send`.
+
+use std::fmt;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use rowan::GreenNode;
+use rowan::GreenNodeData;
+use rowan::GreenToken;
+use rowan::GreenTokenData;
+use rowan::Language;
+use rowan::NodeOrToken;
+use rowan::WalkEvent;
+use wdl_ast::NewRoot;
+use wdl_ast::Span;
+use wdl_ast::SyntaxKind;
+use wdl_ast::TreeNode;
+use wdl_ast::TreeToken;
+use wdl_ast::WorkflowDescriptionLanguage;
+
+/// Internal data for an element in the tree.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct ElementData {
+    /// The parent data.
+    ///
+    /// This is `None` for the root node.
+    parent: Option<Arc<ElementData>>,
+    /// The associated green element.
+    green: NodeOrToken<GreenNode, GreenToken>,
+    /// The index of this element in the parent's list of children.
+    index: usize,
+    /// The offset to the start of this element.
+    offset: usize,
+}
+
+impl ElementData {
+    /// Constructs a new element data.
+    fn new(
+        parent: Arc<ElementData>,
+        green: NodeOrToken<GreenNode, GreenToken>,
+        index: usize,
+        offset: usize,
+    ) -> Self {
+        Self {
+            parent: Some(parent),
+            green,
+            index,
+            offset,
+        }
+    }
+
+    /// Constructs element data for a new root node.
+    fn new_root(green: GreenNode) -> Self {
+        Self {
+            parent: None,
+            green: green.into(),
+            index: 0,
+            offset: 0,
+        }
+    }
+}
+
+/// Represents an element in a syntax tree.
+pub type SyntaxElement = NodeOrToken<SyntaxNode, SyntaxToken>;
+
+/// Represents a syntax node that is `Send`+`Sync`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SyntaxNode(Arc<ElementData>);
+
+impl SyntaxNode {
+    /// Constructs a new child node for this node.
+    fn new_child_node(&self, green: GreenNode, index: usize, offset: usize) -> Self {
+        Self(Arc::new(ElementData::new(
+            self.0.clone(),
+            green.into(),
+            index,
+            offset,
+        )))
+    }
+
+    /// Constructs a new child token for this node.
+    fn new_child_token(&self, green: GreenToken, index: usize, offset: usize) -> SyntaxToken {
+        SyntaxToken(Arc::new(ElementData::new(
+            self.0.clone(),
+            green.into(),
+            index,
+            offset,
+        )))
+    }
+
+    /// Gets the first child node.
+    ///
+    /// Returns `None` if there are no children or if all the children are
+    /// tokens.
+    pub fn first_child(&self) -> Option<SyntaxNode> {
+        self.children().next()
+    }
+
+    /// Gets the first child node or token.
+    ///
+    /// Returns `None` if there are no children.
+    pub fn first_child_or_token(&self) -> Option<SyntaxElement> {
+        self.children_with_tokens().next()
+    }
+
+    /// Gets the next sibling node.
+    ///
+    /// Returns `None` if there is no sibling node.
+    pub fn next_sibling(&self) -> Option<SyntaxNode> {
+        // This should also be a constant-time access rather than having to iterate
+        // We need the offset relative to the start of the parent from the green node to
+        // do that; currently that information is private in `rowan`
+
+        let parent = self.parent()?;
+        let mut children = parent.children();
+
+        while let Some(child) = children.next() {
+            if child.eq(self) {
+                return children.next();
+            }
+        }
+
+        None
+    }
+
+    /// Gets the next sibling node or token.
+    ///
+    /// Returns `None` if there is no sibling node or token.
+    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
+        // This should also be a constant-time access rather than having to iterate
+        // We need the offset relative to the start of the parent from the green node to
+        // do that; currently that information is private in `rowan`
+
+        let parent = self.parent()?;
+        let mut children = parent.children_with_tokens();
+
+        while let Some(child) = children.next() {
+            if let Some(node) = child.as_node() {
+                if node.eq(self) {
+                    return children.next();
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Gets a preorder traversal iterator starting at this node.
+    #[inline]
+    pub fn preorder(&self) -> Preorder {
+        Preorder::new(self.clone())
+    }
+
+    /// Gets a preorder-with-tokens traversal iterator starting at this node.
+    #[inline]
+    pub fn preorder_with_tokens(&self) -> PreorderWithTokens {
+        PreorderWithTokens::new(self.clone())
+    }
+
+    /// Gets an iterator over the descendants with tokens for this node.
+    fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement> {
+        self.preorder_with_tokens().filter_map(|event| match event {
+            WalkEvent::Enter(it) => Some(it),
+            WalkEvent::Leave(_) => None,
+        })
+    }
+}
+
+impl TreeNode for SyntaxNode {
+    type Token = SyntaxToken;
+
+    fn parent(&self) -> Option<Self> {
+        self.0.parent.clone().map(Self)
+    }
+
+    fn kind(&self) -> SyntaxKind {
+        WorkflowDescriptionLanguage::kind_from_raw(self.0.green.kind())
+    }
+
+    fn text(&self) -> impl fmt::Display {
+        SyntaxText(self.clone())
+    }
+
+    fn span(&self) -> Span {
+        Span::new(self.0.offset, usize::from(self.0.green.text_len()))
+    }
+
+    fn children(&self) -> impl Iterator<Item = Self> {
+        let mut offset = self.0.offset;
+        self.0
+            .green
+            .as_node()
+            .expect("should be node")
+            .children()
+            .enumerate()
+            .filter_map(move |(index, child)| {
+                let start = offset;
+                offset += usize::from(child.text_len());
+                Some(self.new_child_node(child.into_node()?.to_owned(), index, start))
+            })
+    }
+
+    fn children_with_tokens(&self) -> impl Iterator<Item = SyntaxElement> {
+        let mut offset = self.0.offset;
+        self.0
+            .green
+            .as_node()
+            .expect("should be node")
+            .children()
+            .enumerate()
+            .map(move |(index, child)| {
+                let start = offset;
+                offset += usize::from(child.text_len());
+                match child {
+                    NodeOrToken::Node(n) => self.new_child_node(n.to_owned(), index, start).into(),
+                    NodeOrToken::Token(t) => {
+                        self.new_child_token(t.to_owned(), index, start).into()
+                    }
+                }
+            })
+    }
+
+    fn last_token(&self) -> Option<Self::Token> {
+        // Unfortunately `rowan` does not expose the relative offset of each green child
+        // If it did, we could easily just look at the last child here instead of
+        // iterating to find the last child's start
+        let mut last: Option<(usize, NodeOrToken<&GreenNodeData, &GreenTokenData>)> = None;
+        let mut start = self.0.offset;
+
+        for (index, child) in self
+            .0
+            .green
+            .as_node()
+            .expect("should be node")
+            .children()
+            .enumerate()
+        {
+            if let Some((_, prev)) = last {
+                start += usize::from(prev.text_len());
+            }
+
+            last = Some((index, child));
+        }
+
+        match last? {
+            (index, NodeOrToken::Node(n)) => {
+                self.new_child_node(n.to_owned(), index, start).last_token()
+            }
+            (index, NodeOrToken::Token(t)) => {
+                Some(self.new_child_token(t.to_owned(), index, start))
+            }
+        }
+    }
+
+    fn descendants(&self) -> impl Iterator<Item = Self> {
+        self.preorder().filter_map(|event| match event {
+            WalkEvent::Enter(node) => Some(node),
+            WalkEvent::Leave(_) => None,
+        })
+    }
+
+    fn ancestors(&self) -> impl Iterator<Item = Self> {
+        std::iter::successors(Some(self.clone()), SyntaxNode::parent)
+    }
+
+    fn is_rule_excepted(&self, _: &str) -> bool {
+        // For engine evaluation, we except all rules
+        true
+    }
+}
+
+impl fmt::Debug for SyntaxNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            let mut level = 0;
+            for event in self.preorder_with_tokens() {
+                match event {
+                    WalkEvent::Enter(element) => {
+                        for _ in 0..level {
+                            write!(f, "  ")?;
+                        }
+                        match element {
+                            NodeOrToken::Node(node) => writeln!(f, "{:?}", node)?,
+                            NodeOrToken::Token(token) => writeln!(f, "{:?}", token)?,
+                        }
+                        level += 1;
+                    }
+                    WalkEvent::Leave(_) => level -= 1,
+                }
+            }
+            assert_eq!(level, 0);
+            Ok(())
+        } else {
+            write!(f, "{:?}@{}", self.kind(), self.span())
+        }
+    }
+}
+
+impl NewRoot<wdl_ast::SyntaxNode> for SyntaxNode {
+    fn new_root(root: wdl_ast::SyntaxNode) -> Self {
+        Self(Arc::new(ElementData::new_root(root.green().into())))
+    }
+}
+
+impl From<SyntaxNode> for SyntaxElement {
+    fn from(value: SyntaxNode) -> Self {
+        Self::Node(value)
+    }
+}
+
+/// Represents a syntax token that is `Send`+`Sync`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SyntaxToken(Arc<ElementData>);
+
+impl SyntaxToken {
+    /// Gets the next sibling node or token.
+    ///
+    /// Returns `None` if there is no next sibling node or token.
+    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
+        // This should also be a constant-time access rather than having to iterate
+        // We need the offset relative to the start of the parent from the green node to
+        // do that
+
+        let parent = self.parent();
+        let mut children = parent.children_with_tokens();
+
+        while let Some(child) = children.next() {
+            if let Some(token) = child.as_token() {
+                if token.eq(self) {
+                    return children.next();
+                }
+            }
+        }
+
+        None
+    }
+}
+
+impl TreeToken for SyntaxToken {
+    type Node = SyntaxNode;
+
+    fn parent(&self) -> Self::Node {
+        self.0
+            .parent
+            .clone()
+            .map(SyntaxNode)
+            .expect("tokens should always have parents")
+    }
+
+    fn kind(&self) -> SyntaxKind {
+        WorkflowDescriptionLanguage::kind_from_raw(self.0.green.kind())
+    }
+
+    fn text(&self) -> &str {
+        self.0.green.as_token().expect("should be token").text()
+    }
+
+    fn span(&self) -> Span {
+        Span::new(self.0.offset, usize::from(self.0.green.text_len()))
+    }
+}
+
+impl fmt::Debug for SyntaxToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}@{:?}", self.kind(), self.span())?;
+        if self.text().len() < 25 {
+            return write!(f, " {:?}", self.text());
+        }
+        let text = self.text();
+        for idx in 21..25 {
+            if text.is_char_boundary(idx) {
+                let text = format!("{} ...", &text[..idx]);
+                return write!(f, " {:?}", text);
+            }
+        }
+        unreachable!()
+    }
+}
+
+impl From<SyntaxToken> for SyntaxElement {
+    fn from(value: SyntaxToken) -> Self {
+        Self::Token(value)
+    }
+}
+
+/// Constant that asserts types are `Send + Sync`; if not, it fails to compile.
+const _: () = {
+    /// Helper that will fail to compile if T is not `Send + Sync`.
+    const fn _assert<T: Send + Sync>() {}
+    _assert::<SyntaxNode>();
+    _assert::<SyntaxToken>();
+};
+
+/// Implements a preorder iterator.
+#[derive(Debug)]
+pub struct Preorder {
+    /// The starting node.
+    start: SyntaxNode,
+    /// The next event for the iterator.
+    next: Option<WalkEvent<SyntaxNode>>,
+}
+
+impl Preorder {
+    /// Constructs a new preorder iterator for the given start node.
+    fn new(start: SyntaxNode) -> Preorder {
+        let next = Some(WalkEvent::Enter(start.clone()));
+        Preorder { start, next }
+    }
+}
+
+impl Iterator for Preorder {
+    type Item = WalkEvent<SyntaxNode>;
+
+    fn next(&mut self) -> Option<WalkEvent<SyntaxNode>> {
+        let next = self.next.take();
+        self.next = next.as_ref().and_then(|next| {
+            Some(match next {
+                WalkEvent::Enter(node) => match node.first_child() {
+                    Some(child) => WalkEvent::Enter(child),
+                    None => WalkEvent::Leave(node.clone()),
+                },
+                WalkEvent::Leave(node) => {
+                    if node == &self.start {
+                        return None;
+                    }
+                    match node.next_sibling() {
+                        Some(sibling) => WalkEvent::Enter(sibling),
+                        None => WalkEvent::Leave(node.parent()?),
+                    }
+                }
+            })
+        });
+        next
+    }
+}
+
+/// Implements a preorder-with-tokens iterator.
+pub struct PreorderWithTokens {
+    /// The starting element.
+    start: SyntaxElement,
+    /// The next event for the iterator.
+    next: Option<WalkEvent<SyntaxElement>>,
+}
+
+impl PreorderWithTokens {
+    /// Constructs a new preorder-with-tokens iterator for the given start node.
+    fn new(start: SyntaxNode) -> PreorderWithTokens {
+        let next = Some(WalkEvent::Enter(start.clone().into()));
+        PreorderWithTokens {
+            start: start.into(),
+            next,
+        }
+    }
+}
+
+impl Iterator for PreorderWithTokens {
+    type Item = WalkEvent<SyntaxElement>;
+
+    fn next(&mut self) -> Option<WalkEvent<SyntaxElement>> {
+        let next = self.next.take();
+        self.next = next.as_ref().and_then(|next| {
+            Some(match next {
+                WalkEvent::Enter(el) => match el {
+                    NodeOrToken::Node(node) => match node.first_child_or_token() {
+                        Some(child) => WalkEvent::Enter(child),
+                        None => WalkEvent::Leave(node.clone().into()),
+                    },
+                    NodeOrToken::Token(token) => WalkEvent::Leave(token.clone().into()),
+                },
+                WalkEvent::Leave(el) if el == &self.start => return None,
+                WalkEvent::Leave(el) => {
+                    let sibling = match el {
+                        NodeOrToken::Node(n) => n.next_sibling_or_token(),
+                        NodeOrToken::Token(t) => t.next_sibling_or_token(),
+                    };
+
+                    match sibling {
+                        Some(sibling) => WalkEvent::Enter(sibling),
+                        None => match el {
+                            NodeOrToken::Node(n) => WalkEvent::Leave(n.parent()?.into()),
+                            NodeOrToken::Token(t) => WalkEvent::Leave(t.parent().into()),
+                        },
+                    }
+                }
+            })
+        });
+        next
+    }
+}
+
+/// Represents the text of a syntax node.
+///
+/// The text of a syntax node is the cumulation of its descendant token texts.
+struct SyntaxText(SyntaxNode);
+
+impl SyntaxText {
+    /// Calls a fallible callback for each chunk of text.
+    pub fn try_for_each_chunk<F: FnMut(&str) -> Result<(), E>, E>(
+        &self,
+        mut f: F,
+    ) -> Result<(), E> {
+        self.try_fold_chunks((), move |(), chunk| f(chunk))
+    }
+
+    /// Attempts to fold each chunk of text into the given accumulator
+    pub fn try_fold_chunks<T, F, E>(&self, init: T, mut f: F) -> Result<T, E>
+    where
+        F: FnMut(T, &str) -> Result<T, E>,
+    {
+        self.tokens_with_spans()
+            .try_fold(init, move |acc, (token, span)| {
+                f(acc, &token.text()[span.start()..span.end()])
+            })
+    }
+
+    /// Gets an iterator over all descendant tokens with their spans.
+    fn tokens_with_spans(&self) -> impl Iterator<Item = (SyntaxToken, Span)> {
+        let span = self.0.span();
+        self.0.descendants_with_tokens().filter_map(move |element| {
+            let token = element.into_token()?;
+            let token_span = token.span();
+            let intersection = span.intersect(token_span)?;
+            Some((
+                token,
+                Span::new(
+                    intersection.start() - token_span.start(),
+                    intersection.len() - (intersection.end() - token_span.end()),
+                ),
+            ))
+        })
+    }
+}
+
+impl fmt::Display for SyntaxText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.try_for_each_chunk(|chunk| fmt::Display::fmt(chunk, f))
+    }
+}

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -226,9 +226,9 @@ impl TreeNode for SyntaxNode {
     }
 
     fn last_token(&self) -> Option<Self::Token> {
-        // Unfortunately `rowan` does not expose the relative offset of each green child.
-        // If it did, we could easily just look at the last child here instead of
-        // iterating to find the last child's start.
+        // Unfortunately `rowan` does not expose the relative offset of each green
+        // child. If it did, we could easily just look at the last child here
+        // instead of iterating to find the last child's start.
         let mut last: Option<(usize, NodeOrToken<&GreenNodeData, &GreenTokenData>)> = None;
         let mut start = self.0.offset;
 

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -1,10 +1,9 @@
-//! Implementation of a syntax tree elements that are `Send`+`Sync`.
+//! Implementation of syntax tree elements that are `Send`+`Sync`.
 //!
 //! This is used by the engine instead of the corresponding types from `rowan`
-//! because their implementation is inherently not `Send`.
+//! because that implementation is inherently not `Send`.
 //!
-//! The engine performs evaluation in an asynchronous fashion, so the AST nodes
-//! need to be `Send`.
+//! As evaluation is required to be asynchronous, AST elements must be `Send`.
 
 use std::fmt;
 use std::hash::Hash;

--- a/wdl-engine/tests/inputs.rs
+++ b/wdl-engine/tests/inputs.rs
@@ -39,6 +39,7 @@ use wdl_analysis::AnalysisResult;
 use wdl_analysis::Analyzer;
 use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::rules;
+use wdl_ast::AstNode;
 use wdl_ast::Diagnostic;
 use wdl_ast::Severity;
 use wdl_engine::Inputs;
@@ -122,7 +123,7 @@ fn run_test(test: &Path, result: AnalysisResult, ntests: &AtomicUsize) -> Result
     };
 
     if let Some(diagnostic) = diagnostics.iter().find(|d| d.severity() == Severity::Error) {
-        let source = result.document().node().syntax().text().to_string();
+        let source = result.document().root().text().to_string();
         let file = SimpleFile::new(&path, &source);
 
         term::emit(

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -52,6 +52,7 @@ use wdl_analysis::Analyzer;
 use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::document::Document;
 use wdl_analysis::rules;
+use wdl_ast::AstNode;
 use wdl_ast::Diagnostic;
 use wdl_ast::Severity;
 use wdl_engine::EvaluatedTask;
@@ -407,7 +408,7 @@ fn compare_evaluation_results(
 
 /// Creates a string from the given diagnostic.
 fn diagnostic_to_string(document: &Document, path: &str, diagnostic: &Diagnostic) -> String {
-    let source = document.node().syntax().text().to_string();
+    let source = document.root().text().to_string();
     let file = SimpleFile::new(path, &source);
 
     let mut buffer = Buffer::no_color();

--- a/wdl-engine/tests/workflows.rs
+++ b/wdl-engine/tests/workflows.rs
@@ -45,6 +45,7 @@ use wdl_analysis::Analyzer;
 use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::document::Document;
 use wdl_analysis::rules;
+use wdl_ast::AstNode;
 use wdl_ast::Diagnostic;
 use wdl_ast::Severity;
 use wdl_engine::EvaluationError;
@@ -226,7 +227,7 @@ async fn run_test(test: &Path, result: AnalysisResult) -> Result<()> {
 
 /// Creates a string from the given diagnostic.
 fn diagnostic_to_string(document: &Document, path: &str, diagnostic: &Diagnostic) -> String {
-    let source = document.node().syntax().text().to_string();
+    let source = document.root().text().to_string();
     let file = SimpleFile::new(path, &source);
 
     let mut buffer = Buffer::no_color();

--- a/wdl-format/CHANGELOG.md
+++ b/wdl-format/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to use new `wdl-ast` API ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
+* Refactored analysis API to support different syntax tree element
+  representations ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 
 ## 0.4.0 - 01-17-2025

--- a/wdl-format/CHANGELOG.md
+++ b/wdl-format/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Updated to use new `wdl-ast` API ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
-* Refactored analysis API to support different syntax tree element
-  representations ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 
 ## 0.4.0 - 01-17-2025

--- a/wdl-format/src/element.rs
+++ b/wdl-format/src/element.rs
@@ -101,7 +101,7 @@ impl AstElementFormatExt for Element {
 /// This function ignores trivia.
 fn collate(node: &Node) -> Option<NonEmpty<Box<FormatElement>>> {
     let mut results = Vec::new();
-    let stream = node.syntax().children_with_tokens().filter_map(|syntax| {
+    let stream = node.inner().children_with_tokens().filter_map(|syntax| {
         if syntax.kind().is_trivia() {
             None
         } else {
@@ -168,7 +168,7 @@ workflow bar # This is an inline comment on the workflow ident.
 
         let version = children.next().expect("version statement element");
         assert_eq!(
-            version.element().syntax().kind(),
+            version.element().inner().kind(),
             SyntaxKind::VersionStatementNode
         );
 
@@ -186,7 +186,7 @@ workflow bar # This is an inline comment on the workflow ident.
 
         let task = children.next().expect("task element");
         assert_eq!(
-            task.element().syntax().kind(),
+            task.element().inner().kind(),
             SyntaxKind::TaskDefinitionNode
         );
 
@@ -216,7 +216,7 @@ workflow bar # This is an inline comment on the workflow ident.
 
         let workflow = children.next().expect("workflow element");
         assert_eq!(
-            workflow.element().syntax().kind(),
+            workflow.element().inner().kind(),
             SyntaxKind::WorkflowDefinitionNode
         );
 

--- a/wdl-format/src/lib.rs
+++ b/wdl-format/src/lib.rs
@@ -123,7 +123,7 @@ impl Writable for &FormatElement {
                 AstNode::MultiplicationExpr(_) => {
                     v1::expr::format_multiplication_expr(self, stream)
                 }
-                AstNode::NameRef(_) => v1::expr::format_name_ref(self, stream),
+                AstNode::NameRefExpr(_) => v1::expr::format_name_ref_expr(self, stream),
                 AstNode::NegationExpr(_) => v1::expr::format_negation_expr(self, stream),
                 AstNode::OutputSection(_) => v1::format_output_section(self, stream),
                 AstNode::PairType(_) => v1::decl::format_pair_type(self, stream),

--- a/wdl-format/src/token/pre.rs
+++ b/wdl-format/src/token/pre.rs
@@ -148,8 +148,8 @@ impl TokenStream<PreToken> {
 
     /// Inserts any preceding trivia into the stream.
     fn push_preceding_trivia(&mut self, token: &wdl_ast::Token) {
-        assert!(!token.syntax().kind().is_trivia());
-        let preceding_trivia = token.syntax().preceding_trivia();
+        assert!(!token.inner().kind().is_trivia());
+        let preceding_trivia = token.inner().preceding_trivia();
         for token in preceding_trivia {
             match token.kind() {
                 SyntaxKind::Whitespace => {
@@ -172,8 +172,8 @@ impl TokenStream<PreToken> {
 
     /// Inserts any inline trivia into the stream.
     fn push_inline_trivia(&mut self, token: &wdl_ast::Token) {
-        assert!(!token.syntax().kind().is_trivia());
-        if let Some(token) = token.syntax().inline_comment() {
+        assert!(!token.inner().kind().is_trivia());
+        if let Some(token) = token.inner().inline_comment() {
             let inline_comment = PreToken::Trivia(Trivia::Comment(Comment::Inline(Rc::new(
                 token.text().trim_end().to_owned(),
             ))));
@@ -189,8 +189,8 @@ impl TokenStream<PreToken> {
     pub fn push_ast_token(&mut self, token: &wdl_ast::Token) {
         self.push_preceding_trivia(token);
         self.0.push(PreToken::Literal(
-            Rc::new(token.syntax().text().to_owned()),
-            token.syntax().kind(),
+            Rc::new(token.inner().text().to_owned()),
+            token.inner().kind(),
         ));
         self.push_inline_trivia(token);
     }
@@ -202,7 +202,7 @@ impl TokenStream<PreToken> {
         self.push_preceding_trivia(token);
         self.0.push(PreToken::Literal(
             Rc::new(replacement),
-            token.syntax().kind(),
+            token.inner().kind(),
         ));
         self.push_inline_trivia(token);
     }

--- a/wdl-format/src/v1.rs
+++ b/wdl-format/src/v1.rs
@@ -51,7 +51,7 @@ pub fn format_ast(element: &FormatElement, stream: &mut TokenStream<PreToken>) {
             .expect("import statement");
         let a_uri = a.uri().text().expect("import uri");
         let b_uri = b.uri().text().expect("import uri");
-        a_uri.as_str().cmp(b_uri.as_str())
+        a_uri.text().cmp(b_uri.text())
     });
 
     stream.blank_lines_allowed_between_comments();

--- a/wdl-format/src/v1/expr.rs
+++ b/wdl-format/src/v1/expr.rs
@@ -104,7 +104,7 @@ pub fn format_placeholder(element: &FormatElement, stream: &mut TokenStream<PreT
 
     let open = children.next().expect("placeholder open");
     assert!(open.element().kind() == SyntaxKind::PlaceholderOpen);
-    let syntax = open.element().syntax();
+    let syntax = open.element().inner();
     let text = syntax.as_token().expect("token").text();
     match text {
         "${" => {
@@ -141,7 +141,7 @@ pub fn format_literal_string(element: &FormatElement, stream: &mut TokenStream<P
             }
             SyntaxKind::LiteralStringText => {
                 let mut replacement = String::new();
-                let syntax = child.element().syntax();
+                let syntax = child.element().inner();
                 let mut chars = syntax.as_token().expect("token").text().chars().peekable();
                 let mut prev_c = None;
                 while let Some(c) = chars.next() {
@@ -258,7 +258,7 @@ pub fn format_literal_float(element: &FormatElement, stream: &mut TokenStream<Pr
 }
 
 /// Formats a [`NameRef`](wdl_ast::v1::NameRef).
-pub fn format_name_ref(element: &FormatElement, stream: &mut TokenStream<PreToken>) {
+pub fn format_name_ref_expr(element: &FormatElement, stream: &mut TokenStream<PreToken>) {
     let mut children = element.children().expect("name ref children");
     let name = children.next().expect("name ref name");
     (&name).write(stream);

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Renamed `NameRefNode` to `NameRefExprNode` ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 
 ## 0.11.0 - 01-17-2025

--- a/wdl-grammar/src/grammar/v1.rs
+++ b/wdl-grammar/src/grammar/v1.rs
@@ -2002,7 +2002,7 @@ fn atom_expr(
         Token::HintsKeyword => literal_hints(parser, marker),
         Token::InputKeyword => literal_input(parser, marker),
         Token::OutputKeyword => literal_output(parser, marker),
-        t if ANY_IDENT.contains(t.into_raw()) => name_ref(parser, marker),
+        t if ANY_IDENT.contains(t.into_raw()) => name_ref_expr(parser, marker),
         _ => unreachable!(),
     }
 }
@@ -2102,8 +2102,9 @@ fn object_item(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, D
     Ok(())
 }
 
-/// Parses a name reference, literal struct expression, or call expression.
-fn name_ref(
+/// Parses a name reference expression, literal struct expression, or call
+/// expression.
+fn name_ref_expr(
     parser: &mut Parser<'_>,
     marker: Marker,
 ) -> Result<CompletedMarker, (Marker, Diagnostic)> {
@@ -2129,7 +2130,7 @@ fn name_ref(
     }
 
     // This is a name reference.
-    Ok(marker.complete(parser, SyntaxKind::NameRefNode))
+    Ok(marker.complete(parser, SyntaxKind::NameRefExprNode))
 }
 
 /// Parses a single item in a literal struct.

--- a/wdl-grammar/src/tree.rs
+++ b/wdl-grammar/src/tree.rs
@@ -310,8 +310,8 @@ pub enum SyntaxKind {
     LiteralOutputItemNode,
     /// Represents a parenthesized expression node.
     ParenthesizedExprNode,
-    /// Represents a name reference node.
-    NameRefNode,
+    /// Represents a name reference expression node.
+    NameRefExprNode,
     /// Represents an `if` expression node.
     IfExprNode,
     /// Represents a logical not expression node.
@@ -529,7 +529,7 @@ impl SyntaxKind {
             Self::LiteralOutputNode => "literal output",
             Self::LiteralOutputItemNode => "literal output item",
             Self::ParenthesizedExprNode => "parenthesized expression",
-            Self::NameRefNode => "name reference",
+            Self::NameRefExprNode => "name reference expression",
             Self::IfExprNode => "`if` expression",
             Self::LogicalNotExprNode => "logical not expression",
             Self::NegationExprNode => "negation expression",

--- a/wdl-grammar/tests/parsing/atoms/source.tree
+++ b/wdl-grammar/tests/parsing/atoms/source.tree
@@ -97,7 +97,7 @@ RootNode@0..661
       Whitespace@205..206 " "
       LiteralArrayNode@206..215
         OpenBracket@206..207 "["
-        NameRefNode@207..208
+        NameRefExprNode@207..208
           Ident@207..208 "a"
         Comma@208..209 ","
         Whitespace@209..210 " "
@@ -267,18 +267,18 @@ RootNode@0..661
           Colon@432..433 ":"
           Whitespace@433..434 " "
           LogicalOrExprNode@434..445
-            NameRefNode@434..435
+            NameRefExprNode@434..435
               Ident@434..435 "c"
             Whitespace@435..436 " "
             LogicalOr@436..438 "||"
             Whitespace@438..439 " "
             LogicalAndExprNode@439..445
-              NameRefNode@439..440
+              NameRefExprNode@439..440
                 Ident@439..440 "d"
               Whitespace@440..441 " "
               LogicalAnd@441..443 "&&"
               Whitespace@443..444 " "
-              NameRefNode@444..445
+              NameRefExprNode@444..445
                 Ident@444..445 "c"
         CloseBrace@445..446 "}"
     Whitespace@446..451 "\n    "
@@ -291,7 +291,7 @@ RootNode@0..661
       Assignment@457..458 "="
       Whitespace@458..459 " "
       IndexExprNode@459..463
-        NameRefNode@459..460
+        NameRefExprNode@459..460
           Ident@459..460 "g"
         OpenBracket@460..461 "["
         LiteralIntegerNode@461..462
@@ -309,13 +309,13 @@ RootNode@0..661
       IfExprNode@476..502
         IfKeyword@476..478 "if"
         Whitespace@478..479 " "
-        NameRefNode@479..480
+        NameRefExprNode@479..480
           Ident@479..480 "c"
         Whitespace@480..481 " "
         ThenKeyword@481..485 "then"
         Whitespace@485..486 " "
         AdditionExprNode@486..491
-          NameRefNode@486..487
+          NameRefExprNode@486..487
             Ident@486..487 "k"
           Whitespace@487..488 " "
           Plus@488..489 "+"
@@ -326,7 +326,7 @@ RootNode@0..661
         ElseKeyword@492..496 "else"
         Whitespace@496..497 " "
         MultiplicationExprNode@497..502
-          NameRefNode@497..498
+          NameRefExprNode@497..498
             Ident@497..498 "a"
           Whitespace@498..499 " "
           Asterisk@499..500 "*"
@@ -429,7 +429,7 @@ RootNode@0..661
       Assignment@647..648 "="
       Whitespace@648..649 " "
       EqualityExprNode@649..658
-        NameRefNode@649..650
+        NameRefExprNode@649..650
           Ident@649..650 "r"
         Whitespace@650..651 " "
         Equal@651..653 "=="

--- a/wdl-grammar/tests/parsing/command-sections/source.tree
+++ b/wdl-grammar/tests/parsing/command-sections/source.tree
@@ -40,7 +40,7 @@ RootNode@0..467
       LiteralCommandText@131..170 "\n        set -e\n      ..."
       PlaceholderNode@170..177
         PlaceholderOpen@170..172 "~{"
-        NameRefNode@172..176
+        NameRefExprNode@172..176
           Ident@172..176 "name"
         CloseBrace@176..177 "}"
       LiteralCommandText@177..258 "\\\\n\"! >> output.txt\n  ..."
@@ -82,13 +82,13 @@ RootNode@0..467
       LiteralCommandText@340..379 "\n        set -e\n      ..."
       PlaceholderNode@379..386
         PlaceholderOpen@379..381 "~{"
-        NameRefNode@381..385
+        NameRefExprNode@381..385
           Ident@381..385 "name"
         CloseBrace@385..386 "}"
       LiteralCommandText@386..422 "\\\\n\"! >> output.txt\n  ..."
       PlaceholderNode@422..432
         PlaceholderOpen@422..424 "${"
-        NameRefNode@424..431
+        NameRefExprNode@424..431
           Ident@424..431 "ENV_VAR"
         CloseBrace@431..432 "}"
       LiteralCommandText@432..463 "\" > env.txt # interpo ..."

--- a/wdl-grammar/tests/parsing/conditional-statements/source.tree
+++ b/wdl-grammar/tests/parsing/conditional-statements/source.tree
@@ -41,7 +41,7 @@ RootNode@0..450
           Whitespace@142..143 " "
           InKeyword@143..145 "in"
           Whitespace@145..146 " "
-          NameRefNode@146..147
+          NameRefExprNode@146..147
             Ident@146..147 "y"
           CloseParen@147..148 ")"
           Whitespace@148..149 " "
@@ -75,7 +75,7 @@ RootNode@0..450
         IfKeyword@323..325 "if"
         Whitespace@325..326 " "
         OpenParen@326..327 "("
-        NameRefNode@327..328
+        NameRefExprNode@327..328
           Ident@327..328 "x"
         CloseParen@328..329 ")"
         Whitespace@329..330 " "

--- a/wdl-grammar/tests/parsing/empty-index-expr/source.tree
+++ b/wdl-grammar/tests/parsing/empty-index-expr/source.tree
@@ -20,7 +20,7 @@ RootNode@0..101
     Whitespace@92..93 " "
     Assignment@93..94 "="
     Whitespace@94..95 " "
-    NameRefNode@95..96
+    NameRefExprNode@95..96
       Ident@95..96 "x"
     OpenBracket@96..97 "["
     CloseBracket@97..98 "]"

--- a/wdl-grammar/tests/parsing/infix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/infix-exprs/source.tree
@@ -39,7 +39,7 @@ RootNode@0..354
       Assignment@99..100 "="
       Whitespace@100..101 " "
       LogicalAndExprNode@101..110
-        NameRefNode@101..102
+        NameRefExprNode@101..102
           Ident@101..102 "a"
         Whitespace@102..103 " "
         LogicalAnd@103..105 "&&"
@@ -56,12 +56,12 @@ RootNode@0..354
       Assignment@125..126 "="
       Whitespace@126..127 " "
       EqualityExprNode@127..133
-        NameRefNode@127..128
+        NameRefExprNode@127..128
           Ident@127..128 "a"
         Whitespace@128..129 " "
         Equal@129..131 "=="
         Whitespace@131..132 " "
-        NameRefNode@132..133
+        NameRefExprNode@132..133
           Ident@132..133 "b"
     Whitespace@133..138 "\n    "
     BoundDeclNode@138..160
@@ -73,7 +73,7 @@ RootNode@0..354
       Assignment@148..149 "="
       Whitespace@149..150 " "
       InequalityExprNode@150..160
-        NameRefNode@150..151
+        NameRefExprNode@150..151
           Ident@150..151 "c"
         Whitespace@151..152 " "
         NotEqual@152..154 "!="

--- a/wdl-grammar/tests/parsing/input-sections/source.tree
+++ b/wdl-grammar/tests/parsing/input-sections/source.tree
@@ -54,7 +54,7 @@ RootNode@0..374
           LiteralStringText@153..160 "Hello, "
           PlaceholderNode@160..164
             PlaceholderOpen@160..162 "~{"
-            NameRefNode@162..163
+            NameRefExprNode@162..163
               Ident@162..163 "a"
             CloseBrace@163..164 "}"
           DoubleQuote@164..165 "\""
@@ -127,7 +127,7 @@ RootNode@0..374
           LiteralStringText@288..295 "Hello, "
           PlaceholderNode@295..299
             PlaceholderOpen@295..297 "~{"
-            NameRefNode@297..298
+            NameRefExprNode@297..298
               Ident@297..298 "a"
             CloseBrace@298..299 "}"
           DoubleQuote@299..300 "\""

--- a/wdl-grammar/tests/parsing/interpolation/source.tree
+++ b/wdl-grammar/tests/parsing/interpolation/source.tree
@@ -39,7 +39,7 @@ RootNode@0..472
         LiteralStringText@110..116 "Hello "
         PlaceholderNode@116..123
           PlaceholderOpen@116..118 "${"
-          NameRefNode@118..122
+          NameRefExprNode@118..122
             Ident@118..122 "name"
           CloseBrace@122..123 "}"
         SingleQuote@123..124 "'"
@@ -57,7 +57,7 @@ RootNode@0..472
         LiteralStringText@141..147 "Hello "
         PlaceholderNode@147..155
           PlaceholderOpen@147..149 "~{"
-          NameRefNode@149..154
+          NameRefExprNode@149..154
             Ident@149..154 "world"
           CloseBrace@154..155 "}"
         DoubleQuote@155..156 "\""
@@ -125,7 +125,7 @@ RootNode@0..472
                 LiteralStringText@256..261 "you, "
                 PlaceholderNode@261..269
                   PlaceholderOpen@261..263 "~{"
-                  NameRefNode@263..268
+                  NameRefExprNode@263..268
                     Ident@263..268 "world"
                   CloseBrace@268..269 "}"
                 DoubleQuote@269..270 "\""

--- a/wdl-grammar/tests/parsing/missing-comma/source.tree
+++ b/wdl-grammar/tests/parsing/missing-comma/source.tree
@@ -33,7 +33,7 @@ RootNode@0..195
         OpenBrace@107..108 "{"
         Whitespace@108..117 "\n        "
         LiteralMapItemNode@117..127
-          NameRefNode@117..120
+          NameRefExprNode@117..120
             Ident@117..120 "foo"
           Colon@120..121 ":"
           Whitespace@121..122 " "
@@ -44,7 +44,7 @@ RootNode@0..195
         Comma@127..128 ","
         Whitespace@128..137 "\n        "
         LiteralMapItemNode@137..147
-          NameRefNode@137..140
+          NameRefExprNode@137..140
             Ident@137..140 "bar"
           Colon@140..141 ":"
           Whitespace@141..142 " "
@@ -62,7 +62,7 @@ RootNode@0..195
         Comma@166..167 ","
         Whitespace@167..176 "\n        "
         LiteralMapItemNode@176..186
-          NameRefNode@176..179
+          NameRefExprNode@176..179
             Ident@176..179 "qux"
           Colon@179..180 ":"
           Whitespace@180..181 " "

--- a/wdl-grammar/tests/parsing/multiline-strings/source.tree
+++ b/wdl-grammar/tests/parsing/multiline-strings/source.tree
@@ -26,13 +26,13 @@ RootNode@0..291
         LiteralStringText@101..241 "\n        Hello! This  ..."
         PlaceholderNode@241..249
           PlaceholderOpen@241..243 "${"
-          NameRefNode@243..248
+          NameRefExprNode@243..248
             Ident@243..248 "value"
           CloseBrace@248..249 "}"
         LiteralStringText@249..253 " or "
         PlaceholderNode@253..261
           PlaceholderOpen@253..255 "~{"
-          NameRefNode@255..260
+          NameRefExprNode@255..260
             Ident@255..260 "value"
           CloseBrace@260..261 "}"
         LiteralStringText@261..285 " for interpolations\n    "

--- a/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.tree
+++ b/wdl-grammar/tests/parsing/multiple-placeholder-opts/source.tree
@@ -63,7 +63,7 @@ RootNode@0..156
               LiteralStringText@147..148 "N"
               DoubleQuote@148..149 "\""
           Whitespace@149..150 " "
-          NameRefNode@150..151
+          NameRefExprNode@150..151
             Ident@150..151 "v"
           CloseBrace@151..152 "}"
         DoubleQuote@152..153 "\""

--- a/wdl-grammar/tests/parsing/name-ref/source.tree
+++ b/wdl-grammar/tests/parsing/name-ref/source.tree
@@ -34,7 +34,7 @@ RootNode@0..118
       Whitespace@90..91 " "
       NegationExprNode@91..93
         Minus@91..92 "-"
-        NameRefNode@92..93
+        NameRefExprNode@92..93
           Ident@92..93 "x"
     Whitespace@93..98 "\n    "
     BoundDeclNode@98..115
@@ -46,18 +46,18 @@ RootNode@0..118
       Assignment@104..105 "="
       Whitespace@105..106 " "
       AdditionExprNode@106..115
-        NameRefNode@106..107
+        NameRefExprNode@106..107
           Ident@106..107 "x"
         Whitespace@107..108 " "
         Plus@108..109 "+"
         Whitespace@109..110 " "
         MultiplicationExprNode@110..115
-          NameRefNode@110..111
+          NameRefExprNode@110..111
             Ident@110..111 "y"
           Whitespace@111..112 " "
           Asterisk@112..113 "*"
           Whitespace@113..114 " "
-          NameRefNode@114..115
+          NameRefExprNode@114..115
             Ident@114..115 "x"
     Whitespace@115..116 "\n"
     CloseBrace@116..117 "}"

--- a/wdl-grammar/tests/parsing/output-sections/source.tree
+++ b/wdl-grammar/tests/parsing/output-sections/source.tree
@@ -61,7 +61,7 @@ RootNode@0..415
           LiteralStringText@166..173 "Hello, "
           PlaceholderNode@173..177
             PlaceholderOpen@173..175 "~{"
-            NameRefNode@175..176
+            NameRefExprNode@175..176
               Ident@175..176 "a"
             CloseBrace@176..177 "}"
           DoubleQuote@177..178 "\""
@@ -177,7 +177,7 @@ RootNode@0..415
           LiteralStringText@339..346 "Hello, "
           PlaceholderNode@346..350
             PlaceholderOpen@346..348 "~{"
-            NameRefNode@348..349
+            NameRefExprNode@348..349
               Ident@348..349 "a"
             CloseBrace@349..350 "}"
           DoubleQuote@350..351 "\""

--- a/wdl-grammar/tests/parsing/postfix-exprs/source.tree
+++ b/wdl-grammar/tests/parsing/postfix-exprs/source.tree
@@ -50,7 +50,7 @@ RootNode@0..324
             Integer@108..111 "100"
           Comma@111..112 ","
           Whitespace@112..113 " "
-          NameRefNode@113..114
+          NameRefExprNode@113..114
             Ident@113..114 "a"
           CloseParen@114..115 ")"
         Comma@115..116 ","
@@ -100,16 +100,16 @@ RootNode@0..324
       Assignment@172..173 "="
       Whitespace@173..174 " "
       IndexExprNode@174..182
-        NameRefNode@174..175
+        NameRefExprNode@174..175
           Ident@174..175 "c"
         OpenBracket@175..176 "["
         AdditionExprNode@176..181
-          NameRefNode@176..177
+          NameRefExprNode@176..177
             Ident@176..177 "a"
           Whitespace@177..178 " "
           Plus@178..179 "+"
           Whitespace@179..180 " "
-          NameRefNode@180..181
+          NameRefExprNode@180..181
             Ident@180..181 "b"
         CloseBracket@181..182 "]"
     Whitespace@182..187 "\n    "
@@ -168,7 +168,7 @@ RootNode@0..324
           Whitespace@306..307 " "
           AccessExprNode@307..316
             AccessExprNode@307..312
-              NameRefNode@307..308
+              NameRefExprNode@307..308
                 Ident@307..308 "e"
               Dot@308..309 "."
               Ident@309..312 "foo"

--- a/wdl-grammar/tests/parsing/recovery-past-string/source.tree
+++ b/wdl-grammar/tests/parsing/recovery-past-string/source.tree
@@ -26,7 +26,7 @@ RootNode@0..235
       DoubleQuote@124..125 "\""
       PlaceholderNode@125..133
         PlaceholderOpen@125..127 "~{"
-        NameRefNode@127..132
+        NameRefExprNode@127..132
           Ident@127..132 "value"
         CloseBrace@132..133 "}"
       DoubleQuote@133..134 "\""
@@ -48,13 +48,13 @@ RootNode@0..235
       OpenHeredoc@183..186 "<<<"
       PlaceholderNode@186..194
         PlaceholderOpen@186..188 "~{"
-        NameRefNode@188..193
+        NameRefExprNode@188..193
           Ident@188..193 "value"
         CloseBrace@193..194 "}"
       LiteralStringText@194..195 " "
       PlaceholderNode@195..203
         PlaceholderOpen@195..197 "${"
-        NameRefNode@197..202
+        NameRefExprNode@197..202
           Ident@197..202 "value"
         CloseBrace@202..203 "}"
       CloseHeredoc@203..206 ">>>"

--- a/wdl-grammar/tests/parsing/struct-literal-with-string/source.tree
+++ b/wdl-grammar/tests/parsing/struct-literal-with-string/source.tree
@@ -81,7 +81,7 @@ RootNode@0..651
       IfKeyword@597..599 "if"
       Whitespace@599..600 " "
       OpenParen@600..601 "("
-      NameRefNode@601..604
+      NameRefExprNode@601..604
         Ident@601..604 "foo"
       CloseParen@604..605 ")"
       Whitespace@605..606 " "

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Updated to use new `wdl-ast` API ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * Relaxed `CommentWhitespace` rule so that it doesn't fire when a comment has extra spaces before it ([#314](https://github.com/stjude-rust-labs/wdl/pull/314)).
 * `fix` messages suggest the correct order of imports to the user in `ImportSort` rule ([#332](https://github.com/stjude-rust-labs/wdl/pull/332)).

--- a/wdl-lint/src/rules/blank_lines_between_elements.rs
+++ b/wdl-lint/src/rules/blank_lines_between_elements.rs
@@ -11,7 +11,6 @@ use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
 use wdl_ast::SyntaxNode;
 use wdl_ast::SyntaxToken;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1::BoundDecl;
@@ -152,10 +151,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_element(task.syntax());
-        let actual_start = skip_preceding_comments(task.syntax());
+        let first = is_first_element(task.inner());
+        let actual_start = skip_preceding_comments(task.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        check_last_token(task.syntax(), state, &self.exceptable_nodes());
+        check_last_token(task.inner(), state, &self.exceptable_nodes());
     }
 
     fn workflow_definition(
@@ -168,10 +167,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_element(workflow.syntax());
-        let actual_start = skip_preceding_comments(workflow.syntax());
+        let first = is_first_element(workflow.inner());
+        let actual_start = skip_preceding_comments(workflow.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        check_last_token(workflow.syntax(), state, &self.exceptable_nodes());
+        check_last_token(workflow.inner(), state, &self.exceptable_nodes());
     }
 
     fn metadata_section(
@@ -187,10 +186,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             self.state = State::MetaSection;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        flag_all_blank_lines_within(section.syntax(), state, &self.exceptable_nodes());
+        flag_all_blank_lines_within(section.inner(), state, &self.exceptable_nodes());
         // flag_all_blank_lines_within() covers check_last_token()
     }
 
@@ -207,10 +206,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             self.state = State::ParameterMetaSection;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        flag_all_blank_lines_within(section.syntax(), state, &self.exceptable_nodes());
+        flag_all_blank_lines_within(section.inner(), state, &self.exceptable_nodes());
         // flag_all_blank_lines_within() covers check_last_token()
     }
 
@@ -227,10 +226,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             self.state = State::InputSection;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        check_last_token(section.syntax(), state, &self.exceptable_nodes());
+        check_last_token(section.inner(), state, &self.exceptable_nodes());
     }
 
     fn command_section(
@@ -243,10 +242,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        check_last_token(section.syntax(), state, &self.exceptable_nodes());
+        check_last_token(section.inner(), state, &self.exceptable_nodes());
     }
 
     fn output_section(
@@ -261,10 +260,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
         } else {
             self.state = State::OutputSection;
         }
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        check_last_token(section.syntax(), state, &self.exceptable_nodes());
+        check_last_token(section.inner(), state, &self.exceptable_nodes());
     }
 
     fn runtime_section(
@@ -280,10 +279,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             self.state = State::RuntimeSection;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        flag_all_blank_lines_within(section.syntax(), state, &self.exceptable_nodes());
+        flag_all_blank_lines_within(section.inner(), state, &self.exceptable_nodes());
         // flag_all_blank_lines_within() covers check_last_token()
     }
 
@@ -300,14 +299,14 @@ impl Visitor for BlankLinesBetweenElementsRule {
 
         // We only care about spacing for calls if they're the "first" thing in a
         // workflow body.
-        let first = is_first_body(stmt.syntax());
+        let first = is_first_body(stmt.inner());
 
-        let prev = skip_preceding_comments(stmt.syntax());
+        let prev = skip_preceding_comments(stmt.inner());
 
         if first {
             check_prior_spacing(&prev, state, true, false, &self.exceptable_nodes());
         }
-        check_last_token(stmt.syntax(), state, &self.exceptable_nodes());
+        check_last_token(stmt.inner(), state, &self.exceptable_nodes());
     }
 
     fn scatter_statement(
@@ -320,14 +319,14 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_body(stmt.syntax());
+        let first = is_first_body(stmt.inner());
 
-        let prev = skip_preceding_comments(stmt.syntax());
+        let prev = skip_preceding_comments(stmt.inner());
 
         if first {
             check_prior_spacing(&prev, state, true, false, &self.exceptable_nodes());
         }
-        check_last_token(stmt.syntax(), state, &self.exceptable_nodes());
+        check_last_token(stmt.inner(), state, &self.exceptable_nodes());
     }
 
     fn struct_definition(
@@ -340,10 +339,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_element(def.syntax());
-        let actual_start = skip_preceding_comments(def.syntax());
+        let first = is_first_element(def.inner());
+        let actual_start = skip_preceding_comments(def.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        check_last_token(def.syntax(), state, &self.exceptable_nodes());
+        check_last_token(def.inner(), state, &self.exceptable_nodes());
     }
 
     fn requirements_section(
@@ -356,10 +355,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        flag_all_blank_lines_within(section.syntax(), state, &self.exceptable_nodes());
+        flag_all_blank_lines_within(section.inner(), state, &self.exceptable_nodes());
         // flag_all_blank_lines_within() covers check_last_token()
     }
 
@@ -373,10 +372,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        flag_all_blank_lines_within(section.syntax(), state, &self.exceptable_nodes());
+        flag_all_blank_lines_within(section.inner(), state, &self.exceptable_nodes());
         // flag_all_blank_lines_within() covers check_last_token()
     }
 
@@ -390,10 +389,10 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_element(section.syntax());
-        let actual_start = skip_preceding_comments(section.syntax());
+        let first = is_first_element(section.inner());
+        let actual_start = skip_preceding_comments(section.inner());
         check_prior_spacing(&actual_start, state, true, first, &self.exceptable_nodes());
-        flag_all_blank_lines_within(section.syntax(), state, &self.exceptable_nodes());
+        flag_all_blank_lines_within(section.inner(), state, &self.exceptable_nodes());
         // flag_all_blank_lines_within() covers check_last_token()
     }
 
@@ -403,7 +402,7 @@ impl Visitor for BlankLinesBetweenElementsRule {
         }
 
         let prior = decl
-            .syntax()
+            .inner()
             .prev_sibling_or_token()
             .and_then(SyntaxElement::into_token);
         if let Some(p) = prior {
@@ -414,15 +413,15 @@ impl Visitor for BlankLinesBetweenElementsRule {
                 if self.state == State::InputSection || self.state == State::OutputSection {
                     if count > 1 {
                         state.exceptable_add(
-                            excess_blank_line(p.text_range().to_span()),
-                            SyntaxElement::from(decl.syntax().clone()),
+                            excess_blank_line(p.text_range().into()),
+                            SyntaxElement::from(decl.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
                 } else {
-                    let first = is_first_body(decl.syntax());
+                    let first = is_first_body(decl.inner());
 
-                    let prev = skip_preceding_comments(decl.syntax());
+                    let prev = skip_preceding_comments(decl.inner());
 
                     if first {
                         check_prior_spacing(&prev, state, true, false, &self.exceptable_nodes());
@@ -437,7 +436,7 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let actual_start = skip_preceding_comments(decl.syntax());
+        let actual_start = skip_preceding_comments(decl.inner());
 
         let prior = actual_start
             .prev_sibling_or_token()
@@ -450,15 +449,15 @@ impl Visitor for BlankLinesBetweenElementsRule {
                 if self.state == State::InputSection || self.state == State::OutputSection {
                     if count > 1 {
                         state.exceptable_add(
-                            excess_blank_line(p.text_range().to_span()),
-                            SyntaxElement::from(decl.syntax().clone()),
+                            excess_blank_line(p.text_range().into()),
+                            SyntaxElement::from(decl.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
                 } else {
-                    let first = is_first_body(decl.syntax());
+                    let first = is_first_body(decl.inner());
 
-                    let prev = skip_preceding_comments(decl.syntax());
+                    let prev = skip_preceding_comments(decl.inner());
 
                     if first {
                         check_prior_spacing(&prev, state, true, false, &self.exceptable_nodes());
@@ -478,14 +477,14 @@ impl Visitor for BlankLinesBetweenElementsRule {
             return;
         }
 
-        let first = is_first_body(stmt.syntax());
+        let first = is_first_body(stmt.inner());
 
-        let prev = skip_preceding_comments(stmt.syntax());
+        let prev = skip_preceding_comments(stmt.inner());
 
         if first {
             check_prior_spacing(&prev, state, true, false, &self.exceptable_nodes());
         }
-        check_last_token(stmt.syntax(), state, &self.exceptable_nodes());
+        check_last_token(stmt.inner(), state, &self.exceptable_nodes());
     }
 }
 
@@ -532,7 +531,7 @@ fn flag_all_blank_lines_within(
                 .count();
             if count > 1 {
                 state.exceptable_add(
-                    excess_blank_line(c.text_range().to_span()),
+                    excess_blank_line(c.text_range().into()),
                     SyntaxElement::from(syntax.clone()),
                     exceptable_nodes,
                 );
@@ -591,7 +590,7 @@ fn check_prior_spacing(
                             .is_some_and(|p| p.kind() != SyntaxKind::VersionStatementNode)
                     {
                         state.exceptable_add(
-                            excess_blank_line(prior.text_range().to_span()),
+                            excess_blank_line(prior.text_range().into()),
                             SyntaxElement::from(syntax.clone()),
                             exceptable_nodes,
                         );
@@ -635,7 +634,7 @@ fn check_last_token(
             let count = prev.text().chars().filter(|c| *c == '\n').count();
             if count > 1 {
                 state.exceptable_add(
-                    excess_blank_line(prev.text_range().to_span()),
+                    excess_blank_line(prev.text_range().into()),
                     SyntaxElement::from(syntax.clone()),
                     exceptable_nodes,
                 );

--- a/wdl-lint/src/rules/call_input_spacing.rs
+++ b/wdl-lint/src/rules/call_input_spacing.rs
@@ -8,7 +8,6 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1::CallStatement;
@@ -124,7 +123,7 @@ impl Visitor for CallInputSpacingRule {
 
         // Check for "{ input:" spacing
         if let Some(input_keyword) = call
-            .syntax()
+            .inner()
             .children_with_tokens()
             .find(|c| c.kind() == SyntaxKind::InputKeyword)
         {
@@ -132,15 +131,15 @@ impl Visitor for CallInputSpacingRule {
                 if whitespace.kind() != SyntaxKind::Whitespace {
                     // If there is no whitespace before the input keyword
                     state.exceptable_add(
-                        call_input_keyword_spacing(input_keyword.text_range().to_span()),
-                        SyntaxElement::from(call.syntax().clone()),
+                        call_input_keyword_spacing(input_keyword.text_range().into()),
+                        SyntaxElement::from(call.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                 } else if !whitespace.as_token().unwrap().text().eq(" ") {
                     // If there is anything other than one space before the input keyword
                     state.exceptable_add(
-                        call_input_incorrect_spacing(whitespace.text_range().to_span()),
-                        SyntaxElement::from(call.syntax().clone()),
+                        call_input_incorrect_spacing(whitespace.text_range().into()),
+                        SyntaxElement::from(call.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                 }
@@ -150,7 +149,7 @@ impl Visitor for CallInputSpacingRule {
         call.inputs().for_each(|input| {
             // Check for assignment spacing
             if let Some(assign) = input
-                .syntax()
+                .inner()
                 .children_with_tokens()
                 .find(|c| c.kind() == SyntaxKind::Assignment)
             {
@@ -161,8 +160,8 @@ impl Visitor for CallInputSpacingRule {
                     (SyntaxKind::Whitespace, SyntaxKind::Whitespace) => {}
                     _ => {
                         state.exceptable_add(
-                            call_input_assignment(assign.text_range().to_span()),
-                            SyntaxElement::from(call.syntax().clone()),
+                            call_input_assignment(assign.text_range().into()),
+                            SyntaxElement::from(call.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
@@ -172,7 +171,7 @@ impl Visitor for CallInputSpacingRule {
 
         // Check for one input per line
         let mut newline_seen = 0;
-        call.syntax()
+        call.inner()
             .children_with_tokens()
             .for_each(|c| match c.kind() {
                 SyntaxKind::Whitespace => {
@@ -183,8 +182,8 @@ impl Visitor for CallInputSpacingRule {
                 SyntaxKind::CallInputItemNode => {
                     if newline_seen == 0 && inputs > 1 {
                         state.exceptable_add(
-                            call_input_missing_newline(c.text_range().to_span()),
-                            SyntaxElement::from(call.syntax().clone()),
+                            call_input_missing_newline(c.text_range().into()),
+                            SyntaxElement::from(call.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use rowan::ast::support;
 use wdl_ast::AstNode;
 use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
@@ -11,10 +12,8 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
-use wdl_ast::support;
 use wdl_ast::v1::CommandPart;
 use wdl_ast::v1::CommandSection;
 
@@ -141,7 +140,7 @@ impl Visitor for CommandSectionMixedIndentationRule {
         'outer: for part in section.parts() {
             match part {
                 CommandPart::Text(text) => {
-                    for (line, start, _) in lines_with_offset(text.as_str()) {
+                    for (line, start, _) in lines_with_offset(text.text()) {
                         // Check to see if we should skip the next line
                         // This happens after we encounter a placeholder
                         if skip_next_line {
@@ -177,16 +176,16 @@ impl Visitor for CommandSectionMixedIndentationRule {
         }
 
         if let Some(span) = mixed_span {
-            let command_keyword = support::token(section.syntax(), SyntaxKind::CommandKeyword)
+            let command_keyword = support::token(section.inner(), SyntaxKind::CommandKeyword)
                 .expect("should have a command keyword token");
 
             state.exceptable_add(
                 mixed_indentation(
-                    command_keyword.text_range().to_span(),
+                    command_keyword.text_range().into(),
                     span,
                     kind.expect("an indentation kind should be present"),
                 ),
-                SyntaxElement::from(section.syntax().clone()),
+                SyntaxElement::from(section.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -134,7 +134,7 @@ impl Visitor for CommentWhitespaceRule {
 
         if is_inline_comment(comment) {
             // check preceding whitespace for two spaces
-            if let Some(prior) = comment.syntax().prev_sibling_or_token() {
+            if let Some(prior) = comment.inner().prev_sibling_or_token() {
                 if prior.kind() != SyntaxKind::Whitespace
                     || prior.as_token().expect("should be a token").text() != "  "
                 {
@@ -142,7 +142,7 @@ impl Visitor for CommentWhitespaceRule {
                     let span = Span::new(comment.span().start(), 1);
                     state.exceptable_add(
                         inline_preceding_whitespace(span),
-                        SyntaxElement::from(comment.syntax().clone()),
+                        SyntaxElement::from(comment.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                 }
@@ -150,14 +150,14 @@ impl Visitor for CommentWhitespaceRule {
         } else {
             // Not an in-line comment, so check indentation level
             let ancestors = comment
-                .syntax()
+                .inner()
                 .parent_ancestors()
                 .filter(filter_parent_ancestors)
                 .count();
             let expected_indentation = INDENT.repeat(ancestors);
 
             match comment
-                .syntax()
+                .inner()
                 .prev_sibling_or_token()
                 .and_then(SyntaxElement::into_token)
             {
@@ -177,7 +177,7 @@ impl Visitor for CommentWhitespaceRule {
                                     expected_indentation.len() / INDENT.len(),
                                     this_indentation.len() / INDENT.len(),
                                 ),
-                                SyntaxElement::from(comment.syntax().clone()),
+                                SyntaxElement::from(comment.inner().clone()),
                                 &self.exceptable_nodes(),
                             ),
                             Ordering::Less => state.exceptable_add(
@@ -186,7 +186,7 @@ impl Visitor for CommentWhitespaceRule {
                                     expected_indentation.len() / INDENT.len(),
                                     this_indentation.len() / INDENT.len(),
                                 ),
-                                SyntaxElement::from(comment.syntax().clone()),
+                                SyntaxElement::from(comment.inner().clone()),
                                 &self.exceptable_nodes(),
                             ),
                             Ordering::Equal => {}
@@ -201,7 +201,7 @@ impl Visitor for CommentWhitespaceRule {
         }
 
         // check the comment for one space following the comment delimiter
-        let mut comment_chars = comment.as_str().chars().peekable();
+        let mut comment_chars = comment.text().chars().peekable();
 
         let mut n_delimiter = 0;
         while let Some('#') = comment_chars.peek() {
@@ -219,7 +219,7 @@ impl Visitor for CommentWhitespaceRule {
         if comment_chars.skip(n_whitespace).count() > 0 && n_whitespace == 0 {
             state.exceptable_add(
                 following_whitespace(Span::new(comment.span().start(), n_delimiter)),
-                SyntaxElement::from(comment.syntax().clone()),
+                SyntaxElement::from(comment.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }
@@ -315,7 +315,7 @@ task foo {
         let comment = Comment::cast(comment.as_token().unwrap().clone()).unwrap();
 
         let ancestors = comment
-            .syntax()
+            .inner()
             .parent_ancestors()
             .filter(super::filter_parent_ancestors)
             .count();
@@ -326,7 +326,7 @@ task foo {
         let comment = Comment::cast(comment.as_token().unwrap().clone()).unwrap();
 
         let ancestors = comment
-            .syntax()
+            .inner()
             .parent_ancestors()
             .filter(super::filter_parent_ancestors)
             .count();
@@ -337,7 +337,7 @@ task foo {
         let comment = Comment::cast(comment.as_token().unwrap().clone()).unwrap();
 
         let ancestors = comment
-            .syntax()
+            .inner()
             .parent_ancestors()
             .filter(super::filter_parent_ancestors)
             .count();
@@ -348,7 +348,7 @@ task foo {
         let comment = Comment::cast(comment.as_token().unwrap().clone()).unwrap();
 
         let ancestors = comment
-            .syntax()
+            .inner()
             .parent_ancestors()
             .filter(super::filter_parent_ancestors)
             .count();
@@ -359,7 +359,7 @@ task foo {
         let comment = Comment::cast(comment.as_token().unwrap().clone()).unwrap();
 
         let ancestors = comment
-            .syntax()
+            .inner()
             .parent_ancestors()
             .filter(super::filter_parent_ancestors)
             .count();

--- a/wdl-lint/src/rules/container_value.rs
+++ b/wdl-lint/src/rules/container_value.rs
@@ -5,7 +5,6 @@
 //! `runtime`/`requirements` sections.
 
 use wdl_ast::AstNode;
-use wdl_ast::AstNodeExt;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
@@ -164,7 +163,7 @@ impl Visitor for ContainerValue {
                 check_container_value(
                     state,
                     value,
-                    SyntaxElement::from(section.syntax().clone()),
+                    SyntaxElement::from(section.inner().clone()),
                     &self.exceptable_nodes(),
                 );
             }
@@ -186,7 +185,7 @@ impl Visitor for ContainerValue {
                 check_container_value(
                     state,
                     value,
-                    SyntaxElement::from(section.syntax().clone()),
+                    SyntaxElement::from(section.inner().clone()),
                     &self.exceptable_nodes(),
                 );
             }

--- a/wdl-lint/src/rules/deprecated_object.rs
+++ b/wdl-lint/src/rules/deprecated_object.rs
@@ -1,7 +1,6 @@
 //! A lint rule for flagging `Object`s as deprecated.
 
 use wdl_ast::AstNode;
-use wdl_ast::AstNodeExt;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
@@ -98,7 +97,7 @@ impl Visitor for DeprecatedObjectRule {
         if let Type::Object(ty) = decl.ty() {
             state.exceptable_add(
                 deprecated_object_use(ty.span()),
-                SyntaxElement::from(decl.syntax().clone()),
+                SyntaxElement::from(decl.inner().clone()),
                 &self.exceptable_nodes(),
             )
         }
@@ -117,7 +116,7 @@ impl Visitor for DeprecatedObjectRule {
         if let Type::Object(ty) = decl.ty() {
             state.exceptable_add(
                 deprecated_object_use(ty.span()),
-                SyntaxElement::from(decl.syntax().clone()),
+                SyntaxElement::from(decl.inner().clone()),
                 &self.exceptable_nodes(),
             )
         }

--- a/wdl-lint/src/rules/deprecated_placeholder_option.rs
+++ b/wdl-lint/src/rules/deprecated_placeholder_option.rs
@@ -1,7 +1,6 @@
 //! A lint rule for flagging placeholder options as deprecated.
 
 use wdl_ast::AstNode;
-use wdl_ast::AstNodeExt;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
@@ -154,7 +153,7 @@ impl Visitor for DeprecatedPlaceholderOptionRule {
             };
             state.exceptable_add(
                 diagnostic,
-                SyntaxElement::from(placeholder.syntax().clone()),
+                SyntaxElement::from(placeholder.inner().clone()),
                 &self.exceptable_nodes(),
             )
         }

--- a/wdl-lint/src/rules/description_missing.rs
+++ b/wdl-lint/src/rules/description_missing.rs
@@ -9,7 +9,6 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1::MetadataSection;
@@ -33,7 +32,7 @@ fn description_missing(span: Span, parent: SectionParent) -> Diagnostic {
 
     Diagnostic::note(format!(
         "{ty} `{name}` is missing a description key",
-        name = name.as_str()
+        name = name.text()
     ))
     .with_rule(ID)
     .with_highlight(span)
@@ -124,20 +123,20 @@ impl Visitor for DescriptionMissingRule {
 
         let description = section
             .items()
-            .find(|entry| entry.name().syntax().to_string() == "description");
+            .find(|entry| entry.name().inner().to_string() == "description");
 
         if description.is_none() {
             state.exceptable_add(
                 description_missing(
                     section
-                        .syntax()
+                        .inner()
                         .first_token()
                         .expect("metadata section should have tokens")
                         .text_range()
-                        .to_span(),
+                        .into(),
                     section.parent(),
                 ),
-                SyntaxElement::from(section.syntax().clone()),
+                SyntaxElement::from(section.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/disallowed_input_name.rs
+++ b/wdl-lint/src/rules/disallowed_input_name.rs
@@ -131,14 +131,14 @@ fn check_decl_name(
     exceptable_nodes: &Option<&'static [SyntaxKind]>,
 ) {
     let name = decl.name();
-    let name = name.as_str();
+    let name = name.text();
 
     let length = name.len();
     if length < 3 {
         // name is too short
         state.exceptable_add(
             decl_identifier_too_short(decl.name().span()),
-            SyntaxElement::from(decl.syntax().clone()),
+            SyntaxElement::from(decl.inner().clone()),
             exceptable_nodes,
         );
     }
@@ -153,7 +153,7 @@ fn check_decl_name(
                         // name starts with "in"
                         state.exceptable_add(
                             decl_identifier_starts_with_in(decl.name().span()),
-                            SyntaxElement::from(decl.syntax().clone()),
+                            SyntaxElement::from(decl.inner().clone()),
                             exceptable_nodes,
                         );
                     } else {
@@ -162,7 +162,7 @@ fn check_decl_name(
                             // name starts with "input"
                             state.exceptable_add(
                                 decl_identifier_starts_with_input(decl.name().span()),
-                                SyntaxElement::from(decl.syntax().clone()),
+                                SyntaxElement::from(decl.inner().clone()),
                                 exceptable_nodes,
                             );
                         }

--- a/wdl-lint/src/rules/disallowed_output_name.rs
+++ b/wdl-lint/src/rules/disallowed_output_name.rs
@@ -130,14 +130,14 @@ fn check_decl_name(
     exceptable_nodes: &Option<&'static [SyntaxKind]>,
 ) {
     let name = decl.name();
-    let name = name.as_str();
+    let name = name.text();
 
     let length = name.len();
     if length < 3 {
         // name is too short
         state.exceptable_add(
             decl_identifier_too_short(decl.name().span()),
-            SyntaxElement::from(decl.syntax().clone()),
+            SyntaxElement::from(decl.inner().clone()),
             exceptable_nodes,
         );
     }
@@ -154,7 +154,7 @@ fn check_decl_name(
                             // name starts with "out"
                             state.exceptable_add(
                                 decl_identifier_starts_with_out(decl.name().span()),
-                                SyntaxElement::from(decl.syntax().clone()),
+                                SyntaxElement::from(decl.inner().clone()),
                                 exceptable_nodes,
                             );
                         } else {
@@ -163,7 +163,7 @@ fn check_decl_name(
                                 // name starts with "output"
                                 state.exceptable_add(
                                     decl_identifier_starts_with_output(decl.name().span()),
-                                    SyntaxElement::from(decl.syntax().clone()),
+                                    SyntaxElement::from(decl.inner().clone()),
                                     exceptable_nodes,
                                 );
                             }

--- a/wdl-lint/src/rules/double_quotes.rs
+++ b/wdl-lint/src/rules/double_quotes.rs
@@ -1,6 +1,6 @@
 //! A lint rule for using double quoted strings.
 
-use wdl_ast::AstNodeExt;
+use wdl_ast::AstNode;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
@@ -93,7 +93,7 @@ impl Visitor for DoubleQuotesRule {
             if s.kind() == LiteralStringKind::SingleQuoted {
                 state.exceptable_add(
                     use_double_quotes(s.span()),
-                    SyntaxElement::from(expr.syntax().clone()),
+                    SyntaxElement::from(expr.inner().clone()),
                     &self.exceptable_nodes(),
                 );
             }

--- a/wdl-lint/src/rules/ending_newline.rs
+++ b/wdl-lint/src/rules/ending_newline.rs
@@ -1,6 +1,7 @@
 //! A lint rule for newlines at the end of the document.
 
 use wdl_ast::Ast;
+use wdl_ast::AstNode;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
@@ -90,7 +91,7 @@ impl Visitor for EndingNewlineRule {
         }
 
         // Get the last token in the document and see if it's whitespace
-        match doc.syntax().last_child_or_token() {
+        match doc.inner().last_child_or_token() {
             Some(last) if last.kind() == SyntaxKind::Whitespace => {
                 // It's whitespace, check if it ends with a newline
                 let last = last.into_token().expect("whitespace should be a token");

--- a/wdl-lint/src/rules/import_placement.rs
+++ b/wdl-lint/src/rules/import_placement.rs
@@ -1,7 +1,6 @@
 //! A lint rule for import placements.
 
 use wdl_ast::AstNode;
-use wdl_ast::AstNodeExt;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
 use wdl_ast::Document;
@@ -98,7 +97,7 @@ impl Visitor for ImportPlacementRule {
         if self.invalid {
             state.exceptable_add(
                 misplaced_import(stmt.span()),
-                SyntaxElement::from(stmt.syntax().clone()),
+                SyntaxElement::from(stmt.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/import_sort.rs
+++ b/wdl-lint/src/rules/import_sort.rs
@@ -8,7 +8,6 @@ use wdl_ast::Document;
 use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1::ImportStatement;
@@ -85,7 +84,7 @@ impl Visitor for ImportSortRule {
 
         // Collect all import statements
         let imports: Vec<_> = doc
-            .syntax()
+            .inner()
             .children_with_tokens()
             .filter(|n| n.kind() == SyntaxKind::ImportStatementNode)
             .filter_map(|c| c.into_node())
@@ -108,7 +107,7 @@ impl Visitor for ImportSortRule {
                 .uri()
                 .text()
                 .expect("import uri");
-            a_uri.as_str().cmp(b_uri.as_str())
+            a_uri.text().cmp(b_uri.text())
         });
 
         if imports != sorted_imports {
@@ -118,7 +117,7 @@ impl Visitor for ImportSortRule {
                 .first_token()
                 .expect("node should have a first token")
                 .text_range()
-                .to_span();
+                .into();
             state.add(import_not_sorted(
                 span,
                 sorted_imports
@@ -142,7 +141,7 @@ impl Visitor for ImportSortRule {
 
         // Check for comments inside this import statement.
         let internal_comments = stmt
-            .syntax()
+            .inner()
             .children_with_tokens()
             .filter(|c| c.kind() == SyntaxKind::Comment)
             .map(|c| c.into_token().unwrap());
@@ -151,7 +150,7 @@ impl Visitor for ImportSortRule {
             // Since this rule can only be excepted in a document-wide fashion,
             // if the rule is running we can directly add the diagnostic
             // without checking for the exceptable nodes
-            state.add(improper_comment(comment.text_range().to_span()));
+            state.add(improper_comment(comment.text_range().into()));
         }
     }
 }

--- a/wdl-lint/src/rules/inconsistent_newlines.rs
+++ b/wdl-lint/src/rules/inconsistent_newlines.rs
@@ -91,12 +91,12 @@ impl Visitor for InconsistentNewlinesRule {
     }
 
     fn whitespace(&mut self, _state: &mut Self::State, whitespace: &Whitespace) {
-        if let Some(pos) = whitespace.as_str().find("\r\n") {
+        if let Some(pos) = whitespace.text().find("\r\n") {
             self.carriage_return += 1;
             if self.newline > 0 && self.first_inconsistent.is_none() {
                 self.first_inconsistent = Some(Span::new(whitespace.span().start() + pos, 2));
             }
-        } else if let Some(pos) = whitespace.as_str().find('\n') {
+        } else if let Some(pos) = whitespace.text().find('\n') {
             self.newline += 1;
             if self.carriage_return > 0 && self.first_inconsistent.is_none() {
                 self.first_inconsistent = Some(Span::new(whitespace.span().start() + pos, 1));

--- a/wdl-lint/src/rules/input_not_sorted.rs
+++ b/wdl-lint/src/rules/input_not_sorted.rs
@@ -11,7 +11,6 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1;
@@ -146,7 +145,7 @@ fn compare_pair_types(a: &v1::PairType, b: &v1::PairType) -> Ordering {
 
 /// Compares the ordering of two type references.
 fn compare_type_refs(a: &v1::TypeRef, b: &v1::TypeRef) -> Ordering {
-    let cmp = a.name().as_str().cmp(b.name().as_str());
+    let cmp = a.name().text().cmp(b.name().text());
     if cmp != Ordering::Equal {
         return cmp;
     }
@@ -259,7 +258,7 @@ impl Visitor for InputNotSortedRule {
         let input_string: String = sorted_decls
             .clone()
             .into_iter()
-            .map(|decl| decl.syntax().text().to_string() + "\n")
+            .map(|decl| decl.inner().text().to_string() + "\n")
             .collect::<String>();
         let mut errors = 0;
 
@@ -273,14 +272,14 @@ impl Visitor for InputNotSortedRule {
             });
         if errors > 0 {
             let span = input
-                .syntax()
+                .inner()
                 .first_token()
                 .expect("input section should have tokens")
                 .text_range()
-                .to_span();
+                .into();
             state.exceptable_add(
                 input_not_sorted(span, input_string),
-                SyntaxElement::from(input.syntax().clone()),
+                SyntaxElement::from(input.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -139,12 +139,12 @@ impl Visitor for LineWidthRule {
     fn whitespace(&mut self, state: &mut Self::State, whitespace: &Whitespace) {
         self.detect_line_too_long(
             state,
-            whitespace.as_str(),
+            whitespace.text(),
             whitespace.span().start(),
             whitespace
-                .syntax()
+                .inner()
                 .prev_sibling_or_token()
-                .unwrap_or(SyntaxElement::from(whitespace.syntax().clone())),
+                .unwrap_or(SyntaxElement::from(whitespace.inner().clone())),
             &self.exceptable_nodes(),
         );
     }
@@ -152,9 +152,9 @@ impl Visitor for LineWidthRule {
     fn command_text(&mut self, state: &mut Self::State, text: &v1::CommandText) {
         self.detect_line_too_long(
             state,
-            text.as_str(),
+            text.text(),
             text.span().start(),
-            SyntaxElement::from(text.syntax().clone()),
+            SyntaxElement::from(text.inner().clone()),
             &self.exceptable_nodes(),
         );
     }

--- a/wdl-lint/src/rules/malformed_lint_directive.rs
+++ b/wdl-lint/src/rules/malformed_lint_directive.rs
@@ -108,7 +108,7 @@ impl Visitor for MalformedLintDirectiveRule {
     }
 
     fn comment(&mut self, state: &mut Self::State, comment: &Comment) {
-        if let Some(lint_directive) = comment.as_str().strip_prefix("#@") {
+        if let Some(lint_directive) = comment.text().strip_prefix("#@") {
             let base_offset = comment.span().start();
 
             if is_inline_comment(comment) {

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -37,7 +37,7 @@ fn missing_param_meta(parent: &SectionParent, missing: &str, span: Span) -> Diag
 
     Diagnostic::warning(format!(
         "{context} `{parent}` is missing a parameter metadata key for input `{missing}`",
-        parent = parent.as_str(),
+        parent = parent.text(),
     ))
     .with_rule(ID)
     .with_label(
@@ -60,7 +60,7 @@ fn extra_param_meta(parent: &SectionParent, extra: &str, span: Span) -> Diagnost
 
     Diagnostic::note(format!(
         "{context} `{parent}` has an extraneous parameter metadata key named `{extra}`",
-        parent = parent.as_str(),
+        parent = parent.text(),
     ))
     .with_rule(ID)
     .with_label(
@@ -112,13 +112,13 @@ fn check_parameter_meta(
     diagnostics: &mut Diagnostics,
     exceptable_nodes: &Option<&'static [SyntaxKind]>,
 ) {
-    let expected: HashMap<_, _> = expected.map(|(i, s)| (i.as_str().to_string(), s)).collect();
+    let expected: HashMap<_, _> = expected.map(|(i, s)| (i.text().to_string(), s)).collect();
 
     let actual: HashMap<_, _> = param_meta
         .items()
         .map(|m| {
             let name = m.name();
-            (name.as_str().to_string(), name.span())
+            (name.text().to_string(), name.span())
         })
         .collect();
 
@@ -126,7 +126,7 @@ fn check_parameter_meta(
         if !actual.contains_key(name) {
             diagnostics.exceptable_add(
                 missing_param_meta(parent, name, *span),
-                SyntaxElement::from(param_meta.syntax().clone()),
+                SyntaxElement::from(param_meta.inner().clone()),
                 exceptable_nodes,
             );
         }
@@ -136,7 +136,7 @@ fn check_parameter_meta(
         if !expected.contains_key(name) {
             diagnostics.exceptable_add(
                 extra_param_meta(parent, name, *span),
-                SyntaxElement::from(param_meta.syntax().clone()),
+                SyntaxElement::from(param_meta.inner().clone()),
                 exceptable_nodes,
             );
         }

--- a/wdl-lint/src/rules/misplaced_lint_directive.rs
+++ b/wdl-lint/src/rules/misplaced_lint_directive.rs
@@ -13,7 +13,6 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 
@@ -47,7 +46,7 @@ fn misplaced_lint_directive(
     .with_label("cannot make an exception for this rule", span)
     .with_label(
         "invalid element for this lint directive",
-        wrong_element.text_range().to_span(),
+        wrong_element.text_range(),
     )
     .with_fix(format!(
         "valid locations for this directive are above: {locations}"
@@ -104,12 +103,12 @@ impl Visitor for MisplacedLintDirectiveRule {
     }
 
     fn comment(&mut self, state: &mut Self::State, comment: &Comment) {
-        if let Some(ids) = comment.as_str().strip_prefix(EXCEPT_COMMENT_PREFIX) {
+        if let Some(ids) = comment.text().strip_prefix(EXCEPT_COMMENT_PREFIX) {
             let start: usize = comment.span().start();
             let mut offset = EXCEPT_COMMENT_PREFIX.len();
 
             let excepted_element = comment
-                .syntax()
+                .inner()
                 .siblings_with_tokens(rowan::Direction::Next)
                 .find_map(|s| {
                     if s.kind() == SyntaxKind::Whitespace || s.kind() == SyntaxKind::Comment {

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -65,7 +65,7 @@ const ID: &str = "MissingMetas";
 fn missing_section(name: Ident, section: Section, context: Context) -> Diagnostic {
     Diagnostic::note(format!(
         "{context} `{name}` is missing a `{section}` section",
-        name = name.as_str(),
+        name = name.text(),
     ))
     .with_rule(ID)
     .with_label(
@@ -79,7 +79,7 @@ fn missing_section(name: Ident, section: Section, context: Context) -> Diagnosti
 fn missing_sections(name: Ident, context: Context) -> Diagnostic {
     Diagnostic::note(format!(
         "{context} `{name}` is missing both `meta` and `parameter_meta` sections",
-        name = name.as_str(),
+        name = name.text(),
     ))
     .with_rule(ID)
     .with_label(
@@ -159,19 +159,19 @@ impl Visitor for MissingMetasRule {
         if inputs_present && task.metadata().is_none() && task.parameter_metadata().is_none() {
             state.exceptable_add(
                 missing_sections(task.name(), Context::Task),
-                SyntaxElement::from(task.syntax().clone()),
+                SyntaxElement::from(task.inner().clone()),
                 &self.exceptable_nodes(),
             );
         } else if task.metadata().is_none() {
             state.exceptable_add(
                 missing_section(task.name(), Section::Meta, Context::Task),
-                SyntaxElement::from(task.syntax().clone()),
+                SyntaxElement::from(task.inner().clone()),
                 &self.exceptable_nodes(),
             );
         } else if inputs_present && task.parameter_metadata().is_none() {
             state.exceptable_add(
                 missing_section(task.name(), Section::ParameterMeta, Context::Task),
-                SyntaxElement::from(task.syntax().clone()),
+                SyntaxElement::from(task.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }
@@ -195,19 +195,19 @@ impl Visitor for MissingMetasRule {
         {
             state.exceptable_add(
                 missing_sections(workflow.name(), Context::Workflow),
-                SyntaxElement::from(workflow.syntax().clone()),
+                SyntaxElement::from(workflow.inner().clone()),
                 &self.exceptable_nodes(),
             );
         } else if workflow.metadata().is_none() {
             state.exceptable_add(
                 missing_section(workflow.name(), Section::Meta, Context::Workflow),
-                SyntaxElement::from(workflow.syntax().clone()),
+                SyntaxElement::from(workflow.inner().clone()),
                 &self.exceptable_nodes(),
             );
         } else if inputs_present && workflow.parameter_metadata().is_none() {
             state.exceptable_add(
                 missing_section(workflow.name(), Section::ParameterMeta, Context::Workflow),
-                SyntaxElement::from(workflow.syntax().clone()),
+                SyntaxElement::from(workflow.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }
@@ -231,19 +231,19 @@ impl Visitor for MissingMetasRule {
         if def.metadata().next().is_none() && def.parameter_metadata().next().is_none() {
             state.exceptable_add(
                 missing_sections(def.name(), Context::Struct),
-                SyntaxElement::from(def.syntax().clone()),
+                SyntaxElement::from(def.inner().clone()),
                 &self.exceptable_nodes(),
             );
         } else if def.metadata().next().is_none() {
             state.exceptable_add(
                 missing_section(def.name(), Section::Meta, Context::Struct),
-                SyntaxElement::from(def.syntax().clone()),
+                SyntaxElement::from(def.inner().clone()),
                 &self.exceptable_nodes(),
             );
         } else if def.parameter_metadata().next().is_none() {
             state.exceptable_add(
                 missing_section(def.name(), Section::ParameterMeta, Context::Struct),
-                SyntaxElement::from(def.syntax().clone()),
+                SyntaxElement::from(def.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -114,8 +114,8 @@ impl Visitor for MissingOutputRule {
         if task.output().is_none() {
             let name = task.name();
             state.exceptable_add(
-                missing_output_section(name.as_str(), Context::Task, name.span()),
-                SyntaxElement::from(task.syntax().clone()),
+                missing_output_section(name.text(), Context::Task, name.span()),
+                SyntaxElement::from(task.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }
@@ -134,8 +134,8 @@ impl Visitor for MissingOutputRule {
         if workflow.output().is_none() {
             let name = workflow.name();
             state.exceptable_add(
-                missing_output_section(name.as_str(), Context::Workflow, name.span()),
-                SyntaxElement::from(workflow.syntax().clone()),
+                missing_output_section(name.text(), Context::Workflow, name.span()),
+                SyntaxElement::from(workflow.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -9,7 +9,6 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1::TaskDefinition;
@@ -109,15 +108,15 @@ impl Visitor for MissingRequirementsRule {
                         let name = task.name();
                         state.exceptable_add(
                             deprecated_runtime_section(
-                                name.as_str(),
+                                name.text(),
                                 runtime
-                                    .syntax()
+                                    .inner()
                                     .first_token()
                                     .expect("runtime section should have tokens")
                                     .text_range()
-                                    .to_span(),
+                                    .into(),
                             ),
-                            SyntaxElement::from(runtime.syntax().clone()),
+                            SyntaxElement::from(runtime.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
@@ -125,8 +124,8 @@ impl Visitor for MissingRequirementsRule {
                         if task.requirements().is_none() {
                             let name = task.name();
                             state.exceptable_add(
-                                missing_requirements_section(name.as_str(), name.span()),
-                                SyntaxElement::from(task.syntax().clone()),
+                                missing_requirements_section(name.text(), name.span()),
+                                SyntaxElement::from(task.inner().clone()),
                                 &self.exceptable_nodes(),
                             );
                         }

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -92,8 +92,8 @@ impl Visitor for MissingRuntimeRule {
             if minor_version <= V1::One && task.runtime().is_none() {
                 let name = task.name();
                 state.exceptable_add(
-                    missing_runtime_section(name.as_str(), name.span()),
-                    SyntaxElement::from(task.syntax().clone()),
+                    missing_runtime_section(name.text(), name.span()),
+                    SyntaxElement::from(task.inner().clone()),
                     &self.exceptable_nodes(),
                 );
             }

--- a/wdl-lint/src/rules/no_curly_commands.rs
+++ b/wdl-lint/src/rules/no_curly_commands.rs
@@ -1,5 +1,6 @@
 //! A lint rule for ensuring no curly commands are used.
 
+use rowan::ast::support;
 use wdl_ast::AstNode;
 use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
@@ -9,10 +10,8 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
-use wdl_ast::support;
 use wdl_ast::v1::CommandSection;
 
 use crate::Rule;
@@ -93,12 +92,12 @@ impl Visitor for NoCurlyCommandsRule {
 
         if !section.is_heredoc() {
             let name = section.parent().name();
-            let command_keyword = support::token(section.syntax(), SyntaxKind::CommandKeyword)
+            let command_keyword = support::token(section.inner(), SyntaxKind::CommandKeyword)
                 .expect("should have a command keyword token");
 
             state.exceptable_add(
-                curly_commands(name.as_str(), command_keyword.text_range().to_span()),
-                SyntaxElement::from(section.syntax().clone()),
+                curly_commands(name.text(), command_keyword.text_range().into()),
+                SyntaxElement::from(section.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/pascal_case.rs
+++ b/wdl-lint/src/rules/pascal_case.rs
@@ -113,10 +113,10 @@ impl Visitor for PascalCaseRule {
 
         let name = def.name();
         check_name(
-            name.as_str(),
+            name.text(),
             name.span(),
             state,
-            SyntaxElement::from(def.syntax().clone()),
+            SyntaxElement::from(def.inner().clone()),
             &self.exceptable_nodes(),
         );
     }

--- a/wdl-lint/src/rules/preamble_comment_after_version.rs
+++ b/wdl-lint/src/rules/preamble_comment_after_version.rs
@@ -99,12 +99,12 @@ impl Visitor for PreambleCommentAfterVersionRule {
             return;
         }
 
-        if !comment.as_str().starts_with("## ") {
+        if !comment.text().starts_with("## ") {
             return;
         }
 
         let mut span = comment.span();
-        let mut current = comment.syntax().next_sibling_or_token();
+        let mut current = comment.inner().next_sibling_or_token();
         while let Some(sibling) = current {
             match sibling.kind() {
                 SyntaxKind::Comment => {
@@ -137,7 +137,7 @@ impl Visitor for PreambleCommentAfterVersionRule {
 
         state.exceptable_add(
             preamble_comment_outside_preamble(span),
-            SyntaxElement::from(comment.syntax().clone()),
+            SyntaxElement::from(comment.inner().clone()),
             &self.exceptable_nodes(),
         );
     }

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -188,7 +188,7 @@ impl Visitor for PreambleFormattingRule {
         // If the next sibling is the version statement, let the VersionFormatting rule
         // handle this particular whitespace
         if whitespace
-            .syntax()
+            .inner()
             .next_sibling_or_token()
             .map(|s| s.kind() == SyntaxKind::VersionStatementNode)
             .unwrap_or(false)
@@ -196,16 +196,16 @@ impl Visitor for PreambleFormattingRule {
             return;
         }
 
-        let s = whitespace.as_str();
+        let s = whitespace.text();
         // If there is a previous token, it must be a comment
-        match whitespace.syntax().prev_token() {
+        match whitespace.inner().prev_token() {
             Some(prev_comment) => {
                 let prev_text = prev_comment.text();
                 let prev_is_lint_directive = is_lint_directive(prev_text);
                 let prev_is_preamble_comment = is_preamble_comment(prev_text);
 
                 let next_token = whitespace
-                    .syntax()
+                    .inner()
                     .next_token()
                     .expect("should have a next token");
                 assert!(
@@ -320,7 +320,7 @@ impl Visitor for PreambleFormattingRule {
             return;
         }
 
-        let text = comment.as_str();
+        let text = comment.text();
         let lint_directive = is_lint_directive(text);
         let preamble_comment = is_preamble_comment(text);
 
@@ -356,7 +356,7 @@ impl Visitor for PreambleFormattingRule {
         // Otherwise, look for the next siblings that might also be problematic;
         // if so, consolidate them into a single diagnostic
         let mut span = comment.span();
-        let mut current = comment.syntax().next_sibling_or_token();
+        let mut current = comment.inner().next_sibling_or_token();
         while let Some(sibling) = current {
             match sibling.kind() {
                 SyntaxKind::Comment => {

--- a/wdl-lint/src/rules/redundant_input_assignment.rs
+++ b/wdl-lint/src/rules/redundant_input_assignment.rs
@@ -2,8 +2,7 @@
 
 use std::fmt::Debug;
 
-use rowan::ast::AstNode;
-use wdl_ast::AstNodeExt;
+use wdl_ast::AstNode;
 use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
 use wdl_ast::Diagnostics;
@@ -97,10 +96,10 @@ impl Visitor for RedundantInputAssignment {
             stmt.inputs().for_each(|input| {
                 if let Some(expr) = input.expr() {
                     if let Some(expr_name) = expr.as_name_ref() {
-                        if expr_name.name().as_str() == input.name().as_str() {
+                        if expr_name.name().text() == input.name().text() {
                             state.exceptable_add(
-                                redundant_input_assignment(input.span(), input.name().as_str()),
-                                SyntaxElement::from(input.syntax().clone()),
+                                redundant_input_assignment(input.span(), input.name().text()),
+                                SyntaxElement::from(input.inner().clone()),
                                 &self.exceptable_nodes(),
                             );
                         }

--- a/wdl-lint/src/rules/section_order.rs
+++ b/wdl-lint/src/rules/section_order.rs
@@ -9,7 +9,6 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1::TaskDefinition;
@@ -173,14 +172,14 @@ impl Visitor for SectionOrderingRule {
                     state.exceptable_add(
                         task_section_order(
                             task.name().span(),
-                            task.name().as_str(),
-                            item.syntax()
+                            task.name().text(),
+                            item.inner()
                                 .first_token()
                                 .expect("task item should have tokens")
                                 .text_range()
-                                .to_span(),
+                                .into(),
                         ),
-                        SyntaxElement::from(task.syntax().clone()),
+                        SyntaxElement::from(task.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                     break;
@@ -229,14 +228,14 @@ impl Visitor for SectionOrderingRule {
                     state.exceptable_add(
                         workflow_section_order(
                             workflow.name().span(),
-                            workflow.name().as_str(),
-                            item.syntax()
+                            workflow.name().text(),
+                            item.inner()
                                 .first_token()
                                 .expect("workflow item should have tokens")
                                 .text_range()
-                                .to_span(),
+                                .into(),
                         ),
-                        SyntaxElement::from(workflow.syntax().clone()),
+                        SyntaxElement::from(workflow.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                     break;

--- a/wdl-lint/src/rules/snake_case.rs
+++ b/wdl-lint/src/rules/snake_case.rs
@@ -225,10 +225,10 @@ impl Visitor for SnakeCaseRule {
         let name = task.name();
         check_name(
             Context::Task,
-            name.as_str(),
+            name.text(),
             name.span(),
             state,
-            SyntaxElement::from(task.syntax().clone()),
+            SyntaxElement::from(task.inner().clone()),
             &self.exceptable_nodes(),
         );
     }
@@ -246,10 +246,10 @@ impl Visitor for SnakeCaseRule {
         let name = workflow.name();
         check_name(
             Context::Workflow,
-            name.as_str(),
+            name.text(),
             name.span(),
             state,
-            SyntaxElement::from(workflow.syntax().clone()),
+            SyntaxElement::from(workflow.inner().clone()),
             &self.exceptable_nodes(),
         );
     }
@@ -263,10 +263,10 @@ impl Visitor for SnakeCaseRule {
         let context = self.determine_decl_context();
         check_name(
             context,
-            name.as_str(),
+            name.text(),
             name.span(),
             state,
-            SyntaxElement::from(decl.syntax().clone()),
+            SyntaxElement::from(decl.inner().clone()),
             &self.exceptable_nodes(),
         );
     }
@@ -280,10 +280,10 @@ impl Visitor for SnakeCaseRule {
         let context = self.determine_decl_context();
         check_name(
             context,
-            name.as_str(),
+            name.text(),
             name.span(),
             state,
-            SyntaxElement::from(decl.syntax().clone()),
+            SyntaxElement::from(decl.inner().clone()),
             &self.exceptable_nodes(),
         );
     }

--- a/wdl-lint/src/rules/todo.rs
+++ b/wdl-lint/src/rules/todo.rs
@@ -68,10 +68,10 @@ impl Visitor for TodoRule {
     }
 
     fn comment(&mut self, state: &mut Self::State, comment: &Comment) {
-        for (offset, pattern) in comment.as_str().match_indices(TODO) {
+        for (offset, pattern) in comment.text().match_indices(TODO) {
             state.exceptable_add(
                 todo_comment(pattern, comment.span(), offset),
-                SyntaxElement::from(comment.syntax().clone()),
+                SyntaxElement::from(comment.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/rules/trailing_comma.rs
+++ b/wdl-lint/src/rules/trailing_comma.rs
@@ -8,7 +8,6 @@ use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
 use wdl_ast::v1::CallStatement;
@@ -111,22 +110,22 @@ impl Visitor for TrailingCommaRule {
         }
 
         // Check if object is multi-line
-        if item.syntax().to_string().contains('\n') && item.items().count() > 1 {
+        if item.inner().to_string().contains('\n') && item.items().count() > 1 {
             let last_child = item.items().last();
             if let Some(last_child) = last_child {
-                let (next_comma, comma_is_next) = find_next_comma(last_child.syntax());
+                let (next_comma, comma_is_next) = find_next_comma(last_child.inner());
                 match next_comma {
                     Some(comma) => {
                         if !comma_is_next {
                             // Comma found, but not next, extraneous trivia
                             state.exceptable_add(
                                 extraneous_content(Span::new(
-                                    last_child.syntax().text_range().end().into(),
+                                    last_child.inner().text_range().end().into(),
                                     (comma.text_range().start()
-                                        - last_child.syntax().text_range().end())
+                                        - last_child.inner().text_range().end())
                                     .into(),
                                 )),
-                                SyntaxElement::from(item.syntax().clone()),
+                                SyntaxElement::from(item.inner().clone()),
                                 &self.exceptable_nodes(),
                             );
                         }
@@ -136,13 +135,13 @@ impl Visitor for TrailingCommaRule {
                         state.exceptable_add(
                             missing_trailing_comma(
                                 last_child
-                                    .syntax()
+                                    .inner()
                                     .last_token()
                                     .expect("object should have tokens")
                                     .text_range()
-                                    .to_span(),
+                                    .into(),
                             ),
-                            SyntaxElement::from(item.syntax().clone()),
+                            SyntaxElement::from(item.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
@@ -162,22 +161,22 @@ impl Visitor for TrailingCommaRule {
         }
 
         // Check if array is multi-line
-        if item.syntax().to_string().contains('\n') && item.elements().count() > 1 {
+        if item.inner().to_string().contains('\n') && item.elements().count() > 1 {
             let last_child = item.elements().last();
             if let Some(last_child) = last_child {
-                let (next_comma, comma_is_next) = find_next_comma(last_child.syntax());
+                let (next_comma, comma_is_next) = find_next_comma(last_child.inner());
                 match next_comma {
                     Some(comma) => {
                         if !comma_is_next {
                             // Comma found, but not next, extraneous trivia
                             state.exceptable_add(
                                 extraneous_content(Span::new(
-                                    last_child.syntax().text_range().end().into(),
+                                    last_child.inner().text_range().end().into(),
                                     (comma.text_range().start()
-                                        - last_child.syntax().text_range().end())
+                                        - last_child.inner().text_range().end())
                                     .into(),
                                 )),
-                                SyntaxElement::from(item.syntax().clone()),
+                                SyntaxElement::from(item.inner().clone()),
                                 &self.exceptable_nodes(),
                             );
                         }
@@ -187,13 +186,13 @@ impl Visitor for TrailingCommaRule {
                         state.exceptable_add(
                             missing_trailing_comma(
                                 last_child
-                                    .syntax()
+                                    .inner()
                                     .last_token()
                                     .expect("array should have tokens")
                                     .text_range()
-                                    .to_span(),
+                                    .into(),
                             ),
-                            SyntaxElement::from(item.syntax().clone()),
+                            SyntaxElement::from(item.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
@@ -220,17 +219,16 @@ impl Visitor for TrailingCommaRule {
 
         call.inputs().for_each(|input| {
             // check each input for trailing comma
-            let (next_comma, comma_is_next) = find_next_comma(input.syntax());
+            let (next_comma, comma_is_next) = find_next_comma(input.inner());
             match next_comma {
                 Some(nc) => {
                     if !comma_is_next {
                         state.exceptable_add(
                             extraneous_content(Span::new(
-                                input.syntax().text_range().end().into(),
-                                (nc.text_range().start() - input.syntax().text_range().end())
-                                    .into(),
+                                input.inner().text_range().end().into(),
+                                (nc.text_range().start() - input.inner().text_range().end()).into(),
                             )),
-                            SyntaxElement::from(call.syntax().clone()),
+                            SyntaxElement::from(call.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
@@ -239,13 +237,13 @@ impl Visitor for TrailingCommaRule {
                     state.exceptable_add(
                         missing_trailing_comma(
                             input
-                                .syntax()
+                                .inner()
                                 .last_token()
                                 .expect("input should have tokens")
                                 .text_range()
-                                .to_span(),
+                                .into(),
                         ),
-                        SyntaxElement::from(call.syntax().clone()),
+                        SyntaxElement::from(call.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                 }
@@ -266,8 +264,8 @@ impl Visitor for TrailingCommaRule {
                 | LiteralExpr::Object(_)
                 | LiteralExpr::Struct(_) => {
                     // Check if array is multi-line
-                    if l.syntax().to_string().contains('\n') && l.syntax().children().count() > 1 {
-                        let last_child = l.syntax().children().last();
+                    if l.inner().to_string().contains('\n') && l.inner().children().count() > 1 {
+                        let last_child = l.inner().children().last();
                         if let Some(last_child) = last_child {
                             let (next_comma, comma_is_next) = find_next_comma(&last_child);
                             match next_comma {
@@ -281,7 +279,7 @@ impl Visitor for TrailingCommaRule {
                                                     - last_child.text_range().end())
                                                 .into(),
                                             )),
-                                            SyntaxElement::from(l.syntax().clone()),
+                                            SyntaxElement::from(l.inner().clone()),
                                             &self.exceptable_nodes(),
                                         );
                                     }
@@ -294,9 +292,9 @@ impl Visitor for TrailingCommaRule {
                                                 .last_token()
                                                 .expect("item should have tokens")
                                                 .text_range()
-                                                .to_span(),
+                                                .into(),
                                         ),
-                                        SyntaxElement::from(l.syntax().clone()),
+                                        SyntaxElement::from(l.inner().clone()),
                                         &self.exceptable_nodes(),
                                     );
                                 }

--- a/wdl-lint/src/rules/unknown_rule.rs
+++ b/wdl-lint/src/rules/unknown_rule.rs
@@ -75,7 +75,7 @@ impl Visitor for UnknownRule {
     }
 
     fn comment(&mut self, state: &mut Self::State, comment: &Comment) {
-        if let Some(ids) = comment.as_str().strip_prefix(EXCEPT_COMMENT_PREFIX) {
+        if let Some(ids) = comment.text().strip_prefix(EXCEPT_COMMENT_PREFIX) {
             let start: usize = comment.span().start();
             let mut offset = EXCEPT_COMMENT_PREFIX.len();
             for id in ids.split(',') {

--- a/wdl-lint/src/rules/version_formatting.rs
+++ b/wdl-lint/src/rules/version_formatting.rs
@@ -8,7 +8,6 @@ use wdl_ast::Document;
 use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxKind;
-use wdl_ast::ToSpan;
 use wdl_ast::VersionStatement;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
@@ -118,7 +117,7 @@ impl Visitor for VersionFormattingRule {
         // If there's a previous sibling or token, it must be whitespace
         // because only comments and whitespace may precede the version statement
         // and whitespace must come between the last comment and the version statement.
-        if let Some(prev_ws) = stmt.syntax().prev_sibling_or_token() {
+        if let Some(prev_ws) = stmt.inner().prev_sibling_or_token() {
             let ws = prev_ws.as_token().expect("expected a token").text();
             // If there's a previous sibling or token, it must be a comment
             match prev_ws.prev_sibling_or_token() {
@@ -127,7 +126,7 @@ impl Visitor for VersionFormattingRule {
                         // There's a special case where the blank line has extra whitespace
                         // but that doesn't appear in the printed diagnostic.
                         let mut diagnostic =
-                            expected_blank_line_before_version(prev_ws.text_range().to_span());
+                            expected_blank_line_before_version(prev_ws.text_range().into());
 
                         if ws.chars().filter(|&c| c == '\n').count() == 2 {
                             for (line, start, end) in lines_with_offset(ws) {
@@ -141,7 +140,7 @@ impl Visitor for VersionFormattingRule {
                                     };
 
                                     diagnostic = diagnostic.with_highlight(Span::new(
-                                        prev_ws.text_range().to_span().start() + start,
+                                        usize::from(prev_ws.text_range().start()) + start,
                                         end - start - end_offset,
                                     ));
                                 }
@@ -151,14 +150,14 @@ impl Visitor for VersionFormattingRule {
                     }
                 }
                 _ => {
-                    state.add(whitespace_before_version(prev_ws.text_range().to_span()));
+                    state.add(whitespace_before_version(prev_ws.text_range().into()));
                 }
             }
         }
 
         // 2. Handle internal whitespace and comments
         for child in stmt
-            .syntax()
+            .inner()
             .children_with_tokens()
             .filter(|c| c.kind() == SyntaxKind::Whitespace || c.kind() == SyntaxKind::Comment)
         {
@@ -166,21 +165,21 @@ impl Visitor for VersionFormattingRule {
                 SyntaxKind::Whitespace => {
                     if child.as_token().expect("expected a token").text() != " " {
                         state.add(unexpected_whitespace_inside_version(
-                            child.text_range().to_span(),
+                            child.text_range().into(),
                         ));
                     }
                 }
                 SyntaxKind::Comment => {
-                    state.add(comment_inside_version(child.text_range().to_span()));
+                    state.add(comment_inside_version(child.text_range().into()));
                 }
                 _ => unreachable!(),
             }
         }
 
         // 3. Handle whitespace after the version statement
-        if let Some(next) = stmt.syntax().next_sibling_or_token() {
+        if let Some(next) = stmt.inner().next_sibling_or_token() {
             if let Some(ws) = next.as_token().and_then(|s| Whitespace::cast(s.clone())) {
-                let s = ws.as_str();
+                let s = ws.text();
                 // Don't add diagnostic if there's nothing but whitespace after the version
                 // statement
                 if s != "\n\n" && s != "\r\n\r\n" && next.next_sibling_or_token().is_some() {

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -82,7 +82,7 @@ impl Visitor for WhitespaceRule {
     type State = Diagnostics;
 
     fn comment(&mut self, state: &mut Self::State, comment: &wdl_ast::Comment) {
-        let comment_str = comment.as_str();
+        let comment_str = comment.text();
         let span = comment.span();
         let trimmed_end = comment_str.trim_end();
         if comment_str != trimmed_end {
@@ -92,7 +92,7 @@ impl Visitor for WhitespaceRule {
                     span.start() + trimmed_end.len(),
                     comment_str.len() - trimmed_end.len(),
                 )),
-                SyntaxElement::from(comment.syntax().clone()),
+                SyntaxElement::from(comment.inner().clone()),
                 &self.exceptable_nodes(),
             )
         }
@@ -136,14 +136,14 @@ impl Visitor for WhitespaceRule {
         // Check to see if this whitespace is the last token in the document (i.e. the
         // parent is the root and there is no sibling)
         let is_last = whitespace
-            .syntax()
+            .inner()
             .parent()
             .expect("should have a parent")
             .kind()
             == SyntaxKind::RootNode
-            && whitespace.syntax().next_sibling_or_token().is_none();
+            && whitespace.inner().next_sibling_or_token().is_none();
 
-        let text = whitespace.as_str();
+        let text = whitespace.text();
         let span = whitespace.span();
         let mut blank_start = None;
         for (i, (line, start, next_start)) in lines_with_offset(text).enumerate() {
@@ -157,13 +157,13 @@ impl Visitor for WhitespaceRule {
                 if i == 0 {
                     state.exceptable_add(
                         trailing_whitespace(Span::new(span.start() + start, line.len())),
-                        SyntaxElement::from(whitespace.syntax().clone()),
+                        SyntaxElement::from(whitespace.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                 } else {
                     state.exceptable_add(
                         only_whitespace(Span::new(span.start() + start, line.len())),
-                        SyntaxElement::from(whitespace.syntax().clone()),
+                        SyntaxElement::from(whitespace.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                 }
@@ -181,7 +181,7 @@ impl Visitor for WhitespaceRule {
         if !is_last && blank_start.is_some() {
             state.exceptable_add(
                 more_than_one_blank_line(span),
-                SyntaxElement::from(whitespace.syntax().clone()),
+                SyntaxElement::from(whitespace.inner().clone()),
                 &self.exceptable_nodes(),
             );
         }

--- a/wdl-lint/src/util.rs
+++ b/wdl-lint/src/util.rs
@@ -14,7 +14,7 @@ use crate::rules::RULE_MAP;
 /// Detect if a comment is in-line or not by looking for `\n` in the prior
 /// whitespace.
 pub fn is_inline_comment(token: &Comment) -> bool {
-    if let Some(prior) = token.syntax().prev_sibling_or_token() {
+    if let Some(prior) = token.inner().prev_sibling_or_token() {
         let whitespace = prior.kind() == SyntaxKind::Whitespace;
         if !whitespace {
             return true;

--- a/wdl-lint/src/visitor.rs
+++ b/wdl-lint/src/visitor.rs
@@ -90,7 +90,7 @@ impl Visitor for LintVisitor {
         self.document_exceptions.extend(
             doc.version_statement()
                 .expect("document should have version statement")
-                .syntax()
+                .inner()
                 .rule_exceptions(),
         );
 

--- a/wdl/examples/explore.rs
+++ b/wdl/examples/explore.rs
@@ -117,10 +117,10 @@ pub fn main() -> Result<()> {
 /// Explores metadata.
 fn explore_metadata(metadata: &MetadataSection) {
     for item in metadata.items() {
-        let value = item.value().syntax().text().to_string();
+        let value = item.value().text().to_string();
         println!(
             "`{name}`: `{value}`",
-            name = item.name().as_str(),
+            name = item.name().text(),
             value = value.trim()
         );
     }
@@ -131,7 +131,7 @@ fn explore_input(input: &InputSection) {
     for decl in input.declarations() {
         println!(
             "`{name}`: `{ty}`",
-            name = decl.name().as_str(),
+            name = decl.name().text(),
             ty = decl.ty()
         );
     }
@@ -142,7 +142,7 @@ fn explore_output(output: &OutputSection) {
     for decl in output.declarations() {
         println!(
             "`{name}`: `{ty}`",
-            name = decl.name().as_str(),
+            name = decl.name().text(),
             ty = decl.ty()
         );
     }
@@ -150,7 +150,7 @@ fn explore_output(output: &OutputSection) {
 
 /// Prints the metadata, input, and output sections from a WDL task.
 fn explore_task(task: &TaskDefinition) {
-    println!("## Task `{name}`", name = task.name().as_str());
+    println!("## Task `{name}`", name = task.name().text());
 
     if let Some(metadata) = task.metadata() {
         println!("\n### Metadata");
@@ -170,7 +170,7 @@ fn explore_task(task: &TaskDefinition) {
 
 /// Prints the metadata, input, and output block from a WDL workflow.
 fn explore_workflow(workflow: &WorkflowDefinition) {
-    println!("## Workflow `{name}`", name = workflow.name().as_str());
+    println!("## Workflow `{name}`", name = workflow.name().text());
 
     if let Some(metadata) = workflow.metadata() {
         println!("\n### Metadata");

--- a/wdl/src/bin/wdl.rs
+++ b/wdl/src/bin/wdl.rs
@@ -41,6 +41,7 @@ use wdl::cli::parse_inputs;
 use wdl::cli::run;
 use wdl::cli::validate_inputs;
 use wdl_analysis::path_to_uri;
+use wdl_ast::AstNode;
 use wdl_ast::Node;
 use wdl_ast::Severity;
 use wdl_doc::document_workspace;
@@ -149,7 +150,7 @@ impl CheckCommand {
                 bail!(e.to_owned());
             }
             document.diagnostics().iter().for_each(|d| {
-                let source = document.node().syntax().text().to_string();
+                let source = document.root().text().to_string();
                 emit_diagnostics(&document.uri().to_string(), &source, &[d.clone()]).unwrap();
             });
         }

--- a/wdl/src/lib.rs
+++ b/wdl/src/lib.rs
@@ -102,13 +102,13 @@ pub mod cli;
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
-
     /// This is a test for checking that the reserved rules in `wdl-lint` match
     /// those from `wdl-analysis`.
     #[cfg(all(feature = "analysis", feature = "lint"))]
     #[test]
     fn reserved_rule_ids() {
+        use std::collections::HashSet;
+
         let rules: HashSet<_> = wdl_analysis::rules().iter().map(|r| r.id()).collect();
         let reserved: HashSet<_> = wdl_lint::RESERVED_RULE_IDS.iter().copied().collect();
 


### PR DESCRIPTION
This PR refactors `wdl-ast` so that all of the AST types take a type parameter for either a node or a token.

This change allows for the AST to operate off of a different representation of `SyntaxNode` and `SyntaxToken` for evaluation.

In the case of `wdl-engine`, evaluation is performed asynchronously and so the node and token types must be `Send`; however, the implementation from `rowan` is not `Send`. With this refactoring, the engine can "morph" the AST returned from analysis to an AST with its own implementation of `SyntaxNode` and `SyntaxToken` that are `Send`.

This cleans up quite a few things in the engine, most notably the engine no longer has to rebuild task and workflow evaluation graphs with `AstPtr`-based graph nodes.

It will also allow the engine's expression evaluator to become fully async in an upcoming change to allow for the stdlib functions to be asynchronous, which is require for the file functions that may fetch files from remote storage.

Many of the changes here stem from a decision to rename two methods in `wdl-ast`: `inner` instead of `syntax` and `text` instead of `as_str`. The rational for using `inner` is that since the underlying types are generic and do not have to be `SyntaxNode` or `SyntaxToken`, calling the method `syntax` no longer makes sense. Additionally, we need a method on the abstract node type for getting its text and `as_str` doesn't work since it must return `impl fmt::Display`; therefore, I decided to name it `text` on both the node and token traits.

This also fixes a bug where we weren't detecting duplicate hints sections in 1.2 documents.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
