### PR TITLE
refactor: make expression evaluation async.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Refactored expression evaluation to make it async ([#357](https://github.com/stjude-rust-labs/wdl/pull/357)).
 * Updated for refactored `wdl-ast` API so that evaluation can now operate
   directly on AST nodes in `async` context ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -54,7 +54,7 @@ impl From<anyhow::Error> for EvaluationError {
 pub type EvaluationResult<T> = Result<T, EvaluationError>;
 
 /// Represents context to an expression evaluator.
-pub trait EvaluationContext {
+pub trait EvaluationContext: Send + Sync {
     /// Gets the supported version of the document being evaluated.
     fn version(&self) -> SupportedVersion;
 

--- a/wdl-engine/src/eval/v1/workflow.rs
+++ b/wdl-engine/src/eval/v1/workflow.rs
@@ -1656,7 +1656,7 @@ impl WorkflowEvaluator {
             &state.work_dir,
             &state.temp_dir,
         ));
-        Ok(evaluator.evaluate_expr(expr)?)
+        Ok(evaluator.evaluate_expr(expr).await?)
     }
 
     /// Evaluates the call inputs of a call statement.
@@ -1682,7 +1682,7 @@ impl WorkflowEvaluator {
                         &state.temp_dir,
                     ));
 
-                    evaluator.evaluate_expr(&expr)?
+                    evaluator.evaluate_expr(&expr).await?
                 }
                 None => scopes
                     .reference(scope)

--- a/wdl-engine/src/stdlib.rs
+++ b/wdl-engine/src/stdlib.rs
@@ -93,7 +93,7 @@ impl CallArgument {
 /// Represents function call context.
 pub struct CallContext<'a> {
     /// The evaluation context for the call.
-    context: &'a mut dyn EvaluationContext,
+    context: &'a dyn EvaluationContext,
     /// The call site span.
     call_site: Span,
     /// The arguments to the call.
@@ -105,7 +105,7 @@ pub struct CallContext<'a> {
 impl<'a> CallContext<'a> {
     /// Constructs a new call context given the call arguments.
     pub fn new(
-        context: &'a mut dyn EvaluationContext,
+        context: &'a dyn EvaluationContext,
         call_site: Span,
         arguments: &'a [CallArgument],
         return_type: Type,

--- a/wdl-engine/src/stdlib/as_map.rs
+++ b/wdl-engine/src/stdlib/as_map.rs
@@ -91,19 +91,16 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn as_map() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn as_map() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "as_map([])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_map([])").await.unwrap();
         assert_eq!(value.unwrap_map().len(), 0);
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::One,
-            "as_map([('foo', 'bar'), ('bar', 'baz')])",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_map([('foo', 'bar'), ('bar', 'baz')])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_map()
             .unwrap()
@@ -117,8 +114,9 @@ mod test {
             .collect();
         assert_eq!(elements, [("foo", "bar"), ("bar", "baz")]);
 
-        let value =
-            eval_v1_expr(&mut env, V1::One, "as_map([('a', 1), ('c', 3), ('b', 2)])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_map([('a', 1), ('c', 3), ('b', 2)])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_map()
             .unwrap()
@@ -132,8 +130,9 @@ mod test {
             .collect();
         assert_eq!(elements, [("a", 1), ("c", 3), ("b", 2)]);
 
-        let value =
-            eval_v1_expr(&mut env, V1::One, "as_map([('a', 1), (None, 3), ('b', 2)])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_map([('a', 1), (None, 3), ('b', 2)])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_map()
             .unwrap()
@@ -147,12 +146,9 @@ mod test {
             .collect();
         assert_eq!(elements, [(Some("a"), 1), (None, 3), (Some("b"), 2)]);
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::One,
-            "as_map(as_pairs({'a': 1, 'c': 3, 'b': 2}))",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_map(as_pairs({'a': 1, 'c': 3, 'b': 2}))")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_map()
             .unwrap()
@@ -166,19 +162,17 @@ mod test {
             .collect();
         assert_eq!(elements, [("a", 1), ("c", 3), ("b", 2)]);
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::One, "as_map([('a', 1), ('c', 3), ('a', 2)])").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "as_map([('a', 1), ('c', 3), ('a', 2)])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `as_map` failed: array contains a duplicate entry for map key `a`"
         );
 
-        let diagnostic = eval_v1_expr(
-            &mut env,
-            V1::One,
-            "as_map([(None, 1), ('c', 3), (None, 2)])",
-        )
-        .unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "as_map([(None, 1), ('c', 3), (None, 2)])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `as_map` failed: array contains a duplicate entry for map key `None`"

--- a/wdl-engine/src/stdlib/as_pairs.rs
+++ b/wdl-engine/src/stdlib/as_pairs.rs
@@ -59,19 +59,16 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn as_pairs() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn as_pairs() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "as_pairs({})").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_pairs({})").await.unwrap();
         assert_eq!(value.unwrap_array().len(), 0);
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::One,
-            "as_pairs({ 'foo': 'bar', 'bar': 'baz' })",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_pairs({ 'foo': 'bar', 'bar': 'baz' })")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -87,7 +84,9 @@ mod test {
             .collect();
         assert_eq!(elements, [("foo", "bar"), ("bar", "baz")]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "as_pairs({'a': 1, 'c': 3, 'b': 2})").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_pairs({'a': 1, 'c': 3, 'b': 2})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -103,7 +102,9 @@ mod test {
             .collect();
         assert_eq!(elements, [("a", 1), ("c", 3), ("b", 2)]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "as_pairs({'a': 1, None: 3, 'b': 2})").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "as_pairs({'a': 1, None: 3, 'b': 2})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()

--- a/wdl-engine/src/stdlib/basename.rs
+++ b/wdl-engine/src/stdlib/basename.rs
@@ -69,23 +69,32 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn basename() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::Two, "basename('/path/to/file.txt')").unwrap();
+    #[tokio::test]
+    async fn basename() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::Two, "basename('/path/to/file.txt')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "file.txt");
 
-        let value =
-            eval_v1_expr(&mut env, V1::Two, "basename('/path/to/file.txt', '.txt')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "basename('/path/to/file.txt', '.txt')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "file");
 
-        let value = eval_v1_expr(&mut env, V1::Two, "basename('/path/to/dir')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "basename('/path/to/dir')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "dir");
 
-        let value = eval_v1_expr(&mut env, V1::Two, "basename('file.txt')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "basename('file.txt')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "file.txt");
 
-        let value = eval_v1_expr(&mut env, V1::Two, "basename('file.txt', '.txt')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "basename('file.txt', '.txt')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "file");
     }
 }

--- a/wdl-engine/src/stdlib/ceil.rs
+++ b/wdl-engine/src/stdlib/ceil.rs
@@ -34,22 +34,22 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn ceil() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::Zero, "ceil(10.5)").unwrap();
+    #[tokio::test]
+    async fn ceil() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::Zero, "ceil(10.5)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 11);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "ceil(10)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "ceil(10)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 10);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "ceil(9.9999)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "ceil(9.9999)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 10);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "ceil(0)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "ceil(0)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "ceil(-5.1)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "ceil(-5.1)").await.unwrap();
         assert_eq!(value.unwrap_integer(), -5);
     }
 }

--- a/wdl-engine/src/stdlib/chunk.rs
+++ b/wdl-engine/src/stdlib/chunk.rs
@@ -67,14 +67,16 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn chunk() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn chunk() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::Two, "chunk([], 10)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "chunk([], 10)").await.unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "chunk([1, 2, 3, 4, 5], 1)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "chunk([1, 2, 3, 4, 5], 1)")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -91,7 +93,9 @@ mod test {
             .collect();
         assert_eq!(elements, [[1], [2], [3], [4], [5]]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "chunk([1, 2, 3, 4, 5], 2)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "chunk([1, 2, 3, 4, 5], 2)")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -108,7 +112,9 @@ mod test {
             .collect();
         assert_eq!(elements, [[1, 2].as_slice(), &[3, 4], &[5]]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "chunk([1, 2, 3, 4, 5], 3)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "chunk([1, 2, 3, 4, 5], 3)")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -125,7 +131,9 @@ mod test {
             .collect();
         assert_eq!(elements, [[1, 2, 3].as_slice(), &[4, 5]]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "chunk([1, 2, 3, 4, 5], 4)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "chunk([1, 2, 3, 4, 5], 4)")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -142,7 +150,9 @@ mod test {
             .collect();
         assert_eq!(elements, [[1, 2, 3, 4].as_slice(), &[5]]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "chunk([1, 2, 3, 4, 5], 5)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "chunk([1, 2, 3, 4, 5], 5)")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -159,7 +169,9 @@ mod test {
             .collect();
         assert_eq!(elements, [[1, 2, 3, 4, 5]]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "chunk([1, 2, 3, 4, 5], 10)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "chunk([1, 2, 3, 4, 5], 10)")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -176,7 +188,9 @@ mod test {
             .collect();
         assert_eq!(elements, [[1, 2, 3, 4, 5]]);
 
-        let diagnostic = eval_v1_expr(&mut env, V1::Two, "chunk([1, 2, 3], -10)").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "chunk([1, 2, 3], -10)")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `chunk` failed: chunk size cannot be negative"

--- a/wdl-engine/src/stdlib/collect_by_key.rs
+++ b/wdl-engine/src/stdlib/collect_by_key.rs
@@ -89,27 +89,31 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn collect_by_key() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn collect_by_key() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::Two, "collect_by_key([])").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "collect_by_key([])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_map().len(), 0);
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "collect_by_key([('a', 1), ('b', 2), ('a', 3)])",
         )
+        .await
         .unwrap();
         assert_eq!(value.to_string(), r#"{"a": [1, 3], "b": [2]}"#);
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "collect_by_key([('a', 1), (None, 2), ('a', 3), (None, 4), ('b', 5), ('c', 6), ('b', \
              7)])",
         )
+        .await
         .unwrap();
         assert_eq!(
             value.to_string(),

--- a/wdl-engine/src/stdlib/contains.rs
+++ b/wdl-engine/src/stdlib/contains.rs
@@ -49,57 +49,67 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn contains() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn contains() {
+        let env = TestEnv::default();
 
         assert!(
-            !eval_v1_expr(&mut env, V1::Two, "contains([], 1)")
+            !eval_v1_expr(&env, V1::Two, "contains([], 1)")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            !eval_v1_expr(&mut env, V1::Two, "contains([], None)")
+            !eval_v1_expr(&env, V1::Two, "contains([], None)")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            eval_v1_expr(&mut env, V1::Two, "contains([1, None, 3], None)")
+            eval_v1_expr(&env, V1::Two, "contains([1, None, 3], None)")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            eval_v1_expr(&mut env, V1::Two, "contains([None], None)")
+            eval_v1_expr(&env, V1::Two, "contains([None], None)")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            eval_v1_expr(&mut env, V1::Two, "contains([1, 2, 3, 4, 5], 2)")
+            eval_v1_expr(&env, V1::Two, "contains([1, 2, 3, 4, 5], 2)")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            !eval_v1_expr(&mut env, V1::Two, "contains([1, 2, 3, 4, 5], 100)")
+            !eval_v1_expr(&env, V1::Two, "contains([1, 2, 3, 4, 5], 100)")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            eval_v1_expr(&mut env, V1::Two, "contains(['foo', 'bar', 'baz'], 'foo')")
+            eval_v1_expr(&env, V1::Two, "contains(['foo', 'bar', 'baz'], 'foo')")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            !eval_v1_expr(&mut env, V1::Two, "contains(['foo', 'bar', 'baz'], 'qux')")
+            !eval_v1_expr(&env, V1::Two, "contains(['foo', 'bar', 'baz'], 'qux')")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            !eval_v1_expr(&mut env, V1::Two, "contains(['foo', None, 'baz'], 'bar')")
+            !eval_v1_expr(&env, V1::Two, "contains(['foo', None, 'baz'], 'bar')")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );
         assert!(
-            eval_v1_expr(&mut env, V1::Two, "contains(['foo', None, 'baz'], None)")
+            eval_v1_expr(&env, V1::Two, "contains(['foo', None, 'baz'], None)")
+                .await
                 .unwrap()
                 .unwrap_boolean()
         );

--- a/wdl-engine/src/stdlib/contains_key.rs
+++ b/wdl-engine/src/stdlib/contains_key.rs
@@ -142,8 +142,8 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn contains_key() {
+    #[tokio::test]
+    async fn contains_key() {
         let mut env = TestEnv::default();
 
         let bar_ty: Type = StructType::new("Bar", [("baz", PrimitiveType::String)]).into();
@@ -152,192 +152,219 @@ mod test {
         let foo_ty = StructType::new("Foo", [("bar", bar_ty)]);
         env.insert_struct("Foo", foo_ty);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "contains_key({}, 1)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "contains_key({}, 1)")
+            .await
+            .unwrap();
         assert!(!value.unwrap_boolean());
 
-        let value =
-            eval_v1_expr(&mut env, V1::Two, "contains_key({ 1: 2, None: 3}, None)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "contains_key({ 1: 2, None: 3}, None)")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "contains_key({ 1: 2 }, 1)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "contains_key({ 1: 2 }, 1)")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': 1, 'bar': 2, 'baz': 3 }, 'qux')",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': 1, 'bar': 2, 'baz': 3 }, 'baz')",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: 3 }, 'qux')",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: 3 }, 'baz')",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': 1, 'bar': 2, 'baz': 3 }, ['qux'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': 1, 'bar': 2, 'baz': 3 }, ['baz'])",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: 3 }, ['qux'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: 3 }, ['baz'])",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(Foo { bar: Bar { baz: 'qux' } }, ['qux'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(Foo { bar: Bar { baz: 'qux' } }, ['bar'])",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': 1, 'bar': 2, 'baz': 3 }, ['qux', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': 1, 'bar': 2, 'baz': 3 }, ['baz', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: 3 }, ['qux', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: 3 }, ['baz', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(Foo { bar: Bar { baz: 'qux' } }, ['qux', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(Foo { bar: Bar { baz: 'qux' } }, ['bar', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': { 'qux': 1 }, 'bar': { 'qux': 2 }, 'baz': { 'qux': 3 } }, \
              ['baz', 'qux'])",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key({ 'foo': { 'qux': 1 }, 'bar': { 'qux': 2 }, 'baz': { 'qux': 3 } }, \
              ['baz', 'qux', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: object { qux: 3 } }, ['baz', 'qux'])",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(object { foo: 1, bar: 2, baz: object { qux: 3 } }, ['baz', 'qux', \
              'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(Foo { bar: Bar { baz: 'qux' } }, ['bar', 'baz'])",
         )
+        .await
         .unwrap();
         assert!(value.unwrap_boolean());
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "contains_key(Foo { bar: Bar { baz: 'qux' } }, ['bar', 'baz', 'nope'])",
         )
+        .await
         .unwrap();
         assert!(!value.unwrap_boolean());
     }

--- a/wdl-engine/src/stdlib/cross.rs
+++ b/wdl-engine/src/stdlib/cross.rs
@@ -69,20 +69,22 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn cross() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn cross() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "cross([], [])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "cross([], [])").await.unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "cross([1], [])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "cross([1], [])").await.unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "cross([], [1])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "cross([], [1])").await.unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "cross([1, 2, 3], ['a', 'b'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "cross([1, 2, 3], ['a', 'b'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()

--- a/wdl-engine/src/stdlib/defined.rs
+++ b/wdl-engine/src/stdlib/defined.rs
@@ -30,23 +30,27 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn defined() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn defined() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "defined('foo')").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "defined('foo')")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "defined(['foo'])").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "defined(['foo'])")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "defined(1)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "defined(1)").await.unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "defined({})").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "defined({})").await.unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "defined(None)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "defined(None)").await.unwrap();
         assert!(!value.unwrap_boolean());
     }
 }

--- a/wdl-engine/src/stdlib/find.rs
+++ b/wdl-engine/src/stdlib/find.rs
@@ -51,22 +51,30 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn find() {
-        let mut env = TestEnv::default();
-        let diagnostic = eval_v1_expr(&mut env, V1::Two, "find('foo bar baz', '?')").unwrap_err();
+    #[tokio::test]
+    async fn find() {
+        let env = TestEnv::default();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "find('foo bar baz', '?')")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "regex parse error:\n    ?\n    ^\nerror: repetition operator missing expression"
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "find('hello world', 'e..o')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "find('hello world', 'e..o')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "ello");
 
-        let value = eval_v1_expr(&mut env, V1::Two, "find('hello world', 'goodbye')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "find('hello world', 'goodbye')")
+            .await
+            .unwrap();
         assert!(value.is_none());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "find('hello\tBob', '\\t')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "find('hello\tBob', '\\t')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "\t");
     }
 }

--- a/wdl-engine/src/stdlib/flatten.rs
+++ b/wdl-engine/src/stdlib/flatten.rs
@@ -57,22 +57,21 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn flatten() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn flatten() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "flatten([])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "flatten([])").await.unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "flatten([[], [], []])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "flatten([[], [], []])")
+            .await
+            .unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::One,
-            "flatten([[1, 2, 3], [4, 5, 6, 7], [8, 9]])",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::One, "flatten([[1, 2, 3], [4, 5, 6, 7], [8, 9]])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -83,10 +82,11 @@ mod test {
         assert_eq!(elements, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "flatten(chunk([1, 2, 3, 4, 5, 6, 7, 8, 9], 1))",
         )
+        .await
         .unwrap();
         let elements: Vec<_> = value
             .as_array()

--- a/wdl-engine/src/stdlib/floor.rs
+++ b/wdl-engine/src/stdlib/floor.rs
@@ -34,22 +34,22 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn floor() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::Zero, "floor(10.5)").unwrap();
+    #[tokio::test]
+    async fn floor() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::Zero, "floor(10.5)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 10);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "floor(10)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "floor(10)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 10);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "floor(9.9999)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "floor(9.9999)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 9);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "floor(0)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "floor(0)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "floor(-5.1)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "floor(-5.1)").await.unwrap();
         assert_eq!(value.unwrap_integer(), -6);
     }
 }

--- a/wdl-engine/src/stdlib/glob.rs
+++ b/wdl-engine/src/stdlib/glob.rs
@@ -92,10 +92,12 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn glob() {
-        let mut env = TestEnv::default();
-        let diagnostic = eval_v1_expr(&mut env, V1::Two, "glob('invalid***')").unwrap_err();
+    #[tokio::test]
+    async fn glob() {
+        let env = TestEnv::default();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "glob('invalid***')")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "invalid glob pattern specified: wildcards are either regular `*` or recursive `**`"
@@ -109,7 +111,7 @@ mod test {
         env.write_file("nested/bar", "bar");
         env.write_file("nested/baz", "baz");
 
-        let value = eval_v1_expr(&mut env, V1::Two, "glob('jam')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "glob('jam')").await.unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -119,7 +121,7 @@ mod test {
             .collect();
         assert!(elements.is_empty());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "glob('*')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "glob('*')").await.unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -129,7 +131,7 @@ mod test {
             .collect();
         assert_eq!(elements, ["bar", "baz", "foo", "qux"]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "glob('ba?')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "glob('ba?')").await.unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -139,7 +141,7 @@ mod test {
             .collect();
         assert_eq!(elements, ["bar", "baz"]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "glob('b*')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "glob('b*')").await.unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -149,7 +151,7 @@ mod test {
             .collect();
         assert_eq!(elements, ["bar", "baz"]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "glob('**/b*')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "glob('**/b*')").await.unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()

--- a/wdl-engine/src/stdlib/join_paths.rs
+++ b/wdl-engine/src/stdlib/join_paths.rs
@@ -144,28 +144,36 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn join_paths() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::Two, "join_paths('/usr', ['bin', 'echo'])").unwrap();
+    #[tokio::test]
+    async fn join_paths() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::Two, "join_paths('/usr', ['bin', 'echo'])")
+            .await
+            .unwrap();
         assert_eq!(
             value.unwrap_file().as_str().replace('\\', "/"),
             "/usr/bin/echo"
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "join_paths(['/usr', 'bin', 'echo'])").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "join_paths(['/usr', 'bin', 'echo'])")
+            .await
+            .unwrap();
         assert_eq!(
             value.unwrap_file().as_str().replace('\\', "/"),
             "/usr/bin/echo"
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "join_paths('mydir', 'mydata.txt')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "join_paths('mydir', 'mydata.txt')")
+            .await
+            .unwrap();
         assert_eq!(
             value.unwrap_file().as_str().replace('\\', "/"),
             "mydir/mydata.txt"
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "join_paths('/usr', 'bin/echo')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "join_paths('/usr', 'bin/echo')")
+            .await
+            .unwrap();
         assert_eq!(
             value.unwrap_file().as_str().replace('\\', "/"),
             "/usr/bin/echo"
@@ -173,31 +181,28 @@ mod test {
 
         #[cfg(unix)]
         {
-            let diagnostic =
-                eval_v1_expr(&mut env, V1::Two, "join_paths('/usr', '/bin/echo')").unwrap_err();
+            let diagnostic = eval_v1_expr(&env, V1::Two, "join_paths('/usr', '/bin/echo')")
+                .await
+                .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
                 "path is required to be a relative path, but an absolute path was provided"
             );
 
-            let diagnostic = eval_v1_expr(
-                &mut env,
-                V1::Two,
-                "join_paths('/usr', ['foo', '/bin/echo'])",
-            )
-            .unwrap_err();
+            let diagnostic =
+                eval_v1_expr(&env, V1::Two, "join_paths('/usr', ['foo', '/bin/echo'])")
+                    .await
+                    .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
                 "index 1 of the array is required to be a relative path, but an absolute path was \
                  provided"
             );
 
-            let diagnostic = eval_v1_expr(
-                &mut env,
-                V1::Two,
-                "join_paths(['/usr', 'foo', '/bin/echo'])",
-            )
-            .unwrap_err();
+            let diagnostic =
+                eval_v1_expr(&env, V1::Two, "join_paths(['/usr', 'foo', '/bin/echo'])")
+                    .await
+                    .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
                 "index 2 of the array is required to be a relative path, but an absolute path was \
@@ -207,19 +212,20 @@ mod test {
 
         #[cfg(windows)]
         {
-            let diagnostic =
-                eval_v1_expr(&mut env, V1::Two, "join_paths('C:\\usr', 'C:\\bin\\echo')")
-                    .unwrap_err();
+            let diagnostic = eval_v1_expr(&env, V1::Two, "join_paths('C:\\usr', 'C:\\bin\\echo')")
+                .await
+                .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
                 "path is required to be a relative path, but an absolute path was provided"
             );
 
             let diagnostic = eval_v1_expr(
-                &mut env,
+                &env,
                 V1::Two,
                 "join_paths('C:\\usr', ['foo', 'C:\\bin\\echo'])",
             )
+            .await
             .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
@@ -228,10 +234,11 @@ mod test {
             );
 
             let diagnostic = eval_v1_expr(
-                &mut env,
+                &env,
                 V1::Two,
                 "join_paths(['C:\\usr', 'foo', 'C:\\bin\\echo'])",
             )
+            .await
             .unwrap_err();
             assert_eq!(
                 diagnostic.message(),

--- a/wdl-engine/src/stdlib/keys.rs
+++ b/wdl-engine/src/stdlib/keys.rs
@@ -73,8 +73,8 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn keys() {
+    #[tokio::test]
+    async fn keys() {
         let mut env = TestEnv::default();
 
         let ty = StructType::new(
@@ -88,11 +88,12 @@ mod test {
 
         env.insert_struct("Foo", ty);
 
-        let value = eval_v1_expr(&mut env, V1::One, "keys({})").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "keys({})").await.unwrap();
         assert_eq!(value.unwrap_array().len(), 0);
 
-        let value =
-            eval_v1_expr(&mut env, V1::One, "keys({'foo': 1, 'bar': 2, 'baz': 3})").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "keys({'foo': 1, 'bar': 2, 'baz': 3})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -102,7 +103,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["foo", "bar", "baz"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "keys({'foo': 1, None: 2, 'baz': 3})").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "keys({'foo': 1, None: 2, 'baz': 3})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -116,8 +119,9 @@ mod test {
             .collect();
         assert_eq!(elements, [Some("foo"), None, Some("baz")]);
 
-        let value =
-            eval_v1_expr(&mut env, V1::Two, "keys(object { foo: 1, bar: 2, baz: 3})").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "keys(object { foo: 1, bar: 2, baz: 3})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -127,8 +131,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["foo", "bar", "baz"]);
 
-        let value =
-            eval_v1_expr(&mut env, V1::Two, "keys(Foo { foo: 1.0, bar: '2', baz: 3})").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "keys(Foo { foo: 1.0, bar: '2', baz: 3})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()

--- a/wdl-engine/src/stdlib/length.rs
+++ b/wdl-engine/src/stdlib/length.rs
@@ -128,42 +128,42 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn length() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn length() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "length([])").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length([])").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "length({})").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length({})").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "length(object {})").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length(object {})")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "length('')").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length('')").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "length([1, 2, 3, 4, 5])").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length([1, 2, 3, 4, 5])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 5);
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::Zero,
-            "length({ 'foo': 1, 'bar': 2, 'baz': 3})",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length({ 'foo': 1, 'bar': 2, 'baz': 3})")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 3);
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::Zero,
-            "length(object { foo: 1, bar: 2, baz: 3})",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length(object { foo: 1, bar: 2, baz: 3})")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 3);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "length('hello world!')").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "length('hello world!')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 12);
     }
 }

--- a/wdl-engine/src/stdlib/matches.rs
+++ b/wdl-engine/src/stdlib/matches.rs
@@ -43,23 +43,30 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn matches() {
-        let mut env = TestEnv::default();
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "matches('foo bar baz', '?')").unwrap_err();
+    #[tokio::test]
+    async fn matches() {
+        let env = TestEnv::default();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "matches('foo bar baz', '?')")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "regex parse error:\n    ?\n    ^\nerror: repetition operator missing expression"
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "matches('hello world', 'e..o')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "matches('hello world', 'e..o')")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "matches('hello world', 'goodbye')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "matches('hello world', 'goodbye')")
+            .await
+            .unwrap();
         assert!(!value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "matches('hello\tBob', '\\t')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "matches('hello\tBob', '\\t')")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
     }
 }

--- a/wdl-engine/src/stdlib/max.rs
+++ b/wdl-engine/src/stdlib/max.rs
@@ -62,74 +62,79 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn max() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::One, "max(7, 42)").unwrap();
+    #[tokio::test]
+    async fn max() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::One, "max(7, 42)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 42);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(42, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(42, 7)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 42);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(-42, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(-42, 7)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 7);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0, -42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0, -42)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0, 42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0, 42)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 42);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(7.0, 42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(7.0, 42)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(42.0, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(42.0, 7)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(-42.0, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(-42.0, 7)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0.0, -42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0.0, -42)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 0.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0.0, 42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0.0, 42)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(7, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(7, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(42, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(42, 7.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(-42, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(-42, 7.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0, -42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0, -42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 0.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(7.0, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(7.0, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(42.0, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(42.0, 7.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(-42.0, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(-42.0, 7.0)")
+            .await
+            .unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0.0, -42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0.0, -42.0)")
+            .await
+            .unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 0.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "max(0.0, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "max(0.0, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 42.0);
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::One,
             "max(12345, max(-100, max(54321, 1234.5678)))",
         )
+        .await
         .unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 54321.0);
     }

--- a/wdl-engine/src/stdlib/min.rs
+++ b/wdl-engine/src/stdlib/min.rs
@@ -62,74 +62,79 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn min() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::One, "min(7, 42)").unwrap();
+    #[tokio::test]
+    async fn min() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::One, "min(7, 42)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 7);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(42, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(42, 7)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 7);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(-42, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(-42, 7)").await.unwrap();
         assert_eq!(value.unwrap_integer(), -42);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0, -42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0, -42)").await.unwrap();
         assert_eq!(value.unwrap_integer(), -42);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0, 42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0, 42)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(7.0, 42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(7.0, 42)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(42.0, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(42.0, 7)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(-42.0, 7)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(-42.0, 7)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0.0, -42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0.0, -42)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0.0, 42)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0.0, 42)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -0.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(7, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(7, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(42, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(42, 7.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(-42, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(-42, 7.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0, -42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0, -42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -0.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(7.0, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(7.0, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(42.0, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(42.0, 7.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 7.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(-42.0, 7.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(-42.0, 7.0)")
+            .await
+            .unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0.0, -42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0.0, -42.0)")
+            .await
+            .unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -42.0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "min(0.0, 42.0)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "min(0.0, 42.0)").await.unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -0.0);
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::One,
             "min(12345, min(-100, min(54321, 1234.5678)))",
         )
+        .await
         .unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), -100.0);
     }

--- a/wdl-engine/src/stdlib/prefix.rs
+++ b/wdl-engine/src/stdlib/prefix.rs
@@ -65,10 +65,12 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn prefix() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::Zero, "prefix('foo', [1, 2, 3])").unwrap();
+    #[tokio::test]
+    async fn prefix() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::Zero, "prefix('foo', [1, 2, 3])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -78,7 +80,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["foo1", "foo2", "foo3"]);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "prefix('foo', [1.0, 1.1, 1.2])").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "prefix('foo', [1.0, 1.1, 1.2])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -88,8 +92,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["foo1.000000", "foo1.100000", "foo1.200000"]);
 
-        let value =
-            eval_v1_expr(&mut env, V1::Zero, "prefix('foo', ['bar', 'baz', 'qux'])").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "prefix('foo', ['bar', 'baz', 'qux'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -99,7 +104,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["foobar", "foobaz", "fooqux"]);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "prefix('foo', [1, None, 3])").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "prefix('foo', [1, None, 3])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -109,7 +116,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["foo1", "foo", "foo3"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "prefix('foo', [])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "prefix('foo', [])")
+            .await
+            .unwrap();
         assert!(value.unwrap_array().is_empty());
     }
 }

--- a/wdl-engine/src/stdlib/quote.rs
+++ b/wdl-engine/src/stdlib/quote.rs
@@ -60,10 +60,12 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn quote() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::One, "quote([1, 2, 3])").unwrap();
+    #[tokio::test]
+    async fn quote() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::One, "quote([1, 2, 3])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -73,7 +75,9 @@ mod test {
             .collect();
         assert_eq!(elements, [r#""1""#, r#""2""#, r#""3""#]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "quote([1.0, 1.1, 1.2])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "quote([1.0, 1.1, 1.2])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -86,7 +90,9 @@ mod test {
             [r#""1.000000""#, r#""1.100000""#, r#""1.200000""#]
         );
 
-        let value = eval_v1_expr(&mut env, V1::One, "quote(['bar', 'baz', 'qux'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "quote(['bar', 'baz', 'qux'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -96,7 +102,9 @@ mod test {
             .collect();
         assert_eq!(elements, [r#""bar""#, r#""baz""#, r#""qux""#]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "quote(['bar', None, 'qux'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "quote(['bar', None, 'qux'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -106,7 +114,7 @@ mod test {
             .collect();
         assert_eq!(elements, [r#""bar""#, r#""""#, r#""qux""#]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "quote([])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "quote([])").await.unwrap();
         assert!(value.unwrap_array().is_empty());
     }
 }

--- a/wdl-engine/src/stdlib/range.rs
+++ b/wdl-engine/src/stdlib/range.rs
@@ -49,13 +49,13 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn range() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::One, "range(0)").unwrap();
+    #[tokio::test]
+    async fn range() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::One, "range(0)").await.unwrap();
         assert_eq!(value.unwrap_array().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "range(10)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "range(10)").await.unwrap();
         assert_eq!(
             value
                 .unwrap_array()
@@ -67,7 +67,7 @@ mod test {
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         );
 
-        let diagnostic = eval_v1_expr(&mut env, V1::One, "range(-10)").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "range(-10)").await.unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `range` failed: array length cannot be negative"

--- a/wdl-engine/src/stdlib/read_boolean.rs
+++ b/wdl-engine/src/stdlib/read_boolean.rs
@@ -82,8 +82,8 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn read_boolean() {
+    #[tokio::test]
+    async fn read_boolean() {
         let mut env = TestEnv::default();
         env.write_file("foo", "true false hello world!");
         env.write_file("bar", "\t\tTrUe   \n");
@@ -91,31 +91,42 @@ mod test {
         env.insert_name("t", PrimitiveValue::new_file("bar"));
         env.insert_name("f", PrimitiveValue::new_file("baz"));
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "read_boolean('does-not-exist')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "read_boolean('does-not-exist')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()
                 .starts_with("call to function `read_boolean` failed: failed to read file")
         );
 
-        let diagnostic = eval_v1_expr(&mut env, V1::Two, "read_boolean('foo')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "read_boolean('foo')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()
                 .contains("does not contain a boolean value on a single line")
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_boolean('bar')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_boolean('bar')")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_boolean(t)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_boolean(t)")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_boolean('baz')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_boolean('baz')")
+            .await
+            .unwrap();
         assert!(!value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_boolean(f)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_boolean(f)")
+            .await
+            .unwrap();
         assert!(!value.unwrap_boolean());
     }
 }

--- a/wdl-engine/src/stdlib/read_json.rs
+++ b/wdl-engine/src/stdlib/read_json.rs
@@ -60,9 +60,9 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn read_json() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn read_json() {
+        let env = TestEnv::default();
         env.write_file("empty.json", "");
         env.write_file("not-json.json", "not json!");
         env.write_file("null.json", "null");
@@ -82,7 +82,9 @@ mod test {
             r#"{ "foo": "bar", "bar!": 12345, "baz": [1, 2, 3] }"#,
         );
 
-        let diagnostic = eval_v1_expr(&mut env, V1::One, "read_json('empty.json')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "read_json('empty.json')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()
@@ -94,7 +96,9 @@ mod test {
                 .contains("EOF while parsing a value at line 1 column 0")
         );
 
-        let diagnostic = eval_v1_expr(&mut env, V1::One, "read_json('not-json.json')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "read_json('not-json.json')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()
@@ -106,22 +110,34 @@ mod test {
                 .contains("expected ident at line 1 column 2")
         );
 
-        let value = eval_v1_expr(&mut env, V1::One, "read_json('true.json')").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "read_json('true.json')")
+            .await
+            .unwrap();
         assert!(value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::One, "read_json('false.json')").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "read_json('false.json')")
+            .await
+            .unwrap();
         assert!(!value.unwrap_boolean());
 
-        let value = eval_v1_expr(&mut env, V1::One, "read_json('string.json')").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "read_json('string.json')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "hello\nworld!");
 
-        let value = eval_v1_expr(&mut env, V1::One, "read_json('int.json')").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "read_json('int.json')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 12345);
 
-        let value = eval_v1_expr(&mut env, V1::One, "read_json('float.json')").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "read_json('float.json')")
+            .await
+            .unwrap();
         approx::assert_relative_eq!(value.unwrap_float(), 12345.6789);
 
-        let value = eval_v1_expr(&mut env, V1::One, "read_json('array.json')").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "read_json('array.json')")
+            .await
+            .unwrap();
         assert_eq!(
             value
                 .unwrap_array()
@@ -133,8 +149,9 @@ mod test {
             [1, 2, 3]
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::One, "read_json('bad_array.json')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "read_json('bad_array.json')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()
@@ -146,7 +163,8 @@ mod test {
                 .contains("a common element type does not exist between `Int` and `String`")
         );
 
-        let value = eval_v1_expr(&mut env, V1::One, "read_json('object.json')")
+        let value = eval_v1_expr(&env, V1::One, "read_json('object.json')")
+            .await
             .unwrap()
             .unwrap_object();
         assert_eq!(
@@ -168,8 +186,9 @@ mod test {
             [1, 2, 3]
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::One, "read_json('bad_object.json')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "read_json('bad_object.json')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()

--- a/wdl-engine/src/stdlib/read_lines.rs
+++ b/wdl-engine/src/stdlib/read_lines.rs
@@ -75,22 +75,25 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn read_lines() {
+    #[tokio::test]
+    async fn read_lines() {
         let mut env = TestEnv::default();
         env.write_file("foo", "\nhello!\nworld!\n\r\nhi!\r\nthere!");
         env.write_file("empty", "");
         env.insert_name("file", PrimitiveValue::new_file("foo"));
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "read_lines('does-not-exist')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "read_lines('does-not-exist')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()
                 .starts_with("call to function `read_lines` failed: failed to open file")
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_lines('foo')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_lines('foo')")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -100,7 +103,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["", "hello!", "world!", "", "hi!", "there!"]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_lines(file)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_lines(file)")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -110,7 +115,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["", "hello!", "world!", "", "hi!", "there!"]);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_lines('empty')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_lines('empty')")
+            .await
+            .unwrap();
         assert!(value.unwrap_array().is_empty());
     }
 }

--- a/wdl-engine/src/stdlib/read_string.rs
+++ b/wdl-engine/src/stdlib/read_string.rs
@@ -52,8 +52,8 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn read_string() {
+    #[tokio::test]
+    async fn read_string() {
         let mut env = TestEnv::default();
         env.write_file("foo", "hello\nworld!\n\r\n");
         env.insert_name(
@@ -66,18 +66,23 @@ mod test {
             ),
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "read_string('does-not-exist')").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "read_string('does-not-exist')")
+            .await
+            .unwrap_err();
         assert!(
             diagnostic
                 .message()
                 .starts_with("call to function `read_string` failed: failed to read file")
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_string('foo')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_string('foo')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "hello\nworld!");
 
-        let value = eval_v1_expr(&mut env, V1::Two, "read_string(file)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "read_string(file)")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "hello\nworld!");
     }
 }

--- a/wdl-engine/src/stdlib/round.rs
+++ b/wdl-engine/src/stdlib/round.rs
@@ -35,31 +35,33 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn round() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(10.5)").unwrap();
+    #[tokio::test]
+    async fn round() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::Zero, "round(10.5)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 11);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(10.3)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "round(10.3)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 10);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(10)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "round(10)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 10);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(9.9999)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "round(9.9999)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 10);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(9.12345)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "round(9.12345)")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 9);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(0)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "round(0)").await.unwrap();
         assert_eq!(value.unwrap_integer(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(-5.1)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "round(-5.1)").await.unwrap();
         assert_eq!(value.unwrap_integer(), -5);
 
-        let value = eval_v1_expr(&mut env, V1::Zero, "round(-5.5)").unwrap();
+        let value = eval_v1_expr(&env, V1::Zero, "round(-5.5)").await.unwrap();
         assert_eq!(value.unwrap_integer(), -6);
     }
 }

--- a/wdl-engine/src/stdlib/select_all.rs
+++ b/wdl-engine/src/stdlib/select_all.rs
@@ -49,17 +49,21 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn select_all() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn select_all() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_all([])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_all([])").await.unwrap();
         assert_eq!(value.unwrap_array().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_all([None, None, None])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_all([None, None, None])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_array().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_all([None, 2, None])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_all([None, 2, None])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -69,7 +73,9 @@ mod test {
             .collect();
         assert_eq!(elements, [2]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_all([1, 2, None])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_all([1, 2, None])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -79,7 +85,9 @@ mod test {
             .collect();
         assert_eq!(elements, [1, 2]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_all([1, 2, 3, None])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_all([1, 2, 3, None])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -89,7 +97,9 @@ mod test {
             .collect();
         assert_eq!(elements, [1, 2, 3]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_all([1, 2, 3])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_all([1, 2, 3])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()

--- a/wdl-engine/src/stdlib/select_first.rs
+++ b/wdl-engine/src/stdlib/select_first.rs
@@ -63,47 +63,62 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn select_first() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn select_first() {
+        let env = TestEnv::default();
 
-        let diagnostic = eval_v1_expr(&mut env, V1::One, "select_first([])").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "select_first([])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `select_first` failed: array is empty"
         );
 
-        let diagnostic = eval_v1_expr(&mut env, V1::One, "select_first([], 1)").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "select_first([], 1)")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `select_first` failed: array is empty"
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::One, "select_first([None, None, None])").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "select_first([None, None, None])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `select_first` failed: array contains only `None` values"
         );
 
-        let value =
-            eval_v1_expr(&mut env, V1::One, "select_first([None, None, None], 12345)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_first([None, None, None], 12345)")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 12345);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_first([1, None, 3])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_first([1, None, 3])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 1);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_first([None, 2, 3])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_first([None, 2, 3])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 2);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_first([None, None, 3])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_first([None, None, 3])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 3);
 
-        let value =
-            eval_v1_expr(&mut env, V1::One, "select_first([None, 2, None], 12345)").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_first([None, 2, None], 12345)")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 2);
 
-        let value = eval_v1_expr(&mut env, V1::One, "select_first([1, 2, 3])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "select_first([1, 2, 3])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_integer(), 1);
     }
 }

--- a/wdl-engine/src/stdlib/sep.rs
+++ b/wdl-engine/src/stdlib/sep.rs
@@ -78,30 +78,37 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn sep() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn sep() {
+        let env = TestEnv::default();
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::One,
             "sep(' ', prefix('-i ', ['file_1', 'file_2']))",
         )
+        .await
         .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "-i file_1 -i file_2");
 
-        let value = eval_v1_expr(&mut env, V1::One, "sep('', ['a', 'b', 'c'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "sep('', ['a', 'b', 'c'])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "abc");
 
-        let value = eval_v1_expr(&mut env, V1::One, "sep(' ', ['a', 'b', 'c'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "sep(' ', ['a', 'b', 'c'])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "a b c");
 
-        let value = eval_v1_expr(&mut env, V1::One, "sep(' ', ['a', None, 'c'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "sep(' ', ['a', None, 'c'])")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "a  c");
 
-        let value = eval_v1_expr(&mut env, V1::One, "sep(',', [1])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "sep(',', [1])").await.unwrap();
         assert_eq!(value.unwrap_string().as_str(), "1");
 
-        let value = eval_v1_expr(&mut env, V1::One, "sep(',', [])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "sep(',', [])").await.unwrap();
         assert_eq!(value.unwrap_string().as_str(), "");
     }
 }

--- a/wdl-engine/src/stdlib/squote.rs
+++ b/wdl-engine/src/stdlib/squote.rs
@@ -58,10 +58,12 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn squote() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::One, "squote([1, 2, 3])").unwrap();
+    #[tokio::test]
+    async fn squote() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::One, "squote([1, 2, 3])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -71,7 +73,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["'1'", "'2'", "'3'"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "squote([1.0, 1.1, 1.2])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "squote([1.0, 1.1, 1.2])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -81,7 +85,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["'1.000000'", "'1.100000'", "'1.200000'"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "squote(['bar', 'baz', 'qux'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "squote(['bar', 'baz', 'qux'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -91,7 +97,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["'bar'", "'baz'", "'qux'"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "squote(['bar', None, 'qux'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "squote(['bar', None, 'qux'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -101,7 +109,7 @@ mod test {
             .collect();
         assert_eq!(elements, ["'bar'", "''", "'qux'"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "squote([])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "squote([])").await.unwrap();
         assert!(value.unwrap_array().is_empty());
     }
 }

--- a/wdl-engine/src/stdlib/stderr.rs
+++ b/wdl-engine/src/stdlib/stderr.rs
@@ -48,10 +48,10 @@ mod test {
     use crate::v1::test::eval_v1_expr;
     use crate::v1::test::eval_v1_expr_with_stdio;
 
-    #[test]
-    fn stderr() {
-        let mut env = TestEnv::default();
-        let diagnostic = eval_v1_expr(&mut env, V1::Two, "stderr()").unwrap_err();
+    #[tokio::test]
+    async fn stderr() {
+        let env = TestEnv::default();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "stderr()").await.unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `stderr` failed: function may only be called in a task output \
@@ -59,12 +59,13 @@ mod test {
         );
 
         let value = eval_v1_expr_with_stdio(
-            &mut env,
+            &env,
             V1::Zero,
             "stderr()",
             PrimitiveValue::new_file("stdout.txt"),
             PrimitiveValue::new_file("stderr.txt"),
         )
+        .await
         .unwrap();
         assert_eq!(value.unwrap_file().as_str(), "stderr.txt");
     }

--- a/wdl-engine/src/stdlib/stdout.rs
+++ b/wdl-engine/src/stdlib/stdout.rs
@@ -48,10 +48,10 @@ mod test {
     use crate::v1::test::eval_v1_expr;
     use crate::v1::test::eval_v1_expr_with_stdio;
 
-    #[test]
-    fn stdout() {
-        let mut env = TestEnv::default();
-        let diagnostic = eval_v1_expr(&mut env, V1::Two, "stdout()").unwrap_err();
+    #[tokio::test]
+    async fn stdout() {
+        let env = TestEnv::default();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "stdout()").await.unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `stdout` failed: function may only be called in a task output \
@@ -59,12 +59,13 @@ mod test {
         );
 
         let value = eval_v1_expr_with_stdio(
-            &mut env,
+            &env,
             V1::Zero,
             "stdout()",
             PrimitiveValue::new_file("stdout.txt"),
             PrimitiveValue::new_file("stderr.txt"),
         )
+        .await
         .unwrap();
         assert_eq!(value.unwrap_file().as_str(), "stdout.txt");
     }

--- a/wdl-engine/src/stdlib/sub.rs
+++ b/wdl-engine/src/stdlib/sub.rs
@@ -59,25 +59,30 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn sub() {
-        let mut env = TestEnv::default();
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "sub('foo bar baz', '?', 'nope')").unwrap_err();
+    #[tokio::test]
+    async fn sub() {
+        let env = TestEnv::default();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "sub('foo bar baz', '?', 'nope')")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "regex parse error:\n    ?\n    ^\nerror: repetition operator missing expression"
         );
 
-        let value =
-            eval_v1_expr(&mut env, V1::Two, "sub('hello world', 'e..o', 'ey there')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "sub('hello world', 'e..o', 'ey there')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "hey there world");
 
-        let value =
-            eval_v1_expr(&mut env, V1::Two, "sub('hello world', 'goodbye', 'nope')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "sub('hello world', 'goodbye', 'nope')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "hello world");
 
-        let value = eval_v1_expr(&mut env, V1::Two, "sub('hello\tBob', '\\t', ' ')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "sub('hello\tBob', '\\t', ' ')")
+            .await
+            .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "hello Bob");
     }
 }

--- a/wdl-engine/src/stdlib/suffix.rs
+++ b/wdl-engine/src/stdlib/suffix.rs
@@ -65,10 +65,12 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn suffix() {
-        let mut env = TestEnv::default();
-        let value = eval_v1_expr(&mut env, V1::One, "suffix('foo', [1, 2, 3])").unwrap();
+    #[tokio::test]
+    async fn suffix() {
+        let env = TestEnv::default();
+        let value = eval_v1_expr(&env, V1::One, "suffix('foo', [1, 2, 3])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -78,7 +80,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["1foo", "2foo", "3foo"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "suffix('foo', [1.0, 1.1, 1.2])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "suffix('foo', [1.0, 1.1, 1.2])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -88,8 +92,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["1.000000foo", "1.100000foo", "1.200000foo"]);
 
-        let value =
-            eval_v1_expr(&mut env, V1::One, "suffix('foo', ['bar', 'baz', 'qux'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "suffix('foo', ['bar', 'baz', 'qux'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -99,7 +104,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["barfoo", "bazfoo", "quxfoo"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "suffix('foo', ['bar', None, 'qux'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "suffix('foo', ['bar', None, 'qux'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -109,7 +116,9 @@ mod test {
             .collect();
         assert_eq!(elements, ["barfoo", "foo", "quxfoo"]);
 
-        let value = eval_v1_expr(&mut env, V1::One, "suffix('foo', [])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "suffix('foo', [])")
+            .await
+            .unwrap();
         assert!(value.unwrap_array().is_empty());
     }
 }

--- a/wdl-engine/src/stdlib/transpose.rs
+++ b/wdl-engine/src/stdlib/transpose.rs
@@ -91,17 +91,21 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn transpose() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn transpose() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "transpose([])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "transpose([])").await.unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "transpose([[], [], []])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "transpose([[], [], []])")
+            .await
+            .unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "transpose([[0, 1, 2], [3, 4, 5]])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "transpose([[0, 1, 2], [3, 4, 5]])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -119,10 +123,11 @@ mod test {
         assert_eq!(elements, [[0, 3], [1, 4], [2, 5]]);
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::One,
             "transpose([['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']])",
         )
+        .await
         .unwrap();
         let elements: Vec<_> = value
             .as_array()
@@ -143,8 +148,9 @@ mod test {
             [["a", "d", "g"], ["b", "e", "h"], ["c", "f", "i"]]
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::One, "transpose([['foo', 'bar'], ['baz']])").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "transpose([['foo', 'bar'], ['baz']])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `transpose` failed: expected array at index 1 to have a length of 2"

--- a/wdl-engine/src/stdlib/unzip.rs
+++ b/wdl-engine/src/stdlib/unzip.rs
@@ -75,17 +75,19 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn unzip() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn unzip() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "unzip([])")
+        let value = eval_v1_expr(&env, V1::One, "unzip([])")
+            .await
             .unwrap()
             .unwrap_pair();
         assert_eq!(value.left().as_array().unwrap().len(), 0);
         assert_eq!(value.right().as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "unzip([(1, 'a'), (2, 'b'), (3, 'c')])")
+        let value = eval_v1_expr(&env, V1::One, "unzip([(1, 'a'), (2, 'b'), (3, 'c')])")
+            .await
             .unwrap()
             .unwrap_pair();
         let left: Vec<_> = value

--- a/wdl-engine/src/stdlib/values.rs
+++ b/wdl-engine/src/stdlib/values.rs
@@ -54,8 +54,8 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn values() {
+    #[tokio::test]
+    async fn values() {
         let mut env = TestEnv::default();
 
         let ty = StructType::new(
@@ -69,11 +69,12 @@ mod test {
 
         env.insert_struct("Foo", ty);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "values({})").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "values({})").await.unwrap();
         assert_eq!(value.unwrap_array().len(), 0);
 
-        let value =
-            eval_v1_expr(&mut env, V1::Two, "values({'foo': 1, 'bar': 2, 'baz': 3})").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "values({'foo': 1, 'bar': 2, 'baz': 3})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -83,12 +84,9 @@ mod test {
             .collect();
         assert_eq!(elements, [1, 2, 3]);
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::Two,
-            "values({'foo': 1, 'bar': None, 'baz': 3})",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "values({'foo': 1, 'bar': None, 'baz': 3})")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()

--- a/wdl-engine/src/stdlib/write_json.rs
+++ b/wdl-engine/src/stdlib/write_json.rs
@@ -119,8 +119,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn write_json() {
+    #[tokio::test]
+    async fn write_json() {
         let mut env = TestEnv::default();
 
         let ty = StructType::new(
@@ -135,89 +135,104 @@ mod test {
         env.insert_name("foo", PrimitiveValue::new_file("foo"));
         env.insert_name("bar", PrimitiveValue::new_file("bar"));
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json(None)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json(None)")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "null",
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json(true)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json(true)")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "true",
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json(false)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json(false)")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "false",
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json(12345)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json(12345)")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "12345",
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json(12345.6789)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json(12345.6789)")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "12345.6789",
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json('hello world!')").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json('hello world!')")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             r#""hello world!""#,
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json(foo)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json(foo)")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             r#""foo""#,
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json(bar)").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json(bar)")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             r#""bar""#,
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json([])").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json([])").await.unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "[]",
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json([1, 2, 3])").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json([1, 2, 3])")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "[\n  1,\n  2,\n  3\n]",
         );
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_json({})").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json({})").await.unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
             "{}",
         );
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::Two,
-            "write_json({'foo': 'bar', 'baz': 'qux'})",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_json({'foo': 'bar', 'baz': 'qux'})")
+            .await
+            .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
             fs::read_to_string(value.unwrap_file().as_str()).expect("failed to read file"),
@@ -225,10 +240,11 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_json(object { foo: 1, bar: 'baz', baz: 1.9 })",
         )
+        .await
         .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(
@@ -237,10 +253,11 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_json(Foo { foo: 1, bar: 'baz', baz: 1.9 })",
         )
+        .await
         .unwrap();
         assert_file_in_temp(&env, &value);
         assert_eq!(

--- a/wdl-engine/src/stdlib/write_lines.rs
+++ b/wdl-engine/src/stdlib/write_lines.rs
@@ -102,11 +102,13 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn write_lines() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn write_lines() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_lines([])").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_lines([])")
+            .await
+            .unwrap();
         assert!(
             value
                 .as_file()
@@ -120,12 +122,9 @@ mod test {
             "",
         );
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::Two,
-            "write_lines(['hello', 'world', '!\n', '!'])",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_lines(['hello', 'world', '!\n', '!'])")
+            .await
+            .unwrap();
         assert!(
             value
                 .as_file()

--- a/wdl-engine/src/stdlib/write_map.rs
+++ b/wdl-engine/src/stdlib/write_map.rs
@@ -112,11 +112,11 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn write_map() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn write_map() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_map({})").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_map({})").await.unwrap();
         assert!(
             value
                 .as_file()
@@ -131,10 +131,11 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_map({ 'foo': 'bar', 'bar': 'baz', 'qux': 'jam' })",
         )
+        .await
         .unwrap();
         assert!(
             value

--- a/wdl-engine/src/stdlib/write_object.rs
+++ b/wdl-engine/src/stdlib/write_object.rs
@@ -150,8 +150,8 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn write_object() {
+    #[tokio::test]
+    async fn write_object() {
         let mut env = TestEnv::default();
 
         let ty = StructType::new(
@@ -165,7 +165,9 @@ mod test {
 
         env.insert_struct("Foo", ty);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_object(object {})").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_object(object {})")
+            .await
+            .unwrap();
         assert!(
             value
                 .as_file()
@@ -180,10 +182,11 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_object(object { foo: 'bar', bar: 1, baz: 3.5 })",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -199,10 +202,11 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_object(Foo { foo: 1, bar: 'foo', baz: true })",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -218,10 +222,11 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_object(object { foo: 1, bar: None, baz: true })",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -236,15 +241,17 @@ mod test {
             "foo\tbar\tbaz\n1\t\ttrue\n",
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "write_object(object { foo: [] })").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "write_object(object { foo: [] })")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `write_object` failed: member `foo` is not a primitive value"
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "write_object(object { foo: '\tbar' })").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "write_object(object { foo: '\tbar' })")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `write_object` failed: member `foo` contains a tab character"

--- a/wdl-engine/src/stdlib/write_tsv.rs
+++ b/wdl-engine/src/stdlib/write_tsv.rs
@@ -417,8 +417,8 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn write_tsv() {
+    #[tokio::test]
+    async fn write_tsv() {
         let mut env = TestEnv::default();
 
         let ty: Type = StructType::new(
@@ -433,7 +433,7 @@ mod test {
 
         env.insert_struct("Foo", ty);
 
-        let value = eval_v1_expr(&mut env, V1::Two, "write_tsv([])").unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_tsv([])").await.unwrap();
         assert!(
             value
                 .as_file()
@@ -448,10 +448,11 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([['foo'], ['foo', 'bar'], ['foo', 'bar', 'baz']])",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -466,12 +467,9 @@ mod test {
             "foo\nfoo\tbar\nfoo\tbar\tbaz\n",
         );
 
-        let value = eval_v1_expr(
-            &mut env,
-            V1::Two,
-            "write_tsv([], true, ['foo', 'bar', 'baz'])",
-        )
-        .unwrap();
+        let value = eval_v1_expr(&env, V1::Two, "write_tsv([], true, ['foo', 'bar', 'baz'])")
+            .await
+            .unwrap();
         assert!(
             value
                 .as_file()
@@ -486,11 +484,12 @@ mod test {
         );
 
         let diagnostic = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([['foo'], ['foo', 'bar'], ['foo', 'bar', 'baz']], true, ['foo', 'bar', \
              'baz'])",
         )
+        .await
         .unwrap_err();
         assert_eq!(
             diagnostic.message(),
@@ -499,11 +498,12 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([['foo'], ['foo', 'bar'], ['foo', 'bar', 'baz']], false, ['foo', 'bar', \
              'baz'])",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -519,11 +519,12 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([Foo { foo: 1, bar: 'hi', baz: true }, Foo { foo: 1234, bar: 'there', baz: \
              false }])",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -539,11 +540,12 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([Foo { foo: 1, bar: 'hi', baz: false }, Foo { foo: 1234, bar: 'there' }], \
              false)",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -559,11 +561,12 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([Foo { foo: 1, bar: 'hi', baz: true }, Foo { foo: 1234, bar: 'there', baz: \
              false }], true)",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -579,11 +582,12 @@ mod test {
         );
 
         let value = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([Foo { foo: 1, bar: 'hi' }, Foo { foo: 1234, bar: 'there', baz: false }], \
              true, ['qux', 'jam', 'cakes'])",
         )
+        .await
         .unwrap();
         assert!(
             value
@@ -599,11 +603,12 @@ mod test {
         );
 
         let diagnostic = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([Foo { foo: 1, bar: 'hi', baz: true }, Foo { foo: 1234, bar: 'there', baz: \
              false }], true, ['qux'])",
         )
+        .await
         .unwrap_err();
         assert_eq!(
             diagnostic.message(),
@@ -611,15 +616,18 @@ mod test {
              but only given 1 header"
         );
 
-        let diagnostic = eval_v1_expr(&mut env, V1::Two, "write_tsv([['\tfoo']])").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "write_tsv([['\tfoo']])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `write_tsv` failed: element of array at index 0 contains a tab \
              character"
         );
 
-        let diagnostic =
-            eval_v1_expr(&mut env, V1::Two, "write_tsv([['foo']], true, ['\tfoo'])").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::Two, "write_tsv([['foo']], true, ['\tfoo'])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `write_tsv` failed: specified column name at index 0 contains a tab \
@@ -627,11 +635,12 @@ mod test {
         );
 
         let diagnostic = eval_v1_expr(
-            &mut env,
+            &env,
             V1::Two,
             "write_tsv([Foo { foo: 1, bar: 'hi', baz: true }, Foo { foo: 1234, bar: 'there', baz: \
              false }], true, ['foo', '\tbar', 'baz'])",
         )
+        .await
         .unwrap_err();
         assert_eq!(
             diagnostic.message(),

--- a/wdl-engine/src/stdlib/zip.rs
+++ b/wdl-engine/src/stdlib/zip.rs
@@ -85,14 +85,16 @@ mod test {
     use crate::v1::test::TestEnv;
     use crate::v1::test::eval_v1_expr;
 
-    #[test]
-    fn zip() {
-        let mut env = TestEnv::default();
+    #[tokio::test]
+    async fn zip() {
+        let env = TestEnv::default();
 
-        let value = eval_v1_expr(&mut env, V1::One, "zip([], [])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "zip([], [])").await.unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
 
-        let value = eval_v1_expr(&mut env, V1::One, "zip([1, 2, 3], ['a', 'b', 'c'])").unwrap();
+        let value = eval_v1_expr(&env, V1::One, "zip([1, 2, 3], ['a', 'b', 'c'])")
+            .await
+            .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()
@@ -108,7 +110,9 @@ mod test {
             .collect();
         assert_eq!(elements, [(1, "a"), (2, "b"), (3, "c")]);
 
-        let diagnostic = eval_v1_expr(&mut env, V1::One, "zip([1, 2, 3], ['a'])").unwrap_err();
+        let diagnostic = eval_v1_expr(&env, V1::One, "zip([1, 2, 3], ['a'])")
+            .await
+            .unwrap_err();
         assert_eq!(
             diagnostic.message(),
             "call to function `zip` failed: expected an array of length 3, but this is an array \


### PR DESCRIPTION
This PR changes the expression evaluator in `wdl-engine` to be async.

This is required for an upcoming change to function evaluation that will allow for the `read_*` functions to work from remote files.

Note that this change does not include a change to the stdlib functions to make their calls actually async; that change will be made shortly in a follow-up commit.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
