### PR TITLE
fix: lsp errors out when a file uri is received instead of directory

### DIFF
--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 
+### Fixed
+
+* Fixed an issue where the LSP would error out when a file URI was received instead of a directory URI
+
 ## 0.6.0 - 01-17-2025
 
 ## 0.5.0 - 10-22-2024

--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Fixed an issue where the LSP would error out when a file URI was received instead of a directory URI
+* Fixed an issue where the LSP was expecting a directory URI instead of file URI ([#362](https://github.com/stjude-rust-labs/wdl/pull/362)).
 
 ## 0.6.0 - 01-17-2025
 

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -438,29 +438,27 @@ impl LanguageServer for Server {
 
         debug!("received `textDocument/didOpen` request: {params:#?}");
 
-        if let Ok(path) = params.text_document.uri.to_file_path() {
-            if let Err(e) = self
-                .analyzer
-                .add_document(path_to_uri(&path).expect("should convert to uri"))
-                .await
-            {
-                error!(
-                    "failed to add document {uri}: {e}",
-                    uri = params.text_document.uri
-                );
-                return;
-            }
+        if let Err(e) = self
+            .analyzer
+            .add_document(params.text_document.uri.clone())
+            .await
+        {
+            error!(
+                "failed to add document {uri}: {e}",
+                uri = params.text_document.uri
+            );
+            return;
+        }
 
-            if let Err(e) = self.analyzer.notify_incremental_change(
-                params.text_document.uri,
-                IncrementalChange {
-                    version: params.text_document.version,
-                    start: Some(params.text_document.text),
-                    edits: Vec::new(),
-                },
-            ) {
-                error!("failed to notify incremental change: {e}");
-            }
+        if let Err(e) = self.analyzer.notify_incremental_change(
+            params.text_document.uri,
+            IncrementalChange {
+                version: params.text_document.version,
+                start: Some(params.text_document.text),
+                edits: Vec::new(),
+            },
+        ) {
+            error!("failed to notify incremental change: {e}");
         }
     }
 

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -439,31 +439,13 @@ impl LanguageServer for Server {
         debug!("received `textDocument/didOpen` request: {params:#?}");
 
         if let Ok(path) = params.text_document.uri.to_file_path() {
-            if path.is_file() {
-                // Handle individual files
-                if let Err(e) = self
-                    .analyzer
-                    .add_document(path_to_uri(&path).expect("should convert to uri"))
-                    .await
-                {
-                    error!(
-                        "failed to add document {uri}: {e}",
-                        uri = params.text_document.uri
-                    );
-                    return;
-                }
-            } else if path.is_dir() {
-                // Handle individual directory
-                if let Err(e) = self.analyzer.add_directory(path).await {
-                    error!(
-                        "failed to add directory {uri}: {e}",
-                        uri = params.text_document.uri
-                    );
-                    return;
-                }
-            } else {
+            if let Err(e) = self
+                .analyzer
+                .add_document(path_to_uri(&path).expect("should convert to uri"))
+                .await
+            {
                 error!(
-                    "document {uri} is not a file or directory",
+                    "failed to add document {uri}: {e}",
                     uri = params.text_document.uri
                 );
                 return;

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -439,9 +439,31 @@ impl LanguageServer for Server {
         debug!("received `textDocument/didOpen` request: {params:#?}");
 
         if let Ok(path) = params.text_document.uri.to_file_path() {
-            if let Err(e) = self.analyzer.add_directory(path).await {
+            if path.is_file() {
+                // Handle individual files
+                if let Err(e) = self
+                    .analyzer
+                    .add_document(path_to_uri(&path).expect("should convert to uri"))
+                    .await
+                {
+                    error!(
+                        "failed to add document {uri}: {e}",
+                        uri = params.text_document.uri
+                    );
+                    return;
+                }
+            } else if path.is_dir() {
+                // Handle individual directory
+                if let Err(e) = self.analyzer.add_directory(path).await {
+                    error!(
+                        "failed to add directory {uri}: {e}",
+                        uri = params.text_document.uri
+                    );
+                    return;
+                }
+            } else {
                 error!(
-                    "failed to add document {uri}: {e}",
+                    "document {uri} is not a file or directory",
                     uri = params.text_document.uri
                 );
                 return;


### PR DESCRIPTION
This pull request fixes the current way of handling URLs in `textDocument/didOpen` event

If i open a single `wdl` file the analyzer can't _add_ the file as currently the analyzer doesn't check if the `URL` it got is a file or a directory, it just assumes its a directory and calls `analyzer.add_directory()`  instead of `analyzer.add_document()`

Error log:

```
2026-03-20T01:10:20.308154Z ERROR wdl_lsp::server: failed to add document file:///home/kiit/dev/stjude-rust-labs/sprocket-vscode/syntaxes/example.wdl: `/home/kiit/dev/stjude-rust-labs/sprocket-vscode/syntaxes/example.wdl` is a file, not a directory
```

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
