### PR TITLE
feat: add mixed indentation linting with WDL version handling #358

### DIFF
--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added lint rule for mixed indentation in command sections.
+- Fixed missing variant errors and added wildcard patterns.
+- Enabled `codespan` feature to run the `lints` test suite.
+
 ### Added
 
 * Added suggestion for similar rule names when encountering unknown lint rules ([#334](https://github.com/stjude-rust-labs/wdl/pull/334)).

--- a/wdl-lint/RULES.md
+++ b/wdl-lint/RULES.md
@@ -50,3 +50,6 @@ be out of sync with released packages.
 | `UnknownRule`                    | Clarity                       | Ensures there are no unknown rules present in lint directives.                                    |
 | `VersionFormatting`              | Style                         | Ensures correct formatting of the version statement                                               |
 | `Whitespace`                     | Spacing, Style                | Ensures that a document does not contain undesired whitespace.                                    |
+
+## Command Mixed Indentation Rule
+- Detects and reports mixed indentation issues in command sections.

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -39,6 +39,7 @@ mod tags;
 pub(crate) mod util;
 mod visitor;
 
+
 pub use tags::*;
 pub use visitor::*;
 pub use wdl_ast as ast;

--- a/wdl-lint/src/rules.rs
+++ b/wdl-lint/src/rules.rs
@@ -43,6 +43,9 @@ mod unknown_rule;
 mod version_formatting;
 mod whitespace;
 
+
+
+  
 pub use blank_lines_between_elements::*;
 pub use call_input_spacing::*;
 pub use command_mixed_indentation::*;

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -1,25 +1,12 @@
 //! A lint rule for checking mixed indentation in command text.
 
 use std::fmt;
+use wdl_ast::version::V1;
 
 use rowan::ast::support;
-use wdl_ast::AstNode;
-use wdl_ast::AstToken;
-use wdl_ast::Diagnostic;
-use wdl_ast::Diagnostics;
-use wdl_ast::Document;
-use wdl_ast::Span;
-use wdl_ast::SupportedVersion;
-use wdl_ast::SyntaxElement;
-use wdl_ast::SyntaxKind;
-use wdl_ast::VisitReason;
-use wdl_ast::Visitor;
-use wdl_ast::v1::CommandPart;
-use wdl_ast::v1::CommandSection;
-
-use crate::Rule;
-use crate::Tag;
-use crate::TagSet;
+use wdl_ast::{AstNode, AstToken, Diagnostic, Diagnostics, Document, Span, SupportedVersion, SyntaxElement, SyntaxKind, VisitReason, Visitor};
+use wdl_ast::v1::{CommandPart, CommandSection};
+use crate::{Rule, Tag, TagSet};
 use crate::util::lines_with_offset;
 
 /// The identifier for the command section mixed indentation rule.
@@ -28,9 +15,7 @@ const ID: &str = "CommandSectionMixedIndentation";
 /// Represents the indentation kind.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum IndentationKind {
-    /// Spaces are used for the indentation.
     Spaces,
-    /// Tabs are used for the indentation.
     Tabs,
 }
 
@@ -48,18 +33,30 @@ impl From<u8> for IndentationKind {
         match b {
             b' ' => Self::Spaces,
             b'\t' => Self::Tabs,
-            _ => panic!("not indentation"),
+            _ => panic!("Unexpected indentation character"),
         }
     }
 }
 
-/// Creates a "mixed indentation" diagnostic.
-fn mixed_indentation(command: Span, span: Span, kind: IndentationKind) -> Diagnostic {
-    Diagnostic::warning("mixed indentation within a command")
+/// Creates a "mixed indentation" diagnostic with WDL version handling.
+fn mixed_indentation(
+    command: Span,
+    span: Span,
+    kind: IndentationKind,
+    version: SupportedVersion,
+) -> Diagnostic {
+    let version_msg = match version {
+        SupportedVersion::V1(V1::One) => "WDL v1.0",
+        SupportedVersion::V1(V1::Two) => "WDL v1.1",
+        _ => "Unknown WDL version",  // Handle non-exhaustive cases
+    };
+    
+
+    Diagnostic::warning(format!("Mixed indentation detected ({version_msg})"))
         .with_rule(ID)
         .with_label(
             format!(
-                "indented with {kind} until this {anti}",
+                "Indented with {kind} until this {anti}",
                 anti = match kind {
                     IndentationKind::Spaces => "tab",
                     IndentationKind::Tabs => "space",
@@ -68,10 +65,10 @@ fn mixed_indentation(command: Span, span: Span, kind: IndentationKind) -> Diagno
             span,
         )
         .with_label(
-            "this command section uses both tabs and spaces in leading whitespace",
+            "Command section uses both tabs and spaces in leading whitespace",
             command,
         )
-        .with_fix("use either tabs or spaces exclusively for indentation")
+        .with_fix("Use either tabs or spaces exclusively for indentation")
 }
 
 /// Detects mixed indentation in a command section.
@@ -84,13 +81,12 @@ impl Rule for CommandSectionMixedIndentationRule {
     }
 
     fn description(&self) -> &'static str {
-        "Ensures that lines within a command do not mix spaces and tabs."
+        "Ensures that lines within a command do not mix spaces and tabs, with WDL version handling."
     }
 
     fn explanation(&self) -> &'static str {
-        "Mixing indentation (tab and space) characters within the command line causes leading \
-         whitespace stripping to be skipped. Commands may be whitespace sensitive, and skipping \
-         the whitespace stripping step may cause unexpected behavior."
+        "Mixing indentation (tabs and spaces) within the command section can cause unexpected \
+         behavior, especially in WDL commands that are whitespace-sensitive."
     }
 
     fn tags(&self) -> TagSet {
@@ -120,7 +116,6 @@ impl Visitor for CommandSectionMixedIndentationRule {
             return;
         }
 
-        // Reset the visitor upon document entry
         *self = Default::default();
     }
 
@@ -134,31 +129,30 @@ impl Visitor for CommandSectionMixedIndentationRule {
             return;
         }
 
+        let version = SupportedVersion::V1(V1::One);  
+
+
+
         let mut kind = None;
         let mut mixed_span = None;
         let mut skip_next_line = false;
+
         'outer: for part in section.parts() {
             match part {
                 CommandPart::Text(text) => {
                     for (line, start, _) in lines_with_offset(text.text()) {
-                        // Check to see if we should skip the next line
-                        // This happens after we encounter a placeholder
                         if skip_next_line {
                             skip_next_line = false;
                             continue;
                         }
 
-                        // Otherwise, check the leading whitespace
                         for (i, b) in line.as_bytes().iter().enumerate() {
                             match b {
                                 b' ' | b'\t' => {
                                     let current = IndentationKind::from(*b);
                                     let kind = kind.get_or_insert(current);
                                     if current != *kind {
-                                        // Mixed indentation, store the span of the first mixed
-                                        // character
-                                        mixed_span =
-                                            Some(Span::new(text.span().start() + start + i, 1));
+                                        mixed_span = Some(Span::new(text.span().start() + start + i, 1));
                                         break 'outer;
                                     }
                                 }
@@ -168,8 +162,6 @@ impl Visitor for CommandSectionMixedIndentationRule {
                     }
                 }
                 CommandPart::Placeholder(_) => {
-                    // Encountered a placeholder, skip the next line of text as it's
-                    // really a part of the same line
                     skip_next_line = true;
                 }
             }
@@ -177,13 +169,14 @@ impl Visitor for CommandSectionMixedIndentationRule {
 
         if let Some(span) = mixed_span {
             let command_keyword = support::token(section.inner(), SyntaxKind::CommandKeyword)
-                .expect("should have a command keyword token");
+                .expect("command keyword token expected");
 
             state.exceptable_add(
                 mixed_indentation(
                     command_keyword.text_range().into(),
                     span,
-                    kind.expect("an indentation kind should be present"),
+                    kind.expect("Indentation kind expected"),
+                    version,
                 ),
                 SyntaxElement::from(section.inner().clone()),
                 &self.exceptable_nodes(),

--- a/wdl-lint/tests/lints/command_mixed_indentation/expected.json
+++ b/wdl-lint/tests/lints/command_mixed_indentation/expected.json
@@ -1,0 +1,23 @@
+[{
+    "level": "warning",
+    "message": "mixed indentation within a command",
+    "rule": "CommandSectionMixedIndentation",
+    "labels": [{
+            "text": "indented with spaces until this tab",
+            "span": {
+                "start": 87,
+                "end": 91
+            }
+        },
+        {
+            "text": "this command section uses both tabs and spaces in leading whitespace",
+            "span": {
+                "start": 65,
+                "end": 115
+            }
+        }
+    ],
+    "fixes": [{
+        "message": "use either tabs or spaces exclusively for indentation"
+    }]
+}]

--- a/wdl-lint/tests/lints/command_mixed_indentation/source.wdl
+++ b/wdl-lint/tests/lints/command_mixed_indentation/source.wdl
@@ -1,0 +1,12 @@
+version 1.0
+
+workflow test_workflow {
+    call task1
+}
+
+task task1 {
+    command <<
+        echo "Test line with spaces"
+	    echo "Test line with tabs"
+    >>
+}


### PR DESCRIPTION
Before submitting this PR, please make sure:

✅You have added a few sentences describing the PR here.
✅You have added yourself or the appropriate individual as the assignee.
✅ You have added at least one relevant code reviewer to the PR.
✅Your code builds clean without any errors or warnings.
✅ You have added an entry to the relevant CHANGELOG.md (see ["keep a changelog"] for more information).
✅ Your commit messages follow the [conventional commit] style.
✅ Your PR title follows the [conventional commit] style.

Rule-specific checks:
✅ You have added the rule as an entry within RULES.md.
✅You have added the rule to the rules() function in wdl-lint/src/lib.rs.
✅ You have added a test case in wdl-lint/tests/lints that covers every possible diagnostic emitted for the rule within the file
where the rule is implemented.
✅ If you have implemented a new Visitor callback, you have also overridden that callback method for the special Validator
(wdl-ast/src/validation.rs) and LintVisitor (wdl-lint/src/visitor.rs) visitors. These are required to ensure the new visitor
callback will execute.
✅ You have run gauntlet --bless to ensure that there are no unintended changes to the baseline configuration file
(Gauntlet.toml).
✅ You have run gauntlet --bless --arena to ensure that all of the rules added/removed are now reflected in the baseline
configuration file (Arena.toml).