### PR TITLE
feat: make stdlib file functions asynchronous.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Make stdlib file functions asynchronous ([#359](https://github.com/stjude-rust-labs/wdl/pull/359)).
 * Refactored expression evaluation to make it async ([#357](https://github.com/stjude-rust-labs/wdl/pull/357)).
 * Updated for refactored `wdl-ast` API so that evaluation can now operate
   directly on AST nodes in `async` context ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).

--- a/wdl-engine/src/eval/v1/expr.rs
+++ b/wdl-engine/src/eval/v1/expr.rs
@@ -1266,6 +1266,7 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                                 .get(target.text())
                                 .expect("should have implementation")
                                 .call(binding, context)
+                                .await
                         }
                         Err(FunctionBindError::RequiresVersion(minimum)) => {
                             Err(unsupported_function(minimum, target.text(), target.span()))

--- a/wdl-engine/src/stdlib/as_map.rs
+++ b/wdl-engine/src/stdlib/as_map.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Map;
@@ -77,7 +78,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[Pair[K, V]]) -> Map[K, V] where `K`: any primitive type",
-                as_map,
+                Callback::Sync(as_map),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/as_pairs.rs
+++ b/wdl-engine/src/stdlib/as_pairs.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -43,7 +44,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Map[K, V]) -> Array[Pair[K, V]] where `K`: any primitive type",
-                as_pairs,
+                Callback::Sync(as_pairs),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/basename.rs
+++ b/wdl-engine/src/stdlib/basename.rs
@@ -6,6 +6,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -53,9 +54,9 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(File, <String>) -> String", basename),
-                Signature::new("(String, <String>) -> String", basename),
-                Signature::new("(Directory, <String>) -> String", basename),
+                Signature::new("(File, <String>) -> String", Callback::Sync(basename)),
+                Signature::new("(String, <String>) -> String", Callback::Sync(basename)),
+                Signature::new("(Directory, <String>) -> String", Callback::Sync(basename)),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/ceil.rs
+++ b/wdl-engine/src/stdlib/ceil.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -23,7 +24,7 @@ fn ceil(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `ceil`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Float) -> Int", ceil)] })
+    Function::new(const { &[Signature::new("(Float) -> Int", Callback::Sync(ceil))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/chunk.rs
+++ b/wdl-engine/src/stdlib/chunk.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -56,7 +57,14 @@ fn chunk(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `chunk`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Array[X], Int) -> Array[Array[X]]", chunk)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(Array[X], Int) -> Array[Array[X]]",
+                Callback::Sync(chunk),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/collect_by_key.rs
+++ b/wdl-engine/src/stdlib/collect_by_key.rs
@@ -4,6 +4,7 @@ use indexmap::IndexMap;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -75,7 +76,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[Pair[K, V]]) -> Map[K, Array[V]] where `K`: any primitive type",
-                collect_by_key,
+                Callback::Sync(collect_by_key),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/contains.rs
+++ b/wdl-engine/src/stdlib/contains.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -36,7 +37,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[P], P) -> Boolean where `P`: any primitive type",
-                contains,
+                Callback::Sync(contains),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/contains_key.rs
+++ b/wdl-engine/src/stdlib/contains_key.rs
@@ -8,6 +8,7 @@ use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::CompoundValue;
@@ -115,18 +116,24 @@ pub const fn descriptor() -> Function {
             &[
                 Signature::new(
                     "(Map[K, V], K) -> Boolean where `K`: any primitive type",
-                    contains_key_map,
+                    Callback::Sync(contains_key_map),
                 ),
-                Signature::new("(Object, String) -> Boolean", contains_key_object),
+                Signature::new(
+                    "(Object, String) -> Boolean",
+                    Callback::Sync(contains_key_object),
+                ),
                 Signature::new(
                     "(Map[String, V], Array[String]) -> Boolean",
-                    contains_key_recursive,
+                    Callback::Sync(contains_key_recursive),
                 ),
                 Signature::new(
                     "(S, Array[String]) -> Boolean where `S`: any structure",
-                    contains_key_recursive,
+                    Callback::Sync(contains_key_recursive),
                 ),
-                Signature::new("(Object, Array[String]) -> Boolean", contains_key_recursive),
+                Signature::new(
+                    "(Object, Array[String]) -> Boolean",
+                    Callback::Sync(contains_key_recursive),
+                ),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/cross.rs
+++ b/wdl-engine/src/stdlib/cross.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -55,7 +56,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[X], Array[Y]) -> Array[Pair[X, Y]]",
-                cross,
+                Callback::Sync(cross),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/defined.rs
+++ b/wdl-engine/src/stdlib/defined.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -20,7 +21,7 @@ fn defined(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `defined`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(X) -> Boolean", defined)] })
+    Function::new(const { &[Signature::new("(X) -> Boolean", Callback::Sync(defined))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/find.rs
+++ b/wdl-engine/src/stdlib/find.rs
@@ -7,6 +7,7 @@ use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -40,7 +41,14 @@ fn find(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `find`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(String, String) -> String?", find)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(String, String) -> String?",
+                Callback::Sync(find),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/flatten.rs
+++ b/wdl-engine/src/stdlib/flatten.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -46,7 +47,14 @@ fn flatten(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `flatten`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Array[Array[X]]) -> Array[X]", flatten)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(Array[Array[X]]) -> Array[X]",
+                Callback::Sync(flatten),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/floor.rs
+++ b/wdl-engine/src/stdlib/floor.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -23,7 +24,7 @@ fn floor(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `floor`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Float) -> Int", floor)] })
+    Function::new(const { &[Signature::new("(Float) -> Int", Callback::Sync(floor))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/glob.rs
+++ b/wdl-engine/src/stdlib/glob.rs
@@ -7,6 +7,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -79,7 +80,14 @@ fn glob(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `glob`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(String) -> Array[File]", glob)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(String) -> Array[File]",
+                Callback::Sync(glob),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/join_paths.rs
+++ b/wdl-engine/src/stdlib/join_paths.rs
@@ -9,6 +9,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -128,9 +129,9 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(File, String) -> File", join_paths_simple),
-                Signature::new("(File, Array[String]+) -> File", join_paths),
-                Signature::new("(Array[String]+) -> File", join_paths),
+                Signature::new("(File, String) -> File", Callback::Sync(join_paths_simple)),
+                Signature::new("(File, Array[String]+) -> File", Callback::Sync(join_paths)),
+                Signature::new("(Array[String]+) -> File", Callback::Sync(join_paths)),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/keys.rs
+++ b/wdl-engine/src/stdlib/keys.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -53,10 +54,13 @@ pub const fn descriptor() -> Function {
             &[
                 Signature::new(
                     "(Map[K, V]) -> Array[K] where `K`: any primitive type",
-                    keys,
+                    Callback::Sync(keys),
                 ),
-                Signature::new("(S) -> Array[String] where `S`: any structure", keys),
-                Signature::new("(Object) -> Array[String]", keys),
+                Signature::new(
+                    "(S) -> Array[String] where `S`: any structure",
+                    Callback::Sync(keys),
+                ),
+                Signature::new("(Object) -> Array[String]", Callback::Sync(keys)),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/length.rs
+++ b/wdl-engine/src/stdlib/length.rs
@@ -5,6 +5,7 @@ use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -111,10 +112,10 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(Array[X]) -> Int", array_length),
-                Signature::new("(Map[K, V]) -> Int", map_length),
-                Signature::new("(Object) -> Int", object_length),
-                Signature::new("(String) -> Int", string_length),
+                Signature::new("(Array[X]) -> Int", Callback::Sync(array_length)),
+                Signature::new("(Map[K, V]) -> Int", Callback::Sync(map_length)),
+                Signature::new("(Object) -> Int", Callback::Sync(object_length)),
+                Signature::new("(String) -> Int", Callback::Sync(string_length)),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/matches.rs
+++ b/wdl-engine/src/stdlib/matches.rs
@@ -5,6 +5,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -32,7 +33,14 @@ fn matches(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `matches`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(String, String) -> Boolean", matches)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(String, String) -> Boolean",
+                Callback::Sync(matches),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/max.rs
+++ b/wdl-engine/src/stdlib/max.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -45,10 +46,10 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(Int, Int) -> Int", int_max),
-                Signature::new("(Int, Float) -> Float", float_max),
-                Signature::new("(Float, Int) -> Float", float_max),
-                Signature::new("(Float, Float) -> Float", float_max),
+                Signature::new("(Int, Int) -> Int", Callback::Sync(int_max)),
+                Signature::new("(Int, Float) -> Float", Callback::Sync(float_max)),
+                Signature::new("(Float, Int) -> Float", Callback::Sync(float_max)),
+                Signature::new("(Float, Float) -> Float", Callback::Sync(float_max)),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/min.rs
+++ b/wdl-engine/src/stdlib/min.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -45,10 +46,10 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(Int, Int) -> Int", int_min),
-                Signature::new("(Int, Float) -> Float", float_min),
-                Signature::new("(Float, Int) -> Float", float_min),
-                Signature::new("(Float, Float) -> Float", float_min),
+                Signature::new("(Int, Int) -> Int", Callback::Sync(int_min)),
+                Signature::new("(Int, Float) -> Float", Callback::Sync(float_min)),
+                Signature::new("(Float, Int) -> Float", Callback::Sync(float_min)),
+                Signature::new("(Float, Float) -> Float", Callback::Sync(float_min)),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/prefix.rs
+++ b/wdl-engine/src/stdlib/prefix.rs
@@ -5,6 +5,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -51,7 +52,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(String, Array[P]) -> Array[String] where `P`: any primitive type",
-                prefix,
+                Callback::Sync(prefix),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/quote.rs
+++ b/wdl-engine/src/stdlib/quote.rs
@@ -4,6 +4,7 @@ use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -46,7 +47,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[P]) -> Array[String] where `P`: any primitive type",
-                quote,
+                Callback::Sync(quote),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/range.rs
+++ b/wdl-engine/src/stdlib/range.rs
@@ -5,6 +5,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -38,7 +39,7 @@ fn range(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `range`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Int) -> Array[Int]", range)] })
+    Function::new(const { &[Signature::new("(Int) -> Array[Int]", Callback::Sync(range))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/read_float.rs
+++ b/wdl-engine/src/stdlib/read_float.rs
@@ -1,13 +1,15 @@
 //! Implements the `read_float` function from the WDL standard library.
 
-use std::fs;
-use std::io::BufRead;
-use std::io::BufReader;
-
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use tokio::fs;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -20,56 +22,67 @@ use crate::diagnostics::function_call_failed;
 /// error is raised.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_float
-fn read_float(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveType::Float));
+fn read_float(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() == 1);
+        debug_assert!(context.return_type_eq(PrimitiveType::Float));
 
-    let path = context.work_dir().join(
-        context
-            .coerce_argument(0, PrimitiveType::File)
-            .unwrap_file()
-            .as_str(),
-    );
+        let path = context.work_dir().join(
+            context
+                .coerce_argument(0, PrimitiveType::File)
+                .unwrap_file()
+                .as_str(),
+        );
 
-    let read_error = |e: std::io::Error| {
-        function_call_failed(
-            "read_float",
-            format!("failed to read file `{path}`: {e}", path = path.display()),
-            context.call_site,
-        )
-    };
+        let read_error = |e: std::io::Error| {
+            function_call_failed(
+                "read_float",
+                format!("failed to read file `{path}`: {e}", path = path.display()),
+                context.call_site,
+            )
+        };
 
-    let invalid_contents = || {
-        function_call_failed(
-            "read_float",
-            format!(
-                "file `{path}` does not contain a float value on a single line",
-                path = path.display()
-            ),
-            context.call_site,
-        )
-    };
+        let invalid_contents = || {
+            function_call_failed(
+                "read_float",
+                format!(
+                    "file `{path}` does not contain a float value on a single line",
+                    path = path.display()
+                ),
+                context.call_site,
+            )
+        };
 
-    let mut lines = BufReader::new(fs::File::open(&path).map_err(read_error)?).lines();
-    let line = lines
-        .next()
-        .ok_or_else(invalid_contents)?
-        .map_err(read_error)?;
+        let mut lines = BufReader::new(fs::File::open(&path).await.map_err(read_error)?).lines();
+        let line = lines
+            .next_line()
+            .await
+            .map_err(read_error)?
+            .ok_or_else(invalid_contents)?;
 
-    if lines.next().is_some() {
-        return Err(invalid_contents());
+        if lines.next_line().await.map_err(read_error)?.is_some() {
+            return Err(invalid_contents());
+        }
+
+        Ok(line
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| invalid_contents())?
+            .into())
     }
-
-    Ok(line
-        .trim()
-        .parse::<f64>()
-        .map_err(|_| invalid_contents())?
-        .into())
+    .boxed()
 }
 
 /// Gets the function describing `read_float`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(File) -> Float", read_float)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(File) -> Float",
+                Callback::Async(read_float),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/read_int.rs
+++ b/wdl-engine/src/stdlib/read_int.rs
@@ -1,13 +1,15 @@
 //! Implements the `read_int` function from the WDL standard library.
 
-use std::fs;
-use std::io::BufRead;
-use std::io::BufReader;
-
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use tokio::fs;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -20,56 +22,60 @@ use crate::diagnostics::function_call_failed;
 /// the file is empty or does not contain a single integer, an error is raised.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_int
-fn read_int(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveType::Integer));
+fn read_int(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() == 1);
+        debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
-    let path = context.work_dir().join(
-        context
-            .coerce_argument(0, PrimitiveType::File)
-            .unwrap_file()
-            .as_str(),
-    );
+        let path = context.work_dir().join(
+            context
+                .coerce_argument(0, PrimitiveType::File)
+                .unwrap_file()
+                .as_str(),
+        );
 
-    let read_error = |e: std::io::Error| {
-        function_call_failed(
-            "read_int",
-            format!("failed to read file `{path}`: {e}", path = path.display()),
-            context.call_site,
-        )
-    };
+        let read_error = |e: std::io::Error| {
+            function_call_failed(
+                "read_int",
+                format!("failed to read file `{path}`: {e}", path = path.display()),
+                context.call_site,
+            )
+        };
 
-    let invalid_contents = || {
-        function_call_failed(
-            "read_int",
-            format!(
-                "file `{path}` does not contain an integer value on a single line",
-                path = path.display()
-            ),
-            context.call_site,
-        )
-    };
+        let invalid_contents = || {
+            function_call_failed(
+                "read_int",
+                format!(
+                    "file `{path}` does not contain an integer value on a single line",
+                    path = path.display()
+                ),
+                context.call_site,
+            )
+        };
 
-    let mut lines = BufReader::new(fs::File::open(&path).map_err(read_error)?).lines();
-    let line = lines
-        .next()
-        .ok_or_else(invalid_contents)?
-        .map_err(read_error)?;
+        let mut lines = BufReader::new(fs::File::open(&path).await.map_err(read_error)?).lines();
+        let line = lines
+            .next_line()
+            .await
+            .map_err(read_error)?
+            .ok_or_else(invalid_contents)?;
 
-    if lines.next().is_some() {
-        return Err(invalid_contents());
+        if lines.next_line().await.map_err(read_error)?.is_some() {
+            return Err(invalid_contents());
+        }
+
+        Ok(line
+            .trim()
+            .parse::<i64>()
+            .map_err(|_| invalid_contents())?
+            .into())
     }
-
-    Ok(line
-        .trim()
-        .parse::<i64>()
-        .map_err(|_| invalid_contents())?
-        .into())
+    .boxed()
 }
 
 /// Gets the function describing `read_int`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(File) -> Int", read_int)] })
+    Function::new(const { &[Signature::new("(File) -> Int", Callback::Async(read_int))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/read_lines.rs
+++ b/wdl-engine/src/stdlib/read_lines.rs
@@ -1,15 +1,17 @@
 //! Implements the `read_lines` function from the WDL standard library.
 
-use std::fs;
-use std::io::BufRead;
-use std::io::BufReader;
-
 use anyhow::Context;
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use tokio::fs;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -28,42 +30,49 @@ use crate::diagnostics::function_call_failed;
 /// If the file is empty, an empty array is returned.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_lines
-fn read_lines(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
+fn read_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() == 1);
+        debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
 
-    let path = context.work_dir().join(
-        context
-            .coerce_argument(0, PrimitiveType::File)
-            .unwrap_file()
-            .as_str(),
-    );
+        let path = context.work_dir().join(
+            context
+                .coerce_argument(0, PrimitiveType::File)
+                .unwrap_file()
+                .as_str(),
+        );
 
-    let file = fs::File::open(&path)
-        .with_context(|| format!("failed to open file `{path}`", path = path.display()))
-        .map_err(|e| function_call_failed("read_lines", format!("{e:?}"), context.call_site))?;
+        let file = fs::File::open(&path)
+            .await
+            .with_context(|| format!("failed to open file `{path}`", path = path.display()))
+            .map_err(|e| function_call_failed("read_lines", format!("{e:?}"), context.call_site))?;
 
-    let elements = BufReader::new(file)
-        .lines()
-        .map(|line| {
-            Ok(PrimitiveValue::new_string(
-                line.with_context(|| {
-                    format!("failed to read file `{path}`", path = path.display())
-                })
-                .map_err(|e| {
-                    function_call_failed("read_lines", format!("{e:?}"), context.call_site)
-                })?,
-            )
-            .into())
-        })
-        .collect::<Result<Vec<Value>, _>>()?;
+        let mut lines = BufReader::new(file).lines();
 
-    Ok(Array::new_unchecked(context.return_type, elements).into())
+        let mut elements = Vec::new();
+        while let Some(line) = lines
+            .next_line()
+            .await
+            .map_err(|e| function_call_failed("read_lines", format!("{e:?}"), context.call_site))?
+        {
+            elements.push(PrimitiveValue::new_string(line).into());
+        }
+
+        Ok(Array::new_unchecked(context.return_type, elements).into())
+    }
+    .boxed()
 }
 
 /// Gets the function describing `read_lines`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(File) -> Array[String]", read_lines)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(File) -> Array[String]",
+                Callback::Async(read_lines),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/read_object.rs
+++ b/wdl-engine/src/stdlib/read_object.rs
@@ -1,19 +1,21 @@
 //! Implements the `read_object` function from the WDL standard library.
 
-use std::fs;
-use std::io::BufRead;
-use std::io::BufReader;
-
 use anyhow::Context;
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use itertools::EitherOrBoth;
 use itertools::Itertools;
+use tokio::fs;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
 use wdl_analysis::types::PrimitiveType;
 use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 use wdl_grammar::lexer::v1::is_ident;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Object;
@@ -36,98 +38,120 @@ use crate::diagnostics::function_call_failed;
 /// in the first row. All of the Object's values are of type String.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_object
-fn read_object(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(Type::Object));
+fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() == 1);
+        debug_assert!(context.return_type_eq(Type::Object));
 
-    let path = context.work_dir().join(
-        context
-            .coerce_argument(0, PrimitiveType::File)
-            .unwrap_file()
-            .as_str(),
-    );
+        let path = context.work_dir().join(
+            context
+                .coerce_argument(0, PrimitiveType::File)
+                .unwrap_file()
+                .as_str(),
+        );
 
-    let expected_two_lines = || {
-        function_call_failed(
-            "read_object",
-            format!(
-                "expected exactly two lines in file `{path}`",
-                path = path.display()
-            ),
-            context.call_site,
-        )
-    };
+        let read_error = |e: std::io::Error| {
+            function_call_failed(
+                "read_object",
+                format!("failed to read file `{path}`: {e}", path = path.display()),
+                context.call_site,
+            )
+        };
 
-    let file = fs::File::open(&path)
-        .with_context(|| format!("failed to open file `{path}`", path = path.display()))
-        .map_err(|e| function_call_failed("read_object", format!("{e:?}"), context.call_site))?;
+        let expected_two_lines = || {
+            function_call_failed(
+                "read_object",
+                format!(
+                    "expected exactly two lines in file `{path}`",
+                    path = path.display()
+                ),
+                context.call_site,
+            )
+        };
 
-    let mut lines = BufReader::new(file).lines();
-    let names = lines
-        .next()
-        .ok_or_else(expected_two_lines)?
-        .with_context(|| format!("failed to read file `{path}`", path = path.display()))
-        .map_err(|e| function_call_failed("read_object", format!("{e:?}"), context.call_site))?;
+        let file = fs::File::open(&path)
+            .await
+            .with_context(|| format!("failed to open file `{path}`", path = path.display()))
+            .map_err(|e| {
+                function_call_failed("read_object", format!("{e:?}"), context.call_site)
+            })?;
 
-    let values = lines
-        .next()
-        .ok_or_else(expected_two_lines)?
-        .with_context(|| format!("failed to read file `{path}`", path = path.display()))
-        .map_err(|e| function_call_failed("read_object", format!("{e:?}"), context.call_site))?;
+        let mut lines = BufReader::new(file).lines();
+        let names = lines
+            .next_line()
+            .await
+            .map_err(read_error)?
+            .ok_or_else(expected_two_lines)?;
 
-    if lines.next().is_some() {
-        return Err(expected_two_lines());
-    }
+        let values = lines
+            .next_line()
+            .await
+            .map_err(read_error)?
+            .ok_or_else(expected_two_lines)?;
 
-    let mut members = IndexMap::new();
-    for e in names.split('\t').zip_longest(values.split('\t')) {
-        match e {
-            EitherOrBoth::Both(name, value) => {
-                if !is_ident(name) {
+        if lines.next_line().await.map_err(read_error)?.is_some() {
+            return Err(expected_two_lines());
+        }
+
+        let mut members = IndexMap::new();
+        for e in names.split('\t').zip_longest(values.split('\t')) {
+            match e {
+                EitherOrBoth::Both(name, value) => {
+                    if !is_ident(name) {
+                        return Err(function_call_failed(
+                            "read_object",
+                            format!(
+                                "invalid column name `{name}` at {path}:1: column name must be a \
+                                 valid WDL identifier",
+                                path = path.display()
+                            ),
+                            context.call_site,
+                        ));
+                    }
+
+                    if members
+                        .insert(name.to_string(), PrimitiveValue::new_string(value).into())
+                        .is_some()
+                    {
+                        return Err(function_call_failed(
+                            "read_object",
+                            format!(
+                                "duplicate column name `{name}` at {path}:1",
+                                path = path.display()
+                            ),
+                            context.call_site,
+                        ));
+                    }
+                }
+                EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => {
                     return Err(function_call_failed(
                         "read_object",
                         format!(
-                            "invalid column name `{name}` at {path}:1: column name must be a \
-                             valid WDL identifier",
+                            "line 2 of file `{path}` does not contain the expected number of \
+                             columns",
                             path = path.display()
                         ),
                         context.call_site,
                     ));
                 }
-
-                if members
-                    .insert(name.to_string(), PrimitiveValue::new_string(value).into())
-                    .is_some()
-                {
-                    return Err(function_call_failed(
-                        "read_object",
-                        format!(
-                            "duplicate column name `{name}` at {path}:1",
-                            path = path.display()
-                        ),
-                        context.call_site,
-                    ));
-                }
-            }
-            EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => {
-                return Err(function_call_failed(
-                    "read_object",
-                    format!(
-                        "line 2 of file `{path}` does not contain the expected number of columns",
-                        path = path.display()
-                    ),
-                    context.call_site,
-                ));
             }
         }
-    }
 
-    Ok(Object::from(members).into())
+        Ok(Object::from(members).into())
+    }
+    .boxed()
 }
 
 /// Gets the function describing `read_object`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(File) -> Object", read_object)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(File) -> Object",
+                Callback::Async(read_object),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/read_tsv.rs
+++ b/wdl-engine/src/stdlib/read_tsv.rs
@@ -1,20 +1,22 @@
 //! Implements the `read_tsv` function from the WDL standard library.
 
-use std::fs;
-use std::io::BufRead;
-use std::io::BufReader;
-
 use anyhow::Context;
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use itertools::Either;
 use itertools::EitherOrBoth;
 use itertools::Itertools;
+use tokio::fs;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 use wdl_grammar::lexer::v1::is_ident;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -59,34 +61,43 @@ impl TsvHeader {
 /// table are all the same length.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
-fn read_tsv_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_array_string_type().clone()));
+fn read_tsv_simple(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() == 1);
+        debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_array_string_type().clone()));
 
-    let path = context.work_dir().join(
-        context
-            .coerce_argument(0, PrimitiveType::File)
-            .unwrap_file()
-            .as_str(),
-    );
+        let path = context.work_dir().join(
+            context
+                .coerce_argument(0, PrimitiveType::File)
+                .unwrap_file()
+                .as_str(),
+        );
 
-    let file = fs::File::open(&path)
-        .with_context(|| format!("failed to open file `{path}`", path = path.display()))
-        .map_err(|e| function_call_failed("read_tsv", format!("{e:?}"), context.call_site))?;
-
-    let mut rows: Vec<Value> = Vec::new();
-    for line in BufReader::new(file).lines() {
-        let line = line
-            .with_context(|| format!("failed to read file `{path}`", path = path.display()))
+        let file = fs::File::open(&path)
+            .await
+            .with_context(|| format!("failed to open file `{path}`", path = path.display()))
             .map_err(|e| function_call_failed("read_tsv", format!("{e:?}"), context.call_site))?;
-        let values = line
-            .split('\t')
-            .map(|s| PrimitiveValue::new_string(s).into())
-            .collect::<Vec<Value>>();
-        rows.push(Array::new_unchecked(ANALYSIS_STDLIB.array_string_type().clone(), values).into());
-    }
 
-    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_array_string_type().clone(), rows).into())
+        let mut lines = BufReader::new(file).lines();
+        let mut rows: Vec<Value> = Vec::new();
+        while let Some(line) = lines
+            .next_line()
+            .await
+            .with_context(|| format!("failed to read file `{path}`", path = path.display()))
+            .map_err(|e| function_call_failed("read_tsv", format!("{e:?}"), context.call_site))?
+        {
+            let values = line
+                .split('\t')
+                .map(|s| PrimitiveValue::new_string(s).into())
+                .collect::<Vec<Value>>();
+            rows.push(
+                Array::new_unchecked(ANALYSIS_STDLIB.array_string_type().clone(), values).into(),
+            );
+        }
+
+        Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_array_string_type().clone(), rows).into())
+    }
+    .boxed()
 }
 
 /// Reads a tab-separated value (TSV) file as an Array[Object] representing a
@@ -109,123 +120,132 @@ fn read_tsv_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 /// line is ignored).
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
-fn read_tsv(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() >= 2 && context.arguments.len() <= 3);
-    debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_object_type().clone()));
+fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() >= 2 && context.arguments.len() <= 3);
+        debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_object_type().clone()));
 
-    let path = context.work_dir().join(
-        context
-            .coerce_argument(0, PrimitiveType::File)
-            .unwrap_file()
-            .as_str(),
-    );
-
-    let file = fs::File::open(&path)
-        .with_context(|| format!("failed to open file `{path}`", path = path.display()))
-        .map_err(|e| function_call_failed("read_tsv", format!("{e:?}"), context.call_site))?;
-
-    let mut lines = BufReader::new(file).lines();
-
-    // Read the file header if there is one; ignore it if the header was directly
-    // specified.
-    let file_has_header = context
-        .coerce_argument(1, PrimitiveType::Boolean)
-        .unwrap_boolean();
-    let header = if context.arguments.len() == 3 {
-        if file_has_header {
-            lines.next();
-        }
-
-        TsvHeader::Specified(
+        let path = context.work_dir().join(
             context
-                .coerce_argument(2, ANALYSIS_STDLIB.array_string_type().clone())
-                .unwrap_array(),
-        )
-    } else if !file_has_header {
-        return Err(function_call_failed(
-            "read_tsv",
-            "argument specifying presence of a file header must be `true`",
-            context.arguments[1].span,
-        ));
-    } else {
-        TsvHeader::File(
-            lines
-                .next()
-                .unwrap_or_else(|| Ok(String::default()))
-                .with_context(|| format!("failed to read file `{path}`", path = path.display()))
-                .map_err(|e| {
-                    function_call_failed("read_tsv", format!("{e:?}"), context.call_site)
-                })?,
-        )
-    };
+                .coerce_argument(0, PrimitiveType::File)
+                .unwrap_file()
+                .as_str(),
+        );
 
-    let mut column_count = 0;
-    if let Some(invalid) = header.columns().find(|c| {
-        column_count += 1;
-        !is_ident(c)
-    }) {
-        return Err(function_call_failed(
-            "read_tsv",
-            if context.arguments.len() == 2 {
-                format!(
-                    "column name `{invalid}` in file `{path}` is not a valid WDL object field name",
-                    path = path.display()
-                )
-            } else {
-                format!("specified name `{invalid}` is not a valid WDL object field name")
-            },
-            context.call_site,
-        ));
-    }
+        let read_error = |e: std::io::Error| {
+            function_call_failed(
+                "read_tsv",
+                format!("failed to read file `{path}`: {e}", path = path.display()),
+                context.call_site,
+            )
+        };
 
-    let mut rows: Vec<Value> = Vec::new();
-    for (index, line) in lines.enumerate() {
-        let line = line
-            .with_context(|| format!("failed to read file `{path}`", path = path.display()))
+        let file = fs::File::open(&path)
+            .await
+            .with_context(|| format!("failed to open file `{path}`", path = path.display()))
             .map_err(|e| function_call_failed("read_tsv", format!("{e:?}"), context.call_site))?;
 
-        let mut members: IndexMap<String, Value> = IndexMap::with_capacity(column_count);
+        let mut lines = BufReader::new(file).lines();
 
-        for e in header.columns().zip_longest(line.split('\t')) {
-            match e {
-                EitherOrBoth::Both(c, v) => {
-                    if members
-                        .insert(c.to_string(), PrimitiveValue::new_string(v).into())
-                        .is_some()
-                    {
+        // Read the file header if there is one; ignore it if the header was directly
+        // specified.
+        let file_has_header = context
+            .coerce_argument(1, PrimitiveType::Boolean)
+            .unwrap_boolean();
+        let header = if context.arguments.len() == 3 {
+            if file_has_header {
+                // Skip the first line
+                lines.next_line().await.map_err(read_error)?;
+            }
+
+            TsvHeader::Specified(
+                context
+                    .coerce_argument(2, ANALYSIS_STDLIB.array_string_type().clone())
+                    .unwrap_array(),
+            )
+        } else if !file_has_header {
+            return Err(function_call_failed(
+                "read_tsv",
+                "argument specifying presence of a file header must be `true`",
+                context.arguments[1].span,
+            ));
+        } else {
+            TsvHeader::File(
+                lines
+                    .next_line()
+                    .await
+                    .map_err(read_error)?
+                    .unwrap_or_default(),
+            )
+        };
+
+        let mut column_count = 0;
+        if let Some(invalid) = header.columns().find(|c| {
+            column_count += 1;
+            !is_ident(c)
+        }) {
+            return Err(function_call_failed(
+                "read_tsv",
+                if context.arguments.len() == 2 {
+                    format!(
+                        "column name `{invalid}` in file `{path}` is not a valid WDL object field \
+                         name",
+                        path = path.display()
+                    )
+                } else {
+                    format!("specified name `{invalid}` is not a valid WDL object field name")
+                },
+                context.call_site,
+            ));
+        }
+
+        let mut rows: Vec<Value> = Vec::new();
+        let mut i = 1 + if file_has_header { 1 } else { 0 };
+        while let Some(line) = lines.next_line().await.map_err(read_error)? {
+            let mut members: IndexMap<String, Value> = IndexMap::with_capacity(column_count);
+
+            for e in header.columns().zip_longest(line.split('\t')) {
+                match e {
+                    EitherOrBoth::Both(c, v) => {
+                        if members
+                            .insert(c.to_string(), PrimitiveValue::new_string(v).into())
+                            .is_some()
+                        {
+                            return Err(function_call_failed(
+                                "read_tsv",
+                                if context.arguments.len() == 2 {
+                                    format!(
+                                        "duplicate column name `{c}` found in file `{path}`",
+                                        path = path.display()
+                                    )
+                                } else {
+                                    format!("duplicate column name `{c}` was specified")
+                                },
+                                context.call_site,
+                            ));
+                        }
+                    }
+                    _ => {
                         return Err(function_call_failed(
                             "read_tsv",
-                            if context.arguments.len() == 2 {
-                                format!(
-                                    "duplicate column name `{c}` found in file `{path}`",
-                                    path = path.display()
-                                )
-                            } else {
-                                format!("duplicate column name `{c}` was specified")
-                            },
+                            format!(
+                                "line {i} in file `{path}` does not have the expected number of \
+                                 columns",
+                                path = path.display()
+                            ),
                             context.call_site,
                         ));
                     }
                 }
-                _ => {
-                    return Err(function_call_failed(
-                        "read_tsv",
-                        format!(
-                            "line {index} in file `{path}` does not have the expected number of \
-                             columns",
-                            index = index + 1 + if file_has_header { 1 } else { 0 },
-                            path = path.display()
-                        ),
-                        context.call_site,
-                    ));
-                }
             }
+
+            rows.push(CompoundValue::Object(members.into()).into());
+            i += 1;
         }
 
-        rows.push(CompoundValue::Object(members.into()).into());
+        Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_object_type().clone(), rows).into())
     }
-
-    Ok(Array::new_unchecked(ANALYSIS_STDLIB.array_object_type().clone(), rows).into())
+    .boxed()
 }
 
 /// Gets the function describing `read_tsv`.
@@ -233,9 +253,18 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(File) -> Array[Array[String]]", read_tsv_simple),
-                Signature::new("(File, Boolean) -> Array[Object]", read_tsv),
-                Signature::new("(File, Boolean, Array[String]) -> Array[Object]", read_tsv),
+                Signature::new(
+                    "(File) -> Array[Array[String]]",
+                    Callback::Async(read_tsv_simple),
+                ),
+                Signature::new(
+                    "(File, Boolean) -> Array[Object]",
+                    Callback::Async(read_tsv),
+                ),
+                Signature::new(
+                    "(File, Boolean, Array[String]) -> Array[Object]",
+                    Callback::Async(read_tsv),
+                ),
             ]
         },
     )

--- a/wdl-engine/src/stdlib/round.rs
+++ b/wdl-engine/src/stdlib/round.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -24,7 +25,7 @@ fn round(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `round`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Float) -> Int", round)] })
+    Function::new(const { &[Signature::new("(Float) -> Int", Callback::Sync(round))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/select_all.rs
+++ b/wdl-engine/src/stdlib/select_all.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -38,7 +39,14 @@ fn select_all(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `select_all`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Array[X]) -> Array[X]", select_all)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(Array[X]) -> Array[X]",
+                Callback::Sync(select_all),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/select_first.rs
+++ b/wdl-engine/src/stdlib/select_first.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -52,7 +53,14 @@ fn select_first(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `select_first`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Array[X], <X>) -> X", select_first)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(Array[X], <X>) -> X",
+                Callback::Sync(select_first),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/sep.rs
+++ b/wdl-engine/src/stdlib/sep.rs
@@ -6,6 +6,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -64,7 +65,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(String, Array[P]) -> String where `P`: any primitive type",
-                sep,
+                Callback::Sync(sep),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/size.rs
+++ b/wdl-engine/src/stdlib/size.rs
@@ -11,6 +11,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::CompoundValue;
@@ -190,14 +191,14 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(None, <String>) -> Float", size),
-                Signature::new("(File?, <String>) -> Float", size),
-                Signature::new("(String?, <String>) -> Float", size),
-                Signature::new("(Directory?, <String>) -> Float", size),
+                Signature::new("(None, <String>) -> Float", Callback::Sync(size)),
+                Signature::new("(File?, <String>) -> Float", Callback::Sync(size)),
+                Signature::new("(String?, <String>) -> Float", Callback::Sync(size)),
+                Signature::new("(Directory?, <String>) -> Float", Callback::Sync(size)),
                 Signature::new(
                     "(X, <String>) -> Float where `X`: any compound type that recursively \
                      contains a `File` or `Directory`",
-                    size,
+                    Callback::Sync(size),
                 ),
             ]
         },

--- a/wdl-engine/src/stdlib/size.rs
+++ b/wdl-engine/src/stdlib/size.rs
@@ -1,12 +1,14 @@
 //! Implements the `size` function from the WDL standard library.
 
 use std::borrow::Cow;
-use std::fs;
 use std::path::Path;
 
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use tokio::fs;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
@@ -28,47 +30,53 @@ use crate::diagnostics::invalid_storage_unit;
 /// unit.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#glob
-fn size(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(!context.arguments.is_empty() && context.arguments.len() < 3);
-    debug_assert!(context.return_type_eq(PrimitiveType::Float));
+fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(!context.arguments.is_empty() && context.arguments.len() < 3);
+        debug_assert!(context.return_type_eq(PrimitiveType::Float));
 
-    let unit = if context.arguments.len() == 2 {
-        let unit = context
-            .coerce_argument(1, PrimitiveType::String)
-            .unwrap_string();
+        let unit = if context.arguments.len() == 2 {
+            let unit = context
+                .coerce_argument(1, PrimitiveType::String)
+                .unwrap_string();
 
-        unit.parse()
-            .map_err(|_| invalid_storage_unit(&unit, context.arguments[1].span))?
-    } else {
-        StorageUnit::default()
-    };
+            unit.parse()
+                .map_err(|_| invalid_storage_unit(&unit, context.arguments[1].span))?
+        } else {
+            StorageUnit::default()
+        };
 
-    // If the first argument is a string, we need to check if it's a file or
-    // directory and treat it as such.
-    let value = match context.arguments[0].value.as_string() {
-        Some(s) => {
-            let path = context.work_dir().join(s.as_str());
-            let metadata = path
-                .metadata()
-                .with_context(|| {
-                    format!(
-                        "failed to read metadata for file `{path}`",
-                        path = path.display()
-                    )
-                })
-                .map_err(|e| function_call_failed("size", format!("{e:?}"), context.call_site))?;
-            if metadata.is_dir() {
-                PrimitiveValue::Directory(s.clone()).into()
-            } else {
-                PrimitiveValue::File(s.clone()).into()
+        // If the first argument is a string, we need to check if it's a file or
+        // directory and treat it as such.
+        let value = match context.arguments[0].value.as_string() {
+            Some(s) => {
+                let path = context.work_dir().join(s.as_str());
+                let metadata = fs::metadata(&path)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to read metadata for file `{path}`",
+                            path = path.display()
+                        )
+                    })
+                    .map_err(|e| {
+                        function_call_failed("size", format!("{e:?}"), context.call_site)
+                    })?;
+                if metadata.is_dir() {
+                    PrimitiveValue::Directory(s.clone()).into()
+                } else {
+                    PrimitiveValue::File(s.clone()).into()
+                }
             }
-        }
-        _ => context.arguments[0].value.clone(),
-    };
+            _ => context.arguments[0].value.clone(),
+        };
 
-    calculate_disk_size(&value, unit, context.work_dir())
-        .map_err(|e| function_call_failed("size", format!("{e:?}"), context.call_site))
-        .map(Into::into)
+        calculate_disk_size(&value, unit, context.work_dir())
+            .await
+            .map_err(|e| function_call_failed("size", format!("{e:?}"), context.call_site))
+            .map(Into::into)
+    }
+    .boxed()
 }
 
 /// Used to calculate the disk size of a value.
@@ -78,25 +86,32 @@ fn size(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 ///
 /// The size of a directory is based on the sum of the files contained in the
 /// directory.
-fn calculate_disk_size(value: &Value, unit: StorageUnit, cwd: &Path) -> Result<f64> {
-    match value {
-        Value::None => Ok(0.0),
-        Value::Primitive(v) => primitive_disk_size(v, unit, cwd),
-        Value::Compound(v) => compound_disk_size(v, unit, cwd),
-        Value::Task(_) => bail!("the size of a task variable cannot be calculated"),
-        Value::Hints(_) => bail!("the size of a hints value cannot be calculated"),
-        Value::Input(_) => bail!("the size of an input value cannot be calculated"),
-        Value::Output(_) => bail!("the size of an output value cannot be calculated"),
-        Value::Call(_) => bail!("the size of a call value cannot be calculated"),
+fn calculate_disk_size<'a>(
+    value: &'a Value,
+    unit: StorageUnit,
+    cwd: &'a Path,
+) -> BoxFuture<'a, Result<f64>> {
+    async move {
+        match value {
+            Value::None => Ok(0.0),
+            Value::Primitive(v) => primitive_disk_size(v, unit, cwd).await,
+            Value::Compound(v) => compound_disk_size(v, unit, cwd).await,
+            Value::Task(_) => bail!("the size of a task variable cannot be calculated"),
+            Value::Hints(_) => bail!("the size of a hints value cannot be calculated"),
+            Value::Input(_) => bail!("the size of an input value cannot be calculated"),
+            Value::Output(_) => bail!("the size of an output value cannot be calculated"),
+            Value::Call(_) => bail!("the size of a call value cannot be calculated"),
+        }
     }
+    .boxed()
 }
 
 /// Calculates the disk size of the given primitive value in the given unit.
-fn primitive_disk_size(value: &PrimitiveValue, unit: StorageUnit, cwd: &Path) -> Result<f64> {
+async fn primitive_disk_size(value: &PrimitiveValue, unit: StorageUnit, cwd: &Path) -> Result<f64> {
     match value {
         PrimitiveValue::File(path) => {
             let path = cwd.join(path.as_str());
-            let metadata = path.metadata().with_context(|| {
+            let metadata = fs::metadata(&path).await.with_context(|| {
                 format!(
                     "failed to read metadata for file `{path}`",
                     path = path.display()
@@ -109,40 +124,60 @@ fn primitive_disk_size(value: &PrimitiveValue, unit: StorageUnit, cwd: &Path) ->
 
             Ok(unit.units(metadata.len()))
         }
-        PrimitiveValue::Directory(path) => calculate_directory_size(&cwd.join(path.as_str()), unit),
+        PrimitiveValue::Directory(path) => {
+            calculate_directory_size(&cwd.join(path.as_str()), unit).await
+        }
         _ => Ok(0.0),
     }
 }
 
 /// Calculates the disk size for a compound value in the given unit.
-fn compound_disk_size(value: &CompoundValue, unit: StorageUnit, cwd: &Path) -> Result<f64> {
+async fn compound_disk_size(value: &CompoundValue, unit: StorageUnit, cwd: &Path) -> Result<f64> {
     match value {
-        CompoundValue::Pair(pair) => Ok(calculate_disk_size(pair.left(), unit, cwd)?
-            + calculate_disk_size(pair.right(), unit, cwd)?),
-        CompoundValue::Array(array) => Ok(array.as_slice().iter().try_fold(0.0, |t, e| {
-            anyhow::Ok(t + calculate_disk_size(e, unit, cwd)?)
-        })?),
-        CompoundValue::Map(map) => Ok(map.iter().try_fold(0.0, |t, (k, v)| {
-            anyhow::Ok(
-                t + match k {
-                    Some(k) => primitive_disk_size(k, unit, cwd)?,
+        CompoundValue::Pair(pair) => Ok(calculate_disk_size(pair.left(), unit, cwd).await?
+            + calculate_disk_size(pair.right(), unit, cwd).await?),
+        CompoundValue::Array(array) => {
+            let mut size = 0.0;
+            for e in array.as_slice() {
+                size += calculate_disk_size(e, unit, cwd).await?;
+            }
+
+            Ok(size)
+        }
+        CompoundValue::Map(map) => {
+            let mut size = 0.0;
+            for (k, v) in map.iter() {
+                size += match k {
+                    Some(k) => primitive_disk_size(k, unit, cwd).await?,
                     None => 0.0,
-                } + calculate_disk_size(v, unit, cwd)?,
-            )
-        })?),
-        CompoundValue::Object(object) => Ok(object.iter().try_fold(0.0, |t, (_, v)| {
-            anyhow::Ok(t + calculate_disk_size(v, unit, cwd)?)
-        })?),
-        CompoundValue::Struct(s) => Ok(s.iter().try_fold(0.0, |t, (_, v)| {
-            anyhow::Ok(t + calculate_disk_size(v, unit, cwd)?)
-        })?),
+                } + calculate_disk_size(v, unit, cwd).await?;
+            }
+
+            Ok(size)
+        }
+        CompoundValue::Object(object) => {
+            let mut size = 0.0;
+            for (_, v) in object.iter() {
+                size += calculate_disk_size(v, unit, cwd).await?;
+            }
+
+            Ok(size)
+        }
+        CompoundValue::Struct(s) => {
+            let mut size = 0.0;
+            for (_, v) in s.iter() {
+                size += calculate_disk_size(v, unit, cwd).await?;
+            }
+
+            Ok(size)
+        }
     }
 }
 
 /// Calculates the size of the given directory in the given unit.
-fn calculate_directory_size(path: &Path, unit: StorageUnit) -> Result<f64> {
+async fn calculate_directory_size(path: &Path, unit: StorageUnit) -> Result<f64> {
     // Don't follow symlinks as a security measure
-    let metadata = path.symlink_metadata().with_context(|| {
+    let metadata = fs::symlink_metadata(&path).await.with_context(|| {
         format!(
             "failed to read metadata for directory `{path}`",
             path = path.display()
@@ -160,16 +195,21 @@ fn calculate_directory_size(path: &Path, unit: StorageUnit) -> Result<f64> {
     // Process each directory in the queue, adding the sizes of its files
     let mut size = 0.0;
     while let Some(path) = queue.pop() {
-        for entry in fs::read_dir(&path)? {
-            let entry = entry.with_context(|| {
-                format!(
-                    "failed to read entry of directory `{path}`",
-                    path = path.display()
-                )
-            })?;
+        let mut dir = fs::read_dir(&path).await.with_context(|| {
+            format!(
+                "failed to read entry of directory `{path}`",
+                path = path.display()
+            )
+        })?;
 
+        while let Some(entry) = dir.next_entry().await.with_context(|| {
+            format!(
+                "failed to read entry of directory `{path}`",
+                path = path.display()
+            )
+        })? {
             // Note: `DirEntry::metadata` doesn't follow symlinks
-            let metadata = entry.metadata().with_context(|| {
+            let metadata = entry.metadata().await.with_context(|| {
                 format!(
                     "failed to read metadata for file `{path}`",
                     path = entry.path().display()
@@ -191,14 +231,14 @@ pub const fn descriptor() -> Function {
     Function::new(
         const {
             &[
-                Signature::new("(None, <String>) -> Float", Callback::Sync(size)),
-                Signature::new("(File?, <String>) -> Float", Callback::Sync(size)),
-                Signature::new("(String?, <String>) -> Float", Callback::Sync(size)),
-                Signature::new("(Directory?, <String>) -> Float", Callback::Sync(size)),
+                Signature::new("(None, <String>) -> Float", Callback::Async(size)),
+                Signature::new("(File?, <String>) -> Float", Callback::Async(size)),
+                Signature::new("(String?, <String>) -> Float", Callback::Async(size)),
+                Signature::new("(Directory?, <String>) -> Float", Callback::Async(size)),
                 Signature::new(
                     "(X, <String>) -> Float where `X`: any compound type that recursively \
                      contains a `File` or `Directory`",
-                    Callback::Sync(size),
+                    Callback::Async(size),
                 ),
             ]
         },

--- a/wdl-engine/src/stdlib/squote.rs
+++ b/wdl-engine/src/stdlib/squote.rs
@@ -4,6 +4,7 @@ use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -44,7 +45,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[P]) -> Array[String] where `P`: any primitive type",
-                squote,
+                Callback::Sync(squote),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/stderr.rs
+++ b/wdl-engine/src/stdlib/stderr.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -35,7 +36,7 @@ fn stderr(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `stderr`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("() -> File", stderr)] })
+    Function::new(const { &[Signature::new("() -> File", Callback::Sync(stderr))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/stdout.rs
+++ b/wdl-engine/src/stdlib/stdout.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
@@ -35,7 +36,7 @@ fn stdout(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `stdout`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("() -> File", stdout)] })
+    Function::new(const { &[Signature::new("() -> File", Callback::Sync(stdout))] })
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/sub.rs
+++ b/wdl-engine/src/stdlib/sub.rs
@@ -7,6 +7,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -48,7 +49,14 @@ fn sub(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
 /// Gets the function describing `sub`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(String, String, String) -> String", sub)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(String, String, String) -> String",
+                Callback::Sync(sub),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/suffix.rs
+++ b/wdl-engine/src/stdlib/suffix.rs
@@ -5,6 +5,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -51,7 +52,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(String, Array[P]) -> Array[String] where `P`: any primitive type",
-                suffix,
+                Callback::Sync(suffix),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/transpose.rs
+++ b/wdl-engine/src/stdlib/transpose.rs
@@ -4,6 +4,7 @@ use wdl_analysis::types::Type;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -77,7 +78,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[Array[X]]) -> Array[Array[X]]",
-                transpose,
+                Callback::Sync(transpose),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/unzip.rs
+++ b/wdl-engine/src/stdlib/unzip.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -61,7 +62,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[Pair[X, Y]]) -> Pair[Array[X], Array[Y]]",
-                unzip,
+                Callback::Sync(unzip),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/values.rs
+++ b/wdl-engine/src/stdlib/values.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -37,7 +38,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Map[K, V]) -> Array[V] where `K`: any primitive type",
-                values,
+                Callback::Sync(values),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/write_json.rs
+++ b/wdl-engine/src/stdlib/write_json.rs
@@ -9,6 +9,7 @@ use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -88,7 +89,9 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(X) -> File where `X`: any JSON-serializable type",
-                write_json,
+                // The `write_json` callback does not need to be async as `serde-json` doesn't
+                // support async writers
+                Callback::Sync(write_json),
             )]
         },
     )

--- a/wdl-engine/src/stdlib/write_lines.rs
+++ b/wdl-engine/src/stdlib/write_lines.rs
@@ -1,15 +1,19 @@
 //! Implements the `write_lines` function from the WDL standard library.
 
-use std::io::BufWriter;
-use std::io::Write;
 use std::path::Path;
 
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use tempfile::NamedTempFile;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufWriter;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -24,72 +28,96 @@ use crate::diagnostics::function_call_failed;
 /// If the Array is empty, an empty file is written.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_lines
-fn write_lines(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveType::File));
+fn write_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() == 1);
+        debug_assert!(context.return_type_eq(PrimitiveType::File));
 
-    // Helper for handling errors while writing to the file.
-    let write_error = |e: std::io::Error| {
-        function_call_failed(
-            "write_lines",
-            format!("failed to write to temporary file: {e}"),
-            context.call_site,
-        )
-    };
+        // Helper for handling errors while writing to the file.
+        let write_error = |e: std::io::Error| {
+            function_call_failed(
+                "write_lines",
+                format!("failed to write to temporary file: {e}"),
+                context.call_site,
+            )
+        };
 
-    let lines = context
-        .coerce_argument(0, ANALYSIS_STDLIB.array_string_type().clone())
-        .unwrap_array();
+        let lines = context
+            .coerce_argument(0, ANALYSIS_STDLIB.array_string_type().clone())
+            .unwrap_array();
 
-    // Create a temporary file that will be persisted after writing the lines
-    let mut file = NamedTempFile::with_prefix_in("tmp", context.temp_dir()).map_err(|e| {
-        function_call_failed(
-            "write_lines",
-            format!("failed to create temporary file: {e}"),
-            context.call_site,
-        )
-    })?;
+        // Create a temporary file that will be persisted after writing the lines
+        let path = NamedTempFile::with_prefix_in("tmp", context.temp_dir())
+            .map_err(|e| {
+                function_call_failed(
+                    "write_lines",
+                    format!("failed to create temporary file: {e}"),
+                    context.call_site,
+                )
+            })?
+            .into_temp_path();
 
-    // Write the lines
-    let mut writer = BufWriter::new(file.as_file_mut());
-    for line in lines.as_slice() {
-        writer
-            .write(line.as_string().unwrap().as_bytes())
-            .map_err(write_error)?;
-        writeln!(&mut writer).map_err(write_error)?;
-    }
-
-    // Consume the writer, flushing the buffer to disk.
-    writer
-        .into_inner()
-        .map_err(|e| write_error(e.into_error()))?;
-
-    let (_, path) = file.keep().map_err(|e| {
-        function_call_failed(
-            "write_lines",
-            format!("failed to keep temporary file: {e}"),
-            context.call_site,
-        )
-    })?;
-
-    Ok(
-        PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
+        // Re-open the file for asynchronous write
+        let file = fs::File::create(&path).await.map_err(|e| {
             function_call_failed(
                 "write_lines",
                 format!(
-                    "path `{path}` cannot be represented as UTF-8",
-                    path = Path::new(&path).display()
+                    "failed to open temporary file `{path}`: {e}",
+                    path = path.display()
                 ),
                 context.call_site,
             )
-        })?)
-        .into(),
-    )
+        })?;
+
+        // Write the lines
+        let mut writer = BufWriter::new(file);
+        for line in lines.as_slice() {
+            writer
+                .write_all(line.as_string().unwrap().as_bytes())
+                .await
+                .map_err(write_error)?;
+            writer.write_all(b"\n").await.map_err(write_error)?;
+        }
+
+        // Flush the writer and drop it
+        writer.flush().await.map_err(write_error)?;
+        drop(writer);
+
+        let path = path.keep().map_err(|e| {
+            function_call_failed(
+                "write_lines",
+                format!("failed to keep temporary file: {e}"),
+                context.call_site,
+            )
+        })?;
+
+        Ok(
+            PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
+                function_call_failed(
+                    "write_lines",
+                    format!(
+                        "path `{path}` cannot be represented as UTF-8",
+                        path = Path::new(&path).display()
+                    ),
+                    context.call_site,
+                )
+            })?)
+            .into(),
+        )
+    }
+    .boxed()
 }
 
 /// Gets the function describing `write_lines`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Array[String]) -> File", write_lines)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(Array[String]) -> File",
+                Callback::Async(write_lines),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/write_map.rs
+++ b/wdl-engine/src/stdlib/write_map.rs
@@ -1,15 +1,19 @@
 //! Implements the `write_map` function from the WDL standard library.
 
-use std::io::BufWriter;
-use std::io::Write;
 use std::path::Path;
 
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use tempfile::NamedTempFile;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufWriter;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
@@ -27,79 +31,107 @@ use crate::diagnostics::function_call_failed;
 /// If the Map is empty, an empty file is written.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_map
-fn write_map(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
-    debug_assert!(context.return_type_eq(PrimitiveType::File));
+fn write_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
+    async move {
+        debug_assert!(context.arguments.len() == 1);
+        debug_assert!(context.return_type_eq(PrimitiveType::File));
 
-    // Helper for handling errors while writing to the file.
-    let write_error = |e: std::io::Error| {
-        function_call_failed(
-            "write_map",
-            format!("failed to write to temporary file: {e}"),
-            context.call_site,
-        )
-    };
+        // Helper for handling errors while writing to the file.
+        let write_error = |e: std::io::Error| {
+            function_call_failed(
+                "write_map",
+                format!("failed to write to temporary file: {e}"),
+                context.call_site,
+            )
+        };
 
-    let map = context
-        .coerce_argument(0, ANALYSIS_STDLIB.map_string_string_type().clone())
-        .unwrap_map();
+        let map = context
+            .coerce_argument(0, ANALYSIS_STDLIB.map_string_string_type().clone())
+            .unwrap_map();
 
-    // Create a temporary file that will be persisted after writing the map
-    let mut file = NamedTempFile::with_prefix_in("tmp", context.temp_dir()).map_err(|e| {
-        function_call_failed(
-            "write_map",
-            format!("failed to create temporary file: {e}"),
-            context.call_site,
-        )
-    })?;
+        // Create a temporary file that will be persisted after writing the map
+        let path = NamedTempFile::with_prefix_in("tmp", context.temp_dir())
+            .map_err(|e| {
+                function_call_failed(
+                    "write_map",
+                    format!("failed to create temporary file: {e}"),
+                    context.call_site,
+                )
+            })?
+            .into_temp_path();
 
-    // Write the lines
-    let mut writer = BufWriter::new(file.as_file_mut());
-    for (key, value) in map.iter() {
-        writeln!(
-            &mut writer,
-            "{key}\t{value}",
-            key = key
-                .as_ref()
-                .expect("key should not be optional")
-                .as_string()
-                .unwrap(),
-            value = value.as_string().unwrap()
-        )
-        .map_err(write_error)?;
-    }
-
-    // Consume the writer, flushing the buffer to disk.
-    writer
-        .into_inner()
-        .map_err(|e| write_error(e.into_error()))?;
-
-    let (_, path) = file.keep().map_err(|e| {
-        function_call_failed(
-            "write_map",
-            format!("failed to keep temporary file: {e}"),
-            context.call_site,
-        )
-    })?;
-
-    Ok(
-        PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
+        // Re-open the file for asynchronous write
+        let file = fs::File::create(&path).await.map_err(|e| {
             function_call_failed(
                 "write_map",
                 format!(
-                    "path `{path}` cannot be represented as UTF-8",
-                    path = Path::new(&path).display()
+                    "failed to open temporary file `{path}`: {e}",
+                    path = path.display()
                 ),
                 context.call_site,
             )
-        })?)
-        .into(),
-    )
+        })?;
+
+        // Write the lines
+        let mut writer = BufWriter::new(file);
+        for (key, value) in map.iter() {
+            writer
+                .write_all(
+                    key.as_ref()
+                        .expect("key should not be optional")
+                        .as_string()
+                        .unwrap()
+                        .as_bytes(),
+                )
+                .await
+                .map_err(write_error)?;
+            writer.write_all(b"\t").await.map_err(write_error)?;
+            writer
+                .write_all(value.as_string().unwrap().as_bytes())
+                .await
+                .map_err(write_error)?;
+            writer.write_all(b"\n").await.map_err(write_error)?;
+        }
+
+        // Flush the writer and drop it
+        writer.flush().await.map_err(write_error)?;
+        drop(writer);
+
+        let path = path.keep().map_err(|e| {
+            function_call_failed(
+                "write_map",
+                format!("failed to keep temporary file: {e}"),
+                context.call_site,
+            )
+        })?;
+
+        Ok(
+            PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
+                function_call_failed(
+                    "write_map",
+                    format!(
+                        "path `{path}` cannot be represented as UTF-8",
+                        path = Path::new(&path).display()
+                    ),
+                    context.call_site,
+                )
+            })?)
+            .into(),
+        )
+    }
+    .boxed()
 }
 
 /// Gets the function describing `write_map`.
 pub const fn descriptor() -> Function {
-    Function::new(const { &[Signature::new("(Map[String, String]) -> File", write_map)] })
+    Function::new(
+        const {
+            &[Signature::new(
+                "(Map[String, String]) -> File",
+                Callback::Async(write_map),
+            )]
+        },
+    )
 }
 
 #[cfg(test)]

--- a/wdl-engine/src/stdlib/zip.rs
+++ b/wdl-engine/src/stdlib/zip.rs
@@ -3,6 +3,7 @@
 use wdl_ast::Diagnostic;
 
 use super::CallContext;
+use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Array;
@@ -71,7 +72,7 @@ pub const fn descriptor() -> Function {
         const {
             &[Signature::new(
                 "(Array[X], Array[Y]) -> Array[Pair[X, Y]]",
-                zip,
+                Callback::Sync(zip),
             )]
         },
     )


### PR DESCRIPTION
This PR makes the file-related functions from the WDL standard library asynchronous.

In addition to using async I/O for reading and writing to files, this change will enable the `read_*` functions to support reading remote files on-demand.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
