### PR TITLE
fix: handle input dependencies in workflow graph evaluation

### DIFF
--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -850,7 +850,8 @@ fn populate_workflow(
     )];
     let mut output_scope = None;
 
-    // For static analysis, we don't need to provide inputs to the workflow graph builder
+    // For static analysis, we don't need to provide inputs to the workflow graph
+    // builder
     let graph =
         WorkflowGraphBuilder::default().build(workflow, &mut document.diagnostics, |_| false);
 

--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -849,7 +849,10 @@ fn populate_workflow(
             .expect("should have braced scope span"),
     )];
     let mut output_scope = None;
-    let graph = WorkflowGraphBuilder::default().build(workflow, &mut document.diagnostics);
+
+    // For static analysis, we don't need to provide inputs to the workflow graph builder
+    let graph =
+        WorkflowGraphBuilder::default().build(workflow, &mut document.diagnostics, |_| false);
 
     for index in toposort(&graph, None).expect("graph should be acyclic") {
         match graph[index].clone() {

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed path translation to mount inputs individually (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Fixed not including task temp directories in mounts (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Fixed an incorrect type being used for scatter statement outputs ([#316](https://github.com/stjude-rust-labs/wdl/pull/316)).
+* Fixed handling of input dependencies in workflow graph evaluation ([#360](https://github.com/stjude-rust-labs/wdl/pull/360)).
 
 ### Changed
 

--- a/wdl-engine/src/eval/v1/workflow.rs
+++ b/wdl-engine/src/eval/v1/workflow.rs
@@ -736,7 +736,11 @@ impl WorkflowEvaluator {
 
         // Build an evaluation graph for the workflow
         let mut diagnostics = Vec::new();
-        let graph = WorkflowGraphBuilder::default().build(&definition, &mut diagnostics);
+
+        // We need to provide inputs to the workflow graph builder to avoid adding
+        // dependency edges from the default expressions if a value was provided
+        let graph = WorkflowGraphBuilder::default()
+            .build(&definition, &mut diagnostics, |name| inputs.contains(name));
         if let Some(diagnostic) = diagnostics.pop() {
             return Err(diagnostic.into());
         }

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -330,6 +330,13 @@ impl WorkflowInputs {
         self.inputs.insert(name.into(), value.into())
     }
 
+    /// Checks if the inputs contain a value with the specified name.
+    ///
+    /// This does not check nested call inputs.
+    pub fn contains(&self, name: &str) -> bool {
+        self.inputs.contains_key(name)
+    }
+
     /// Replaces any `File` or `Directory` input values with joining the
     /// specified path with the value.
     ///


### PR DESCRIPTION
This pull request fixes an issue in `wdl-engine `where workflow input dependencies were not being handled correctly during graph evaluation.

- update `WorkflowGraphBuilder` to skip dependency edges for provided inputs to enable parallel task execution when dependencies are satisfied
- add unit tests to verify graph structure with and without provided inputs, using example given in #356 

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/

Closes: #356 