### PR TITLE
chore: adds an action to close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,45 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  check_stale_issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Gather labels
+        run: |
+          awaiting_labels=$(
+            gh label list --json name --jq '.[] | \
+            select(.name | test("^S-awaiting")) | \
+            .name'
+          )
+          echo "Found relevant labels: $awaiting_labels"
+          echo "awaiting_labels=$awaiting_labels" >> $GITHUB_ENV
+      - name: Gather pull requests
+        id: get_issues
+        run: |
+          date=$(date --date='10 days ago' --utc +%Y-%m-%dT%H:%M:%SZ)
+          prs=""
+          for label in $awaiting_labels; do
+            pr_numbers=$(
+              gh pr list --label "$label" --json "number,updatedAt" --jq '.[] | \
+                select(.updatedAt < "$date") | .number')
+            prs="$prs $pr_numbers"
+          done
+          echo "prs=$prs" >> $GITHUB_ENV
+      - name: Close pull requests
+        if: env.prs != ''
+        run: |
+          for number in $prs; do
+            gh issue comment $number --body "This PR has been awaiting action for \
+            more than 10 days with no response. Because of this inactivity, the PR \
+            is being closed. If you continue working on the PR, please comment here \
+            when it is ready for re-review."
+            gh issue close $number
+          done


### PR DESCRIPTION
Adds an action to comment and close stale pull requests.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
