### PR TITLE
feat: Enable linking between related lint rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,9 @@ There are a handful of reasons the CI may have turned red. Try the following fix
     - while reviewing, ask yourself if the printed diagnostics are clear and informative
 5. consider which nodes should be "exceptable" for this rule
     - See "[How should I decide which nodes to add to `exceptable_nodes()`?](#how-should-i-decide-which-nodes-to-add-to-exceptable_nodes)" for more information on this process
-5. repeat
+6. consider if your new rule relates to existing ones and implement the `related_rules()` method accordingly.
+    - See "[How should i decide which rules to link using related_rules()?](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md#how-should-i-decide-which-rules-to-link-using-related_rules)" for detailed guidance.
+7. repeat
 
 ### Can you explain how rules use `exceptable_nodes()` and `exceptable_add()`?
 
@@ -99,11 +101,19 @@ Minimal: We want to have as few exceptable nodes as possible for each rule, whil
 
 Comprehensive: Try to cover as many _unique_ sets of potential diagnostics as possible with the nodes returned by `exceptable_nodes()`. An individual diagnostic should be able to targeted by a lint directive, and so should any unique group of diagnostics.
 
+### How should I decide which rules to link using `related_rules()`?
+
+When deciding which rules should link to which other rules, please consider these criteria:
+
+- If diagnostic `X` is likely to co-occur with diagnostic `Y` within the same lint pass (addressing them often happens together). This means rule `X` should implement `related_rules` to include `Y`'s ID, and rule `Y` should implement it to include `X`'s ID.
+- If correcting diagnostic `X` naively (without considering other rules) is likely to result in diagnostic `Y` being emitted in a subsequent lint pass. Rule `X` should implement `related_rules` to include `Y`'s ID, but rule `Y` should _not_ link back to rule `X` in this case, as the user fixing `Y` isn't necessarily led back to the context of `X`.
+
 ## Further reading
 
 * `exceptable_add()` defined [here](https://github.com/stjude-rust-labs/wdl/blob/wdl-v0.8.0/wdl-ast/src/validation.rs#L50).
 * See [here](https://docs.rs/wdl/latest/wdl/grammar/type.SyntaxNode.html) for the `SyntaxNode` docs.
 * The PR which introduced `exceptable_nodes()` and `exceptable_add()` is [#162](https://github.com/stjude-rust-labs/wdl/pull/162).
 * That PR fixed issue [#135](https://github.com/stjude-rust-labs/wdl/issues/135)
+* The PR which introduced `related_rules()` is [#371](https://github.com/stjude-rust-labs/wdl/pull/371))
 
 [issues]: https://github.com/stjude-rust-labs/wdl/issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,10 @@ Comprehensive: Try to cover as many _unique_ sets of potential diagnostics as po
 
 When deciding which rules should link to which other rules, please consider these criteria:
 
-- If diagnostic `X` is likely to co-occur with diagnostic `Y` within the same lint pass (addressing them often happens together). This means rule `X` should implement `related_rules` to include `Y`'s ID, and rule `Y` should implement it to include `X`'s ID.
-- If correcting diagnostic `X` naively (without considering other rules) is likely to result in diagnostic `Y` being emitted in a subsequent lint pass. Rule `X` should implement `related_rules` to include `Y`'s ID, but rule `Y` should _not_ link back to rule `X` in this case, as the user fixing `Y` isn't necessarily led back to the context of `X`.
+- If diagnostic `X` is likely to co-occur with diagnostic `Y` within the same lint pass (addressing them often happens together):
+    - rule `X` should implement `related_rules` to include `Y`'s ID, and rule `Y` should implement it to include `X`'s ID.
+- If correcting diagnostic `X` naively (without considering other rules) is likely to result in diagnostic `Y` being emitted in a subsequent lint pass:
+    - rule `X` should implement `related_rules` to include `Y`'s ID, but rule `Y` should _not_ link back to rule `X` in this case, as the user fixing `Y` isn't necessarily led back to the context of `X`.
 
 ## Further reading
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ There are a handful of reasons the CI may have turned red. Try the following fix
 5. consider which nodes should be "exceptable" for this rule
     - See "[How should I decide which nodes to add to `exceptable_nodes()`?](#how-should-i-decide-which-nodes-to-add-to-exceptable_nodes)" for more information on this process
 6. consider if your new rule relates to existing ones and implement the `related_rules()` method accordingly.
-    - See "[How should i decide which rules to link using related_rules()?](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md#how-should-i-decide-which-rules-to-link-using-related_rules)" for detailed guidance.
+    - See "[How should i decide which rules to link using related_rules()?](#how-should-i-decide-which-rules-to-link-using-related_rules)" for detailed guidance.
 7. repeat
 
 ### Can you explain how rules use `exceptable_nodes()` and `exceptable_add()`?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,6 @@ When deciding which rules should link to which other rules, please consider thes
 * See [here](https://docs.rs/wdl/latest/wdl/grammar/type.SyntaxNode.html) for the `SyntaxNode` docs.
 * The PR which introduced `exceptable_nodes()` and `exceptable_add()` is [#162](https://github.com/stjude-rust-labs/wdl/pull/162).
 * That PR fixed issue [#135](https://github.com/stjude-rust-labs/wdl/issues/135)
-* The PR which introduced `related_rules()` is [#371](https://github.com/stjude-rust-labs/wdl/pull/371))
+* The PR which introduced `related_rules()` is [#371](https://github.com/stjude-rust-labs/wdl/pull/371)
 
 [issues]: https://github.com/stjude-rust-labs/wdl/issues

--- a/wdl-analysis/src/rules.rs
+++ b/wdl-analysis/src/rules.rs
@@ -38,9 +38,6 @@ pub trait Rule: Send + Sync {
 
     /// Gets the severity of the rule.
     fn severity(&self) -> Severity;
-
-    /// Gets the related rules ids for this rule.
-    fn related_rules(&self) -> &[&'static str];
 }
 
 /// Gets the list of all analysis rules.
@@ -111,10 +108,6 @@ impl Rule for UnusedImportRule {
     fn severity(&self) -> Severity {
         self.0
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &[]
-    }
 }
 
 /// Represents the unused input rule.
@@ -154,10 +147,6 @@ impl Rule for UnusedInputRule {
 
     fn severity(&self) -> Severity {
         self.0
-    }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["DisallowedInputName"]
     }
 }
 
@@ -200,10 +189,6 @@ impl Rule for UnusedDeclarationRule {
     fn severity(&self) -> Severity {
         self.0
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["SnakeCase"]
-    }
 }
 
 /// Represents the unused call rule.
@@ -243,10 +228,6 @@ impl Rule for UnusedCallRule {
     fn severity(&self) -> Severity {
         self.0
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &[]
-    }
 }
 
 /// Represents the unnecessary call rule.
@@ -285,9 +266,5 @@ impl Rule for UnnecessaryFunctionCall {
 
     fn severity(&self) -> Severity {
         self.0
-    }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &[]
     }
 }

--- a/wdl-analysis/src/rules.rs
+++ b/wdl-analysis/src/rules.rs
@@ -38,6 +38,11 @@ pub trait Rule: Send + Sync {
 
     /// Gets the severity of the rule.
     fn severity(&self) -> Severity;
+
+    /// Gets the related rules ids for this rule.
+    fn related_rules(&self) -> &'static [&'static str] {
+        &[]
+    }
 }
 
 /// Gets the list of all analysis rules.
@@ -148,6 +153,10 @@ impl Rule for UnusedInputRule {
     fn severity(&self) -> Severity {
         self.0
     }
+
+    fn related_rules(&self) -> &'static [&'static str] {
+        &["DisallowedInputName"]
+    }
 }
 
 /// Represents the unused declaration rule.
@@ -188,6 +197,10 @@ impl Rule for UnusedDeclarationRule {
 
     fn severity(&self) -> Severity {
         self.0
+    }
+
+    fn related_rules(&self) -> &'static [&'static str] {
+        &["SnakeCase"]
     }
 }
 

--- a/wdl-analysis/src/rules.rs
+++ b/wdl-analysis/src/rules.rs
@@ -40,9 +40,7 @@ pub trait Rule: Send + Sync {
     fn severity(&self) -> Severity;
 
     /// Gets the related rules ids for this rule.
-    fn related_rules(&self) -> &'static [&'static str] {
-        &[]
-    }
+    fn related_rules(&self) -> &[&'static str];
 }
 
 /// Gets the list of all analysis rules.
@@ -113,6 +111,10 @@ impl Rule for UnusedImportRule {
     fn severity(&self) -> Severity {
         self.0
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 /// Represents the unused input rule.
@@ -154,7 +156,7 @@ impl Rule for UnusedInputRule {
         self.0
     }
 
-    fn related_rules(&self) -> &'static [&'static str] {
+    fn related_rules(&self) -> &[&'static str] {
         &["DisallowedInputName"]
     }
 }
@@ -199,7 +201,7 @@ impl Rule for UnusedDeclarationRule {
         self.0
     }
 
-    fn related_rules(&self) -> &'static [&'static str] {
+    fn related_rules(&self) -> &[&'static str] {
         &["SnakeCase"]
     }
 }
@@ -241,6 +243,10 @@ impl Rule for UnusedCallRule {
     fn severity(&self) -> Severity {
         self.0
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 /// Represents the unnecessary call rule.
@@ -279,5 +285,9 @@ impl Rule for UnnecessaryFunctionCall {
 
     fn severity(&self) -> Severity {
         self.0
+    }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
     }
 }

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added suggestion for similar rule names when encountering unknown lint rules ([#334](https://github.com/stjude-rust-labs/wdl/pull/334)).
 * Added `DisallowedDeclarationName` rule ([#343](https://github.com/stjude-rust-labs/wdl/pull/343)).
+* Added `Rule::related_rules()` for linking related lint rules ([#371](https://github.com/stjude-rust-labs/wdl/pull/371)).
 
 ### Changed
 

--- a/wdl-lint/RULES.md
+++ b/wdl-lint/RULES.md
@@ -9,7 +9,7 @@ be out of sync with released packages.
 | Name                             | Tags                          | Description                                                                                       |
 |:---------------------------------|:------------------------------|:--------------------------------------------------------------------------------------------------|
 | `BlankLinesBetweenElements`      | Spacing                       | Ensures proper blank space between elements                                                       |
-| `CallInputSpacing`               | Style, Clarity, Spacing       | Ensures proper spacing for call inputs                                                            |
+| `CallInputSpacing`               | Clarity, Spacing, Style       | Ensures proper spacing for call inputs                                                            |
 | `CommandSectionMixedIndentation` | Clarity, Correctness, Spacing | Ensures that lines within a command do not mix spaces and tabs.                                   |
 | `CommentWhitespace`              | Spacing                       | Ensures that comments are properly spaced.                                                        |
 | `ContainerValue`                 | Clarity, Portability          | Ensures that the value for `container` keys in `runtime`/`requirements` sections are well-formed. |
@@ -24,26 +24,26 @@ be out of sync with released packages.
 | `ExpressionSpacing`              | Spacing                       | Ensures that expressions are properly spaced.                                                     |
 | `ImportPlacement`                | Clarity, Sorting              | Ensures that imports are placed between the version statement and any document items.             |
 | `ImportSort`                     | Clarity, Style                | Ensures that imports are sorted lexicographically.                                                |
-| `ImportWhitespace`               | Clarity, Style, Spacing       | Ensures that there is no extraneous whitespace between or within imports.                         |
+| `ImportWhitespace`               | Clarity, Spacing, Style       | Ensures that there is no extraneous whitespace between or within imports.                         |
 | `InconsistentNewlines`           | Clarity, Style                | Ensures that newlines are used consistently within the file.                                      |
-| `InputSorting`                   | Style, Clarity, Sorting       | Ensures that input declarations are sorted                                                        |
+| `InputSorting`                   | Clarity, Sorting, Style       | Ensures that input declarations are sorted                                                        |
 | `KeyValuePairs`                  | Style                         | Ensures that metadata objects and arrays are properly spaced.                                     |
 | `LineWidth`                      | Clarity, Spacing, Style       | Ensures that lines do not exceed a certain width.                                                 |
 | `MalformedLintDirective`         | Clarity, Correctness          | Ensures there are no malformed lint directives.                                                   |
 | `MatchingParameterMeta`          | Completeness                  | Ensures that inputs have a matching entry in a `parameter_meta` section.                          |
 | `MisplacedLintDirective`         | Clarity, Correctness          | Ensures there are no misplaced lint directives.                                                   |
-| `MissingMetas`                   | Completeness, Clarity         | Ensures that tasks have both a meta and a parameter_meta section.                                 |
+| `MissingMetas`                   | Clarity, Completeness         | Ensures that tasks have both a meta and a parameter_meta section.                                 |
 | `MissingOutput`                  | Completeness, Portability     | Ensures that tasks have an output section.                                                        |
 | `MissingRequirements`            | Completeness, Portability     | Ensures that >=v1.2 tasks have a requirements section.                                            |
 | `MissingRuntime`                 | Completeness, Portability     | Ensures that tasks have a runtime section.                                                        |
-| `NonmatchingOutput`              | Completeness                  | Ensures that each output field is documented in the meta section under `meta.outputs`.            |
 | `NoCurlyCommands`                | Clarity                       | Ensures that tasks use heredoc syntax in command sections.                                        |
+| `NonmatchingOutput`              | Completeness                  | Ensures that each output field is documented in the meta section under `meta.outputs`.            |
 | `PascalCase`                     | Clarity, Naming, Style        | Ensures that structs are defined with PascalCase names.                                           |
 | `PreambleCommentAfterVersion`    | Clarity                       | Ensures that documents have correct comments in the preamble.                                     |
-| `PreambleFormatting`             | Spacing, Style, Clarity       | Ensures that documents have correct whitespace in the preamble.                                   |
-| `RuntimeSectionKeys`             | Completeness, Deprecated      | Ensures that runtime sections have the appropriate keys.                                          |
+| `PreambleFormatting`             | Clarity, Spacing, Style       | Ensures that documents have correct whitespace in the preamble.                                   |
 | `RedundantInputAssignment`       | Style                         | Ensures that redundant input assignments are shortened                                            |
-| `SectionOrdering`                | Sorting, Style                | Ensures that sections within structs, tasks and workflows are sorted.                             |
+| `RuntimeSectionKeys`             | Completeness, Deprecated      | Ensures that runtime sections have the appropriate keys.                                          |
+| `SectionOrdering`                | Sorting, Style                | Ensures that sections within tasks and workflows are sorted.                                      |
 | `ShellCheck`                     | Correctness, Portability      | (BETA) Ensures that command sections are free of shellcheck diagnostics.                          |
 | `SnakeCase`                      | Clarity, Naming, Style        | Ensures that tasks, workflows, and variables are defined with snake_case names.                   |
 | `Todo`                           | Completeness                  | Ensures that `TODO` statements are flagged for followup.                                          |

--- a/wdl-lint/RULES.md
+++ b/wdl-lint/RULES.md
@@ -26,7 +26,7 @@ be out of sync with released packages.
 | `ImportSort`                     | Clarity, Style                | Ensures that imports are sorted lexicographically.                                                |
 | `ImportWhitespace`               | Clarity, Style, Spacing       | Ensures that there is no extraneous whitespace between or within imports.                         |
 | `InconsistentNewlines`           | Clarity, Style                | Ensures that newlines are used consistently within the file.                                      |
-| `InputSorting`                   | Style                         | Ensures that input declarations are sorted                                                        |
+| `InputSorting`                   | Style, Clarity, Sorting       | Ensures that input declarations are sorted                                                        |
 | `KeyValuePairs`                  | Style                         | Ensures that metadata objects and arrays are properly spaced.                                     |
 | `LineWidth`                      | Clarity, Spacing, Style       | Ensures that lines do not exceed a certain width.                                                 |
 | `MalformedLintDirective`         | Clarity, Correctness          | Ensures there are no malformed lint directives.                                                   |

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -167,6 +167,10 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
         for r in &rules {
             for related_id in r.related_rules() {
                 if !rule_ids.contains(related_id) {
+                    // If a related rule is a reserved rule, then it's fine.
+                    if RESERVED_RULE_IDS.contains(&related_id) {
+                        continue;
+                    }
                     panic!(
                         "Rule `{id}` refers to a related rule `{related_id}` which does not exist \
                          in the default rule set.",

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -86,8 +86,6 @@ pub trait Rule: Visitor<State = Diagnostics> {
     /// This can be used by tools (like `sprocket explain`) to suggest other
     /// relevant rules to the user based on potential logical connections or
     /// common co-occurrences of issues.
-    ///
-    /// By default, this returns an empty list.
     fn related_rules(&self) -> &[&'static str];
 }
 
@@ -138,8 +136,8 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
         Box::<rules::RedundantInputAssignment>::default(),
     ];
 
-    // Ensure all the rule ids are unique and pascal case, and related rules are
-    // valid and exist
+    // Ensure all the rule IDs are unique and pascal case and that related rules are
+    // valid, exist and not self-referential.
     #[cfg(debug_assertions)]
     {
         use std::collections::HashSet;
@@ -194,7 +192,8 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
 pub fn optional_rules() -> Vec<Box<dyn Rule>> {
     let opt_rules: Vec<Box<dyn Rule>> = vec![Box::<rules::ShellCheckRule>::default()];
 
-    // Ensure all the rule ids are unique and pascal case
+    // Ensure all the rule IDs are unique and pascal case and that related rules are
+    // valid, exist and not self-referential.
     #[cfg(debug_assertions)]
     {
         use std::collections::HashSet;

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -88,8 +88,8 @@ pub trait Rule: Visitor<State = Diagnostics> {
     /// common co-occurrences of issues.
     ///
     /// By default, this returns an empty list.
-    fn related_rules(&self) -> Vec<&'static str> {
-        Vec::new()
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
     }
 }
 

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -166,7 +166,7 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
             for related_id in r.related_rules() {
                 if !rule_ids.contains(related_id) {
                     // If a related rule is a reserved rule, then it's fine.
-                    if RESERVED_RULE_IDS.contains(&related_id) {
+                    if RESERVED_RULE_IDS.contains(related_id) {
                         continue;
                     }
                     panic!(

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -88,9 +88,7 @@ pub trait Rule: Visitor<State = Diagnostics> {
     /// common co-occurrences of issues.
     ///
     /// By default, this returns an empty list.
-    fn related_rules(&self) -> &[&'static str] {
-        &[]
-    }
+    fn related_rules(&self) -> &[&'static str];
 }
 
 /// Gets the default rule set.

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -80,6 +80,17 @@ pub trait Rule: Visitor<State = Diagnostics> {
     ///
     /// If `None` is returned, all nodes are exceptable.
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]>;
+
+    /// Gets the ID of rules that are related to this rule.
+    ///
+    /// This can be used by tools (like `sprocket explain`) to suggest other
+    /// relevant rules to the user based on potential logical connections or
+    /// common co-occurrences of issues.
+    ///
+    /// By default, this returns an empty list.
+    fn related_rules(&self) -> Vec<&'static str> {
+        Vec::new()
+    }
 }
 
 /// Gets the default rule set.
@@ -129,23 +140,40 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
         Box::<rules::RedundantInputAssignment>::default(),
     ];
 
-    // Ensure all the rule ids are unique and pascal case
+    // Ensure all the rule ids are unique and pascal case, and related rules are
+    // valid and exist
     #[cfg(debug_assertions)]
     {
+        use std::collections::HashSet;
+
         use convert_case::Case;
         use convert_case::Casing;
-        let mut set = std::collections::HashSet::new();
+
+        let mut rule_ids = HashSet::new();
         for r in &rules {
             if r.id().to_case(Case::Pascal) != r.id() {
                 panic!("lint rule id `{id}` is not pascal case", id = r.id());
             }
 
-            if !set.insert(r.id()) {
+            if !rule_ids.insert(r.id()) {
                 panic!("duplicate rule id `{id}`", id = r.id());
             }
 
             if RESERVED_RULE_IDS.contains(&r.id()) {
                 panic!("rule id `{id}` is reserved", id = r.id());
+            }
+        }
+
+        for r in &rules {
+            for related_id in r.related_rules() {
+                if !rule_ids.contains(related_id) {
+                    panic!(
+                        "Rule `{id}` refers to a related rule `{related_id}` which does not exist \
+                         in the default rule set.",
+                        id = r.id(),
+                        related_id = related_id
+                    );
+                }
             }
         }
     }
@@ -160,23 +188,48 @@ pub fn optional_rules() -> Vec<Box<dyn Rule>> {
     // Ensure all the rule ids are unique and pascal case
     #[cfg(debug_assertions)]
     {
+        use std::collections::HashSet;
+        use std::iter::FromIterator;
+
         use convert_case::Case;
         use convert_case::Casing;
 
-        use crate::rules;
-        let mut set: std::collections::HashSet<&str> =
-            std::collections::HashSet::from_iter(rules().iter().map(|r| r.id()));
-        for r in opt_rules.iter() {
-            if r.id().to_case(Case::Pascal) != r.id() {
-                panic!("lint rule id `{id}` is not pascal case", id = r.id());
+        let default_rule_ids: HashSet<&str> = HashSet::from_iter(rules().iter().map(|r| r.id()));
+        let mut opt_rule_ids = HashSet::new();
+
+        for r in &opt_rules {
+            let id = r.id();
+            if id.to_case(Case::Pascal) != id {
+                panic!("lint rule id `{id}` is not pascal case", id = id);
             }
 
-            if !set.insert(r.id()) {
-                panic!("duplicate rule id `{id}`", id = r.id());
+            if default_rule_ids.contains(id) {
+                panic!(
+                    "optional rule id `{id}` conflicts with a default rule id",
+                    id = id
+                );
             }
 
-            if RESERVED_RULE_IDS.contains(&r.id()) {
-                panic!("rule id `{id}` is reserved", id = r.id());
+            if !opt_rule_ids.insert(id) {
+                panic!("duplicate rule id `{id}`", id = id);
+            }
+
+            if RESERVED_RULE_IDS.contains(&id) {
+                panic!("rule id `{id}` is reserved", id = id);
+            }
+        }
+
+        let all_rule_ids: HashSet<&str> = default_rule_ids.union(&opt_rule_ids).copied().collect();
+        for r in &opt_rules {
+            for related_id in r.related_rules() {
+                if !all_rule_ids.contains(related_id) {
+                    panic!(
+                        "optional rule `{id}` refers to a related rule `{related_id}` which does \
+                         not exist.",
+                        id = r.id(),
+                        related_id = related_id
+                    );
+                }
             }
         }
     }

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -163,6 +163,7 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
         }
 
         for r in &rules {
+            let self_id = &r.id();
             for related_id in r.related_rules() {
                 if !rule_ids.contains(related_id) {
                     // If a related rule is a reserved rule, then it's fine.
@@ -174,6 +175,12 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
                          in the default rule set.",
                         id = r.id(),
                         related_id = related_id
+                    );
+                }
+                if related_id == self_id {
+                    panic!(
+                        "Rule `{id}` refers to itself in its related rules. This is not allowed.",
+                        id = self_id
                     );
                 }
             }
@@ -223,6 +230,7 @@ pub fn optional_rules() -> Vec<Box<dyn Rule>> {
 
         let all_rule_ids: HashSet<&str> = default_rule_ids.union(&opt_rule_ids).copied().collect();
         for r in &opt_rules {
+            let self_id = &r.id();
             for related_id in r.related_rules() {
                 if !all_rule_ids.contains(related_id) {
                     panic!(
@@ -230,6 +238,14 @@ pub fn optional_rules() -> Vec<Box<dyn Rule>> {
                          not exist.",
                         id = r.id(),
                         related_id = related_id
+                    );
+                }
+
+                if related_id == self_id {
+                    panic!(
+                        "optional rule `{id}` refers to itself in its related rules. This is not \
+                         allowed.",
+                        id = self_id
                     );
                 }
             }

--- a/wdl-lint/src/rules/blank_lines_between_elements.rs
+++ b/wdl-lint/src/rules/blank_lines_between_elements.rs
@@ -121,6 +121,10 @@ impl Rule for BlankLinesBetweenElementsRule {
             SyntaxKind::CommandSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for BlankLinesBetweenElementsRule {

--- a/wdl-lint/src/rules/call_input_spacing.rs
+++ b/wdl-lint/src/rules/call_input_spacing.rs
@@ -85,6 +85,10 @@ impl Rule for CallInputSpacingRule {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for CallInputSpacingRule {

--- a/wdl-lint/src/rules/call_input_spacing.rs
+++ b/wdl-lint/src/rules/call_input_spacing.rs
@@ -85,6 +85,10 @@ impl Rule for CallInputSpacingRule {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["TrailingComma"]
+    }
 }
 
 impl Visitor for CallInputSpacingRule {

--- a/wdl-lint/src/rules/call_input_spacing.rs
+++ b/wdl-lint/src/rules/call_input_spacing.rs
@@ -86,8 +86,8 @@ impl Rule for CallInputSpacingRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["TrailingComma"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["TrailingComma"]
     }
 }
 

--- a/wdl-lint/src/rules/call_input_spacing.rs
+++ b/wdl-lint/src/rules/call_input_spacing.rs
@@ -85,10 +85,6 @@ impl Rule for CallInputSpacingRule {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["TrailingComma"]
-    }
 }
 
 impl Visitor for CallInputSpacingRule {

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -104,10 +104,6 @@ impl Rule for CommandSectionMixedIndentationRule {
             SyntaxKind::CommandSectionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["Whitespace"]
-    }
 }
 
 impl Visitor for CommandSectionMixedIndentationRule {

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -104,6 +104,10 @@ impl Rule for CommandSectionMixedIndentationRule {
             SyntaxKind::CommandSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["NoCurlyCommands"]
+    }
 }
 
 impl Visitor for CommandSectionMixedIndentationRule {

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -104,6 +104,10 @@ impl Rule for CommandSectionMixedIndentationRule {
             SyntaxKind::CommandSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["Whitespace"]
+    }
 }
 
 impl Visitor for CommandSectionMixedIndentationRule {

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -106,7 +106,7 @@ impl Rule for CommandSectionMixedIndentationRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["NoCurlyCommands"]
+        &[]
     }
 }
 

--- a/wdl-lint/src/rules/command_mixed_indentation.rs
+++ b/wdl-lint/src/rules/command_mixed_indentation.rs
@@ -105,8 +105,8 @@ impl Rule for CommandSectionMixedIndentationRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["Whitespace"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["Whitespace"]
     }
 }
 

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -95,6 +95,10 @@ impl Rule for CommentWhitespaceRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for CommentWhitespaceRule {

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -96,8 +96,8 @@ impl Rule for CommentWhitespaceRule {
         None
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["Whitespace"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["Whitespace"]
     }
 }
 

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -95,10 +95,6 @@ impl Rule for CommentWhitespaceRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["Whitespace"]
-    }
 }
 
 impl Visitor for CommentWhitespaceRule {

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -95,6 +95,10 @@ impl Rule for CommentWhitespaceRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["Whitespace"]
+    }
 }
 
 impl Visitor for CommentWhitespaceRule {

--- a/wdl-lint/src/rules/container_value.rs
+++ b/wdl-lint/src/rules/container_value.rs
@@ -139,6 +139,10 @@ impl Rule for ContainerValue {
             SyntaxKind::RequirementsSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for ContainerValue {

--- a/wdl-lint/src/rules/deprecated_object.rs
+++ b/wdl-lint/src/rules/deprecated_object.rs
@@ -64,6 +64,10 @@ impl Rule for DeprecatedObjectRule {
             SyntaxKind::UnboundDeclNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["DeprecatedPlaceholderOption", "RuntimeSectionKeys"]
+    }
 }
 
 impl Visitor for DeprecatedObjectRule {

--- a/wdl-lint/src/rules/deprecated_placeholder_option.rs
+++ b/wdl-lint/src/rules/deprecated_placeholder_option.rs
@@ -99,6 +99,10 @@ impl Rule for DeprecatedPlaceholderOptionRule {
     fn tags(&self) -> TagSet {
         TagSet::new(&[Tag::Deprecated])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["DeprecatedObject", "RuntimeSectionKeys"]
+    }
 }
 
 impl Visitor for DeprecatedPlaceholderOptionRule {

--- a/wdl-lint/src/rules/description_missing.rs
+++ b/wdl-lint/src/rules/description_missing.rs
@@ -74,6 +74,10 @@ impl Rule for DescriptionMissingRule {
             SyntaxKind::MetadataSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MissingMetas"]
+    }
 }
 
 impl Visitor for DescriptionMissingRule {

--- a/wdl-lint/src/rules/description_missing.rs
+++ b/wdl-lint/src/rules/description_missing.rs
@@ -74,10 +74,6 @@ impl Rule for DescriptionMissingRule {
             SyntaxKind::MetadataSectionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MissingMetas"]
-    }
 }
 
 impl Visitor for DescriptionMissingRule {

--- a/wdl-lint/src/rules/description_missing.rs
+++ b/wdl-lint/src/rules/description_missing.rs
@@ -75,8 +75,8 @@ impl Rule for DescriptionMissingRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MissingMetas"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MissingMetas"]
     }
 }
 

--- a/wdl-lint/src/rules/description_missing.rs
+++ b/wdl-lint/src/rules/description_missing.rs
@@ -74,6 +74,17 @@ impl Rule for DescriptionMissingRule {
             SyntaxKind::MetadataSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "MatchingParameterMeta",
+            "MissingOutput",
+            "MissingRequirements",
+            "MissingRuntime",
+            "NonmatchingOutput",
+            "Todo",
+        ]
+    }
 }
 
 impl Visitor for DescriptionMissingRule {

--- a/wdl-lint/src/rules/description_missing.rs
+++ b/wdl-lint/src/rules/description_missing.rs
@@ -82,7 +82,6 @@ impl Rule for DescriptionMissingRule {
             "MissingRequirements",
             "MissingRuntime",
             "NonmatchingOutput",
-            "Todo",
         ]
     }
 }

--- a/wdl-lint/src/rules/disallowed_declaration_name.rs
+++ b/wdl-lint/src/rules/disallowed_declaration_name.rs
@@ -65,6 +65,10 @@ impl Rule for DisallowedDeclarationNameRule {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for DisallowedDeclarationNameRule {

--- a/wdl-lint/src/rules/disallowed_declaration_name.rs
+++ b/wdl-lint/src/rules/disallowed_declaration_name.rs
@@ -67,7 +67,7 @@ impl Rule for DisallowedDeclarationNameRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &[]
+        &["DisallowedInputName", "DisallowedOutputName"]
     }
 }
 

--- a/wdl-lint/src/rules/disallowed_input_name.rs
+++ b/wdl-lint/src/rules/disallowed_input_name.rs
@@ -85,7 +85,7 @@ impl Rule for DisallowedInputNameRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["DisallowedOutputName", "UnusedInput"]
+        &["DisallowedOutputName", "DisallowedDeclarationName"]
     }
 }
 

--- a/wdl-lint/src/rules/disallowed_input_name.rs
+++ b/wdl-lint/src/rules/disallowed_input_name.rs
@@ -84,8 +84,8 @@ impl Rule for DisallowedInputNameRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["SnakeCase"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["SnakeCase"]
     }
 }
 

--- a/wdl-lint/src/rules/disallowed_input_name.rs
+++ b/wdl-lint/src/rules/disallowed_input_name.rs
@@ -83,6 +83,10 @@ impl Rule for DisallowedInputNameRule {
             SyntaxKind::UnboundDeclNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["SnakeCase"]
+    }
 }
 
 impl Visitor for DisallowedInputNameRule {

--- a/wdl-lint/src/rules/disallowed_input_name.rs
+++ b/wdl-lint/src/rules/disallowed_input_name.rs
@@ -83,6 +83,10 @@ impl Rule for DisallowedInputNameRule {
             SyntaxKind::UnboundDeclNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["DisallowedOutputName", "UnusedInput"]
+    }
 }
 
 impl Visitor for DisallowedInputNameRule {

--- a/wdl-lint/src/rules/disallowed_input_name.rs
+++ b/wdl-lint/src/rules/disallowed_input_name.rs
@@ -83,10 +83,6 @@ impl Rule for DisallowedInputNameRule {
             SyntaxKind::UnboundDeclNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["SnakeCase"]
-    }
 }
 
 impl Visitor for DisallowedInputNameRule {

--- a/wdl-lint/src/rules/disallowed_output_name.rs
+++ b/wdl-lint/src/rules/disallowed_output_name.rs
@@ -83,8 +83,8 @@ impl Rule for DisallowedOutputNameRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["SnakeCase"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["SnakeCase"]
     }
 }
 

--- a/wdl-lint/src/rules/disallowed_output_name.rs
+++ b/wdl-lint/src/rules/disallowed_output_name.rs
@@ -84,7 +84,7 @@ impl Rule for DisallowedOutputNameRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["DisallowedInputName"]
+        &["DisallowedInputName", "DisallowedDeclarationName"]
     }
 }
 

--- a/wdl-lint/src/rules/disallowed_output_name.rs
+++ b/wdl-lint/src/rules/disallowed_output_name.rs
@@ -82,10 +82,6 @@ impl Rule for DisallowedOutputNameRule {
             SyntaxKind::BoundDeclNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["SnakeCase"]
-    }
 }
 
 impl Visitor for DisallowedOutputNameRule {

--- a/wdl-lint/src/rules/disallowed_output_name.rs
+++ b/wdl-lint/src/rules/disallowed_output_name.rs
@@ -82,6 +82,10 @@ impl Rule for DisallowedOutputNameRule {
             SyntaxKind::BoundDeclNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["SnakeCase"]
+    }
 }
 
 impl Visitor for DisallowedOutputNameRule {

--- a/wdl-lint/src/rules/disallowed_output_name.rs
+++ b/wdl-lint/src/rules/disallowed_output_name.rs
@@ -82,6 +82,10 @@ impl Rule for DisallowedOutputNameRule {
             SyntaxKind::BoundDeclNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["DisallowedInputName"]
+    }
 }
 
 impl Visitor for DisallowedOutputNameRule {

--- a/wdl-lint/src/rules/double_quotes.rs
+++ b/wdl-lint/src/rules/double_quotes.rs
@@ -64,6 +64,10 @@ impl Rule for DoubleQuotesRule {
             SyntaxKind::LiteralStringNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for DoubleQuotesRule {

--- a/wdl-lint/src/rules/ending_newline.rs
+++ b/wdl-lint/src/rules/ending_newline.rs
@@ -66,6 +66,10 @@ impl Rule for EndingNewlineRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for EndingNewlineRule {

--- a/wdl-lint/src/rules/ending_newline.rs
+++ b/wdl-lint/src/rules/ending_newline.rs
@@ -66,10 +66,6 @@ impl Rule for EndingNewlineRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["Whitespace"]
-    }
 }
 
 impl Visitor for EndingNewlineRule {

--- a/wdl-lint/src/rules/ending_newline.rs
+++ b/wdl-lint/src/rules/ending_newline.rs
@@ -67,8 +67,8 @@ impl Rule for EndingNewlineRule {
         Some(&[SyntaxKind::VersionStatementNode])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["Whitespace"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["Whitespace"]
     }
 }
 

--- a/wdl-lint/src/rules/ending_newline.rs
+++ b/wdl-lint/src/rules/ending_newline.rs
@@ -66,6 +66,10 @@ impl Rule for EndingNewlineRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["Whitespace"]
+    }
 }
 
 impl Visitor for EndingNewlineRule {

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -202,10 +202,6 @@ impl Rule for ExpressionSpacingRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["LineWidth"]
-    }
 }
 
 impl Visitor for ExpressionSpacingRule {

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -202,6 +202,10 @@ impl Rule for ExpressionSpacingRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for ExpressionSpacingRule {

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -204,7 +204,7 @@ impl Rule for ExpressionSpacingRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &[]
+        &["LineWidth"]
     }
 }
 

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -157,29 +157,29 @@ impl Rule for ExpressionSpacingRule {
     fn explanation(&self) -> &'static str {
         "Proper spacing is important for readability and consistency. This rule ensures that \
          expressions are spaced properly.
-         
+
          The following tokens should be surrounded by whitespace when used as an infix: `=`, `==`, \
          `!=`, `&&`, `||`, `<`, `<=`, `>`, `>=`, `+`, `-`, `*`, `/`, and `%`.
-         
+
          The following tokens should not be followed by whitespace when used as a prefix: `-`, and \
          `!`.
-         
+
          Opening brackets (`(`, `[`, and `{`) should not be followed by a space, but may be \
          followed by a newline. Closing brackets (`)`, `]`, and `}`) should not be preceded by a \
          space, but may be preceded by a newline.
-         
+
          Sometimes a long expression will exceed the maximum line width. In these cases, one or \
          more linebreaks must be introduced. Line continuations should be indented one more level \
          than the beginning of the expression. There should never be more than one level of \
          indentation change per-line.
-         
+
          If bracketed content (things between `()`, `[]`, or `{}`) must be split onto multiple \
          lines, a newline should follow the opening bracket, the contents should be indented an \
          additional level, then the closing bracket should be de-indented to match the indentation \
          of the opening bracket. If you are line splitting an expression on an infix operator, the \
          operator and at least the beginning of the RHS operand should be on the continued line. \
          (i.e. an operator should not be on a line by itself.)
-         
+
          If you are using the `if...then...else...` construct as part of your expression and it \
          needs to be line split, the entire construct should be wrapped in parentheses (`()`). The \
          opening parenthesis should be immediately followed by a newline. `if`, `then`, and `else` \
@@ -188,7 +188,7 @@ impl Rule for ExpressionSpacingRule {
          parenthesis. If you are using the `if...then...else...` construct on one line, it does \
          not need to be wrapped in parentheses. However, if any of the 3 clauses are more complex \
          than a single identifier, they should be wrapped in parentheses.
-         
+
          Sometimes a developer will choose to line split an expression despite it being able to \
          all fit on one line that is <=90 characters wide. That is perfectly acceptable. There is \
          'wiggle' room allowed by the above rules. This is intentional, and allows developers to \
@@ -201,6 +201,10 @@ impl Rule for ExpressionSpacingRule {
 
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
+    }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["LineWidth"]
     }
 }
 

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -203,8 +203,8 @@ impl Rule for ExpressionSpacingRule {
         None
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["LineWidth"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["LineWidth"]
     }
 }
 

--- a/wdl-lint/src/rules/import_placement.rs
+++ b/wdl-lint/src/rules/import_placement.rs
@@ -64,6 +64,10 @@ impl Rule for ImportPlacementRule {
             SyntaxKind::ImportStatementNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for ImportPlacementRule {

--- a/wdl-lint/src/rules/import_placement.rs
+++ b/wdl-lint/src/rules/import_placement.rs
@@ -64,6 +64,10 @@ impl Rule for ImportPlacementRule {
             SyntaxKind::ImportStatementNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["ImportSort", "ImportWhitespace"]
+    }
 }
 
 impl Visitor for ImportPlacementRule {

--- a/wdl-lint/src/rules/import_placement.rs
+++ b/wdl-lint/src/rules/import_placement.rs
@@ -64,10 +64,6 @@ impl Rule for ImportPlacementRule {
             SyntaxKind::ImportStatementNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["ImportSort", "ImportWhitespace"]
-    }
 }
 
 impl Visitor for ImportPlacementRule {

--- a/wdl-lint/src/rules/import_placement.rs
+++ b/wdl-lint/src/rules/import_placement.rs
@@ -65,8 +65,8 @@ impl Rule for ImportPlacementRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["ImportSort", "ImportWhitespace"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["ImportSort", "ImportWhitespace"]
     }
 }
 

--- a/wdl-lint/src/rules/import_sort.rs
+++ b/wdl-lint/src/rules/import_sort.rs
@@ -66,7 +66,7 @@ impl Rule for ImportSortRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["InputSorting", "SectionOrdering"]
+        &[]
     }
 }
 

--- a/wdl-lint/src/rules/import_sort.rs
+++ b/wdl-lint/src/rules/import_sort.rs
@@ -64,10 +64,6 @@ impl Rule for ImportSortRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["ImportWhitespace"]
-    }
 }
 
 impl Visitor for ImportSortRule {

--- a/wdl-lint/src/rules/import_sort.rs
+++ b/wdl-lint/src/rules/import_sort.rs
@@ -65,8 +65,8 @@ impl Rule for ImportSortRule {
         Some(&[SyntaxKind::VersionStatementNode])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["ImportWhitespace"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["ImportWhitespace"]
     }
 }
 

--- a/wdl-lint/src/rules/import_sort.rs
+++ b/wdl-lint/src/rules/import_sort.rs
@@ -64,6 +64,10 @@ impl Rule for ImportSortRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["InputSorting", "SectionOrdering"]
+    }
 }
 
 impl Visitor for ImportSortRule {

--- a/wdl-lint/src/rules/import_sort.rs
+++ b/wdl-lint/src/rules/import_sort.rs
@@ -64,6 +64,10 @@ impl Rule for ImportSortRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["ImportWhitespace"]
+    }
 }
 
 impl Visitor for ImportSortRule {

--- a/wdl-lint/src/rules/import_whitespace.rs
+++ b/wdl-lint/src/rules/import_whitespace.rs
@@ -81,6 +81,10 @@ impl Rule for ImportWhitespaceRule {
             SyntaxKind::ImportStatementNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for ImportWhitespaceRule {

--- a/wdl-lint/src/rules/import_whitespace.rs
+++ b/wdl-lint/src/rules/import_whitespace.rs
@@ -81,6 +81,10 @@ impl Rule for ImportWhitespaceRule {
             SyntaxKind::ImportStatementNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["ImportSort"]
+    }
 }
 
 impl Visitor for ImportWhitespaceRule {

--- a/wdl-lint/src/rules/import_whitespace.rs
+++ b/wdl-lint/src/rules/import_whitespace.rs
@@ -82,8 +82,8 @@ impl Rule for ImportWhitespaceRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["ImportSort"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["ImportSort"]
     }
 }
 

--- a/wdl-lint/src/rules/import_whitespace.rs
+++ b/wdl-lint/src/rules/import_whitespace.rs
@@ -81,10 +81,6 @@ impl Rule for ImportWhitespaceRule {
             SyntaxKind::ImportStatementNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["ImportSort"]
-    }
 }
 
 impl Visitor for ImportWhitespaceRule {

--- a/wdl-lint/src/rules/inconsistent_newlines.rs
+++ b/wdl-lint/src/rules/inconsistent_newlines.rs
@@ -63,6 +63,10 @@ impl Rule for InconsistentNewlinesRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for InconsistentNewlinesRule {

--- a/wdl-lint/src/rules/inconsistent_newlines.rs
+++ b/wdl-lint/src/rules/inconsistent_newlines.rs
@@ -63,10 +63,6 @@ impl Rule for InconsistentNewlinesRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["Whitespace"]
-    }
 }
 
 impl Visitor for InconsistentNewlinesRule {

--- a/wdl-lint/src/rules/inconsistent_newlines.rs
+++ b/wdl-lint/src/rules/inconsistent_newlines.rs
@@ -64,8 +64,8 @@ impl Rule for InconsistentNewlinesRule {
         Some(&[SyntaxKind::VersionStatementNode])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["Whitespace"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["Whitespace"]
     }
 }
 

--- a/wdl-lint/src/rules/inconsistent_newlines.rs
+++ b/wdl-lint/src/rules/inconsistent_newlines.rs
@@ -63,6 +63,10 @@ impl Rule for InconsistentNewlinesRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["Whitespace"]
+    }
 }
 
 impl Visitor for InconsistentNewlinesRule {

--- a/wdl-lint/src/rules/input_not_sorted.rs
+++ b/wdl-lint/src/rules/input_not_sorted.rs
@@ -220,6 +220,10 @@ impl Rule for InputNotSortedRule {
             SyntaxKind::InputSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["DisallowedInputName"]
+    }
 }
 
 impl Visitor for InputNotSortedRule {

--- a/wdl-lint/src/rules/input_not_sorted.rs
+++ b/wdl-lint/src/rules/input_not_sorted.rs
@@ -221,8 +221,8 @@ impl Rule for InputNotSortedRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["DisallowedInputName"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["DisallowedInputName"]
     }
 }
 

--- a/wdl-lint/src/rules/input_not_sorted.rs
+++ b/wdl-lint/src/rules/input_not_sorted.rs
@@ -220,6 +220,10 @@ impl Rule for InputNotSortedRule {
             SyntaxKind::InputSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["ImportSort", "SectionOrdering"]
+    }
 }
 
 impl Visitor for InputNotSortedRule {

--- a/wdl-lint/src/rules/input_not_sorted.rs
+++ b/wdl-lint/src/rules/input_not_sorted.rs
@@ -220,10 +220,6 @@ impl Rule for InputNotSortedRule {
             SyntaxKind::InputSectionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["DisallowedInputName"]
-    }
 }
 
 impl Visitor for InputNotSortedRule {

--- a/wdl-lint/src/rules/input_not_sorted.rs
+++ b/wdl-lint/src/rules/input_not_sorted.rs
@@ -222,7 +222,7 @@ impl Rule for InputNotSortedRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["ImportSort", "SectionOrdering"]
+        &["MatchingParameterMeta"]
     }
 }
 

--- a/wdl-lint/src/rules/key_value_pairs.rs
+++ b/wdl-lint/src/rules/key_value_pairs.rs
@@ -100,6 +100,10 @@ impl Rule for KeyValuePairsRule {
             SyntaxKind::ParameterMetadataSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for KeyValuePairsRule {

--- a/wdl-lint/src/rules/key_value_pairs.rs
+++ b/wdl-lint/src/rules/key_value_pairs.rs
@@ -101,8 +101,8 @@ impl Rule for KeyValuePairsRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["TrailingComma"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["TrailingComma"]
     }
 }
 

--- a/wdl-lint/src/rules/key_value_pairs.rs
+++ b/wdl-lint/src/rules/key_value_pairs.rs
@@ -100,10 +100,6 @@ impl Rule for KeyValuePairsRule {
             SyntaxKind::ParameterMetadataSectionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["TrailingComma"]
-    }
 }
 
 impl Visitor for KeyValuePairsRule {

--- a/wdl-lint/src/rules/key_value_pairs.rs
+++ b/wdl-lint/src/rules/key_value_pairs.rs
@@ -100,6 +100,10 @@ impl Rule for KeyValuePairsRule {
             SyntaxKind::ParameterMetadataSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["TrailingComma"]
+    }
 }
 
 impl Visitor for KeyValuePairsRule {

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -115,7 +115,7 @@ impl Rule for LineWidthRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &[]
+        &["ExpressionSpacing"]
     }
 }
 

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -113,6 +113,10 @@ impl Rule for LineWidthRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for LineWidthRule {

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -113,10 +113,6 @@ impl Rule for LineWidthRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         None
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["ExpressionSpacing"]
-    }
 }
 
 impl Visitor for LineWidthRule {

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -114,8 +114,8 @@ impl Rule for LineWidthRule {
         None
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["ExpressionSpacing"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["ExpressionSpacing"]
     }
 }
 

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -113,6 +113,10 @@ impl Rule for LineWidthRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["ExpressionSpacing"]
+    }
 }
 
 impl Visitor for LineWidthRule {

--- a/wdl-lint/src/rules/malformed_lint_directive.rs
+++ b/wdl-lint/src/rules/malformed_lint_directive.rs
@@ -98,6 +98,10 @@ impl Rule for MalformedLintDirectiveRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for MalformedLintDirectiveRule {

--- a/wdl-lint/src/rules/malformed_lint_directive.rs
+++ b/wdl-lint/src/rules/malformed_lint_directive.rs
@@ -98,10 +98,6 @@ impl Rule for MalformedLintDirectiveRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         None
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MisplacedLintDirective", "UnknownRule"]
-    }
 }
 
 impl Visitor for MalformedLintDirectiveRule {

--- a/wdl-lint/src/rules/malformed_lint_directive.rs
+++ b/wdl-lint/src/rules/malformed_lint_directive.rs
@@ -99,8 +99,8 @@ impl Rule for MalformedLintDirectiveRule {
         None
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MisplacedLintDirective", "UnknownRule"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MisplacedLintDirective", "UnknownRule"]
     }
 }
 

--- a/wdl-lint/src/rules/malformed_lint_directive.rs
+++ b/wdl-lint/src/rules/malformed_lint_directive.rs
@@ -98,6 +98,10 @@ impl Rule for MalformedLintDirectiveRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MisplacedLintDirective", "UnknownRule"]
+    }
 }
 
 impl Visitor for MalformedLintDirectiveRule {

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -106,12 +106,10 @@ impl Rule for MatchingParameterMetaRule {
     fn related_rules(&self) -> &[&'static str] {
         &[
             "DescriptionMissing",
-            "MissingMetas",
             "MissingOutput",
             "MissingRequirements",
             "MissingRuntime",
             "NonmatchingOutput",
-            "Todo",
         ]
     }
 }

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -102,6 +102,18 @@ impl Rule for MatchingParameterMetaRule {
             SyntaxKind::ParameterMetadataSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "DescriptionMissing",
+            "MissingMetas",
+            "MissingOutput",
+            "MissingRequirements",
+            "MissingRuntime",
+            "NonmatchingOutput",
+            "Todo",
+        ]
+    }
 }
 
 /// Checks for both missing and extra items in a `parameter_meta` section.

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -102,10 +102,6 @@ impl Rule for MatchingParameterMetaRule {
             SyntaxKind::ParameterMetadataSectionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MissingMetas"]
-    }
 }
 
 /// Checks for both missing and extra items in a `parameter_meta` section.

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -103,8 +103,8 @@ impl Rule for MatchingParameterMetaRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MissingMetas"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MissingMetas"]
     }
 }
 

--- a/wdl-lint/src/rules/matching_parameter_meta.rs
+++ b/wdl-lint/src/rules/matching_parameter_meta.rs
@@ -102,6 +102,10 @@ impl Rule for MatchingParameterMetaRule {
             SyntaxKind::ParameterMetadataSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MissingMetas"]
+    }
 }
 
 /// Checks for both missing and extra items in a `parameter_meta` section.

--- a/wdl-lint/src/rules/misplaced_lint_directive.rs
+++ b/wdl-lint/src/rules/misplaced_lint_directive.rs
@@ -93,6 +93,10 @@ impl Rule for MisplacedLintDirectiveRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for MisplacedLintDirectiveRule {

--- a/wdl-lint/src/rules/misplaced_lint_directive.rs
+++ b/wdl-lint/src/rules/misplaced_lint_directive.rs
@@ -93,6 +93,10 @@ impl Rule for MisplacedLintDirectiveRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MalformedLintDirective"]
+    }
 }
 
 impl Visitor for MisplacedLintDirectiveRule {

--- a/wdl-lint/src/rules/misplaced_lint_directive.rs
+++ b/wdl-lint/src/rules/misplaced_lint_directive.rs
@@ -93,10 +93,6 @@ impl Rule for MisplacedLintDirectiveRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MalformedLintDirective"]
-    }
 }
 
 impl Visitor for MisplacedLintDirectiveRule {

--- a/wdl-lint/src/rules/misplaced_lint_directive.rs
+++ b/wdl-lint/src/rules/misplaced_lint_directive.rs
@@ -94,8 +94,8 @@ impl Rule for MisplacedLintDirectiveRule {
         Some(&[SyntaxKind::VersionStatementNode])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MalformedLintDirective"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MalformedLintDirective"]
     }
 }
 

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -123,6 +123,18 @@ impl Rule for MissingMetasRule {
             SyntaxKind::StructDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "DescriptionMissing",
+            "MatchingParameterMeta",
+            "MissingOutput",
+            "MissingRequirements",
+            "MissingRuntime",
+            "NonmatchingOutput",
+            "Todo",
+        ]
+    }
 }
 
 impl Visitor for MissingMetasRule {

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -123,10 +123,6 @@ impl Rule for MissingMetasRule {
             SyntaxKind::StructDefinitionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["DescriptionMissing", "MatchingParameterMeta"]
-    }
 }
 
 impl Visitor for MissingMetasRule {

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -123,6 +123,10 @@ impl Rule for MissingMetasRule {
             SyntaxKind::StructDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["DescriptionMissing", "MatchingParameterMeta"]
+    }
 }
 
 impl Visitor for MissingMetasRule {

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -132,7 +132,6 @@ impl Rule for MissingMetasRule {
             "MissingRequirements",
             "MissingRuntime",
             "NonmatchingOutput",
-            "Todo",
         ]
     }
 }

--- a/wdl-lint/src/rules/missing_metas.rs
+++ b/wdl-lint/src/rules/missing_metas.rs
@@ -124,8 +124,8 @@ impl Rule for MissingMetasRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["DescriptionMissing", "MatchingParameterMeta"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["DescriptionMissing", "MatchingParameterMeta"]
     }
 }
 

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -86,11 +86,9 @@ impl Rule for MissingOutputRule {
         &[
             "DescriptionMissing",
             "MatchingParameterMeta",
-            "MissingMetas",
             "MissingRequirements",
             "MissingRuntime",
             "NonmatchingOutput",
-            "Todo",
         ]
     }
 }

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -81,6 +81,10 @@ impl Rule for MissingOutputRule {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["NonmatchingOutput"]
+    }
 }
 
 impl Visitor for MissingOutputRule {

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -81,10 +81,6 @@ impl Rule for MissingOutputRule {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["NonmatchingOutput"]
-    }
 }
 
 impl Visitor for MissingOutputRule {

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -82,8 +82,8 @@ impl Rule for MissingOutputRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["NonmatchingOutput"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["NonmatchingOutput"]
     }
 }
 

--- a/wdl-lint/src/rules/missing_output.rs
+++ b/wdl-lint/src/rules/missing_output.rs
@@ -81,6 +81,18 @@ impl Rule for MissingOutputRule {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "DescriptionMissing",
+            "MatchingParameterMeta",
+            "MissingMetas",
+            "MissingRequirements",
+            "MissingRuntime",
+            "NonmatchingOutput",
+            "Todo",
+        ]
+    }
 }
 
 impl Visitor for MissingOutputRule {

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -77,9 +77,7 @@ impl Rule for MissingRequirementsRule {
             "MatchingParameterMeta",
             "MissingMetas",
             "MissingOutput",
-            "MissingRuntime",
             "NonmatchingOutput",
-            "Todo",
         ]
     }
 }

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -69,6 +69,19 @@ impl Rule for MissingRequirementsRule {
             SyntaxKind::TaskDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "RuntimeSectionKeys",
+            "DescriptionMissing",
+            "MatchingParameterMeta",
+            "MissingMetas",
+            "MissingOutput",
+            "MissingRuntime",
+            "NonmatchingOutput",
+            "Todo",
+        ]
+    }
 }
 
 impl Visitor for MissingRequirementsRule {

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -69,10 +69,6 @@ impl Rule for MissingRequirementsRule {
             SyntaxKind::TaskDefinitionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MissingRuntime"]
-    }
 }
 
 impl Visitor for MissingRequirementsRule {

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -70,8 +70,8 @@ impl Rule for MissingRequirementsRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MissingRuntime"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MissingRuntime"]
     }
 }
 

--- a/wdl-lint/src/rules/missing_requirements.rs
+++ b/wdl-lint/src/rules/missing_requirements.rs
@@ -69,6 +69,10 @@ impl Rule for MissingRequirementsRule {
             SyntaxKind::TaskDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MissingRuntime"]
+    }
 }
 
 impl Visitor for MissingRequirementsRule {

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -56,6 +56,18 @@ impl Rule for MissingRuntimeRule {
             SyntaxKind::TaskDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "DescriptionMissing",
+            "MatchingParameterMeta",
+            "MissingMetas",
+            "MissingOutput",
+            "MissingRequirements",
+            "NonmatchingOutput",
+            "Todo",
+        ]
+    }
 }
 
 impl Visitor for MissingRuntimeRule {

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -57,8 +57,8 @@ impl Rule for MissingRuntimeRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MissingRequirements"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MissingRequirements"]
     }
 }
 

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -63,9 +63,7 @@ impl Rule for MissingRuntimeRule {
             "MatchingParameterMeta",
             "MissingMetas",
             "MissingOutput",
-            "MissingRequirements",
             "NonmatchingOutput",
-            "Todo",
         ]
     }
 }

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -56,10 +56,6 @@ impl Rule for MissingRuntimeRule {
             SyntaxKind::TaskDefinitionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MissingRequirements"]
-    }
 }
 
 impl Visitor for MissingRuntimeRule {

--- a/wdl-lint/src/rules/missing_runtime.rs
+++ b/wdl-lint/src/rules/missing_runtime.rs
@@ -56,6 +56,10 @@ impl Rule for MissingRuntimeRule {
             SyntaxKind::TaskDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MissingRequirements"]
+    }
 }
 
 impl Visitor for MissingRuntimeRule {

--- a/wdl-lint/src/rules/no_curly_commands.rs
+++ b/wdl-lint/src/rules/no_curly_commands.rs
@@ -60,6 +60,10 @@ impl Rule for NoCurlyCommandsRule {
             SyntaxKind::CommandSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["CommandSectionMixedIndentation"]
+    }
 }
 
 impl Visitor for NoCurlyCommandsRule {

--- a/wdl-lint/src/rules/no_curly_commands.rs
+++ b/wdl-lint/src/rules/no_curly_commands.rs
@@ -62,7 +62,7 @@ impl Rule for NoCurlyCommandsRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["CommandSectionMixedIndentation"]
+        &[]
     }
 }
 

--- a/wdl-lint/src/rules/nonmatching_output.rs
+++ b/wdl-lint/src/rules/nonmatching_output.rs
@@ -137,6 +137,10 @@ impl Rule for NonmatchingOutputRule<'_> {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MissingOutput"]
+    }
 }
 
 /// Check each output key exists in the `outputs` key within the `meta` section.

--- a/wdl-lint/src/rules/nonmatching_output.rs
+++ b/wdl-lint/src/rules/nonmatching_output.rs
@@ -138,8 +138,8 @@ impl Rule for NonmatchingOutputRule<'_> {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MissingOutput"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MissingOutput"]
     }
 }
 

--- a/wdl-lint/src/rules/nonmatching_output.rs
+++ b/wdl-lint/src/rules/nonmatching_output.rs
@@ -142,11 +142,9 @@ impl Rule for NonmatchingOutputRule<'_> {
         &[
             "DescriptionMissing",
             "MatchingParameterMeta",
-            "MissingMetas",
             "MissingOutput",
             "MissingRequirements",
             "MissingRuntime",
-            "Todo",
         ]
     }
 }

--- a/wdl-lint/src/rules/nonmatching_output.rs
+++ b/wdl-lint/src/rules/nonmatching_output.rs
@@ -137,10 +137,6 @@ impl Rule for NonmatchingOutputRule<'_> {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MissingOutput"]
-    }
 }
 
 /// Check each output key exists in the `outputs` key within the `meta` section.

--- a/wdl-lint/src/rules/nonmatching_output.rs
+++ b/wdl-lint/src/rules/nonmatching_output.rs
@@ -137,6 +137,18 @@ impl Rule for NonmatchingOutputRule<'_> {
             SyntaxKind::WorkflowDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "DescriptionMissing",
+            "MatchingParameterMeta",
+            "MissingMetas",
+            "MissingOutput",
+            "MissingRequirements",
+            "MissingRuntime",
+            "Todo",
+        ]
+    }
 }
 
 /// Check each output key exists in the `outputs` key within the `meta` section.

--- a/wdl-lint/src/rules/pascal_case.rs
+++ b/wdl-lint/src/rules/pascal_case.rs
@@ -59,6 +59,10 @@ impl Rule for PascalCaseRule {
             SyntaxKind::StructDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["SnakeCase"]
+    }
 }
 
 /// Checks if the given name is pascal case, and if not adds a warning to the

--- a/wdl-lint/src/rules/preamble_comment_after_version.rs
+++ b/wdl-lint/src/rules/preamble_comment_after_version.rs
@@ -58,6 +58,10 @@ impl Rule for PreambleCommentAfterVersionRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for PreambleCommentAfterVersionRule {

--- a/wdl-lint/src/rules/preamble_comment_after_version.rs
+++ b/wdl-lint/src/rules/preamble_comment_after_version.rs
@@ -58,6 +58,10 @@ impl Rule for PreambleCommentAfterVersionRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["PreambleFormatting"]
+    }
 }
 
 impl Visitor for PreambleCommentAfterVersionRule {

--- a/wdl-lint/src/rules/preamble_comment_after_version.rs
+++ b/wdl-lint/src/rules/preamble_comment_after_version.rs
@@ -59,8 +59,8 @@ impl Rule for PreambleCommentAfterVersionRule {
         None
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["PreambleFormatting"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["PreambleFormatting"]
     }
 }
 

--- a/wdl-lint/src/rules/preamble_comment_after_version.rs
+++ b/wdl-lint/src/rules/preamble_comment_after_version.rs
@@ -58,10 +58,6 @@ impl Rule for PreambleCommentAfterVersionRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["PreambleFormatting"]
-    }
 }
 
 impl Visitor for PreambleCommentAfterVersionRule {

--- a/wdl-lint/src/rules/preamble_comment_after_version.rs
+++ b/wdl-lint/src/rules/preamble_comment_after_version.rs
@@ -60,7 +60,7 @@ impl Rule for PreambleCommentAfterVersionRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &[]
+        &["PreambleFormatting"]
     }
 }
 

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -157,8 +157,8 @@ impl Rule for PreambleFormattingRule {
         Some(&[SyntaxKind::VersionStatementNode])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["VersionFormatting"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["VersionFormatting"]
     }
 }
 

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -156,6 +156,10 @@ impl Rule for PreambleFormattingRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for PreambleFormattingRule {

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -156,10 +156,6 @@ impl Rule for PreambleFormattingRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["VersionFormatting"]
-    }
 }
 
 impl Visitor for PreambleFormattingRule {

--- a/wdl-lint/src/rules/preamble_formatting.rs
+++ b/wdl-lint/src/rules/preamble_formatting.rs
@@ -119,7 +119,7 @@ impl Rule for PreambleFormattingRule {
         "The document preamble is defined as anything before the version declaration statement and \
          the version declaration statement itself. Only comments and whitespace are permitted \
          before the version declaration.
-         
+
          All comments in the preamble should conform to one of two special formats:
 
             1. \"lint directives\" are special comments that begin with `#@ except:` followed by a \
@@ -137,14 +137,14 @@ impl Rule for PreambleFormattingRule {
          any whitespace before the comment).  If lint directives are present, they should be the \
          absolute beginning of the document. Multiple lint directives are permitted, but they \
          should not be interleaved with preamble comments or blank lines.
-         
+
          A space should follow the double-pound-sign if there is any text within the preamble \
          comment. \"Empty\" preamble comments are permitted and should not have any whitespace \
          following the `##`. Comments beginning with 3 or more pound signs before the version \
          declaration are not permitted. All preamble comments should be in a single block without \
          blank lines. Following this block, there should always be a blank line before the version \
          statement.
-         
+
          Both lint directives and preamble comments are optional, and if they are not present, \
          there should be no comments or whitespace before the version declaration."
     }
@@ -155,6 +155,10 @@ impl Rule for PreambleFormattingRule {
 
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
+    }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["VersionFormatting"]
     }
 }
 

--- a/wdl-lint/src/rules/redundant_input_assignment.rs
+++ b/wdl-lint/src/rules/redundant_input_assignment.rs
@@ -59,6 +59,10 @@ impl Rule for RedundantInputAssignment {
             wdl_ast::SyntaxKind::CallInputItemNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for RedundantInputAssignment {

--- a/wdl-lint/src/rules/runtime_section_keys.rs
+++ b/wdl-lint/src/rules/runtime_section_keys.rs
@@ -342,10 +342,6 @@ impl Rule for RuntimeSectionKeysRule {
             SyntaxKind::RuntimeSectionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MissingRuntime", "MissingRequirements"]
-    }
 }
 
 /// A utility method to parse the recommended keys from a static set of runtime

--- a/wdl-lint/src/rules/runtime_section_keys.rs
+++ b/wdl-lint/src/rules/runtime_section_keys.rs
@@ -314,12 +314,12 @@ impl Rule for RuntimeSectionKeysRule {
 
     fn explanation(&self) -> &'static str {
         "The behavior of this rule is different depending on the WDL version:
-        
+
         For WDL v1.0 documents, the `docker` and `memory` keys are recommended, but the inclusion \
          of any number of other keys is permitted.
-        
-        For WDL v1.1 documents, 
-        
+
+        For WDL v1.1 documents,
+
         - A list of mandatory, reserved keywords will be recommended for inclusion if they are not \
          present. Here, 'mandatory' refers to the requirement that all execution engines support \
          this key—not that the key must be present in the `runtime` section.
@@ -327,7 +327,7 @@ impl Rule for RuntimeSectionKeysRule {
          missing (as their support in execution engines is not guaranteed).
         - The WDL v1.1 specification deprecates the inclusion of non-reserved keys in a  `runtime` \
          section. As such, any non-reserved keys will be flagged for removal.
-         
+
          For WDL v1.2 documents and later, this rule does not evaluate because `runtime` sections \
          were deprecated in this version."
     }
@@ -341,6 +341,10 @@ impl Rule for RuntimeSectionKeysRule {
             SyntaxKind::VersionStatementNode,
             SyntaxKind::RuntimeSectionNode,
         ])
+    }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MissingRuntime", "MissingRequirements"]
     }
 }
 

--- a/wdl-lint/src/rules/runtime_section_keys.rs
+++ b/wdl-lint/src/rules/runtime_section_keys.rs
@@ -343,8 +343,8 @@ impl Rule for RuntimeSectionKeysRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MissingRuntime", "MissingRequirements"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MissingRuntime", "MissingRequirements"]
     }
 }
 

--- a/wdl-lint/src/rules/runtime_section_keys.rs
+++ b/wdl-lint/src/rules/runtime_section_keys.rs
@@ -342,6 +342,14 @@ impl Rule for RuntimeSectionKeysRule {
             SyntaxKind::RuntimeSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "DeprecatedObject",
+            "DeprecatedPlaceholderOption",
+            "MissingRequirements",
+        ]
+    }
 }
 
 /// A utility method to parse the recommended keys from a static set of runtime

--- a/wdl-lint/src/rules/runtime_section_keys.rs
+++ b/wdl-lint/src/rules/runtime_section_keys.rs
@@ -344,11 +344,7 @@ impl Rule for RuntimeSectionKeysRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &[
-            "DeprecatedObject",
-            "DeprecatedPlaceholderOption",
-            "MissingRequirements",
-        ]
+        &["DeprecatedObject", "DeprecatedPlaceholderOption"]
     }
 }
 

--- a/wdl-lint/src/rules/section_order.rs
+++ b/wdl-lint/src/rules/section_order.rs
@@ -99,7 +99,7 @@ impl Rule for SectionOrderingRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["ImportSort", "InputSorting"]
+        &[]
     }
 }
 

--- a/wdl-lint/src/rules/section_order.rs
+++ b/wdl-lint/src/rules/section_order.rs
@@ -97,6 +97,10 @@ impl Rule for SectionOrderingRule {
             SyntaxKind::StructDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MissingMetas", "MissingOutput"]
+    }
 }
 
 /// Track the encountered sections.

--- a/wdl-lint/src/rules/section_order.rs
+++ b/wdl-lint/src/rules/section_order.rs
@@ -98,8 +98,8 @@ impl Rule for SectionOrderingRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MissingMetas", "MissingOutput"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MissingMetas", "MissingOutput"]
     }
 }
 

--- a/wdl-lint/src/rules/section_order.rs
+++ b/wdl-lint/src/rules/section_order.rs
@@ -97,6 +97,10 @@ impl Rule for SectionOrderingRule {
             SyntaxKind::StructDefinitionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["ImportSort", "InputSorting"]
+    }
 }
 
 /// Track the encountered sections.

--- a/wdl-lint/src/rules/section_order.rs
+++ b/wdl-lint/src/rules/section_order.rs
@@ -97,10 +97,6 @@ impl Rule for SectionOrderingRule {
             SyntaxKind::StructDefinitionNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MissingMetas", "MissingOutput"]
-    }
 }
 
 /// Track the encountered sections.

--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -225,6 +225,10 @@ impl Rule for ShellCheckRule {
             SyntaxKind::CommandSectionNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 /// Convert a WDL `Placeholder` to a bash variable declaration.

--- a/wdl-lint/src/rules/snake_case.rs
+++ b/wdl-lint/src/rules/snake_case.rs
@@ -147,8 +147,8 @@ impl Rule for SnakeCaseRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["DisallowedInputName", "DisallowedOutputName"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["DisallowedInputName", "DisallowedOutputName"]
     }
 }
 

--- a/wdl-lint/src/rules/snake_case.rs
+++ b/wdl-lint/src/rules/snake_case.rs
@@ -148,7 +148,7 @@ impl Rule for SnakeCaseRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &["PascalCase", "UnusedDeclaration"]
+        &["PascalCase"]
     }
 }
 

--- a/wdl-lint/src/rules/snake_case.rs
+++ b/wdl-lint/src/rules/snake_case.rs
@@ -146,10 +146,6 @@ impl Rule for SnakeCaseRule {
             SyntaxKind::UnboundDeclNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["DisallowedInputName", "DisallowedOutputName"]
-    }
 }
 
 impl Visitor for SnakeCaseRule {

--- a/wdl-lint/src/rules/snake_case.rs
+++ b/wdl-lint/src/rules/snake_case.rs
@@ -146,6 +146,10 @@ impl Rule for SnakeCaseRule {
             SyntaxKind::UnboundDeclNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &["PascalCase", "UnusedDeclaration"]
+    }
 }
 
 impl Visitor for SnakeCaseRule {

--- a/wdl-lint/src/rules/snake_case.rs
+++ b/wdl-lint/src/rules/snake_case.rs
@@ -146,6 +146,10 @@ impl Rule for SnakeCaseRule {
             SyntaxKind::UnboundDeclNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["DisallowedInputName", "DisallowedOutputName"]
+    }
 }
 
 impl Visitor for SnakeCaseRule {

--- a/wdl-lint/src/rules/todo.rs
+++ b/wdl-lint/src/rules/todo.rs
@@ -60,15 +60,7 @@ impl Rule for TodoRule {
     }
 
     fn related_rules(&self) -> &[&'static str] {
-        &[
-            "DescriptionMissing",
-            "MatchingParameterMeta",
-            "MissingMetas",
-            "MissingOutput",
-            "MissingRequirements",
-            "MissingRuntime",
-            "NonmatchingOutput",
-        ]
+        &[]
     }
 }
 

--- a/wdl-lint/src/rules/todo.rs
+++ b/wdl-lint/src/rules/todo.rs
@@ -58,6 +58,18 @@ impl Rule for TodoRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[
+            "DescriptionMissing",
+            "MatchingParameterMeta",
+            "MissingMetas",
+            "MissingOutput",
+            "MissingRequirements",
+            "MissingRuntime",
+            "NonmatchingOutput",
+        ]
+    }
 }
 
 impl Visitor for TodoRule {

--- a/wdl-lint/src/rules/trailing_comma.rs
+++ b/wdl-lint/src/rules/trailing_comma.rs
@@ -79,6 +79,10 @@ impl Rule for TrailingCommaRule {
             SyntaxKind::LiteralObjectNode,
         ])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for TrailingCommaRule {

--- a/wdl-lint/src/rules/trailing_comma.rs
+++ b/wdl-lint/src/rules/trailing_comma.rs
@@ -79,10 +79,6 @@ impl Rule for TrailingCommaRule {
             SyntaxKind::LiteralObjectNode,
         ])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["KeyValuePairs", "CallInputSpacing"]
-    }
 }
 
 impl Visitor for TrailingCommaRule {

--- a/wdl-lint/src/rules/trailing_comma.rs
+++ b/wdl-lint/src/rules/trailing_comma.rs
@@ -80,8 +80,8 @@ impl Rule for TrailingCommaRule {
         ])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["KeyValuePairs", "CallInputSpacing"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["KeyValuePairs", "CallInputSpacing"]
     }
 }
 

--- a/wdl-lint/src/rules/trailing_comma.rs
+++ b/wdl-lint/src/rules/trailing_comma.rs
@@ -79,6 +79,10 @@ impl Rule for TrailingCommaRule {
             SyntaxKind::LiteralObjectNode,
         ])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["KeyValuePairs", "CallInputSpacing"]
+    }
 }
 
 impl Visitor for TrailingCommaRule {

--- a/wdl-lint/src/rules/unknown_rule.rs
+++ b/wdl-lint/src/rules/unknown_rule.rs
@@ -65,6 +65,10 @@ impl Rule for UnknownRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for UnknownRule {

--- a/wdl-lint/src/rules/unknown_rule.rs
+++ b/wdl-lint/src/rules/unknown_rule.rs
@@ -65,10 +65,6 @@ impl Rule for UnknownRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["MalformedLintDirective"]
-    }
 }
 
 impl Visitor for UnknownRule {

--- a/wdl-lint/src/rules/unknown_rule.rs
+++ b/wdl-lint/src/rules/unknown_rule.rs
@@ -65,6 +65,10 @@ impl Rule for UnknownRule {
     fn exceptable_nodes(&self) -> Option<&'static [wdl_ast::SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["MalformedLintDirective"]
+    }
 }
 
 impl Visitor for UnknownRule {

--- a/wdl-lint/src/rules/unknown_rule.rs
+++ b/wdl-lint/src/rules/unknown_rule.rs
@@ -66,8 +66,8 @@ impl Rule for UnknownRule {
         Some(&[SyntaxKind::VersionStatementNode])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["MalformedLintDirective"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["MalformedLintDirective"]
     }
 }
 

--- a/wdl-lint/src/rules/version_formatting.rs
+++ b/wdl-lint/src/rules/version_formatting.rs
@@ -94,6 +94,10 @@ impl Rule for VersionFormattingRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for VersionFormattingRule {

--- a/wdl-lint/src/rules/version_formatting.rs
+++ b/wdl-lint/src/rules/version_formatting.rs
@@ -94,10 +94,6 @@ impl Rule for VersionFormattingRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &["PreambleFormatting"]
-    }
 }
 
 impl Visitor for VersionFormattingRule {

--- a/wdl-lint/src/rules/version_formatting.rs
+++ b/wdl-lint/src/rules/version_formatting.rs
@@ -95,8 +95,8 @@ impl Rule for VersionFormattingRule {
         Some(&[SyntaxKind::VersionStatementNode])
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec!["PreambleFormatting"]
+    fn related_rules(&self) -> &[&'static str] {
+        &["PreambleFormatting"]
     }
 }
 

--- a/wdl-lint/src/rules/version_formatting.rs
+++ b/wdl-lint/src/rules/version_formatting.rs
@@ -94,6 +94,10 @@ impl Rule for VersionFormattingRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         Some(&[SyntaxKind::VersionStatementNode])
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec!["PreambleFormatting"]
+    }
 }
 
 impl Visitor for VersionFormattingRule {

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -76,6 +76,10 @@ impl Rule for WhitespaceRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> &[&'static str] {
+        &[]
+    }
 }
 
 impl Visitor for WhitespaceRule {

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -77,8 +77,8 @@ impl Rule for WhitespaceRule {
         None
     }
 
-    fn related_rules(&self) -> Vec<&'static str> {
-        vec![
+    fn related_rules(&self) -> &[&'static str] {
+        &[
             "BlankLinesBetweenElements",
             "EndingNewline",
             "CommentWhitespace",

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -76,14 +76,6 @@ impl Rule for WhitespaceRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
-
-    fn related_rules(&self) -> &[&'static str] {
-        &[
-            "BlankLinesBetweenElements",
-            "EndingNewline",
-            "CommentWhitespace",
-        ]
-    }
 }
 
 impl Visitor for WhitespaceRule {

--- a/wdl-lint/src/rules/whitespace.rs
+++ b/wdl-lint/src/rules/whitespace.rs
@@ -76,6 +76,14 @@ impl Rule for WhitespaceRule {
     fn exceptable_nodes(&self) -> Option<&'static [SyntaxKind]> {
         None
     }
+
+    fn related_rules(&self) -> Vec<&'static str> {
+        vec![
+            "BlankLinesBetweenElements",
+            "EndingNewline",
+            "CommentWhitespace",
+        ]
+    }
 }
 
 impl Visitor for WhitespaceRule {

--- a/wdl-lint/tests/lints/section-ordering/source.errors
+++ b/wdl-lint/tests/lints/section-ordering/source.errors
@@ -40,7 +40,7 @@ note[SectionOrdering]: sections are not in order for struct `Corge`
 49 │     meta {}
    │     ---- this section is out of order
    │
-   = fix: order as `meta`, `parameter_meta`, `members`
+   = fix: order as `meta`, `parameter_meta`, members
 
 note[SectionOrdering]: sections are not in order for struct `Grault`
    ┌─ tests/lints/section-ordering/source.wdl:53:8
@@ -51,5 +51,5 @@ note[SectionOrdering]: sections are not in order for struct `Grault`
 55 │     meta {}
    │     ---- this section is out of order
    │
-   = fix: order as `meta`, `parameter_meta`, `members`
+   = fix: order as `meta`, `parameter_meta`, members
 


### PR DESCRIPTION
This pull request adds support for linking related lint rules, which would allow `sprocket explain` to provide better guidance to users.

This change adds a `related_rules`  to the `Rule` trait.

- added debug assertions to validate related rule IDs during development builds.
- I've tried to add rules which seem related as a first pass


Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.


[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
