### PR TITLE
feat: Tags now implement TryFrom

### DIFF
--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `DisallowedDeclarationName` rule ([#343](https://github.com/stjude-rust-labs/wdl/pull/343)).
 * Added `DEFINITIONS.md` file with centralized documentation for WDL concepts ([#195](https://github.com/stjude-rust-labs/wdl/pull/195)).
 * Added `Rule::related_rules()` for linking related lint rules ([#371](https://github.com/stjude-rust-labs/wdl/pull/371)).
+* Added `TryFrom` for Tags to convert stings to Tag enums ([#374](https://github.com/stjude-rust-labs/wdl/pull/374)).
 
 ### Changed
 

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `DisallowedDeclarationName` rule ([#343](https://github.com/stjude-rust-labs/wdl/pull/343)).
 * Added `DEFINITIONS.md` file with centralized documentation for WDL concepts ([#195](https://github.com/stjude-rust-labs/wdl/pull/195)).
 * Added `Rule::related_rules()` for linking related lint rules ([#371](https://github.com/stjude-rust-labs/wdl/pull/371)).
-* Added `TryFrom` for Tags to convert stings to Tag enums ([#374](https://github.com/stjude-rust-labs/wdl/pull/374)).
+* Added `TryFrom` for Tags to convert strings to Tag enums ([#374](https://github.com/stjude-rust-labs/wdl/pull/374)).
 
 ### Changed
 

--- a/wdl-lint/src/tags.rs
+++ b/wdl-lint/src/tags.rs
@@ -48,16 +48,16 @@ impl std::convert::TryFrom<&str> for Tag {
     type Error = UnknownTagError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value.to_lowercase().as_str() {
-            "completeness" => Ok(Self::Completeness),
-            "naming" => Ok(Self::Naming),
-            "spacing" => Ok(Self::Spacing),
-            "style" => Ok(Self::Style),
-            "clarity" => Ok(Self::Clarity),
-            "portability" => Ok(Self::Portability),
-            "correctness" => Ok(Self::Correctness),
-            "sorting" => Ok(Self::Sorting),
-            "deprecated" => Ok(Self::Deprecated),
+        match value {
+            s if s.eq_ignore_ascii_case("completeness") => Ok(Self::Completeness),
+            s if s.eq_ignore_ascii_case("naming") => Ok(Self::Naming),
+            s if s.eq_ignore_ascii_case("spacing") => Ok(Self::Spacing),
+            s if s.eq_ignore_ascii_case("style") => Ok(Self::Style),
+            s if s.eq_ignore_ascii_case("clarity") => Ok(Self::Clarity),
+            s if s.eq_ignore_ascii_case("portability") => Ok(Self::Portability),
+            s if s.eq_ignore_ascii_case("correctness") => Ok(Self::Correctness),
+            s if s.eq_ignore_ascii_case("sorting") => Ok(Self::Sorting),
+            s if s.eq_ignore_ascii_case("deprecated") => Ok(Self::Deprecated),
             _ => Err(UnknownTagError(value.to_string())),
         }
     }

--- a/wdl-lint/src/tags.rs
+++ b/wdl-lint/src/tags.rs
@@ -32,6 +32,37 @@ pub enum Tag {
     Deprecated,
 }
 
+/// An error for when an unknown tag is encountered.
+#[derive(Debug)]
+pub struct UnknownTagError(String);
+
+impl std::fmt::Display for UnknownTagError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown tag: {}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownTagError {}
+
+impl std::convert::TryFrom<&str> for Tag {
+    type Error = UnknownTagError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "completeness" => Ok(Self::Completeness),
+            "naming" => Ok(Self::Naming),
+            "spacing" => Ok(Self::Spacing),
+            "style" => Ok(Self::Style),
+            "clarity" => Ok(Self::Clarity),
+            "portability" => Ok(Self::Portability),
+            "correctness" => Ok(Self::Correctness),
+            "sorting" => Ok(Self::Sorting),
+            "deprecated" => Ok(Self::Deprecated),
+            _ => Err(UnknownTagError(value.to_string())),
+        }
+    }
+}
+
 impl std::fmt::Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
Tags now implement `TryFrom`, this will be used in `sprocket explain` for parsing tags through cli

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.


[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
