### PR TITLE
fix: eliminate `cargo doc` warnings.

### DIFF
--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -4,7 +4,7 @@
 //! files to bump the version of all crates.
 //!
 //! The binary was adapted from this script written by the bytecodealliance
-//! team: https://github.com/bytecodealliance/cargo-component/blob/5cf73a6e8fee84c12f6f0c13bf74ebe938fa9514/ci/publish.rs
+//! team: <https://github.com/bytecodealliance/cargo-component/blob/5cf73a6e8fee84c12f6f0c13bf74ebe938fa9514/ci/publish.rs>
 //!
 //! The binary is intended to be run in two phases:
 //!

--- a/wdl-ast/src/element.rs
+++ b/wdl-ast/src/element.rs
@@ -717,7 +717,7 @@ impl<N: TreeNode> Element<N> {
             .expect("expected `Element::Token` but got a different variant")
     }
 
-    /// Gets the underlying [`SyntaxElement`] from the [`Element`].
+    /// Gets the inner node or token from the [`Element`].
     pub fn inner(&self) -> NodeOrToken<N, N::Token> {
         match self {
             Element::Node(node) => NodeOrToken::Node(node.inner().clone()),
@@ -733,7 +733,7 @@ impl<N: TreeNode> Element<N> {
         }
     }
 
-    /// Returns whether the [`SyntaxElement`] represents trivia.
+    /// Returns whether the [`Element`] represents trivia.
     pub fn is_trivia(&self) -> bool {
         match self {
             Element::Node(node) => node.inner().kind().is_trivia(),

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -246,10 +246,10 @@ impl<N: TreeNode> Expr<N> {
         }
     }
 
-    /// Attempts to get a reference to the inner [`NameRef`].
+    /// Attempts to get a reference to the inner [`NameRefExpr`].
     ///
-    /// * If `self` is a [`Expr::Name`], then a reference to the inner
-    ///   [`NameRef`] is returned wrapped in [`Some`].
+    /// * If `self` is a [`Expr::NameRef`], then a reference to the inner
+    ///   [`NameRefExpr`] is returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
     pub fn as_name_ref(&self) -> Option<&NameRefExpr<N>> {
         match self {
@@ -258,10 +258,10 @@ impl<N: TreeNode> Expr<N> {
         }
     }
 
-    /// Consumes `self` and attempts to return the inner [`NameRef`].
+    /// Consumes `self` and attempts to return the inner [`NameRefExpr`].
     ///
-    /// * If `self` is a [`Expr::Name`], then the inner [`NameRef`] is returned
-    ///   wrapped in [`Some`].
+    /// * If `self` is a [`Expr::NameRef`], then the inner [`NameRefExpr`] is
+    ///   returned wrapped in [`Some`].
     /// * Else, [`None`] is returned.
     pub fn into_name_ref(self) -> Option<NameRefExpr<N>> {
         match self {

--- a/wdl-doc/src/callable.rs
+++ b/wdl-doc/src/callable.rs
@@ -20,7 +20,7 @@ use crate::parameter::InputOutput;
 use crate::parameter::Parameter;
 
 /// A map of metadata key-value pairs, sorted by key.
-type MetaMap = BTreeMap<String, MetadataValue>;
+pub type MetaMap = BTreeMap<String, MetadataValue>;
 
 /// A group of inputs.
 #[derive(Debug, Eq, PartialEq)]

--- a/wdl-format/src/v1/expr.rs
+++ b/wdl-format/src/v1/expr.rs
@@ -257,7 +257,7 @@ pub fn format_literal_float(element: &FormatElement, stream: &mut TokenStream<Pr
     }
 }
 
-/// Formats a [`NameRef`](wdl_ast::v1::NameRef).
+/// Formats a [`NameRefExpr`](wdl_ast::v1::NameRefExpr).
 pub fn format_name_ref_expr(element: &FormatElement, stream: &mut TokenStream<PreToken>) {
     let mut children = element.children().expect("name ref children");
     let name = children.next().expect("name ref name");


### PR DESCRIPTION
Fixes some renamed types and a few other warnings from `cargo doc`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
