### PR TITLE
feat: Enforce Section Ordering for Struct definitions

### DIFF
--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
 * Relaxed `CommentWhitespace` rule so that it doesn't fire when a comment has extra spaces before it ([#314](https://github.com/stjude-rust-labs/wdl/pull/314)).
 * `fix` messages suggest the correct order of imports to the user in `ImportSort` rule ([#332](https://github.com/stjude-rust-labs/wdl/pull/332)).
+* Updated `SectionOrdering` to support ordering of `struct` definitions ([#367](https://github.com/stjude-rust-labs/wdl/pull/367)
 
 ### Fixed
 

--- a/wdl-lint/RULES.md
+++ b/wdl-lint/RULES.md
@@ -43,7 +43,7 @@ be out of sync with released packages.
 | `PreambleFormatting`             | Spacing, Style, Clarity       | Ensures that documents have correct whitespace in the preamble.                                   |
 | `RuntimeSectionKeys`             | Completeness, Deprecated      | Ensures that runtime sections have the appropriate keys.                                          |
 | `RedundantInputAssignment`       | Style                         | Ensures that redundant input assignments are shortened                                            |
-| `SectionOrdering`                | Sorting, Style                | Ensures that sections within tasks and workflows are sorted.                                      |
+| `SectionOrdering`                | Sorting, Style                | Ensures that sections within structs, tasks and workflows are sorted.                                      |
 | `ShellCheck`                     | Correctness, Portability      | (BETA) Ensures that command sections are free of shellcheck diagnostics.                          |
 | `SnakeCase`                      | Clarity, Naming, Style        | Ensures that tasks, workflows, and variables are defined with snake_case names.                   |
 | `Todo`                           | Completeness                  | Ensures that `TODO` statements are flagged for followup.                                          |

--- a/wdl-lint/src/rules/section_order.rs
+++ b/wdl-lint/src/rules/section_order.rs
@@ -11,6 +11,8 @@ use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
 use wdl_ast::VisitReason;
 use wdl_ast::Visitor;
+use wdl_ast::v1::StructDefinition;
+use wdl_ast::v1::StructItem;
 use wdl_ast::v1::TaskDefinition;
 use wdl_ast::v1::TaskItem;
 use wdl_ast::v1::WorkflowDefinition;
@@ -50,6 +52,15 @@ fn task_section_order(span: Span, name: &str, problem_span: Span) -> Diagnostic 
         )
 }
 
+/// Create a sturct section order diagnostic.
+fn struct_section_order(span: Span, name: &str, problem_span: Span) -> Diagnostic {
+    Diagnostic::note(format!("sections are not in order for struct `{name}`"))
+        .with_rule(ID)
+        .with_label("this struct contains sections that are out of order", span)
+        .with_label("this section is out of order", problem_span)
+        .with_fix("order as `meta`, `parameter_meta`, `members`")
+}
+
 /// Detects section ordering issues.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct SectionOrderingRule;
@@ -68,7 +79,10 @@ impl Rule for SectionOrderingRule {
          parameter_meta, input, (body), output. \"(body)\" represents all calls and declarations.
 
         For tasks, if present, the following sections must be in this order: meta, parameter_meta, \
-         input, (private declarations), command, output, runtime, requirements, hints."
+         input, (private declarations), command, output, runtime, requirements, hints.
+
+        For structs, if present, the following sections must be in this order: meta, \
+         parameter_meta, members."
     }
 
     fn tags(&self) -> TagSet {
@@ -80,6 +94,7 @@ impl Rule for SectionOrderingRule {
             SyntaxKind::VersionStatementNode,
             SyntaxKind::TaskDefinitionNode,
             SyntaxKind::WorkflowDefinitionNode,
+            SyntaxKind::StructDefinitionNode,
         ])
     }
 }
@@ -236,6 +251,48 @@ impl Visitor for SectionOrderingRule {
                                 .into(),
                         ),
                         SyntaxElement::from(workflow.inner().clone()),
+                        &self.exceptable_nodes(),
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    fn struct_definition(
+        &mut self,
+        state: &mut Self::State,
+        reason: VisitReason,
+        struct_def: &StructDefinition,
+    ) {
+        if reason == VisitReason::Exit {
+            return;
+        }
+
+        let mut encountered = State::Start;
+        for item in struct_def.items() {
+            match item {
+                StructItem::Metadata(_) if encountered <= State::Meta => {
+                    encountered = State::Meta;
+                }
+                StructItem::ParameterMetadata(_) if encountered <= State::ParameterMeta => {
+                    encountered = State::ParameterMeta;
+                }
+                StructItem::Member(_) if encountered <= State::Decl => {
+                    encountered = State::Decl;
+                }
+                _ => {
+                    state.exceptable_add(
+                        struct_section_order(
+                            struct_def.name().span(),
+                            struct_def.name().text(),
+                            item.inner()
+                                .first_token()
+                                .expect("struct item should have tokens")
+                                .text_range()
+                                .into(),
+                        ),
+                        SyntaxElement::from(struct_def.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                     break;

--- a/wdl-lint/tests/lints/description-missing/source.errors
+++ b/wdl-lint/tests/lints/description-missing/source.errors
@@ -14,6 +14,17 @@ note[DescriptionMissing]: workflow `bar` is missing a description key
    │
    = fix: add a `description` key to the meta section
 
+note[SectionOrdering]: sections are not in order for struct `Baz`
+   ┌─ tests/lints/description-missing/source.wdl:27:8
+   │
+27 │ struct Baz {
+   │        ^^^ this struct contains sections that are out of order
+   ·
+30 │     meta {
+   │     ---- this section is out of order
+   │
+   = fix: order as `meta`, `parameter_meta`, `members`
+
 note[DescriptionMissing]: struct `Baz` is missing a description key
    ┌─ tests/lints/description-missing/source.wdl:30:5
    │

--- a/wdl-lint/tests/lints/malformed-lint-directive/source.errors
+++ b/wdl-lint/tests/lints/malformed-lint-directive/source.errors
@@ -22,6 +22,17 @@ warning[MalformedLintDirective]: expected a colon to follow a lint directive
    │
    = fix: add a colon after the lint directive
 
+note[SectionOrdering]: sections are not in order for struct `Baz`
+   ┌─ tests/lints/malformed-lint-directive/source.wdl:33:8
+   │
+33 │ struct Baz {  #@ except: this should be flagged for being inlined
+   │        ^^^ this struct contains sections that are out of order
+   ·
+36 │     meta {
+   │     ---- this section is out of order
+   │
+   = fix: order as `meta`, `parameter_meta`, `members`
+
 warning[MalformedLintDirective]: lint directive must be on its own line
    ┌─ tests/lints/malformed-lint-directive/source.wdl:33:15
    │

--- a/wdl-lint/tests/lints/missing-struct-meta/source.errors
+++ b/wdl-lint/tests/lints/missing-struct-meta/source.errors
@@ -1,3 +1,14 @@
+note[SectionOrdering]: sections are not in order for struct `Test`
+  ┌─ tests/lints/missing-struct-meta/source.wdl:5:8
+  │
+5 │ struct Test {
+  │        ^^^^ this struct contains sections that are out of order
+  ·
+8 │     parameter_meta {
+  │     -------------- this section is out of order
+  │
+  = fix: order as `meta`, `parameter_meta`, `members`
+
 note[MissingMetas]: struct `Test` is missing a `meta` section
   ┌─ tests/lints/missing-struct-meta/source.wdl:5:8
   │

--- a/wdl-lint/tests/lints/missing-struct-param-meta/source.errors
+++ b/wdl-lint/tests/lints/missing-struct-param-meta/source.errors
@@ -1,3 +1,14 @@
+note[SectionOrdering]: sections are not in order for struct `Test`
+  ┌─ tests/lints/missing-struct-param-meta/source.wdl:5:8
+  │
+5 │ struct Test {
+  │        ^^^^ this struct contains sections that are out of order
+  ·
+8 │     meta {
+  │     ---- this section is out of order
+  │
+  = fix: order as `meta`, `parameter_meta`, `members`
+
 note[MissingMetas]: struct `Test` is missing a `parameter_meta` section
   ┌─ tests/lints/missing-struct-param-meta/source.wdl:5:8
   │

--- a/wdl-lint/tests/lints/section-ordering/source.errors
+++ b/wdl-lint/tests/lints/section-ordering/source.errors
@@ -31,3 +31,25 @@ note[SectionOrdering]: sections are not in order for task `qux`
    │
    = fix: order as `meta`, `parameter_meta`, `input`, private declarations, `command`, `output`, `requirements`/`runtime`
 
+note[SectionOrdering]: sections are not in order for struct `Corge`
+   ┌─ tests/lints/section-ordering/source.wdl:45:8
+   │
+45 │ struct Corge {
+   │        ^^^^^ this struct contains sections that are out of order
+   ·
+49 │     meta {}
+   │     ---- this section is out of order
+   │
+   = fix: order as `meta`, `parameter_meta`, `members`
+
+note[SectionOrdering]: sections are not in order for struct `Grault`
+   ┌─ tests/lints/section-ordering/source.wdl:53:8
+   │
+53 │ struct Grault {
+   │        ^^^^^^ this struct contains sections that are out of order
+54 │     Int x
+55 │     meta {}
+   │     ---- this section is out of order
+   │
+   = fix: order as `meta`, `parameter_meta`, `members`
+

--- a/wdl-lint/tests/lints/section-ordering/source.wdl
+++ b/wdl-lint/tests/lints/section-ordering/source.wdl
@@ -33,3 +33,29 @@ task qux {
     command <<<>>>
     output {}
 }
+
+struct Quux {
+    meta {}
+    parameter_meta {
+        x: "an integer"
+    }
+    Int x
+}
+
+struct Corge {
+    parameter_meta {
+        x: "an integer"
+    }
+    meta {}
+    Int x
+}
+
+struct Grault {
+    Int x
+    meta {}
+    parameter_meta {
+        x: "an integer"
+        y: "an integer"
+    }
+    Int y
+}

--- a/wdl-lint/tests/lints/struct-matching-param-meta/source.errors
+++ b/wdl-lint/tests/lints/struct-matching-param-meta/source.errors
@@ -1,3 +1,14 @@
+note[SectionOrdering]: sections are not in order for struct `Text`
+   ┌─ tests/lints/struct-matching-param-meta/source.wdl:6:8
+   │
+ 6 │ struct Text {
+   │        ^^^^ this struct contains sections that are out of order
+   ·
+10 │     meta {
+   │     ---- this section is out of order
+   │
+   = fix: order as `meta`, `parameter_meta`, `members`
+
 warning[MatchingParameterMeta]: struct `Text` is missing a parameter metadata key for input `does_not_exist`
   ┌─ tests/lints/struct-matching-param-meta/source.wdl:8:12
   │


### PR DESCRIPTION
This pull request updates an existing Lint rule `SectionOrdering` to support struct definitions

- specified sequence: `meta` -> `parameter_meta` -> `member` declarations.
- update test to include correct and incorrect section ordering examples
- closes: #202 

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

Rule specific checks:

- [x] You have ~~added~~ updated the rule as an entry within `RULES.md`.
- [x] You have added a test case in `wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
- [x] You have run `gauntlet --bless` to ensure that there are no 
      unintended changes to the baseline configuration file (`Gauntlet.toml`).
- [x] You have run `gauntlet --bless --arena` to ensure that all of the 
      rules added/removed are now reflected in the baseline configuration file 
      (`Arena.toml`).

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
