### PR TITLE
feat: support cloud storage URIs in the downloader.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added support for cloud storage URIs (#[367](https://github.com/stjude-rust-labs/wdl/pull/367)).
 * Added support reading of remote files from the stdlib file functions (#[364](https://github.com/stjude-rust-labs/wdl/pull/364))
 * Added support for graceful cancellation of evaluation (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Added support for `max_cpu` and `max_memory` hints in task evaluation (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).

--- a/wdl-engine/src/config.rs
+++ b/wdl-engine/src/config.rs
@@ -1,5 +1,6 @@
 //! Implementation of engine configuration.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -41,6 +42,9 @@ pub struct Config {
     /// Task execution backend configuration.
     #[serde(default)]
     pub backend: BackendConfig,
+    /// Storage configuration.
+    #[serde(default)]
+    pub storage: StorageConfig,
 }
 
 impl Config {
@@ -50,6 +54,7 @@ impl Config {
         self.workflow.validate()?;
         self.task.validate()?;
         self.backend.validate()?;
+        self.storage.validate()?;
         Ok(())
     }
 
@@ -87,6 +92,101 @@ pub struct HttpConfig {
 
 impl HttpConfig {
     /// Validates the HTTP configuration.
+    pub fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Represents storage configuration.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct StorageConfig {
+    /// Azure Blob Storage configuration.
+    #[serde(default)]
+    pub azure: AzureStorageConfig,
+    /// AWS S3 configuration.
+    #[serde(default)]
+    pub s3: S3StorageConfig,
+    /// Google Cloud Storage configuration.
+    #[serde(default)]
+    pub google: GoogleStorageConfig,
+}
+
+impl StorageConfig {
+    /// Validates the HTTP configuration.
+    pub fn validate(&self) -> Result<()> {
+        self.azure.validate()?;
+        self.s3.validate()?;
+        self.google.validate()?;
+        Ok(())
+    }
+}
+
+/// Represents configuration for Azure Blob Storage.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct AzureStorageConfig {
+    /// The Azure Blob Storage authentication configuration.
+    ///
+    /// The key for the outer map is the storage account name.
+    ///
+    /// The key for the inner map is the container name.
+    ///
+    /// The value for the inner map is the SAS token query string to apply to
+    /// matching Azure Blob Storage URLs.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub auth: HashMap<String, HashMap<String, String>>,
+}
+
+impl AzureStorageConfig {
+    /// Validates the Azure Blob Storage configuration.
+    pub fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Represents configuration for AWS S3 storage.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct S3StorageConfig {
+    /// The default region to use for S3-schemed URLs (e.g.
+    /// `s3://<bucket>/<blob>`).
+    ///
+    /// Defaults to `us-east-1`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+
+    /// The AWS S3 storage authentication configuration.
+    ///
+    /// The key for the map is the bucket name.
+    ///
+    /// The value for the map is the presigned query string.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub auth: HashMap<String, String>,
+}
+
+impl S3StorageConfig {
+    /// Validates the AWS S3 storage configuration.
+    pub fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Represents configuration for Google Cloud Storage.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct GoogleStorageConfig {
+    /// The Google Cloud Storage authentication configuration.
+    ///
+    /// The key for the map is the bucket name.
+    ///
+    /// The value for the map is the presigned query string.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub auth: HashMap<String, String>,
+}
+
+impl GoogleStorageConfig {
+    /// Validates the Google Cloud Storage configuration.
     pub fn validate(&self) -> Result<()> {
         Ok(())
     }

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -437,13 +437,11 @@ impl TaskEvaluator {
     ) -> Result<Self> {
         config.validate()?;
 
-        let downloader = match &config.http.cache {
-            Some(cache) => HttpDownloader::new_with_cache(cache),
-            None => HttpDownloader::new()?,
-        };
+        let config = Arc::new(config);
+        let downloader = HttpDownloader::new(config.clone())?;
 
         Ok(Self {
-            config: Arc::new(config),
+            config,
             backend,
             token,
             downloader,

--- a/wdl-engine/src/eval/v1/workflow.rs
+++ b/wdl-engine/src/eval/v1/workflow.rs
@@ -627,13 +627,11 @@ impl WorkflowEvaluator {
     ) -> Result<Self> {
         config.validate()?;
 
-        let downloader = match &config.http.cache {
-            Some(cache) => HttpDownloader::new_with_cache(cache),
-            None => HttpDownloader::new()?,
-        };
+        let config = Arc::new(config);
+        let downloader = HttpDownloader::new(config.clone())?;
 
         Ok(Self {
-            config: Arc::new(config),
+            config,
             backend,
             token,
             downloader,

--- a/wdl-engine/src/http.rs
+++ b/wdl-engine/src/http.rs
@@ -35,7 +35,7 @@ use url::Url;
 use crate::config::Config;
 
 mod azure;
-mod gs;
+mod google;
 mod s3;
 
 /// The default cache subdirectory that is appended to the system cache
@@ -240,7 +240,7 @@ impl HttpDownloader {
         }
 
         // Finally, attempt to apply auth for Google Cloud Storage
-        gs::apply_auth(&self.config.storage.google, url);
+        google::apply_auth(&self.config.storage.google, url);
     }
 }
 
@@ -272,7 +272,7 @@ impl Downloader for HttpDownloader {
                 "http" | "https" => url,
                 "az" => azure::rewrite_url(&url)?,
                 "s3" => s3::rewrite_url(&self.config.storage.s3, &url)?,
-                "gs" => gs::rewrite_url(&url)?,
+                "gs" => google::rewrite_url(&url)?,
                 _ => return Ok(None),
             };
 

--- a/wdl-engine/src/http.rs
+++ b/wdl-engine/src/http.rs
@@ -1,6 +1,8 @@
 //! Implementation of remote file downloads over HTTP.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
+use std::fmt;
 use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
@@ -30,10 +32,15 @@ use tracing::debug;
 use tracing::info;
 use url::Url;
 
+use crate::config::Config;
+
+mod azure;
+mod gs;
+mod s3;
+
 /// The default cache subdirectory that is appended to the system cache
 /// directory.
 const DEFAULT_CACHE_SUBDIR: &str = "wdl";
-
 /// A trait implemented by types responsible for downloading remote files over
 /// HTTP for evaluation.
 pub trait Downloader {
@@ -92,6 +99,8 @@ pub enum Status {
 /// The downloader can be cheaply cloned.
 #[derive(Clone)]
 pub struct HttpDownloader {
+    /// The engine evaluation configuration.
+    config: Arc<Config>,
     /// The underlying HTTP client.
     client: ClientWithMiddleware,
     /// The HTTP cache shared with the client.
@@ -101,18 +110,15 @@ pub struct HttpDownloader {
 }
 
 impl HttpDownloader {
-    /// Constructs a new HTTP downloader using the system cache directory.
-    pub fn new() -> Result<Self> {
-        Ok(Self::new_with_cache(
-            dirs::cache_dir()
+    /// Constructs a new HTTP downloader with the given configuration.
+    pub fn new(config: Arc<Config>) -> Result<Self> {
+        let cache_dir: Cow<'_, Path> = match &config.http.cache {
+            Some(dir) => dir.into(),
+            None => dirs::cache_dir()
                 .context("failed to determine system cache directory")?
-                .join(DEFAULT_CACHE_SUBDIR),
-        ))
-    }
-
-    /// Constructs a new downloader with the given cache directory.
-    pub fn new_with_cache(cache_dir: impl Into<PathBuf>) -> Self {
-        let cache_dir = cache_dir.into();
+                .join(DEFAULT_CACHE_SUBDIR)
+                .into(),
+        };
 
         info!(
             "using HTTP download cache directory `{dir}`",
@@ -121,36 +127,52 @@ impl HttpDownloader {
 
         let cache = Arc::new(Cache::new(DefaultCacheStorage::new(cache_dir)));
 
-        Self {
+        Ok(Self {
+            config,
             client: ClientBuilder::new(Client::new())
                 .with_arc(cache.clone())
                 .build(),
             cache,
             downloads: Default::default(),
-        }
+        })
     }
 
     /// Gets the file at the given URL.
     ///
     /// Returns the file's local location upon success.
     async fn get(&self, url: &Url) -> Result<Location> {
-        // TODO: add auth tokens for s3/az/gs requests
+        struct DisplayUrl<'a>(&'a Url);
+
+        impl fmt::Display for DisplayUrl<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                // Only write the scheme, host, and path so that potential authentication
+                // information doesn't end up in the log
+                write!(
+                    f,
+                    "{scheme}://{host}{path}",
+                    scheme = self.0.scheme(),
+                    host = self.0.host_str().unwrap_or(""),
+                    path = self.0.path()
+                )
+            }
+        }
+
+        // TODO: progress indicator?
+        info!("downloading `{url}`", url = DisplayUrl(url));
 
         // Perform the download
-        let response = self
-            .client
-            .get(url.as_str())
-            .send()
-            .await
-            .with_context(|| format!("failed to download `{url}`"))?;
+        let response = self.client.get(url.as_str()).send().await?;
 
         let status = response.status();
         if !status.is_success() {
             if let Ok(text) = response.text().await {
-                debug!("response from get of `{url}` was `{text}`");
+                debug!(
+                    "response from get of `{url}` was `{text}`",
+                    url = DisplayUrl(url)
+                );
             }
 
-            bail!("failed to download `{url}`: server responded with status {status}");
+            bail!("server responded with status {status}");
         }
 
         if let Some(digest) = response
@@ -164,6 +186,7 @@ impl HttpDownloader {
 
             debug!(
                 "`{url}` was previously downloaded to `{path}`",
+                url = DisplayUrl(url),
                 path = path.display()
             );
 
@@ -179,6 +202,7 @@ impl HttpDownloader {
         debug!(
             "response body for `{url}` was not present in cache: downloading to temporary file \
              `{path}`",
+            url = DisplayUrl(url),
             path = path.display()
         );
 
@@ -186,8 +210,12 @@ impl HttpDownloader {
         let mut writer = BufWriter::new(fs::File::from(file));
 
         while let Some(bytes) = stream.next().await {
-            let bytes =
-                bytes.with_context(|| format!("failed to read response body from `{url}`"))?;
+            let bytes = bytes.with_context(|| {
+                format!(
+                    "failed to read response body from `{url}`",
+                    url = DisplayUrl(url)
+                )
+            })?;
             writer.write_all(&bytes).await.with_context(|| {
                 format!(
                     "failed to write to temporary file `{path}`",
@@ -197,6 +225,22 @@ impl HttpDownloader {
         }
 
         Ok(Location::Temp(path.into()))
+    }
+
+    /// Applies authentication to the given URL.
+    fn apply_auth(&self, url: &mut Url) {
+        // Attempt to apply auth for Azure storage
+        if azure::apply_auth(&self.config.storage.azure, url) {
+            return;
+        }
+
+        // Attempt to apply auth for S3 storage
+        if s3::apply_auth(&self.config.storage.s3, url) {
+            return;
+        }
+
+        // Finally, attempt to apply auth for Google Cloud Storage
+        gs::apply_auth(&self.config.storage.google, url);
     }
 }
 
@@ -217,7 +261,7 @@ impl Downloader for HttpDownloader {
                 Err(_) => return Ok(None),
             };
 
-            match url.scheme() {
+            let mut url = match url.scheme() {
                 "file" => {
                     // If it can be converted to a path, return the path; otherwise `None`
                     return Ok(match url.to_file_path() {
@@ -225,11 +269,17 @@ impl Downloader for HttpDownloader {
                         Err(_) => None,
                     });
                 }
-                "http" | "https" => {}
-                // TODO: support s3/az/gs URI here, including downloading of blobs under a shared
-                // prefix
+                "http" | "https" => url,
+                "az" => azure::rewrite_url(&url)?,
+                "s3" => s3::rewrite_url(&self.config.storage.s3, &url)?,
+                "gs" => gs::rewrite_url(&url)?,
                 _ => return Ok(None),
-            }
+            };
+
+            // TODO: support downloading "directories" for cloud storage URLs
+
+            // Apply any authentication to the URL based on configuration
+            self.apply_auth(&mut url);
 
             // This loop exists so that all requests to download the same URL will block
             // waiting for a notification that the download has completed.
@@ -268,9 +318,6 @@ impl Downloader for HttpDownloader {
                 retried = true;
                 continue;
             }
-
-            // TODO: progress indicator?
-            info!("downloading `{url}` to the cache");
 
             // Perform the download
             let res = self.get(&url).await.map_err(Arc::from);

--- a/wdl-engine/src/http/azure.rs
+++ b/wdl-engine/src/http/azure.rs
@@ -1,0 +1,194 @@
+//! Implementation of support for Azure Blob Storage URLs.
+
+use anyhow::Context;
+use anyhow::Result;
+use url::Url;
+
+use crate::config::AzureStorageConfig;
+
+/// The Azure Blob Storage domain suffix.
+const AZURE_STORAGE_DOMAIN_SUFFIX: &str = ".blob.core.windows.net";
+
+/// Rewrites an Azure Blob Storage URL (az://) into a HTTPS URL.
+pub(crate) fn rewrite_url(url: &Url) -> Result<Url> {
+    assert_eq!(url.scheme(), "az");
+
+    let account = url
+        .host_str()
+        .with_context(|| format!("invalid Azure URL `{url}`: storage account name is missing"))?;
+
+    match (url.query(), url.fragment()) {
+        (None, None) => format!(
+            "https://{account}{AZURE_STORAGE_DOMAIN_SUFFIX}{path}",
+            path = url.path()
+        ),
+        (None, Some(fragment)) => {
+            format!(
+                "https://{account}{AZURE_STORAGE_DOMAIN_SUFFIX}{path}#{fragment}",
+                path = url.path()
+            )
+        }
+        (Some(query), None) => format!(
+            "https://{account}{AZURE_STORAGE_DOMAIN_SUFFIX}{path}?{query}",
+            path = url.path()
+        ),
+        (Some(query), Some(fragment)) => {
+            format!(
+                "https://{account}{AZURE_STORAGE_DOMAIN_SUFFIX}{path}?{query}#{fragment}",
+                path = url.path()
+            )
+        }
+    }
+    .parse()
+    .with_context(|| format!("invalid Azure URL `{url}`"))
+}
+
+/// Applies Azure SAS token authentication to the given URL.
+///
+/// Returns `true` if the URL was for Azure or `false` if it was not.
+pub(crate) fn apply_auth(config: &AzureStorageConfig, url: &mut Url) -> bool {
+    // Only apply auth for HTTPS URLs
+    if url.scheme() != "https" {
+        return false;
+    }
+
+    if let Some(url::Host::Domain(domain)) = url.host() {
+        if let Some(account) = domain.strip_suffix(AZURE_STORAGE_DOMAIN_SUFFIX) {
+            // If the URL already has a query string, don't modify it
+            if url.query().is_some() {
+                return true;
+            }
+
+            if let Some(mut segments) = url.path_segments() {
+                // Determine the container name; if there's only one path segment, then use the
+                // `$root` container
+                let container = match (segments.next(), segments.next()) {
+                    (Some(_), None) => "$root",
+                    (Some(container), Some(_)) => container,
+                    _ => return true,
+                };
+
+                if let Some(containers) = config.auth.get(account) {
+                    if let Some(token) = containers.get(container) {
+                        let token = token.strip_prefix('?').unwrap_or(token);
+                        url.set_query(Some(token));
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn it_rewrites_urls() {
+        let url = rewrite_url(&"az://foo/bar/baz".parse().unwrap()).unwrap();
+        assert_eq!(url.as_str(), "https://foo.blob.core.windows.net/bar/baz");
+
+        let url = rewrite_url(&"az://foo/bar/baz#qux".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.blob.core.windows.net/bar/baz#qux"
+        );
+
+        let url = rewrite_url(&"az://foo/bar/baz?qux=quux".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.blob.core.windows.net/bar/baz?qux=quux"
+        );
+
+        let url =
+            rewrite_url(&"az://foo/bar/baz?qux=quux&jam=cakes#frag".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.blob.core.windows.net/bar/baz?qux=quux&jam=cakes#frag"
+        );
+    }
+
+    #[test]
+    fn it_applies_auth() {
+        let mut config = AzureStorageConfig::default();
+        config.auth.insert(
+            "account".to_string(),
+            HashMap::from_iter([
+                ("container1".to_string(), "token1=foo".to_string()),
+                ("container2".to_string(), "?token2=bar".to_string()),
+                ("$root".to_string(), "token3=qux".to_string()),
+            ]),
+        );
+
+        // Not an Azure URL
+        let mut url = "https://example.com/bar/baz".parse().unwrap();
+        assert!(!apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://example.com/bar/baz");
+
+        // Not using HTTPS
+        let mut url = "http://foo.blob.core.windows.net/bar/baz".parse().unwrap();
+        assert!(!apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "http://foo.blob.core.windows.net/bar/baz");
+
+        // Azure URL but unknown account
+        let mut url = "https://foo.blob.core.windows.net/bar/baz".parse().unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://foo.blob.core.windows.net/bar/baz");
+
+        // Azure URL but unknown container
+        let mut url = "https://account.blob.core.windows.net/bar/baz"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://account.blob.core.windows.net/bar/baz"
+        );
+
+        // Matching with first auth token
+        let mut url = "https://account.blob.core.windows.net/container1/foo"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://account.blob.core.windows.net/container1/foo?token1=foo"
+        );
+
+        // Matching with second auth token
+        let mut url = "https://account.blob.core.windows.net/container2/foo"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://account.blob.core.windows.net/container2/foo?token2=bar"
+        );
+
+        // Matching with third auth token
+        let mut url = "https://account.blob.core.windows.net/foo".parse().unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://account.blob.core.windows.net/foo?token3=qux"
+        );
+
+        // Matching with query params already present
+        let mut url = "https://account.blob.core.windows.net/container1/foo?a=b"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://account.blob.core.windows.net/container1/foo?a=b"
+        );
+    }
+}

--- a/wdl-engine/src/http/google.rs
+++ b/wdl-engine/src/http/google.rs
@@ -151,9 +151,14 @@ mod test {
         assert_eq!(url.as_str(), "https://example.com/bar/baz");
 
         // Not using HTTPS
-        let mut url = "http://foo.storage.googleapis.com/bar/baz".parse().unwrap();
+        let mut url = "http://storage.googleapis.com/bucket1/foo/bar"
+            .parse()
+            .unwrap();
         assert!(!apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "http://foo.storage.googleapis.com/bar/baz");
+        assert_eq!(
+            url.as_str(),
+            "http://storage.googleapis.com/bucket1/foo/bar"
+        );
 
         // Unknown bucket (path)
         let mut url = "https://storage.googleapis.com/foo/bar/baz"

--- a/wdl-engine/src/http/gs.rs
+++ b/wdl-engine/src/http/gs.rs
@@ -1,0 +1,222 @@
+//! Implementation of support for Google Cloud Storage URLs.
+
+use anyhow::Context;
+use anyhow::Result;
+use url::Url;
+
+use crate::config::GoogleStorageConfig;
+
+/// The Google Storage domain.
+const GOOGLE_STORAGE_DOMAIN: &str = "storage.googleapis.com";
+
+/// Rewrites a Google Cloud Storage URL (gs://) into a HTTPS URL.
+pub(crate) fn rewrite_url(url: &Url) -> Result<Url> {
+    assert_eq!(url.scheme(), "gs");
+
+    let bucket = url.host_str().with_context(|| {
+        format!("invalid Google Cloud Storage URL `{url}`: bucket name is missing")
+    })?;
+
+    match (url.query(), url.fragment()) {
+        (None, None) => format!(
+            "https://{bucket}.{GOOGLE_STORAGE_DOMAIN}{path}",
+            path = url.path()
+        ),
+        (None, Some(fragment)) => {
+            format!(
+                "https://{bucket}.{GOOGLE_STORAGE_DOMAIN}{path}#{fragment}",
+                path = url.path()
+            )
+        }
+        (Some(query), None) => format!(
+            "https://{bucket}.{GOOGLE_STORAGE_DOMAIN}{path}?{query}",
+            path = url.path()
+        ),
+        (Some(query), Some(fragment)) => {
+            format!(
+                "https://{bucket}.{GOOGLE_STORAGE_DOMAIN}{path}?{query}#{fragment}",
+                path = url.path()
+            )
+        }
+    }
+    .parse()
+    .with_context(|| format!("invalid Google Cloud Storage URL `{url}`"))
+}
+
+/// Applies Google Cloud Storage presigned signatures to the given URL.
+///
+/// Returns `true` if the URL was for Google Cloud Storage or `false` if it was
+/// not.
+pub(crate) fn apply_auth(config: &GoogleStorageConfig, url: &mut Url) -> bool {
+    // Only apply auth for HTTPS URLs
+    if url.scheme() != "https" {
+        return false;
+    }
+
+    if let Some(url::Host::Domain(domain)) = url.host() {
+        if let Some(domain) = domain.strip_suffix(GOOGLE_STORAGE_DOMAIN) {
+            // If the URL already has a query string, don't modify it
+            if url.query().is_some() {
+                return true;
+            }
+
+            // There are two supported URL formats:
+            // 1) Path style e.g. `https://storage.googleapis.com/<bucket>/<object>`
+            // 2) Virtual-host style, e.g. `https://<bucket>.storage.googleapis.com/<object>`.
+            let bucket = if domain.is_empty() {
+                // This is a path style URL; bucket is first path segment
+                let mut segments = match url.path_segments() {
+                    Some(segments) => segments,
+                    None => return true,
+                };
+
+                match segments.next() {
+                    Some(bucket) => bucket,
+                    None => return true,
+                }
+            } else {
+                // This is a virtual-host style URL; bucket is first subdomain
+                let mut subdomains = domain.split('.');
+                let bucket = match subdomains.next() {
+                    Some(bucket) => bucket,
+                    None => return true,
+                };
+
+                // Ensure there is nothing between the subdomain and the GCS domain
+                match subdomains.next() {
+                    Some("") => {}
+                    _ => return true,
+                }
+
+                bucket
+            };
+
+            if let Some(sig) = config.auth.get(bucket) {
+                let sig = sig.strip_prefix('?').unwrap_or(sig);
+                url.set_query(Some(sig));
+            }
+
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn it_rewrites_urls() {
+        let url = rewrite_url(&"gs://foo/bar/baz".parse().unwrap()).unwrap();
+        assert_eq!(url.as_str(), "https://foo.storage.googleapis.com/bar/baz");
+
+        let url = rewrite_url(&"gs://foo/bar/baz#qux".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.storage.googleapis.com/bar/baz#qux"
+        );
+
+        let url = rewrite_url(&"gs://foo/bar/baz?qux=quux".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.storage.googleapis.com/bar/baz?qux=quux"
+        );
+
+        let url =
+            rewrite_url(&"gs://foo/bar/baz?qux=quux&jam=cakes#frag".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.storage.googleapis.com/bar/baz?qux=quux&jam=cakes#frag"
+        );
+    }
+
+    #[test]
+    fn it_applies_auth() {
+        let mut config = GoogleStorageConfig::default();
+        config
+            .auth
+            .insert("bucket1".to_string(), "token1=foo".to_string());
+
+        config
+            .auth
+            .insert("bucket2".to_string(), "?token2=bar".to_string());
+
+        // Not an GS URL
+        let mut url = "https://example.com/bar/baz".parse().unwrap();
+        assert!(!apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://example.com/bar/baz");
+
+        // Not using HTTPS
+        let mut url = "http://foo.storage.googleapis.com/bar/baz".parse().unwrap();
+        assert!(!apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "http://foo.storage.googleapis.com/bar/baz");
+
+        // Unknown bucket (path)
+        let mut url = "https://storage.googleapis.com/foo/bar/baz"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://storage.googleapis.com/foo/bar/baz");
+
+        // Unknown bucket (vhost)
+        let mut url = "https://foo.storage.googleapis.com/bar/baz"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://foo.storage.googleapis.com/bar/baz");
+
+        // Matching with first auth token (path)
+        let mut url = "https://storage.googleapis.com/bucket1/foo/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://storage.googleapis.com/bucket1/foo/bar?token1=foo"
+        );
+
+        // Matching with first auth token (vhost)
+        let mut url = "https://bucket1.storage.googleapis.com/foo/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://bucket1.storage.googleapis.com/foo/bar?token1=foo"
+        );
+
+        // Matching with second auth token (path)
+        let mut url = "https://storage.googleapis.com/bucket2/foo/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://storage.googleapis.com/bucket2/foo/bar?token2=bar"
+        );
+
+        // Matching with second auth token (vhost)
+        let mut url = "https://bucket2.storage.googleapis.com/foo/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://bucket2.storage.googleapis.com/foo/bar?token2=bar"
+        );
+
+        // Matching with query params already present
+        let mut url = "https://storage.googleapis.com/bucket2/foo/bar?a=b"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://storage.googleapis.com/bucket2/foo/bar?a=b"
+        );
+    }
+}

--- a/wdl-engine/src/http/s3.rs
+++ b/wdl-engine/src/http/s3.rs
@@ -174,13 +174,13 @@ mod test {
         assert_eq!(url.as_str(), "https://example.com/bar/baz");
 
         // Not using HTTPS
-        let mut url = "http://foo.s3.us-west-1.amazonaws.com/bar/baz"
+        let mut url = "http://s3.us-east-1.amazonaws.com/bucket1/bar"
             .parse()
             .unwrap();
         assert!(!apply_auth(&config, &mut url));
         assert_eq!(
             url.as_str(),
-            "http://foo.s3.us-west-1.amazonaws.com/bar/baz"
+            "http://s3.us-east-1.amazonaws.com/bucket1/bar"
         );
 
         // Unknown bucket (path without region)

--- a/wdl-engine/src/http/s3.rs
+++ b/wdl-engine/src/http/s3.rs
@@ -1,0 +1,271 @@
+//! Implementation of support for Amazon AWS S3 URLs.
+
+use anyhow::Context;
+use anyhow::Result;
+use url::Url;
+
+use crate::config::S3StorageConfig;
+
+/// The S3 storage domain suffix.
+const S3_STORAGE_DOMAIN_SUFFIX: &str = ".amazonaws.com";
+
+/// The default S3 URL region.
+const DEFAULT_REGION: &str = "us-east-1";
+
+/// Rewrites an S3 URL (s3://) into a HTTPS URL.
+pub(crate) fn rewrite_url(config: &S3StorageConfig, url: &Url) -> Result<Url> {
+    assert_eq!(url.scheme(), "s3");
+
+    let region = config.region.as_deref().unwrap_or(DEFAULT_REGION);
+
+    let bucket = url
+        .host_str()
+        .with_context(|| format!("invalid S3 URL `{url}`: bucket name is missing"))?;
+
+    match (url.query(), url.fragment()) {
+        (None, None) => format!(
+            "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}",
+            path = url.path()
+        ),
+        (None, Some(fragment)) => {
+            format!(
+                "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}#{fragment}",
+                path = url.path()
+            )
+        }
+        (Some(query), None) => {
+            format!(
+                "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}?{query}",
+                path = url.path()
+            )
+        }
+        (Some(query), Some(fragment)) => {
+            format!(
+                "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}?{query}#{fragment}",
+                path = url.path()
+            )
+        }
+    }
+    .parse()
+    .with_context(|| format!("invalid S3 URL `{url}`"))
+}
+
+/// Applies S3 presigned signatures to the given URL.
+///
+/// Returns `true` if the URL was for S3 or `false` if it was not.
+pub(crate) fn apply_auth(config: &S3StorageConfig, url: &mut Url) -> bool {
+    // Only apply auth for HTTPS URLs
+    if url.scheme() != "https" {
+        return false;
+    }
+
+    if let Some(url::Host::Domain(domain)) = url.host() {
+        if let Some(domain) = domain.strip_suffix(S3_STORAGE_DOMAIN_SUFFIX) {
+            // If the URL already has a query string, don't modify it
+            if url.query().is_some() {
+                return true;
+            }
+
+            // There are three supported URL formats:
+            // 1) Path style without region, e.g. `https://s3.amazonaws.com/<bucket>/<object>`
+            // 2) Path style with region, e.g. `https://s3.<region>.amazonaws.com/<bucket>/<object>`.
+            // 3) Virtual-host style, e.g. `https://<bucket>.s3.<region>.amazonaws.com/<object>`.
+            let bucket = if domain == "s3"
+                || domain == "S3"
+                || domain.starts_with("s3.")
+                || domain.starts_with("S3.")
+            {
+                // This is a path style URL; bucket is first path segment
+                let mut segments = match url.path_segments() {
+                    Some(segments) => segments,
+                    None => return true,
+                };
+
+                match segments.next() {
+                    Some(bucket) => bucket,
+                    None => return true,
+                }
+            } else {
+                // This is a virtual-host style URL; bucket is first subdomain
+                let mut subdomains = domain.split('.');
+                let bucket = match subdomains.next() {
+                    Some(bucket) => bucket,
+                    None => return true,
+                };
+
+                // Ensure the URL is for the S3 service
+                match subdomains.next() {
+                    Some("s3") | Some("S3") => {}
+                    _ => return true,
+                }
+
+                bucket
+            };
+
+            if let Some(sig) = config.auth.get(bucket) {
+                let sig = sig.strip_prefix('?').unwrap_or(sig);
+                url.set_query(Some(sig));
+            }
+
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn it_rewrites_urls() {
+        // Default region is us-east-1
+        let url = rewrite_url(&Default::default(), &"s3://foo/bar/baz".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.s3.us-east-1.amazonaws.com/bar/baz"
+        );
+
+        // Ensure users can change the default region via the config
+        let config = S3StorageConfig {
+            region: Some("us-west-1".to_string()),
+            ..Default::default()
+        };
+        let url = rewrite_url(&config, &"s3://foo/bar/baz#qux".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.s3.us-west-1.amazonaws.com/bar/baz#qux"
+        );
+
+        let url = rewrite_url(&config, &"s3://foo/bar/baz?qux=quux".parse().unwrap()).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.s3.us-west-1.amazonaws.com/bar/baz?qux=quux"
+        );
+
+        let url = rewrite_url(
+            &config,
+            &"s3://foo/bar/baz?qux=quux&jam=cakes#frag".parse().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://foo.s3.us-west-1.amazonaws.com/bar/baz?qux=quux&jam=cakes#frag"
+        );
+    }
+
+    #[test]
+    fn it_applies_auth() {
+        let mut config = S3StorageConfig::default();
+        config
+            .auth
+            .insert("bucket1".to_string(), "token1=foo".to_string());
+
+        config
+            .auth
+            .insert("bucket2".to_string(), "?token2=bar".to_string());
+
+        // Not an S3 URL
+        let mut url = "https://example.com/bar/baz".parse().unwrap();
+        assert!(!apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://example.com/bar/baz");
+
+        // Not using HTTPS
+        let mut url = "http://foo.s3.us-west-1.amazonaws.com/bar/baz"
+            .parse()
+            .unwrap();
+        assert!(!apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "http://foo.s3.us-west-1.amazonaws.com/bar/baz"
+        );
+
+        // Unknown bucket (path without region)
+        let mut url = "https://s3.amazonaws.com/foo/bar".parse().unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://s3.amazonaws.com/foo/bar");
+
+        // Unknown bucket (path with region)
+        let mut url = "https://s3.us-east-1.amazonaws.com/foo/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://s3.us-east-1.amazonaws.com/foo/bar");
+
+        // Unknown bucket (vhost)
+        let mut url = "https://foo.s3.us-east-1.amazonaws.com/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(url.as_str(), "https://foo.s3.us-east-1.amazonaws.com/bar");
+
+        // Matching with first token (path without region)
+        let mut url = "https://s3.amazonaws.com/bucket1/bar".parse().unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://s3.amazonaws.com/bucket1/bar?token1=foo"
+        );
+
+        // Matching with first token(path with region)
+        let mut url = "https://s3.us-east-1.amazonaws.com/bucket1/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://s3.us-east-1.amazonaws.com/bucket1/bar?token1=foo"
+        );
+
+        // Matching with first token (vhost)
+        let mut url = "https://bucket1.s3.us-east-1.amazonaws.com/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://bucket1.s3.us-east-1.amazonaws.com/bar?token1=foo"
+        );
+
+        // Matching with second token (path without region)
+        let mut url = "https://s3.amazonaws.com/bucket2/bar".parse().unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://s3.amazonaws.com/bucket2/bar?token2=bar"
+        );
+
+        // Matching with second token(path with region)
+        let mut url = "https://s3.us-east-1.amazonaws.com/bucket2/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://s3.us-east-1.amazonaws.com/bucket2/bar?token2=bar"
+        );
+
+        // Matching with second token (vhost)
+        let mut url = "https://bucket2.s3.us-east-1.amazonaws.com/bar"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://bucket2.s3.us-east-1.amazonaws.com/bar?token2=bar"
+        );
+
+        // Matching with query params already present
+        let mut url = "https://bucket2.s3.us-east-1.amazonaws.com/bar?a=b"
+            .parse()
+            .unwrap();
+        assert!(apply_auth(&config, &mut url));
+        assert_eq!(
+            url.as_str(),
+            "https://bucket2.s3.us-east-1.amazonaws.com/bar?a=b"
+        );
+    }
+}


### PR DESCRIPTION
This commit implements support for cloud storage URIs:

* `az://<account>/<container>/<blob>` for Azure Blob Storage
* `s3://<bucket>/<object>` for AWS S3
* `gs://<bucket>/<object>` for Google Cloud Storage

Additionally, the configuration format has been updated to include sections on authentication tokens for the different services.

The authentication tokens are the query strings for presigned URLs.

This allows the engine configuration to store only a signature that grants access to a resource without storing the storage account keys.

As we aren't yet localizing inputs for local task executions, the support for these URLs is currently limited to the `read_*` functions from the WDL standard library; once input localization is properly implemented, you'll be able to use these URIs in an inputs file.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
