### PR TITLE
fix: improve handling of URLs in file functions.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: docker pull ubuntu:latest
+        if: runner.os == 'Linux'
       - run: cargo test --all --all-features
       - run: cargo test --all-features --examples
 

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed support for URLs in file stdlib functions (#[369](https://github.com/stjude-rust-labs/wdl/pull/369)).
 * Fixed panic when an input path in a complex type did not exist (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Fixed path translation in nested placeholder evaluation (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Fixed path translation to mount inputs individually (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).

--- a/wdl-engine/src/diagnostics.rs
+++ b/wdl-engine/src/diagnostics.rs
@@ -161,44 +161,6 @@ pub fn multiline_string_requirement(span: Span) -> Diagnostic {
     Diagnostic::error("use of multi-line strings requires WDL version 1.2").with_highlight(span)
 }
 
-/// Creates an "invalid regular expression" diagnostic.
-pub fn invalid_regex(error: &regex::Error, span: Span) -> Diagnostic {
-    Diagnostic::error(error.to_string()).with_highlight(span)
-}
-
-/// Creates a "path not relative" diagnostic.
-pub fn path_not_relative(span: Span) -> Diagnostic {
-    Diagnostic::error("path is required to be a relative path, but an absolute path was provided")
-        .with_highlight(span)
-}
-
-/// Creates an "array path not relative" diagnostic.
-pub fn array_path_not_relative(index: usize, span: Span) -> Diagnostic {
-    Diagnostic::error(format!(
-        "index {index} of the array is required to be a relative path, but an absolute path was \
-         provided"
-    ))
-    .with_highlight(span)
-}
-
-/// Creates an "invalid glob pattern" diagnostic.
-pub fn invalid_glob_pattern(error: &glob::PatternError, span: Span) -> Diagnostic {
-    Diagnostic::error(format!(
-        "invalid glob pattern specified: {error}",
-        error = error.msg
-    ))
-    .with_highlight(span)
-}
-
-/// Creates an "invalid storage unit" diagnostic.
-pub fn invalid_storage_unit(unit: &str, span: Span) -> Diagnostic {
-    Diagnostic::error(format!(
-        "invalid storage unit `{unit}`; supported units are `B`, `KB`, `K`, `MB`, `M`, `GB`, `G`, \
-         `TB`, `T`, `KiB`, `Ki`, `MiB`, `Mi`, `GiB`, `Gi`, `TiB`, and `Ti`",
-    ))
-    .with_highlight(span)
-}
-
 /// Creates a "function call failed" diagnostic.
 pub fn function_call_failed(name: &str, error: impl fmt::Display, span: Span) -> Diagnostic {
     Diagnostic::error(format!("call to function `{name}` failed: {error}")).with_highlight(span)

--- a/wdl-engine/src/stdlib/as_map.rs
+++ b/wdl-engine/src/stdlib/as_map.rs
@@ -14,6 +14,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "as_map";
+
 /// Used for displaying duplicate key errors.
 struct DuplicateKeyError(Option<PrimitiveValue>);
 
@@ -62,7 +65,7 @@ fn as_map(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
         if elements.insert(key.clone(), pair.right().clone()).is_some() {
             return Err(function_call_failed(
-                "as_map",
+                FUNCTION_NAME,
                 DuplicateKeyError(key),
                 context.arguments[0].span,
             ));

--- a/wdl-engine/src/stdlib/basename.rs
+++ b/wdl-engine/src/stdlib/basename.rs
@@ -43,13 +43,17 @@ fn basename(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
-    if let Ok(url) = path.parse::<Url>() {
-        let base = url
-            .path_segments()
-            .and_then(|mut segments| segments.next_back())
-            .unwrap_or("");
+    // Do not attempt to parse absolute Windows paths (and by extension, we do not
+    // support single-character schemed URLs)
+    if path.get(1..2) != Some(":") {
+        if let Ok(url) = path.parse::<Url>() {
+            let base = url
+                .path_segments()
+                .and_then(|mut segments| segments.next_back())
+                .unwrap_or("");
 
-        return Ok(PrimitiveValue::new_string(remove_suffix(context, base)).into());
+            return Ok(PrimitiveValue::new_string(remove_suffix(context, base)).into());
+        }
     }
 
     let base = Path::new(path.as_str())

--- a/wdl-engine/src/stdlib/basename.rs
+++ b/wdl-engine/src/stdlib/basename.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use url::Url;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
@@ -21,6 +22,20 @@ use crate::Value;
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#basename
 fn basename(context: CallContext<'_>) -> Result<Value, Diagnostic> {
+    fn remove_suffix<'a>(context: CallContext<'_>, base: &'a str) -> &'a str {
+        if context.arguments.len() == 2 {
+            base.strip_suffix(
+                context
+                    .coerce_argument(1, PrimitiveType::String)
+                    .unwrap_string()
+                    .as_str(),
+            )
+            .unwrap_or(base)
+        } else {
+            base
+        }
+    }
+
     debug_assert!(!context.arguments.is_empty() && context.arguments.len() < 3);
     debug_assert!(context.return_type_eq(PrimitiveType::String));
 
@@ -28,25 +43,20 @@ fn basename(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
-    match Path::new(path.as_str()).file_name() {
-        Some(base) => {
-            let base = base.to_str().expect("should be UTF-8");
-            let base = if context.arguments.len() == 2 {
-                base.strip_suffix(
-                    context
-                        .coerce_argument(1, PrimitiveType::String)
-                        .unwrap_string()
-                        .as_str(),
-                )
-                .unwrap_or(base)
-            } else {
-                base
-            };
+    if let Ok(url) = path.parse::<Url>() {
+        let base = url
+            .path_segments()
+            .and_then(|mut segments| segments.next_back())
+            .unwrap_or("");
 
-            Ok(PrimitiveValue::new_string(base).into())
-        }
-        None => Ok(PrimitiveValue::String(path).into()),
+        return Ok(PrimitiveValue::new_string(remove_suffix(context, base)).into());
     }
+
+    let base = Path::new(path.as_str())
+        .file_name()
+        .map(|f| f.to_str().expect("should be UTF-8"))
+        .unwrap_or("");
+    Ok(PrimitiveValue::new_string(remove_suffix(context, base)).into())
 }
 
 /// Gets the function describing `basename`.
@@ -97,5 +107,47 @@ mod test {
             .await
             .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "file");
+
+        let value = eval_v1_expr(&env, V1::Two, "basename('file.txt', '.jpg')")
+            .await
+            .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "file.txt");
+
+        let value = eval_v1_expr(&env, V1::Two, "basename('https://example.com')")
+            .await
+            .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "");
+
+        let value = eval_v1_expr(&env, V1::Two, "basename('https://example.com/foo')")
+            .await
+            .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "foo");
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "basename('https://example.com/foo/bar/baz.txt')",
+        )
+        .await
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "baz.txt");
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "basename('https://example.com/foo/bar/baz.txt?foo=baz', '.txt')",
+        )
+        .await
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "baz");
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "basename('https://example.com/foo/bar/baz.txt#hmm', '.jpg')",
+        )
+        .await
+        .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "baz.txt");
     }
 }

--- a/wdl-engine/src/stdlib/chunk.rs
+++ b/wdl-engine/src/stdlib/chunk.rs
@@ -10,6 +10,9 @@ use crate::Array;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "chunk";
+
 /// Given an array and a length `n`, splits the array into consecutive,
 /// non-overlapping arrays of n elements.
 ///
@@ -32,7 +35,7 @@ fn chunk(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
     if size < 0 {
         return Err(function_call_failed(
-            "chunk",
+            FUNCTION_NAME,
             "chunk size cannot be negative",
             context.arguments[1].span,
         ));

--- a/wdl-engine/src/stdlib/find.rs
+++ b/wdl-engine/src/stdlib/find.rs
@@ -14,6 +14,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "find";
+
 /// Given two String parameters `input` and `pattern`, searches for the
 /// occurrence of `pattern` within `input` and returns the first match or `None`
 /// if there are no matches.
@@ -31,7 +34,7 @@ fn find(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .unwrap_string();
 
     let regex = Regex::new(pattern.as_str())
-        .map_err(|e| function_call_failed("find", &e, context.arguments[1].span))?;
+        .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
 
     match regex.find(input.as_str()) {
         Some(m) => Ok(PrimitiveValue::new_string(m.as_str()).into()),

--- a/wdl-engine/src/stdlib/find.rs
+++ b/wdl-engine/src/stdlib/find.rs
@@ -12,7 +12,7 @@ use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
 use crate::Value;
-use crate::diagnostics::invalid_regex;
+use crate::diagnostics::function_call_failed;
 
 /// Given two String parameters `input` and `pattern`, searches for the
 /// occurrence of `pattern` within `input` and returns the first match or `None`
@@ -30,8 +30,8 @@ fn find(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
-    let regex =
-        Regex::new(pattern.as_str()).map_err(|e| invalid_regex(&e, context.arguments[1].span))?;
+    let regex = Regex::new(pattern.as_str())
+        .map_err(|e| function_call_failed("find", &e, context.arguments[1].span))?;
 
     match regex.find(input.as_str()) {
         Some(m) => Ok(PrimitiveValue::new_string(m.as_str()).into()),
@@ -67,7 +67,8 @@ mod test {
             .unwrap_err();
         assert_eq!(
             diagnostic.message(),
-            "regex parse error:\n    ?\n    ^\nerror: repetition operator missing expression"
+            "call to function `find` failed: regex parse error:\n    ?\n    ^\nerror: repetition \
+             operator missing expression"
         );
 
         let value = eval_v1_expr(&env, V1::Two, "find('hello world', 'e..o')")

--- a/wdl-engine/src/stdlib/glob.rs
+++ b/wdl-engine/src/stdlib/glob.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use url::Url;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
@@ -14,7 +15,6 @@ use crate::Array;
 use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
-use crate::diagnostics::invalid_glob_pattern;
 
 /// Returns the Bash expansion of the glob string relative to the task's
 /// execution directory, and in the same order (i.e. lexicographical).
@@ -28,11 +28,50 @@ fn glob(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(0, PrimitiveType::String)
         .unwrap_string();
 
+    // Prevent glob of non-file URLs
+    let path = if let Ok(url) = path.parse::<Url>() {
+        if url.scheme() != "file" {
+            return Err(function_call_failed(
+                "glob",
+                format!("path `{path}` cannot be globbed: only `file` scheme URLs are supported"),
+                context.call_site,
+            ));
+        }
+
+        match url.to_file_path() {
+            Ok(path) => path,
+            Err(_) => {
+                return Err(function_call_failed(
+                    "glob",
+                    format!("path `{path}` cannot be represented as a local file path"),
+                    context.call_site,
+                ));
+            }
+        }
+    } else {
+        context.work_dir().join(path.as_str())
+    };
+
+    let path = path.to_str().ok_or_else(|| {
+        function_call_failed(
+            "glob",
+            format!(
+                "path `{path}` cannot be represented as UTF-8",
+                path = path.display()
+            ),
+            context.call_site,
+        )
+    })?;
+
     // TODO: replace glob with walkpath and globmatch
     let mut elements: Vec<Value> = Vec::new();
-    for path in glob::glob(&context.work_dir().join(path.as_str()).to_string_lossy())
-        .map_err(|e| invalid_glob_pattern(&e, context.arguments[0].span))?
-    {
+    for path in glob::glob(path).map_err(|e| {
+        function_call_failed(
+            "glob",
+            format!("invalid glob pattern specified: {msg}", msg = e.msg),
+            context.arguments[0].span,
+        )
+    })? {
         let path = path.map_err(|e| function_call_failed("glob", &e, context.call_site))?;
 
         // Filter out directories (only files are returned from WDL's `glob` function)
@@ -95,6 +134,7 @@ mod test {
     use std::fs;
 
     use pretty_assertions::assert_eq;
+    use url::Url;
     use wdl_ast::version::V1;
 
     use crate::v1::test::TestEnv;
@@ -103,12 +143,30 @@ mod test {
     #[tokio::test]
     async fn glob() {
         let env = TestEnv::default();
+
+        // Create a URL for the working directory and force it to end with `/`
+        let mut work_dir_url = Url::from_file_path(env.work_dir()).expect("should convert");
+        if let Ok(mut segments) = work_dir_url.path_segments_mut() {
+            segments.pop_if_empty();
+            segments.push("");
+        }
+
         let diagnostic = eval_v1_expr(&env, V1::Two, "glob('invalid***')")
             .await
             .unwrap_err();
         assert_eq!(
             diagnostic.message(),
-            "invalid glob pattern specified: wildcards are either regular `*` or recursive `**`"
+            "call to function `glob` failed: invalid glob pattern specified: wildcards are either \
+             regular `*` or recursive `**`"
+        );
+
+        let diagnostic = eval_v1_expr(&env, V1::Two, "glob('https://example.com/**')")
+            .await
+            .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "call to function `glob` failed: path `https://example.com/**` cannot be globbed: \
+             only `file` scheme URLs are supported"
         );
 
         env.write_file("qux", "qux");
@@ -130,6 +188,25 @@ mod test {
         assert!(elements.is_empty());
 
         let value = eval_v1_expr(&env, V1::Two, "glob('*')").await.unwrap();
+        let elements: Vec<_> = value
+            .as_array()
+            .unwrap()
+            .as_slice()
+            .iter()
+            .map(|v| v.as_file().unwrap().as_str())
+            .collect();
+        assert_eq!(elements, ["bar", "baz", "foo", "qux"]);
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            &format!(
+                "glob('{url}')",
+                url = work_dir_url.join("*").unwrap().as_str()
+            ),
+        )
+        .await
+        .unwrap();
         let elements: Vec<_> = value
             .as_array()
             .unwrap()

--- a/wdl-engine/src/stdlib/join_paths.rs
+++ b/wdl-engine/src/stdlib/join_paths.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use url::Url;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
@@ -14,8 +15,7 @@ use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
 use crate::Value;
-use crate::diagnostics::array_path_not_relative;
-use crate::diagnostics::path_not_relative;
+use crate::diagnostics::function_call_failed;
 
 /// Joins together two paths into an absolute path in the host
 /// filesystem.
@@ -38,9 +38,45 @@ fn join_paths_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
+    if let Ok(mut url) = first.parse::<Url>() {
+        if second.starts_with('/') | second.contains(":") {
+            return Err(function_call_failed(
+                "join_paths",
+                format!("path `{second}` is not a relative path"),
+                context.arguments[1].span,
+            ));
+        }
+
+        // For consistency with `PathBuf::push`, push an empty segment so that we treat
+        // the last segment as a directory; otherwise, `Url::join` will treat it as a
+        // file.
+        if let Ok(mut segments) = url.path_segments_mut() {
+            segments.pop_if_empty();
+            segments.push("");
+        }
+
+        return url
+            .join(&second)
+            .map(|u| PrimitiveValue::new_file(u).into())
+            .map_err(|_| {
+                function_call_failed(
+                    "join_paths",
+                    format!("path `{second}` cannot be joined with URL `{url}`"),
+                    context.arguments[1].span,
+                )
+            });
+    }
+
     let second = Path::new(second.as_str());
     if !second.is_relative() {
-        return Err(path_not_relative(context.arguments[1].span));
+        return Err(function_call_failed(
+            "join_paths",
+            format!(
+                "path `{second}` is not a relative path",
+                second = second.display()
+            ),
+            context.arguments[1].span,
+        ));
     }
 
     let mut path = PathBuf::from(Arc::unwrap_or_clone(first));
@@ -98,6 +134,42 @@ fn join_paths(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         (first, array, false, context.arguments[1].span)
     };
 
+    if let Ok(mut url) = first.parse::<Url>() {
+        for (i, element) in array
+            .as_slice()
+            .iter()
+            .enumerate()
+            .skip(if skip { 1 } else { 0 })
+        {
+            let next = element.as_string().expect("element should be string");
+            if next.starts_with('/') || next.starts_with("//") | next.contains(":") {
+                return Err(function_call_failed(
+                    "join_paths",
+                    format!("path `{next}` (array index {i}) is not a relative path"),
+                    array_span,
+                ));
+            }
+
+            // For consistency with `PathBuf::push`, push an empty segment so that we treat
+            // the last segment as a directory; otherwise, `Url::join` will treat it as a
+            // file.
+            if let Ok(mut segments) = url.path_segments_mut() {
+                segments.pop_if_empty();
+                segments.push("");
+            }
+
+            url = url.join(next).map_err(|_| {
+                function_call_failed(
+                    "join_paths",
+                    format!("path `{next}` (array index {i}) cannot be joined with URL `{url}`"),
+                    context.arguments[1].span,
+                )
+            })?;
+        }
+
+        return Ok(PrimitiveValue::new_file(url).into());
+    }
+
     let mut path = PathBuf::from(Arc::unwrap_or_clone(first));
 
     for (i, element) in array
@@ -107,13 +179,16 @@ fn join_paths(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .skip(if skip { 1 } else { 0 })
     {
         let next = element.as_string().expect("element should be string");
-
-        let next = Path::new(next.as_str());
-        if !next.is_relative() {
-            return Err(array_path_not_relative(i, array_span));
+        let p = Path::new(next.as_str());
+        if !p.is_relative() {
+            return Err(function_call_failed(
+                "join_paths",
+                format!("path `{next}` (array index {i}) is not a relative path"),
+                array_span,
+            ));
         }
 
-        path.push(next);
+        path.push(p);
     }
 
     Ok(PrimitiveValue::new_file(
@@ -187,7 +262,7 @@ mod test {
                 .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
-                "path is required to be a relative path, but an absolute path was provided"
+                "call to function `join_paths` failed: path `/bin/echo` is not a relative path"
             );
 
             let diagnostic =
@@ -196,8 +271,8 @@ mod test {
                     .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
-                "index 1 of the array is required to be a relative path, but an absolute path was \
-                 provided"
+                "call to function `join_paths` failed: path `/bin/echo` (array index 1) is not a \
+                 relative path"
             );
 
             let diagnostic =
@@ -206,8 +281,8 @@ mod test {
                     .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
-                "index 2 of the array is required to be a relative path, but an absolute path was \
-                 provided"
+                "call to function `join_paths` failed: path `/bin/echo` (array index 2) is not a \
+                 relative path"
             );
         }
 
@@ -218,7 +293,8 @@ mod test {
                 .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
-                "path is required to be a relative path, but an absolute path was provided"
+                "path `C:\\bin\\echo` is required to be a relative path, but an absolute path was \
+                 provided"
             );
 
             let diagnostic = eval_v1_expr(
@@ -230,8 +306,8 @@ mod test {
             .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
-                "index 1 of the array is required to be a relative path, but an absolute path was \
-                 provided"
+                "call to function `join_paths` failed: path `C:\\bin\\echo` (array index 1) is \
+                 not a relative path"
             );
 
             let diagnostic = eval_v1_expr(
@@ -243,9 +319,103 @@ mod test {
             .unwrap_err();
             assert_eq!(
                 diagnostic.message(),
-                "index 2 of the array is required to be a relative path, but an absolute path was \
-                 provided"
+                "call to function `join_paths` failed: path `C:\\bin\\echo` (array index 2) is \
+                 not a relative path"
             );
         }
+
+        let diagnostic = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com', '/foo/bar')",
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "call to function `join_paths` failed: path `/foo/bar` is not a relative path"
+        );
+
+        let diagnostic = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com', '//wrong.org/foo')",
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "call to function `join_paths` failed: path `//wrong.org/foo` is not a relative path"
+        );
+
+        let diagnostic = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com', 'https://wrong.org/foo')",
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "call to function `join_paths` failed: path `https://wrong.org/foo` is not a relative \
+             path"
+        );
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com', 'foo/bar/baz')",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            value.unwrap_file().as_str(),
+            "https://example.com/foo/bar/baz"
+        );
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com/foo/bar/', 'baz')",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            value.unwrap_file().as_str(),
+            "https://example.com/foo/bar/baz"
+        );
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com/foo/bar', '../baz')",
+        )
+        .await
+        .unwrap();
+        assert_eq!(value.unwrap_file().as_str(), "https://example.com/foo/baz");
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com/foo/bar', ['nope', '../baz', 'qux'])",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            value.unwrap_file().as_str(),
+            "https://example.com/foo/bar/baz/qux"
+        );
+
+        let value = eval_v1_expr(
+            &env,
+            V1::Two,
+            "join_paths('https://example.com/foo/bar?foo=jam', 'baz?foo=qux')",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            value.unwrap_file().as_str(),
+            "https://example.com/foo/bar/baz?foo=qux"
+        );
     }
 }

--- a/wdl-engine/src/stdlib/length.rs
+++ b/wdl-engine/src/stdlib/length.rs
@@ -11,6 +11,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "length";
+
 /// Returns the length of the input argument as an Int:
 ///
 /// For an `Array[X]` argument: the number of elements in the array.
@@ -28,7 +31,7 @@ fn array_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     )
     .map_err(|_| {
         function_call_failed(
-            "length",
+            FUNCTION_NAME,
             "array length exceeds a signed 64-bit integer",
             context.call_site,
         )
@@ -53,7 +56,7 @@ fn map_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     )
     .map_err(|_| {
         function_call_failed(
-            "length",
+            FUNCTION_NAME,
             "map length exceeds a signed 64-bit integer",
             context.call_site,
         )
@@ -74,7 +77,7 @@ fn object_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     Ok(i64::try_from(object.len())
         .map_err(|_| {
             function_call_failed(
-                "length",
+                FUNCTION_NAME,
                 "object members length exceeds a signed 64-bit integer",
                 context.call_site,
             )
@@ -99,7 +102,7 @@ fn string_length(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     Ok(i64::try_from(s.chars().count())
         .map_err(|_| {
             function_call_failed(
-                "length",
+                FUNCTION_NAME,
                 "string character length exceeds a signed 64-bit integer",
                 context.call_site,
             )

--- a/wdl-engine/src/stdlib/matches.rs
+++ b/wdl-engine/src/stdlib/matches.rs
@@ -9,7 +9,7 @@ use super::Callback;
 use super::Function;
 use super::Signature;
 use crate::Value;
-use crate::diagnostics::invalid_regex;
+use crate::diagnostics::function_call_failed;
 
 /// Given two String parameters `input` and `pattern`, tests whether `pattern`
 /// matches `input` at least once.
@@ -26,8 +26,8 @@ fn matches(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
-    let regex =
-        Regex::new(pattern.as_str()).map_err(|e| invalid_regex(&e, context.arguments[1].span))?;
+    let regex = Regex::new(pattern.as_str())
+        .map_err(|e| function_call_failed("matches", &e, context.arguments[1].span))?;
     Ok(regex.is_match(input.as_str()).into())
 }
 
@@ -59,7 +59,8 @@ mod test {
             .unwrap_err();
         assert_eq!(
             diagnostic.message(),
-            "regex parse error:\n    ?\n    ^\nerror: repetition operator missing expression"
+            "call to function `matches` failed: regex parse error:\n    ?\n    ^\nerror: \
+             repetition operator missing expression"
         );
 
         let value = eval_v1_expr(&env, V1::Two, "matches('hello world', 'e..o')")

--- a/wdl-engine/src/stdlib/matches.rs
+++ b/wdl-engine/src/stdlib/matches.rs
@@ -11,6 +11,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "matches";
+
 /// Given two String parameters `input` and `pattern`, tests whether `pattern`
 /// matches `input` at least once.
 ///
@@ -27,7 +30,7 @@ fn matches(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .unwrap_string();
 
     let regex = Regex::new(pattern.as_str())
-        .map_err(|e| function_call_failed("matches", &e, context.arguments[1].span))?;
+        .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
     Ok(regex.is_match(input.as_str()).into())
 }
 

--- a/wdl-engine/src/stdlib/range.rs
+++ b/wdl-engine/src/stdlib/range.rs
@@ -12,6 +12,9 @@ use crate::Array;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "range";
+
 /// Creates an array of the given length containing sequential integers starting
 /// from 0.
 ///
@@ -28,7 +31,7 @@ fn range(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
     if n < 0 {
         return Err(function_call_failed(
-            "range",
+            FUNCTION_NAME,
             "array length cannot be negative",
             context.arguments[0].span,
         ));

--- a/wdl-engine/src/stdlib/read_boolean.rs
+++ b/wdl-engine/src/stdlib/read_boolean.rs
@@ -18,6 +18,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_boolean";
+
 /// Reads a file that contains a single line containing only a boolean value and
 /// (optional) whitespace.
 ///
@@ -42,7 +45,7 @@ fn read_boolean(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_boolean",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -55,7 +58,7 @@ fn read_boolean(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_boolean",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -66,7 +69,7 @@ fn read_boolean(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
 
         let invalid_contents = || {
             function_call_failed(
-                "read_boolean",
+                FUNCTION_NAME,
                 format!("file `{path}` does not contain a boolean value on a single line"),
                 context.call_site,
             )

--- a/wdl-engine/src/stdlib/read_float.rs
+++ b/wdl-engine/src/stdlib/read_float.rs
@@ -18,6 +18,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_float";
+
 /// Reads a file that contains only a float value and (optional) whitespace.
 ///
 /// If the line contains a valid floating point number, that value is returned
@@ -41,7 +44,7 @@ fn read_float(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_float",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -54,7 +57,7 @@ fn read_float(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_float",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -65,7 +68,7 @@ fn read_float(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
 
         let invalid_contents = || {
             function_call_failed(
-                "read_float",
+                FUNCTION_NAME,
                 format!("file `{path}` does not contain a float value on a single line"),
                 context.call_site,
             )

--- a/wdl-engine/src/stdlib/read_int.rs
+++ b/wdl-engine/src/stdlib/read_int.rs
@@ -18,6 +18,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_int";
+
 /// Reads a file that contains a single line containing only an integer and
 /// (optional) whitespace.
 ///
@@ -41,7 +44,7 @@ fn read_int(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_int",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -54,7 +57,7 @@ fn read_int(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_int",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -65,7 +68,7 @@ fn read_int(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
 
         let invalid_contents = || {
             function_call_failed(
-                "read_int",
+                FUNCTION_NAME,
                 format!("file `{path}` does not contain an integer value on a single line"),
                 context.call_site,
             )

--- a/wdl-engine/src/stdlib/read_lines.rs
+++ b/wdl-engine/src/stdlib/read_lines.rs
@@ -21,6 +21,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_lines";
+
 /// Reads each line of a file as a String, and returns all lines in the file as
 /// an Array[String].
 ///
@@ -48,7 +51,7 @@ fn read_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_lines",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -61,7 +64,7 @@ fn read_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_lines",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()

--- a/wdl-engine/src/stdlib/read_map.rs
+++ b/wdl-engine/src/stdlib/read_map.rs
@@ -22,6 +22,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_map";
+
 /// Reads a tab-separated value (TSV) file representing a set of pairs.
 ///
 /// Each row must have exactly two columns, e.g., col1\tcol2.
@@ -52,7 +55,7 @@ fn read_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_map",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -65,7 +68,7 @@ fn read_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_map",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -84,7 +87,7 @@ fn read_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
                 Some((key, value)) if !value.contains('\t') => (key, value),
                 _ => {
                     return Err(function_call_failed(
-                        "read_map",
+                        FUNCTION_NAME,
                         format!("line {i} in file `{path}` does not contain exactly two columns",),
                         context.call_site,
                     ));
@@ -99,7 +102,7 @@ fn read_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
                 .is_some()
             {
                 return Err(function_call_failed(
-                    "read_map",
+                    FUNCTION_NAME,
                     format!("line {i} in file `{path}` contains duplicate key name `{key}`",),
                     context.call_site,
                 ));

--- a/wdl-engine/src/stdlib/read_object.rs
+++ b/wdl-engine/src/stdlib/read_object.rs
@@ -25,6 +25,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_object";
+
 /// Reads a tab-separated value (TSV) file representing the names and values of
 /// the members of an Object.
 ///
@@ -56,7 +59,7 @@ fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_object",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -69,7 +72,7 @@ fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_object",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -80,7 +83,7 @@ fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
 
         let expected_two_lines = || {
             function_call_failed(
-                "read_object",
+                FUNCTION_NAME,
                 format!("expected exactly two lines in file `{path}`"),
                 context.call_site,
             )
@@ -111,7 +114,7 @@ fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
                 EitherOrBoth::Both(name, value) => {
                     if !is_ident(name) {
                         return Err(function_call_failed(
-                            "read_object",
+                            FUNCTION_NAME,
                             format!(
                                 "line 1 of file `{path}` contains invalid column name `{name}`: \
                                  column name must be a valid WDL identifier"
@@ -125,7 +128,7 @@ fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
                         .is_some()
                     {
                         return Err(function_call_failed(
-                            "read_object",
+                            FUNCTION_NAME,
                             format!(
                                 "line 1 of file `{path}` contains duplicate column name `{name}`"
                             ),
@@ -135,7 +138,7 @@ fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
                 }
                 EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => {
                     return Err(function_call_failed(
-                        "read_object",
+                        FUNCTION_NAME,
                         format!(
                             "line 2 of file `{path}` does not contain the expected number of \
                              columns"

--- a/wdl-engine/src/stdlib/read_objects.rs
+++ b/wdl-engine/src/stdlib/read_objects.rs
@@ -26,6 +26,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_objects";
+
 /// Reads a tab-separated value (TSV) file representing the names and values of
 /// the members of any number of Objects.
 ///
@@ -60,7 +63,7 @@ fn read_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_objects",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -73,7 +76,7 @@ fn read_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_objects",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -99,7 +102,7 @@ fn read_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
         for name in names.split('\t') {
             if !is_ident(name) {
                 return Err(function_call_failed(
-                    "read_objects",
+                    FUNCTION_NAME,
                     format!(
                         "line 1 of file `{path}` contains invalid column name `{name}`: column \
                          name must be a valid WDL identifier"
@@ -121,7 +124,7 @@ fn read_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
                             .is_some()
                         {
                             return Err(function_call_failed(
-                                "read_objects",
+                                FUNCTION_NAME,
                                 format!(
                                     "line 1 of file `{path}` contains duplicate column name \
                                      `{name}`"
@@ -132,7 +135,7 @@ fn read_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
                     }
                     EitherOrBoth::Left(_) | EitherOrBoth::Right(_) => {
                         return Err(function_call_failed(
-                            "read_objects",
+                            FUNCTION_NAME,
                             format!(
                                 "line {i} of file `{path}` does not contain the expected number \
                                  of columns"

--- a/wdl-engine/src/stdlib/read_string.rs
+++ b/wdl-engine/src/stdlib/read_string.rs
@@ -17,6 +17,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_string";
+
 /// Reads an entire file as a String, with any trailing end-of-line characters
 /// (\r and \n) stripped off.
 ///
@@ -39,7 +42,7 @@ fn read_string(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_string",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -52,7 +55,7 @@ fn read_string(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_string",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()

--- a/wdl-engine/src/stdlib/read_tsv.rs
+++ b/wdl-engine/src/stdlib/read_tsv.rs
@@ -27,6 +27,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "read_tsv";
+
 /// Represents a header in a TSV (tab-separated value) file.
 enum TsvHeader {
     /// The header was explicitly specified as an `Array[String]`.
@@ -79,7 +82,7 @@ fn read_tsv_simple(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diag
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_tsv",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -92,7 +95,7 @@ fn read_tsv_simple(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diag
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_tsv",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -155,7 +158,7 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             .await
             .map_err(|e| {
                 function_call_failed(
-                    "read_tsv",
+                    FUNCTION_NAME,
                     format!("failed to download file `{path}`: {e:?}"),
                     context.call_site,
                 )
@@ -168,7 +171,7 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
-                "read_tsv",
+                FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
                     path = cache_path.display()
@@ -199,7 +202,7 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             )
         } else if !file_has_header {
             return Err(function_call_failed(
-                "read_tsv",
+                FUNCTION_NAME,
                 "argument specifying presence of a file header must be `true`",
                 context.arguments[1].span,
             ));
@@ -219,7 +222,7 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             !is_ident(c)
         }) {
             return Err(function_call_failed(
-                "read_tsv",
+                FUNCTION_NAME,
                 if context.arguments.len() == 2 {
                     format!(
                         "column name `{invalid}` in file `{path}` is not a valid WDL object field \
@@ -245,7 +248,7 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
                             .is_some()
                         {
                             return Err(function_call_failed(
-                                "read_tsv",
+                                FUNCTION_NAME,
                                 if context.arguments.len() == 2 {
                                     format!("duplicate column name `{c}` found in file `{path}`")
                                 } else {
@@ -257,7 +260,7 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
                     }
                     _ => {
                         return Err(function_call_failed(
-                            "read_tsv",
+                            FUNCTION_NAME,
                             format!(
                                 "line {i} in file `{path}` does not have the expected number of \
                                  columns"

--- a/wdl-engine/src/stdlib/select_first.rs
+++ b/wdl-engine/src/stdlib/select_first.rs
@@ -9,6 +9,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "select_first";
+
 /// Selects the first - i.e., left-most - non-None value from an Array of
 /// optional values.
 ///
@@ -29,7 +32,7 @@ fn select_first(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
     if array.is_empty() {
         return Err(function_call_failed(
-            "select_first",
+            FUNCTION_NAME,
             "array is empty",
             context.arguments[0].span,
         ));
@@ -40,7 +43,7 @@ fn select_first(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         None => {
             if context.arguments.len() < 2 {
                 return Err(function_call_failed(
-                    "select_first",
+                    FUNCTION_NAME,
                     "array contains only `None` values",
                     context.arguments[0].span,
                 ));

--- a/wdl-engine/src/stdlib/size.rs
+++ b/wdl-engine/src/stdlib/size.rs
@@ -24,6 +24,9 @@ use crate::StorageUnit;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "size";
+
 /// Converts a string to a file path.
 ///
 /// This conversion supports `file://` schemed URLs.
@@ -63,7 +66,7 @@ fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
 
             unit.parse().map_err(|_| {
                 function_call_failed(
-                    "size",
+                    FUNCTION_NAME,
                     format!(
                         "invalid storage unit `{unit}`: supported units are `B`, `KB`, `K`, `MB`, \
                          `M`, `GB`, `G`, `TB`, `T`, `KiB`, `Ki`, `MiB`, `Mi`, `GiB`, `Gi`, `TiB`, \
@@ -81,7 +84,7 @@ fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
         let value = match context.arguments[0].value.as_string() {
             Some(s) => {
                 let path = to_file_path(context.work_dir(), s).map_err(|e| {
-                    function_call_failed("size", format!("{e:?}"), context.call_site)
+                    function_call_failed(FUNCTION_NAME, format!("{e:?}"), context.call_site)
                 })?;
                 let metadata = fs::metadata(&path)
                     .await
@@ -92,7 +95,7 @@ fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
                         )
                     })
                     .map_err(|e| {
-                        function_call_failed("size", format!("{e:?}"), context.call_site)
+                        function_call_failed(FUNCTION_NAME, format!("{e:?}"), context.call_site)
                     })?;
                 if metadata.is_dir() {
                     PrimitiveValue::Directory(s.clone()).into()
@@ -105,7 +108,7 @@ fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
 
         calculate_disk_size(&value, unit, context.work_dir())
             .await
-            .map_err(|e| function_call_failed("size", format!("{e:?}"), context.call_site))
+            .map_err(|e| function_call_failed(FUNCTION_NAME, format!("{e:?}"), context.call_site))
             .map(Into::into)
     }
     .boxed()

--- a/wdl-engine/src/stdlib/size.rs
+++ b/wdl-engine/src/stdlib/size.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -9,6 +10,7 @@ use anyhow::bail;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::fs;
+use url::Url;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
@@ -21,7 +23,26 @@ use crate::PrimitiveValue;
 use crate::StorageUnit;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
-use crate::diagnostics::invalid_storage_unit;
+
+/// Converts a string to a file path.
+///
+/// This conversion supports `file://` schemed URLs.
+fn to_file_path(cwd: &Path, path: &str) -> Result<PathBuf> {
+    if let Ok(url) = path.parse::<Url>() {
+        if url.scheme() != "file" {
+            bail!("path `{path}` cannot be sized: only `file` scheme URLs are supported");
+        }
+
+        match url.to_file_path() {
+            Ok(path) => Ok(path),
+            Err(_) => {
+                bail!("path `{path}` cannot be represented as a local file path");
+            }
+        }
+    } else {
+        Ok(cwd.join(path))
+    }
+}
 
 /// Determines the size of a file, directory, or the sum total sizes of the
 /// files/directories contained within a compound value. The files may be
@@ -40,8 +61,17 @@ fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
                 .coerce_argument(1, PrimitiveType::String)
                 .unwrap_string();
 
-            unit.parse()
-                .map_err(|_| invalid_storage_unit(&unit, context.arguments[1].span))?
+            unit.parse().map_err(|_| {
+                function_call_failed(
+                    "size",
+                    format!(
+                        "invalid storage unit `{unit}`: supported units are `B`, `KB`, `K`, `MB`, \
+                         `M`, `GB`, `G`, `TB`, `T`, `KiB`, `Ki`, `MiB`, `Mi`, `GiB`, `Gi`, `TiB`, \
+                         and `Ti`",
+                    ),
+                    context.arguments[1].span,
+                )
+            })?
         } else {
             StorageUnit::default()
         };
@@ -50,7 +80,9 @@ fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
         // directory and treat it as such.
         let value = match context.arguments[0].value.as_string() {
             Some(s) => {
-                let path = context.work_dir().join(s.as_str());
+                let path = to_file_path(context.work_dir(), s).map_err(|e| {
+                    function_call_failed("size", format!("{e:?}"), context.call_site)
+                })?;
                 let metadata = fs::metadata(&path)
                     .await
                     .with_context(|| {
@@ -110,7 +142,7 @@ fn calculate_disk_size<'a>(
 async fn primitive_disk_size(value: &PrimitiveValue, unit: StorageUnit, cwd: &Path) -> Result<f64> {
     match value {
         PrimitiveValue::File(path) => {
-            let path = cwd.join(path.as_str());
+            let path = to_file_path(cwd, path)?;
             let metadata = fs::metadata(&path).await.with_context(|| {
                 format!(
                     "failed to read metadata for file `{path}`",
@@ -125,7 +157,8 @@ async fn primitive_disk_size(value: &PrimitiveValue, unit: StorageUnit, cwd: &Pa
             Ok(unit.units(metadata.len()))
         }
         PrimitiveValue::Directory(path) => {
-            calculate_directory_size(&cwd.join(path.as_str()), unit).await
+            let path = to_file_path(cwd, path)?;
+            calculate_directory_size(&path, unit).await
         }
         _ => Ok(0.0),
     }
@@ -248,6 +281,7 @@ pub const fn descriptor() -> Function {
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
+    use url::Url;
     use wdl_ast::version::V1;
 
     use crate::PrimitiveValue;
@@ -257,6 +291,13 @@ mod test {
     #[tokio::test]
     async fn size() {
         let mut env = TestEnv::default();
+
+        // Create a URL for the working directory and force it to end with `/`
+        let mut work_dir_url = Url::from_file_path(env.work_dir()).expect("should convert");
+        if let Ok(mut segments) = work_dir_url.path_segments_mut() {
+            segments.pop_if_empty();
+            segments.push("");
+        }
 
         // 10 byte file
         env.write_file("foo", "0123456789");
@@ -284,8 +325,18 @@ mod test {
             .unwrap_err();
         assert_eq!(
             diagnostic.message(),
-            "invalid storage unit `invalid`; supported units are `B`, `KB`, `K`, `MB`, `M`, `GB`, \
-             `G`, `TB`, `T`, `KiB`, `Ki`, `MiB`, `Mi`, `GiB`, `Gi`, `TiB`, and `Ti`"
+            "call to function `size` failed: invalid storage unit `invalid`: supported units are \
+             `B`, `KB`, `K`, `MB`, `M`, `GB`, `G`, `TB`, `T`, `KiB`, `Ki`, `MiB`, `Mi`, `GiB`, \
+             `Gi`, `TiB`, and `Ti`"
+        );
+
+        let diagnostic = eval_v1_expr(&env, V1::Two, "size('https://example.com/foo')")
+            .await
+            .unwrap_err();
+        assert_eq!(
+            diagnostic.message(),
+            "call to function `size` failed: path `https://example.com/foo` cannot be sized: only \
+             `file` scheme URLs are supported"
         );
 
         let diagnostic = eval_v1_expr(&env, V1::Two, "size('does-not-exist', 'B')")
@@ -323,6 +374,18 @@ mod test {
             let value = eval_v1_expr(&env, V1::Two, &format!("size('foo', '{unit}')"))
                 .await
                 .unwrap();
+            approx::assert_relative_eq!(value.unwrap_float(), expected);
+
+            let value = eval_v1_expr(
+                &env,
+                V1::Two,
+                &format!(
+                    "size('{url}', '{unit}')",
+                    url = work_dir_url.join("foo").unwrap().as_str()
+                ),
+            )
+            .await
+            .unwrap();
             approx::assert_relative_eq!(value.unwrap_float(), expected);
         }
 

--- a/wdl-engine/src/stdlib/size.rs
+++ b/wdl-engine/src/stdlib/size.rs
@@ -31,16 +31,22 @@ const FUNCTION_NAME: &str = "size";
 ///
 /// This conversion supports `file://` schemed URLs.
 fn to_file_path(cwd: &Path, path: &str) -> Result<PathBuf> {
-    if let Ok(url) = path.parse::<Url>() {
-        if url.scheme() != "file" {
-            bail!("path `{path}` cannot be sized: only `file` scheme URLs are supported");
-        }
-
-        match url.to_file_path() {
-            Ok(path) => Ok(path),
-            Err(_) => {
-                bail!("path `{path}` cannot be represented as a local file path");
+    // Do not attempt to parse absolute Windows paths (and by extension, we do not
+    // support single-character schemed URLs)
+    if path.get(1..2) != Some(":") {
+        if let Ok(url) = path.parse::<Url>() {
+            if url.scheme() != "file" {
+                bail!("path `{path}` cannot be sized: only `file` scheme URLs are supported");
             }
+
+            match url.to_file_path() {
+                Ok(path) => Ok(path),
+                Err(_) => {
+                    bail!("path `{path}` cannot be represented as a local file path");
+                }
+            }
+        } else {
+            Ok(cwd.join(path))
         }
     } else {
         Ok(cwd.join(path))

--- a/wdl-engine/src/stdlib/stderr.rs
+++ b/wdl-engine/src/stdlib/stderr.rs
@@ -10,6 +10,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "stderr";
+
 /// Returns the value of the executed command's standard error (stderr) as a
 /// File
 ///
@@ -27,7 +30,7 @@ fn stderr(context: CallContext<'_>) -> Result<Value, Diagnostic> {
             Ok(stderr.clone())
         }
         None => Err(function_call_failed(
-            "stderr",
+            FUNCTION_NAME,
             "function may only be called in a task output section",
             context.call_site,
         )),

--- a/wdl-engine/src/stdlib/stdout.rs
+++ b/wdl-engine/src/stdlib/stdout.rs
@@ -10,6 +10,9 @@ use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "stdout";
+
 /// Returns the value of the executed command's standard output (stdout) as a
 /// File.
 ///
@@ -27,7 +30,7 @@ fn stdout(context: CallContext<'_>) -> Result<Value, Diagnostic> {
             Ok(stdout.clone())
         }
         None => Err(function_call_failed(
-            "stdout",
+            FUNCTION_NAME,
             "function may only be called in a task output section",
             context.call_site,
         )),

--- a/wdl-engine/src/stdlib/sub.rs
+++ b/wdl-engine/src/stdlib/sub.rs
@@ -12,7 +12,7 @@ use super::Function;
 use super::Signature;
 use crate::PrimitiveValue;
 use crate::Value;
-use crate::diagnostics::invalid_regex;
+use crate::diagnostics::function_call_failed;
 
 /// Given three String parameters `input`, `pattern`, and `replace`, this
 /// function replaces all non-overlapping occurrences of `pattern` in `input`
@@ -33,8 +33,8 @@ fn sub(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(2, PrimitiveType::String)
         .unwrap_string();
 
-    let regex =
-        Regex::new(pattern.as_str()).map_err(|e| invalid_regex(&e, context.arguments[1].span))?;
+    let regex = Regex::new(pattern.as_str())
+        .map_err(|e| function_call_failed("sub", &e, context.arguments[1].span))?;
     match regex.replace(input.as_str(), replacement.as_str()) {
         Cow::Borrowed(_) => {
             // No replacements, just return the input
@@ -75,7 +75,8 @@ mod test {
             .unwrap_err();
         assert_eq!(
             diagnostic.message(),
-            "regex parse error:\n    ?\n    ^\nerror: repetition operator missing expression"
+            "call to function `sub` failed: regex parse error:\n    ?\n    ^\nerror: repetition \
+             operator missing expression"
         );
 
         let value = eval_v1_expr(&env, V1::Two, "sub('hello world', 'e..o', 'ey there')")

--- a/wdl-engine/src/stdlib/sub.rs
+++ b/wdl-engine/src/stdlib/sub.rs
@@ -14,6 +14,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "sub";
+
 /// Given three String parameters `input`, `pattern`, and `replace`, this
 /// function replaces all non-overlapping occurrences of `pattern` in `input`
 /// with `replace`.
@@ -34,7 +37,7 @@ fn sub(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .unwrap_string();
 
     let regex = Regex::new(pattern.as_str())
-        .map_err(|e| function_call_failed("sub", &e, context.arguments[1].span))?;
+        .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
     match regex.replace(input.as_str(), replacement.as_str()) {
         Cow::Borrowed(_) => {
             // No replacements, just return the input

--- a/wdl-engine/src/stdlib/transpose.rs
+++ b/wdl-engine/src/stdlib/transpose.rs
@@ -11,6 +11,9 @@ use crate::Array;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "transpose";
+
 /// Transposes a two-dimensional array according to the standard matrix
 /// transposition rules, i.e. each row of the input array becomes a column of
 /// the output array.
@@ -57,7 +60,7 @@ fn transpose(context: CallContext<'_>) -> Result<Value, Diagnostic> {
                 .expect("element should be an array");
             if inner.len() != columns {
                 return Err(function_call_failed(
-                    "transpose",
+                    FUNCTION_NAME,
                     format!("expected array at index {j} to have a length of {columns}"),
                     context.call_site,
                 ));

--- a/wdl-engine/src/stdlib/write_json.rs
+++ b/wdl-engine/src/stdlib/write_json.rs
@@ -16,6 +16,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "write_json";
+
 /// Writes a JSON file with the serialized form of a WDL value.
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_json
@@ -26,7 +29,7 @@ fn write_json(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     // Helper for handling errors while writing to the file.
     let write_error = |e: std::io::Error| {
         function_call_failed(
-            "write_json",
+            FUNCTION_NAME,
             format!("failed to write to temporary file: {e}"),
             context.call_site,
         )
@@ -35,7 +38,7 @@ fn write_json(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     // Create a temporary file that will be persisted after writing the lines
     let mut file = NamedTempFile::with_prefix_in("tmp", context.temp_dir()).map_err(|e| {
         function_call_failed(
-            "write_json",
+            FUNCTION_NAME,
             format!("failed to create temporary file: {e}"),
             context.call_site,
         )
@@ -49,7 +52,7 @@ fn write_json(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .serialize(&mut serializer)
         .map_err(|e| {
             function_call_failed(
-                "write_json",
+                FUNCTION_NAME,
                 format!("failed to serialize value: {e}"),
                 context.call_site,
             )
@@ -62,7 +65,7 @@ fn write_json(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
     let (_, path) = file.keep().map_err(|e| {
         function_call_failed(
-            "write_json",
+            FUNCTION_NAME,
             format!("failed to keep temporary file: {e}"),
             context.call_site,
         )
@@ -71,7 +74,7 @@ fn write_json(context: CallContext<'_>) -> Result<Value, Diagnostic> {
     Ok(
         PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
             function_call_failed(
-                "write_json",
+                FUNCTION_NAME,
                 format!(
                     "path `{path}` cannot be represented as UTF-8",
                     path = Path::new(&path).display()

--- a/wdl-engine/src/stdlib/write_lines.rs
+++ b/wdl-engine/src/stdlib/write_lines.rs
@@ -20,6 +20,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "write_lines";
+
 /// Writes a file with one line for each element in a Array[String].
 ///
 /// All lines are terminated by the newline (\n) character (following the POSIX
@@ -36,7 +39,7 @@ fn write_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
         // Helper for handling errors while writing to the file.
         let write_error = |e: std::io::Error| {
             function_call_failed(
-                "write_lines",
+                FUNCTION_NAME,
                 format!("failed to write to temporary file: {e}"),
                 context.call_site,
             )
@@ -50,7 +53,7 @@ fn write_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
         let (file, path) = NamedTempFile::with_prefix_in("tmp", context.temp_dir())
             .map_err(|e| {
                 function_call_failed(
-                    "write_lines",
+                    FUNCTION_NAME,
                     format!("failed to create temporary file: {e}"),
                     context.call_site,
                 )
@@ -73,7 +76,7 @@ fn write_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
 
         let path = path.keep().map_err(|e| {
             function_call_failed(
-                "write_lines",
+                FUNCTION_NAME,
                 format!("failed to keep temporary file: {e}"),
                 context.call_site,
             )
@@ -82,7 +85,7 @@ fn write_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
         Ok(
             PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
                 function_call_failed(
-                    "write_lines",
+                    FUNCTION_NAME,
                     format!(
                         "path `{path}` cannot be represented as UTF-8",
                         path = Path::new(&path).display()

--- a/wdl-engine/src/stdlib/write_map.rs
+++ b/wdl-engine/src/stdlib/write_map.rs
@@ -20,6 +20,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "write_map";
+
 /// Writes a tab-separated value (TSV) file with one line for each element in a
 /// Map[String, String].
 ///
@@ -39,7 +42,7 @@ fn write_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic
         // Helper for handling errors while writing to the file.
         let write_error = |e: std::io::Error| {
             function_call_failed(
-                "write_map",
+                FUNCTION_NAME,
                 format!("failed to write to temporary file: {e}"),
                 context.call_site,
             )
@@ -53,7 +56,7 @@ fn write_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic
         let (file, path) = NamedTempFile::with_prefix_in("tmp", context.temp_dir())
             .map_err(|e| {
                 function_call_failed(
-                    "write_map",
+                    FUNCTION_NAME,
                     format!("failed to create temporary file: {e}"),
                     context.call_site,
                 )
@@ -87,7 +90,7 @@ fn write_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic
 
         let path = path.keep().map_err(|e| {
             function_call_failed(
-                "write_map",
+                FUNCTION_NAME,
                 format!("failed to keep temporary file: {e}"),
                 context.call_site,
             )
@@ -96,7 +99,7 @@ fn write_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic
         Ok(
             PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
                 function_call_failed(
-                    "write_map",
+                    FUNCTION_NAME,
                     format!(
                         "path `{path}` cannot be represented as UTF-8",
                         path = Path::new(&path).display()

--- a/wdl-engine/src/stdlib/write_object.rs
+++ b/wdl-engine/src/stdlib/write_object.rs
@@ -21,6 +21,9 @@ use crate::Value;
 use crate::diagnostics::function_call_failed;
 use crate::stdlib::write_tsv::write_tsv_value;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "write_object";
+
 /// Writes a tab-separated value (TSV) file with the contents of a Object or
 /// Struct.
 ///
@@ -41,7 +44,7 @@ fn write_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
         // Helper for handling errors while writing to the file.
         let write_error = |e: std::io::Error| {
             function_call_failed(
-                "write_object",
+                FUNCTION_NAME,
                 format!("failed to write to temporary file: {e}"),
                 context.call_site,
             )
@@ -53,7 +56,7 @@ fn write_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
         let (file, path) = NamedTempFile::with_prefix_in("tmp", context.temp_dir())
             .map_err(|e| {
                 function_call_failed(
-                    "write_object",
+                    FUNCTION_NAME,
                     format!("failed to create temporary file: {e}"),
                     context.call_site,
                 )
@@ -86,7 +89,7 @@ fn write_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
                     Value::Primitive(v) => {
                         if !write_tsv_value(&mut writer, v).await.map_err(write_error)? {
                             return Err(function_call_failed(
-                                "write_object",
+                                FUNCTION_NAME,
                                 format!("member `{key}` contains a tab character"),
                                 context.call_site,
                             ));
@@ -94,7 +97,7 @@ fn write_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
                     }
                     _ => {
                         return Err(function_call_failed(
-                            "write_object",
+                            FUNCTION_NAME,
                             format!("member `{key}` is not a primitive value"),
                             context.call_site,
                         ));
@@ -111,7 +114,7 @@ fn write_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
 
         let path = path.keep().map_err(|e| {
             function_call_failed(
-                "write_object",
+                FUNCTION_NAME,
                 format!("failed to keep temporary file: {e}"),
                 context.call_site,
             )
@@ -120,7 +123,7 @@ fn write_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
         Ok(
             PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
                 function_call_failed(
-                    "write_object",
+                    FUNCTION_NAME,
                     format!(
                         "path `{path}` cannot be represented as UTF-8",
                         path = Path::new(&path).display()

--- a/wdl-engine/src/stdlib/write_tsv.rs
+++ b/wdl-engine/src/stdlib/write_tsv.rs
@@ -23,6 +23,9 @@ use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "write_tsv";
+
 /// Writes a primitive value as a TSV value.
 ///
 /// Returns `Ok(true)` if the value was written.
@@ -57,7 +60,7 @@ async fn write_array_tsv_file(
     // Helper for handling errors while writing to the file.
     let write_error = |e: std::io::Error| {
         function_call_failed(
-            "write_tsv",
+            FUNCTION_NAME,
             format!("failed to write to temporary file: {e}"),
             call_site,
         )
@@ -67,7 +70,7 @@ async fn write_array_tsv_file(
     let (file, path) = NamedTempFile::with_prefix_in("tmp", tmp)
         .map_err(|e| {
             function_call_failed(
-                "write_tsv",
+                FUNCTION_NAME,
                 format!("failed to create temporary file: {e}"),
                 call_site,
             )
@@ -83,7 +86,7 @@ async fn write_array_tsv_file(
                 let name = name.as_string().unwrap();
                 if name.contains('\t') {
                     return Err(function_call_failed(
-                        "write_tsv",
+                        FUNCTION_NAME,
                         format!("specified column name at index {i} contains a tab character"),
                         call_site,
                     ));
@@ -111,7 +114,7 @@ async fn write_array_tsv_file(
         if let Some(column_count) = column_count {
             if row.len() != column_count {
                 return Err(function_call_failed(
-                    "write_tsv",
+                    FUNCTION_NAME,
                     format!(
                         "expected {column_count} column{s1} for every row but array at index \
                          {index} has length {len}",
@@ -127,7 +130,7 @@ async fn write_array_tsv_file(
             let column = column.as_string().unwrap();
             if column.contains('\t') {
                 return Err(function_call_failed(
-                    "write_tsv",
+                    FUNCTION_NAME,
                     format!("element of array at index {index} contains a tab character"),
                     call_site,
                 ));
@@ -152,7 +155,7 @@ async fn write_array_tsv_file(
 
     let path = path.keep().map_err(|e| {
         function_call_failed(
-            "write_tsv",
+            FUNCTION_NAME,
             format!("failed to keep temporary file: {e}"),
             call_site,
         )
@@ -161,7 +164,7 @@ async fn write_array_tsv_file(
     Ok(
         PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
             function_call_failed(
-                "write_tsv",
+                FUNCTION_NAME,
                 format!(
                     "path `{path}` cannot be represented as UTF-8",
                     path = Path::new(&path).display()
@@ -250,7 +253,7 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
         // Helper for handling errors while writing to the file.
         let write_error = |e: std::io::Error| {
             function_call_failed(
-                "write_tsv",
+                FUNCTION_NAME,
                 format!("failed to write to temporary file: {e}"),
                 context.call_site,
             )
@@ -278,7 +281,7 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
         let (file, path) = NamedTempFile::with_prefix_in("tmp", context.temp_dir())
             .map_err(|e| {
                 function_call_failed(
-                    "write_tsv",
+                    FUNCTION_NAME,
                     format!("failed to create temporary file: {e}"),
                     context.call_site,
                 )
@@ -305,7 +308,7 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
                     // Ensure the header count matches the element count
                     if header.len() != ty.members().len() {
                         return Err(function_call_failed(
-                            "write_tsv",
+                            FUNCTION_NAME,
                             format!(
                                 "expected {expected} header{s1} as the struct has {expected} \
                                  member{s1}, but only given {actual} header{s2}",
@@ -323,7 +326,7 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
                         let name = name.as_string().unwrap();
                         if name.contains('\t') {
                             return Err(function_call_failed(
-                                "write_tsv",
+                                FUNCTION_NAME,
                                 format!(
                                     "specified column name at index {i} contains a tab character"
                                 ),
@@ -372,7 +375,7 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
                     Value::Primitive(v) => {
                         if !write_tsv_value(&mut writer, v).await.map_err(write_error)? {
                             return Err(function_call_failed(
-                                "write_tsv",
+                                FUNCTION_NAME,
                                 format!("member `{name}` contains a tab character"),
                                 context.call_site,
                             ));
@@ -391,7 +394,7 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
 
         let path = path.keep().map_err(|e| {
             function_call_failed(
-                "write_tsv",
+                FUNCTION_NAME,
                 format!("failed to keep temporary file: {e}"),
                 context.call_site,
             )
@@ -400,7 +403,7 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
         Ok(
             PrimitiveValue::new_file(path.into_os_string().into_string().map_err(|path| {
                 function_call_failed(
-                    "write_tsv",
+                    FUNCTION_NAME,
                     format!(
                         "path `{path}` cannot be represented as UTF-8",
                         path = Path::new(&path).display()

--- a/wdl-engine/src/stdlib/zip.rs
+++ b/wdl-engine/src/stdlib/zip.rs
@@ -11,6 +11,9 @@ use crate::Pair;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
 
+/// The name of the function defined in this file for use in diagnostics.
+const FUNCTION_NAME: &str = "zip";
+
 /// Creates an array of Pairs containing the dot product of two input arrays,
 /// i.e., the elements at the same indices in each array X[i] and Y[i] are
 /// combined together into (X[i], Y[i]) for each i in range(length(X)).
@@ -35,7 +38,7 @@ fn zip(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
     if left.len() != right.len() {
         return Err(function_call_failed(
-            "zip",
+            FUNCTION_NAME,
             format!(
                 "expected an array of length {left}, but this is an array of length {right}",
                 left = left.len(),


### PR DESCRIPTION
* allow `glob` to operate off of `file://` URLs.
* allow `size` to operate off of `file://` URLs.
* allow `basename` to operate off of any URLs.

This PR also removes custom diagnostics from the stdlib functions so that all of the standard library functions now use `function_called_failed` diagnostics for errors. It gives a more consistent diagnostic for function calls.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
