### PR TITLE
feat: localization of remote files.

### DIFF
--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -341,6 +341,11 @@ impl Task {
         &self.name
     }
 
+    /// Gets the span of the name.
+    pub fn name_span(&self) -> Span {
+        self.name_span
+    }
+
     /// Gets the scope of the task.
     pub fn scope(&self) -> ScopeRef<'_> {
         ScopeRef::new(&self.scopes, ScopeIndex(0))
@@ -384,6 +389,11 @@ impl Workflow {
     /// Gets the name of the workflow.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Gets the span of the name.
+    pub fn name_span(&self) -> Span {
+        self.name_span
     }
 
     /// Gets the scope of the workflow.

--- a/wdl-analysis/tests/analysis.rs
+++ b/wdl-analysis/tests/analysis.rs
@@ -99,7 +99,12 @@ fn compare_result(path: &Path, result: &str, is_error: bool) -> Result<()> {
     }
 
     let expected = fs::read_to_string(path)
-        .with_context(|| format!("failed to read result file `{path}`", path = path.display()))?
+        .with_context(|| {
+            format!(
+                "failed to read result file `{path}`: expected contents to be `{result}`",
+                path = path.display()
+            )
+        })?
         .replace("\r\n", "\n");
 
     if expected != result {

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Implemented remote file localization for task execution (#[386](https://github.com/stjude-rust-labs/wdl/pull/386)).
+
 ## 0.2.0 - 04-01-2025
 
 #### Added

--- a/wdl-engine/src/backend/crankshaft.rs
+++ b/wdl-engine/src/backend/crankshaft.rs
@@ -20,6 +20,8 @@ use crankshaft::engine::task::Input;
 use crankshaft::engine::task::Resources;
 use crankshaft::engine::task::input::Contents;
 use crankshaft::engine::task::input::Type;
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use nonempty::NonEmpty;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
@@ -27,15 +29,23 @@ use tracing::info;
 
 use super::TaskExecutionBackend;
 use super::TaskExecutionConstraints;
+use super::TaskExecutionEvents;
+use super::TaskExecutionResult;
 use super::TaskManager;
 use super::TaskManagerRequest;
 use super::TaskSpawnRequest;
+use crate::InputAccess;
+use crate::InputTrie;
 use crate::ONE_GIBIBYTE;
 use crate::Value;
+use crate::WORK_DIR_NAME;
 use crate::config::CrankshaftBackendConfig;
 use crate::config::CrankshaftBackendKind;
 use crate::config::DEFAULT_TASK_SHELL;
 use crate::config::TaskConfig;
+use crate::http::Downloader;
+use crate::http::Location;
+use crate::path::EvaluationPath;
 use crate::v1::container;
 use crate::v1::cpu;
 use crate::v1::max_cpu;
@@ -47,6 +57,15 @@ use crate::v1::memory;
 /// This controls the initial size of the bloom filter and how many names are
 /// prepopulated into the name generator.
 const INITIAL_EXPECTED_NAMES: usize = 1000;
+
+/// The root guest path for inputs.
+const GUEST_INPUTS_DIR: &str = "/mnt/inputs";
+
+/// The guest working directory.
+const GUEST_WORK_DIR: &str = "/mnt/work";
+
+/// The guest path for the command file.
+const GUEST_COMMAND_PATH: &str = "/mnt/command";
 
 /// Represents a crankshaft task request.
 ///
@@ -85,10 +104,11 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
         self.memory
     }
 
-    async fn run(self, spawned: oneshot::Sender<()>) -> Result<i32> {
+    async fn run(self, spawned: oneshot::Sender<()>) -> Result<TaskExecutionResult> {
         // Create the working directory
-        let work_dir = self.inner.root.work_dir();
-        fs::create_dir_all(work_dir).with_context(|| {
+        // TODO: this should only be done for local task execution
+        let work_dir = self.inner.root.attempt_dir().join(WORK_DIR_NAME);
+        fs::create_dir_all(&work_dir).with_context(|| {
             format!(
                 "failed to create directory `{path}`",
                 path = work_dir.display()
@@ -96,39 +116,71 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
         })?;
 
         // Write the evaluated command to disk
+        // This is done even for remote execution so that a copy exists locally
         let command_path = self.inner.root.command();
-        fs::write(command_path, &self.inner.command).with_context(|| {
+        fs::write(command_path, self.inner.command()).with_context(|| {
             format!(
                 "failed to write command contents to `{path}`",
                 path = command_path.display()
             )
         })?;
 
-        let inputs = self
-            .inner
-            .mounts
-            .iter()
-            .filter(|m| m.host.exists())
-            .map(|m| {
-                Ok(Arc::new(
+        let mut inputs = Vec::with_capacity(self.inner.inputs().len() + 2);
+        for input in self.inner.inputs().iter() {
+            if let Some(guest_path) = input.guest_path() {
+                let is_dir =
+                    input
+                        .location()
+                        .map(|l| l.is_dir())
+                        .unwrap_or_else(|| match input.path() {
+                            EvaluationPath::Local(path) => path.is_dir(),
+                            EvaluationPath::Remote(url) => url.as_str().ends_with('/'),
+                        });
+
+                inputs.push(Arc::new(
                     Input::builder()
-                        .path(
-                            m.guest
-                                .as_os_str()
-                                .to_str()
-                                .context("task input path is not UTF-8")?,
+                        .path(guest_path)
+                        .contents(
+                            input
+                                .location()
+                                .map(|l| Contents::Path(l.to_path_buf()))
+                                .unwrap_or_else(|| match input.path() {
+                                    EvaluationPath::Local(path) => Contents::Path(path.clone()),
+                                    EvaluationPath::Remote(url) => Contents::Url(url.clone()),
+                                }),
                         )
-                        .contents(Contents::Path(m.host.clone()))
-                        .ty(if m.host.is_dir() {
-                            Type::Directory
-                        } else {
-                            Type::File
+                        .ty(if is_dir { Type::Directory } else { Type::File })
+                        .read_only(match input.access() {
+                            InputAccess::ReadOnly => true,
+                            InputAccess::ReadWrite => false,
                         })
-                        .read_only(m.read_only)
                         .build(),
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
+                ));
+            }
+        }
+
+        // Add an input for the work directory
+        // TODO: we should not do this for remote backends
+        inputs.push(Arc::new(
+            Input::builder()
+                .path(GUEST_WORK_DIR)
+                .contents(Contents::Path(work_dir.to_path_buf()))
+                .ty(Type::Directory)
+                .read_only(false)
+                .build(),
+        ));
+
+        // Add an input for the command
+        inputs.push(Arc::new(
+            Input::builder()
+                .path(GUEST_COMMAND_PATH)
+                .contents(Contents::Path(command_path.to_path_buf()))
+                .ty(Type::File)
+                .read_only(true)
+                .build(),
+        ));
+
+        // TODO: for remote backends, add an output for the working directory
 
         let task = Task::builder()
             .name(self.name)
@@ -141,27 +193,9 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
                             .map(|s| s.as_str())
                             .unwrap_or(DEFAULT_TASK_SHELL),
                     )
-                    .args([
-                        "-C".to_string(),
-                        self.inner
-                            .mounts
-                            .guest(command_path)
-                            .expect("should have guest path")
-                            .as_os_str()
-                            .to_str()
-                            .context("command path is not UTF-8")?
-                            .to_string(),
-                    ])
-                    .work_dir(
-                        self.inner
-                            .mounts
-                            .guest(work_dir)
-                            .expect("should have guest path")
-                            .as_os_str()
-                            .to_str()
-                            .context("working directory path is not UTF-8")?,
-                    )
-                    .env(self.inner.env.as_ref().clone())
+                    .args(["-C".to_string(), GUEST_COMMAND_PATH.to_string()])
+                    .work_dir(GUEST_WORK_DIR)
+                    .env(self.inner.env().clone())
                     .build(),
             ))
             .inputs(inputs)
@@ -199,7 +233,12 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
                 path = self.inner.root.stderr().display()
             )
         })?;
-        Ok(output.status.code().expect("should have exit code"))
+
+        Ok(TaskExecutionResult {
+            exit_code: output.status.code().expect("should have exit code"),
+            // TODO: fix this for remote execution
+            work_dir: EvaluationPath::Local(work_dir),
+        })
     }
 }
 
@@ -318,23 +357,68 @@ impl TaskExecutionBackend for CrankshaftBackend {
         })
     }
 
-    fn container_root_dir(&self) -> Option<&Path> {
-        Some(Path::new("/mnt/task"))
+    fn guest_work_dir(&self) -> Option<&Path> {
+        Some(Path::new(GUEST_WORK_DIR))
+    }
+
+    fn localize_inputs<'a, 'b, 'c, 'd>(
+        &'a self,
+        downloader: &'b dyn Downloader,
+        inputs: &'c mut [crate::eval::Input],
+    ) -> BoxFuture<'d, Result<()>>
+    where
+        'a: 'd,
+        'b: 'd,
+        'c: 'd,
+        Self: 'd,
+    {
+        async {
+            // Construct a trie for mapping input guest paths
+            let mut trie = InputTrie::default();
+            for input in inputs.iter() {
+                trie.insert(input)?;
+            }
+
+            for (index, guest_path) in trie.calculate_guest_paths(GUEST_INPUTS_DIR)? {
+                inputs[index].set_guest_path(guest_path);
+            }
+
+            // Localize all inputs
+            // TODO: only do this for local task execution
+            for input in inputs {
+                // TODO: parallelize the downloads
+                let location = match input.path() {
+                    EvaluationPath::Local(path) => Location::Path(path.into()),
+                    EvaluationPath::Remote(url) => downloader
+                        .download(url)
+                        .await
+                        .map_err(|e| anyhow!("failed to localize `{url}`: {e:?}"))?,
+                };
+
+                input.set_location(location.into_owned());
+            }
+
+            Ok(())
+        }
+        .boxed()
     }
 
     fn spawn(
         &self,
         request: TaskSpawnRequest,
         token: CancellationToken,
-    ) -> Result<(oneshot::Receiver<()>, oneshot::Receiver<Result<i32>>)> {
+    ) -> Result<TaskExecutionEvents> {
         let (spawned_tx, spawned_rx) = oneshot::channel();
         let (completed_tx, completed_rx) = oneshot::channel();
 
-        let container = container(&request.requirements, self.container.as_deref()).into_owned();
-        let cpu = cpu(&request.requirements);
-        let memory = memory(&request.requirements)? as u64;
-        let max_cpu = max_cpu(&request.hints);
-        let max_memory = max_memory(&request.hints)?.map(|i| i as u64);
+        let requirements = request.requirements();
+        let hints = request.hints();
+
+        let container = container(requirements, self.container.as_deref()).into_owned();
+        let cpu = cpu(requirements);
+        let memory = memory(requirements)? as u64;
+        let max_cpu = max_cpu(hints);
+        let max_memory = max_memory(hints)?.map(|i| i as u64);
 
         let name = format!(
             "{id}-{generated}",
@@ -363,6 +447,9 @@ impl TaskExecutionBackend for CrankshaftBackend {
             completed_tx,
         );
 
-        Ok((spawned_rx, completed_rx))
+        Ok(TaskExecutionEvents {
+            spawned: spawned_rx,
+            completed: completed_rx,
+        })
     }
 }

--- a/wdl-engine/src/backend/crankshaft.rs
+++ b/wdl-engine/src/backend/crankshaft.rs
@@ -34,7 +34,6 @@ use super::TaskExecutionResult;
 use super::TaskManager;
 use super::TaskManagerRequest;
 use super::TaskSpawnRequest;
-use crate::InputAccess;
 use crate::InputTrie;
 use crate::ONE_GIBIBYTE;
 use crate::Value;
@@ -125,6 +124,8 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
             )
         })?;
 
+        // Allocate the inputs, which will always be, at most, the number of inputs plus
+        // the working directory and command
         let mut inputs = Vec::with_capacity(self.inner.inputs().len() + 2);
         for input in self.inner.inputs().iter() {
             if let Some(guest_path) = input.guest_path() {
@@ -157,10 +158,7 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
                                     }),
                             )
                             .ty(if is_dir { Type::Directory } else { Type::File })
-                            .read_only(match input.access() {
-                                InputAccess::ReadOnly => true,
-                                InputAccess::ReadWrite => false,
-                            })
+                            .read_only(true)
                             .build(),
                     ));
                 }

--- a/wdl-engine/src/diagnostics.rs
+++ b/wdl-engine/src/diagnostics.rs
@@ -181,3 +181,10 @@ pub fn output_evaluation_failed(
 
     Diagnostic::error(format!("{e:#}")).with_highlight(span)
 }
+
+/// Creates a "task localization failed" diagnostic.
+pub fn task_localization_failed(e: anyhow::Error, name: &str, span: Span) -> Diagnostic {
+    let e = e.context(format!("failed to localize inputs for task `{name}`"));
+
+    Diagnostic::error(format!("{e:#}")).with_highlight(span)
+}

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -3,11 +3,11 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::ffi::OsStr;
+use std::fmt;
 use std::path::Component;
 use std::path::MAIN_SEPARATOR;
 use std::path::Path;
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -24,9 +24,12 @@ use wdl_ast::v1::TASK_REQUIREMENT_RETURN_CODES_ALIAS;
 use crate::CompoundValue;
 use crate::Outputs;
 use crate::PrimitiveValue;
+use crate::TaskExecutionResult;
 use crate::TaskExecutionRoot;
 use crate::Value;
 use crate::http::Downloader;
+use crate::http::Location;
+use crate::path::EvaluationPath;
 
 pub mod v1;
 
@@ -66,7 +69,9 @@ pub trait EvaluationContext: Send + Sync {
     fn resolve_type_name(&self, name: &str, span: Span) -> Result<Type, Diagnostic>;
 
     /// Gets the working directory for the evaluation.
-    fn work_dir(&self) -> &Path;
+    ///
+    /// Returns `None` if the task execution hasn't occurred yet.
+    fn work_dir(&self) -> Option<&EvaluationPath>;
 
     /// Gets the temp directory for the evaluation.
     fn temp_dir(&self) -> &Path;
@@ -89,7 +94,7 @@ pub trait EvaluationContext: Send + Sync {
     /// Translates a host path to a guest path.
     ///
     /// Returns `None` if no translation is available.
-    fn translate_path(&self, path: &Path) -> Option<Cow<'_, Path>>;
+    fn translate_path(&self, path: &str) -> Option<Cow<'_, Path>>;
 
     /// Gets the downloader to use for evaluating expressions.
     fn downloader(&self) -> &dyn Downloader;
@@ -210,16 +215,20 @@ impl<'a> ScopeRef<'a> {
 
     /// Iterates over each name and value visible to the scope and calls the
     /// provided callback.
-    pub fn for_each(&self, mut cb: impl FnMut(&str, &Value)) {
+    ///
+    /// Stops iterating and returns an error if the callback returns an error.
+    pub fn for_each(&self, mut cb: impl FnMut(&str, &Value) -> Result<()>) -> Result<()> {
         let mut current = Some(self.index);
 
         while let Some(index) = current {
             for (n, v) in self.scopes[index.0].local() {
-                cb(n, v);
+                cb(n, v)?;
             }
 
             current = self.scopes[index.0].parent;
         }
+
+        Ok(())
     }
 
     /// Gets the value of a name local to this scope.
@@ -250,12 +259,12 @@ impl<'a> ScopeRef<'a> {
 /// Represents an evaluated task.
 #[derive(Debug)]
 pub struct EvaluatedTask {
-    /// The evaluated task's status code.
-    status_code: i32,
+    /// The evaluated task's exit code.
+    exit_code: i32,
+    /// The task execution root.
+    root: Arc<TaskExecutionRoot>,
     /// The working directory of the executed task.
-    work_dir: PathBuf,
-    /// The command file of the executed task.
-    command: PathBuf,
+    work_dir: EvaluationPath,
     /// The value to return from the `stdout` function.
     stdout: Value,
     /// The value to return from the `stderr` function.
@@ -274,7 +283,7 @@ impl EvaluatedTask {
     /// Constructs a new evaluated task.
     ///
     /// Returns an error if the stdout or stderr paths are not UTF-8.
-    fn new(root: &TaskExecutionRoot, status_code: i32) -> anyhow::Result<Self> {
+    fn new(root: Arc<TaskExecutionRoot>, result: TaskExecutionResult) -> anyhow::Result<Self> {
         let stdout = PrimitiveValue::new_file(root.stdout().to_str().with_context(|| {
             format!(
                 "path to stdout file `{path}` is not UTF-8",
@@ -291,28 +300,28 @@ impl EvaluatedTask {
         .into();
 
         Ok(Self {
-            status_code,
-            work_dir: root.work_dir().into(),
-            command: root.command().into(),
+            exit_code: result.exit_code,
+            root,
+            work_dir: result.work_dir,
             stdout,
             stderr,
             outputs: Ok(Default::default()),
         })
     }
 
-    /// Gets the status code of the evaluated task.
-    pub fn status_code(&self) -> i32 {
-        self.status_code
+    /// Gets the exit code of the evaluated task.
+    pub fn exit_code(&self) -> i32 {
+        self.exit_code
+    }
+
+    /// Gets the task execution root for the evaluated task.
+    pub fn root(&self) -> &TaskExecutionRoot {
+        &self.root
     }
 
     /// Gets the working directory of the evaluated task.
-    pub fn work_dir(&self) -> &Path {
+    pub fn work_dir(&self) -> &EvaluationPath {
         &self.work_dir
-    }
-
-    /// Gets the command file of the evaluated task.
-    pub fn command(&self) -> &Path {
-        &self.command
     }
 
     /// Gets the stdout value of the evaluated task.
@@ -365,21 +374,21 @@ impl EvaluatedTask {
                     );
                 }
                 Value::Primitive(PrimitiveValue::Integer(ok)) => {
-                    if self.status_code == i32::try_from(*ok).unwrap_or_default() {
+                    if self.exit_code == i32::try_from(*ok).unwrap_or_default() {
                         error = false;
                     }
                 }
                 Value::Compound(CompoundValue::Array(codes)) => {
                     error = !codes.as_slice().iter().any(|v| {
                         v.as_integer()
-                            .map(|i| i32::try_from(i).unwrap_or_default() == self.status_code)
+                            .map(|i| i32::try_from(i).unwrap_or_default() == self.exit_code)
                             .unwrap_or(false)
                     });
                 }
                 _ => unreachable!("unexpected return codes value"),
             }
         } else {
-            error = self.status_code != 0;
+            error = self.exit_code != 0;
         }
 
         if error {
@@ -387,7 +396,7 @@ impl EvaluatedTask {
                 "task process has terminated with status code {code}; see the `stdout` and \
                  `stderr` files in execution directory `{dir}{MAIN_SEPARATOR}` for task command \
                  output",
-                code = self.status_code,
+                code = self.exit_code,
                 dir = Path::new(self.stderr.as_file().unwrap().as_str())
                     .parent()
                     .expect("parent should exist")
@@ -399,279 +408,295 @@ impl EvaluatedTask {
     }
 }
 
-/// Represents a mount of a file or directory for backends that use containers.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Mount {
-    /// The host path for the mount.
-    pub host: PathBuf,
-    /// The guest path for the mount.
-    pub guest: PathBuf,
-    /// Whether or not the mount should be read-only.
-    pub read_only: bool,
+/// Represents the access for an input.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum InputAccess {
+    /// The input will be read-only.
+    ReadOnly,
+    /// The input will be read-write.
+    ReadWrite,
 }
 
-impl Mount {
-    /// Creates a new mount with the given host and guest paths.
-    pub fn new(host: impl Into<PathBuf>, guest: impl Into<PathBuf>, read_only: bool) -> Self {
+impl fmt::Display for InputAccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadOnly => write!(f, "read-only"),
+            Self::ReadWrite => write!(f, "read-write"),
+        }
+    }
+}
+
+/// Represents a `File` or `Directory` input to a task.
+#[derive(Debug, Clone)]
+pub struct Input {
+    /// The path for the input.
+    path: EvaluationPath,
+    /// The download location for the input.
+    ///
+    /// This is `Some` if the input has been downloaded to a known location.
+    location: Option<Location<'static>>,
+    /// The guest path for the input.
+    guest_path: Option<String>,
+    /// The access for the input.
+    access: InputAccess,
+}
+
+impl Input {
+    /// Creates a new input with the given path and access.
+    pub fn new(path: EvaluationPath, access: InputAccess) -> Self {
         Self {
-            host: host.into(),
-            guest: guest.into(),
-            read_only,
+            path,
+            location: None,
+            guest_path: None,
+            access,
         }
+    }
+
+    /// Gets the path to the input.
+    pub fn path(&self) -> &EvaluationPath {
+        &self.path
+    }
+
+    /// Gets the location of the input if it has been downloaded.
+    pub fn location(&self) -> Option<&Path> {
+        self.location.as_deref()
+    }
+
+    /// Sets the location of the input.
+    pub fn set_location(&mut self, location: Location<'static>) {
+        self.location = Some(location);
+    }
+
+    /// Gets the guest path for the input.
+    pub fn guest_path(&self) -> Option<&str> {
+        self.guest_path.as_deref()
+    }
+
+    /// Sets the guest path for the input.
+    pub fn set_guest_path(&mut self, path: impl Into<String>) {
+        self.guest_path = Some(path.into());
+    }
+
+    /// Gets the access for the input.
+    pub fn access(&self) -> InputAccess {
+        self.access
     }
 }
 
-/// Represents a collection of mounts for mapping host and guest paths for task
-/// execution backends that use containers.
-#[derive(Debug, Default)]
-pub struct Mounts(Vec<Mount>);
-
-impl Mounts {
-    /// Gets the guest path for the given host path.
-    ///
-    /// Returns `None` if there is no guest path mapped for the given path.
-    pub fn guest(&self, host: impl AsRef<Path>) -> Option<Cow<'_, Path>> {
-        let host = host.as_ref();
-
-        for mp in &self.0 {
-            if let Ok(stripped) = host.strip_prefix(&mp.host) {
-                if stripped.as_os_str().is_empty() {
-                    return Some(mp.guest.as_path().into());
-                }
-
-                return Some(Path::new(&mp.guest).join(stripped).into());
-            }
-        }
-
-        None
-    }
-
-    /// Gets the host path for the given guest path.
-    ///
-    /// Returns `None` if there is no host path mapped for the given path.
-    pub fn host(&self, guest: impl AsRef<Path>) -> Option<Cow<'_, Path>> {
-        let guest = guest.as_ref();
-
-        for mp in &self.0 {
-            if let Ok(stripped) = guest.strip_prefix(&mp.guest) {
-                if stripped.as_os_str().is_empty() {
-                    return Some(mp.host.as_path().into());
-                }
-
-                return Some(Path::new(&mp.host).join(stripped).into());
-            }
-        }
-
-        None
-    }
-
-    /// Returns an iterator of mounts within the collection.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &Mount> {
-        self.0.iter()
-    }
-
-    /// Returns the number of mounts in the collection.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if the collection is empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Inserts a mount into the collection.
-    pub fn insert(&mut self, mp: impl Into<Mount>) {
-        self.0.push(mp.into());
-    }
-}
-
-/// Represents a node in a path trie.
+/// Represents a node in an input trie.
 #[derive(Debug)]
-struct PathTrieNode<'a> {
-    /// The path component represented by this node.
-    component: Component<'a>,
+struct InputTrieNode<'a> {
     /// The children of this node.
     ///
     /// A `BTreeMap` is used here to get a consistent walk of the tree.
-    children: BTreeMap<&'a OsStr, Self>,
+    children: BTreeMap<&'a str, Self>,
     /// The identifier of the node in the trie.
     ///
     /// A node's identifier is used when formatting guest paths of children.
     id: usize,
-    /// Whether or not the node is terminal.
+    /// The input represented by this node.
     ///
-    /// A value of `true` indicates that the path was explicitly inserted into
-    /// the trie.
-    terminal: bool,
-    /// Whether or not a mount at a terminal path is considered read-only.
-    read_only: bool,
+    /// This is `Some` only for terminal nodes in the trie.
+    ///
+    /// The first element in the tuple is the index of the input.
+    input: Option<(usize, &'a Input)>,
 }
 
-impl<'a> PathTrieNode<'a> {
-    /// Constructs a new path trie node with the given normal path component.
-    fn new(component: Component<'a>, id: usize) -> Self {
+impl InputTrieNode<'_> {
+    /// Constructs a new input trie node with the given component.
+    fn new(id: usize) -> Self {
         Self {
-            component,
             children: Default::default(),
             id,
-            terminal: false,
-            read_only: false,
+            input: None,
         }
     }
 
-    /// Inserts any mounts for the node.
-    fn insert_mounts(
+    /// Calculates the guest path for all terminal nodes in the trie.
+    fn calculate_guest_paths(
         &self,
-        root: &'a Path,
-        host: &mut PathBuf,
-        mounts: &mut Mounts,
+        root: &str,
         parent_id: usize,
-    ) {
-        // Push the component onto the host path and pop it after any traversals
-        host.push(self.component);
+        paths: &mut Vec<(usize, String)>,
+    ) -> Result<()> {
+        // Invoke the callback for any terminal node in the trie
+        if let Some((index, input)) = self.input {
+            let file_name = input.path.file_name()?.unwrap_or("");
 
-        if let Component::Prefix(_) = self.component {
-            // Because we store the root and prefix in reverse order in the trie, push a
-            // root following a prefix
-            host.push(Component::RootDir);
-        }
-
-        // For terminal nodes, we add a mount and stop recursing
-        // Any terminal nodes that are descendant from this node will be treated as
-        // relative to this node in any mappings
-        if self.terminal {
-            let filename = host.file_name().and_then(|n| n.to_str()).unwrap_or("");
-
-            // Use format! for the path so that it always appears unix-style
-            // The parent id is used so that children of the same parent share the same
-            // parent directory
-            mounts.0.push(Mount {
-                host: host.clone(),
-                guest: format!(
-                    "{root}{sep}{parent_id}{sep2}{filename}",
-                    root = root.display(),
-                    sep = if root.as_os_str().as_encoded_bytes().last() == Some(&b'/') {
+            // If the file name is empty, it means this is a root URL
+            let guest_path = if file_name.is_empty() {
+                format!(
+                    "{root}{sep}{parent_id}/.root",
+                    root = root,
+                    sep = if root.as_bytes().last() == Some(&b'/') {
+                        ""
+                    } else {
+                        "/"
+                    }
+                )
+            } else {
+                format!(
+                    "{root}{sep}{parent_id}/{file_name}",
+                    root = root,
+                    sep = if root.as_bytes().last() == Some(&b'/') {
                         ""
                     } else {
                         "/"
                     },
-                    sep2 = if filename.is_empty() { "" } else { "/" },
                 )
-                .into(),
-                read_only: self.read_only,
-            });
-        } else {
-            // Otherwise, traverse into the children
-            for child in self.children.values() {
-                child.insert_mounts(root, host, mounts, self.id);
-            }
+            };
+
+            paths.push((index, guest_path));
         }
 
-        if let Component::Prefix(_) = self.component {
-            host.pop();
+        // Traverse into the children
+        for child in self.children.values() {
+            child.calculate_guest_paths(root, self.id, paths)?;
         }
 
-        host.pop();
+        Ok(())
     }
 }
 
-impl Default for PathTrieNode<'_> {
-    fn default() -> Self {
-        Self {
-            component: Component::RootDir,
-            children: Default::default(),
-            id: 0,
-            terminal: false,
-            read_only: false,
-        }
-    }
-}
-
-/// Represents a prefix trie based on file system paths.
+/// Represents a prefix trie based on input paths.
 ///
-/// This is used to determine container mounts.
+/// This is used to determine guest paths for inputs.
 ///
-/// From the root to a terminal node represents a host path.
-///
-/// If a terminal path has descendants that are also terminal, only the ancestor
-/// nearest the root will be added as a mount; its descendants will be mapped as
-/// relative paths.
-///
-/// Host and guest paths are mapped according to the mounts.
+/// From the root to a terminal node represents a unique input.
 #[derive(Debug)]
-pub struct PathTrie<'a> {
-    /// The root node of the trie.
+pub struct InputTrie<'a> {
+    /// The URL path children of the tree.
     ///
-    /// `None` indicates an empty trie.
-    root: PathTrieNode<'a>,
-    /// The number of nodes in the trie.
+    /// The key in the map is the scheme of each URL.
     ///
-    /// Used to provide an identifier to each node.
+    /// A `BTreeMap` is used here to get a consistent walk of the tree.
+    urls: BTreeMap<&'a str, InputTrieNode<'a>>,
+    /// The local path children of the tree.
     ///
-    /// The trie always has at least one node (the root).
+    /// The key in the map is the first component of each path.
+    ///
+    /// A `BTreeMap` is used here to get a consistent walk of the tree.
+    paths: BTreeMap<&'a str, InputTrieNode<'a>>,
+    /// The next node identifier.
+    next_id: usize,
+    /// The number of inputs in the trie.
     count: usize,
 }
 
-impl<'a> PathTrie<'a> {
-    /// Inserts a new path into the trie.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided path is not absolute or if it contains `.` or
-    /// `..` components.
-    pub fn insert(&mut self, path: &'a Path, read_only: bool) {
-        assert!(
-            path.is_absolute(),
-            "a path must be absolute to add to the trie"
-        );
-
-        let mut node = &mut self.root;
-
-        for component in path.components() {
-            match component {
-                Component::RootDir => {
-                    // Skip the root directory as we already have it in the trie
-                    continue;
-                }
-                Component::Prefix(_) | Component::Normal(_) => {
-                    // Accept the component
-                }
-                Component::CurDir | Component::ParentDir => {
-                    panic!("path may not contain `.` or `..`");
-                }
-            }
-
-            node = node
-                .children
-                .entry(component.as_os_str())
-                .or_insert_with(|| {
-                    let node = PathTrieNode::new(component, self.count);
+impl<'a> InputTrie<'a> {
+    /// Inserts a new input into the trie.
+    pub fn insert(&mut self, input: &'a Input) -> Result<()> {
+        let node = match &input.path {
+            EvaluationPath::Local(path) => {
+                // Don't both inserting anything into the trie for relative paths
+                // We still consider the input part of the trie, but it will never have a guest
+                // path
+                if path.is_relative() {
                     self.count += 1;
+                    return Ok(());
+                }
+
+                let mut components = path.components();
+
+                let component = components
+                    .next()
+                    .context("input path cannot be empty")?
+                    .as_os_str()
+                    .to_str()
+                    .with_context(|| {
+                        format!("input path `{path}` is not UTF-8", path = path.display())
+                    })?;
+                let mut node = self.paths.entry(component).or_insert_with(|| {
+                    let node = InputTrieNode::new(self.next_id);
+                    self.next_id += 1;
                     node
                 });
-        }
 
-        node.terminal = true;
-        node.read_only = read_only;
+                for component in components {
+                    match component {
+                        Component::CurDir | Component::ParentDir => {
+                            bail!(
+                                "input path `{path}` may not contain `.` or `..`",
+                                path = path.display()
+                            );
+                        }
+                        _ => {}
+                    }
+
+                    let component = component.as_os_str().to_str().with_context(|| {
+                        format!("input path `{path}` is not UTF-8", path = path.display())
+                    })?;
+                    node = node.children.entry(component).or_insert_with(|| {
+                        let node = InputTrieNode::new(self.next_id);
+                        self.next_id += 1;
+                        node
+                    });
+                }
+
+                node
+            }
+            EvaluationPath::Remote(url) => {
+                // Insert for scheme
+                let mut node = self.urls.entry(url.scheme()).or_insert_with(|| {
+                    let node = InputTrieNode::new(self.next_id);
+                    self.next_id += 1;
+                    node
+                });
+
+                // Insert the authority
+                node = node.children.entry(url.authority()).or_insert_with(|| {
+                    let node = InputTrieNode::new(self.next_id);
+                    self.next_id += 1;
+                    node
+                });
+
+                // Insert the path segments
+                if let Some(segments) = url.path_segments() {
+                    for segment in segments {
+                        node = node.children.entry(segment).or_insert_with(|| {
+                            let node = InputTrieNode::new(self.next_id);
+                            self.next_id += 1;
+                            node
+                        });
+                    }
+                }
+
+                // Ignore query parameters and fragments
+                node
+            }
+        };
+
+        node.input = Some((self.count, input));
+        self.count += 1;
+        Ok(())
     }
 
-    /// Converts the path trie into mounts based on the provided guest root
-    /// directory.
-    pub fn into_mounts(self, guest_root: impl AsRef<Path>) -> Mounts {
-        let mut mounts = Mounts::default();
-        let mut host = PathBuf::new();
-        self.root
-            .insert_mounts(guest_root.as_ref(), &mut host, &mut mounts, 0);
-        mounts
+    /// Calculates guest paths for the inputs in the trie.
+    ///
+    /// Returns a collection of input insertion index paired with the calculated
+    /// guest path.
+    pub fn calculate_guest_paths(&self, root: &str) -> Result<Vec<(usize, String)>> {
+        let mut paths = Vec::with_capacity(self.count);
+        for child in self.urls.values() {
+            child.calculate_guest_paths(root, 0, &mut paths)?;
+        }
+
+        for child in self.paths.values() {
+            child.calculate_guest_paths(root, 0, &mut paths)?;
+        }
+
+        Ok(paths)
     }
 }
 
-impl Default for PathTrie<'_> {
+impl Default for InputTrie<'_> {
     fn default() -> Self {
         Self {
-            root: Default::default(),
-            count: 1,
+            urls: Default::default(),
+            paths: Default::default(),
+            // The first id starts at 1 as 0 is considered the "virtual root" of the trie
+            next_id: 1,
+            count: 0,
         }
     }
 }
@@ -684,190 +709,194 @@ mod test {
 
     #[test]
     fn empty_trie() {
-        let empty = PathTrie::default();
-        let mounts = empty.into_mounts("/mnt/");
-        assert_eq!(mounts.iter().count(), 0);
-        assert_eq!(mounts.len(), 0);
-        assert!(mounts.is_empty());
+        let empty = InputTrie::default();
+        let paths = empty.calculate_guest_paths("/mnt/").unwrap();
+        assert!(paths.is_empty());
     }
 
     #[cfg(unix)]
     #[test]
-    fn trie_with_terminal_root_unix() {
-        let mut trie = PathTrie::default();
-        trie.insert(Path::new("/"), true);
-        trie.insert(Path::new("/relative/from/root"), true);
-        let mounts = trie.into_mounts("/mnt/");
-        assert_eq!(mounts.iter().count(), 1);
-        assert_eq!(mounts.len(), 1);
-        assert!(!mounts.is_empty());
+    fn non_empty_trie_unix() {
+        let mut trie = InputTrie::default();
+        let inputs = [
+            Input::new("/".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new("/foo/bar/foo.txt".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new("/foo/bar/bar.txt".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new("/foo/baz/foo.txt".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new("/foo/baz/bar.txt".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new("/bar/foo/foo.txt".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new("/bar/foo/bar.txt".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new("/baz".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new(
+                "https://example.com/".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/bar/foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/bar/bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/baz/foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/baz/bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/bar/foo/foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/bar/foo/bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://foo.com/bar".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+        ];
 
-        // Note: the mounts are always in lexical order
-        let collected: Vec<_> = mounts.iter().collect();
-        assert_eq!(collected, [&Mount::new("/", "/mnt/0", true)]);
-
-        for (host, guest) in [
-            ("/", "/mnt/0"),
-            ("/foo/bar/foo.txt", "/mnt/0/foo/bar/foo.txt"),
-            ("/bar/foo/foo.txt", "/mnt/0/bar/foo/foo.txt"),
-            ("/any/other/path", "/mnt/0/any/other/path"),
-        ] {
-            assert_eq!(
-                mounts.guest(host).as_deref(),
-                Some(Path::new(guest)),
-                "unexpected guest path for host path `{host}`"
-            );
-            assert_eq!(
-                mounts.host(guest).as_deref(),
-                Some(Path::new(host)),
-                "unexpected host path for guest path `{guest}`"
-            );
+        for input in &inputs {
+            trie.insert(input).unwrap();
         }
+
+        // The important part of the guest paths are:
+        // 1) The guest file name should be the same (or `.root` if the path is
+        //    considered to be root)
+        // 2) Paths with the same parent should have the same guest parent
+        let paths = trie.calculate_guest_paths("/mnt/").unwrap();
+        let paths: Vec<_> = paths
+            .iter()
+            .map(|(index, guest)| (inputs[*index].path().to_str().unwrap(), guest.as_str()))
+            .collect();
+
+        assert_eq!(
+            paths,
+            [
+                ("https://example.com/", "/mnt/15/.root"),
+                ("https://example.com/bar/foo/bar.txt", "/mnt/25/bar.txt"),
+                ("https://example.com/bar/foo/foo.txt", "/mnt/25/foo.txt"),
+                ("https://example.com/foo/bar/bar.txt", "/mnt/18/bar.txt"),
+                ("https://example.com/foo/bar/foo.txt", "/mnt/18/foo.txt"),
+                ("https://example.com/foo/baz/bar.txt", "/mnt/21/bar.txt"),
+                ("https://example.com/foo/baz/foo.txt", "/mnt/21/foo.txt"),
+                ("https://foo.com/bar", "/mnt/28/bar"),
+                ("/", "/mnt/0/.root"),
+                ("/bar/foo/bar.txt", "/mnt/10/bar.txt"),
+                ("/bar/foo/foo.txt", "/mnt/10/foo.txt"),
+                ("/baz", "/mnt/1/baz"),
+                ("/foo/bar/bar.txt", "/mnt/3/bar.txt"),
+                ("/foo/bar/foo.txt", "/mnt/3/foo.txt"),
+                ("/foo/baz/bar.txt", "/mnt/6/bar.txt"),
+                ("/foo/baz/foo.txt", "/mnt/6/foo.txt"),
+            ]
+        );
     }
 
     #[cfg(windows)]
     #[test]
-    fn root_with_terminal_root_windows() {
-        let mut trie = PathTrie::default();
-        trie.insert(Path::new("C:\\"), true);
-        trie.insert(Path::new("C:\\relative\\from\\root"), true);
-        let mounts = trie.into_mounts("/mnt/");
-        assert_eq!(mounts.iter().count(), 1);
-        assert_eq!(mounts.len(), 1);
-        assert!(!mounts.is_empty());
+    fn non_empty_trie_windows() {
+        let mut trie = InputTrie::default();
+        let inputs = [
+            Input::new("C:\\".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new(
+                "C:\\foo\\bar\\foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "C:\\foo\\bar\\bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "C:\\foo\\baz\\foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "C:\\foo\\baz\\bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "C:\\bar\\foo\\foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "C:\\bar\\foo\\bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new("C:\\baz".parse().unwrap(), InputAccess::ReadOnly),
+            Input::new(
+                "https://example.com/".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/bar/foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/bar/bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/baz/foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/foo/baz/bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/bar/foo/foo.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://example.com/bar/foo/bar.txt".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+            Input::new(
+                "https://foo.com/bar".parse().unwrap(),
+                InputAccess::ReadOnly,
+            ),
+        ];
 
-        // Note: the mounts are always in lexical order
-        let collected: Vec<_> = mounts.iter().collect();
-        assert_eq!(collected, [&Mount::new("C:\\", "/mnt/0", true)]);
-
-        for (host, guest) in [
-            ("C:\\", "/mnt/0"),
-            ("C:\\foo\\bar\\foo.txt", "/mnt/0/foo/bar/foo.txt"),
-            ("C:\\bar\\foo\\foo.txt", "/mnt/0/bar/foo/foo.txt"),
-            ("C:\\any\\other\\path", "/mnt/0/any/other/path"),
-        ] {
-            assert_eq!(
-                mounts.guest(host).as_deref(),
-                Some(Path::new(guest)),
-                "unexpected guest path for host path `{host}`"
-            );
-            assert_eq!(
-                mounts.host(guest).as_deref(),
-                Some(Path::new(host)),
-                "unexpected host path for guest path `{guest}`"
-            );
+        for input in &inputs {
+            trie.insert(input).unwrap();
         }
-    }
 
-    #[cfg(unix)]
-    #[test]
-    fn trie_with_common_paths_unix() {
-        let mut trie = PathTrie::default();
-        trie.insert(Path::new("/foo/bar/foo.txt"), true);
-        trie.insert(Path::new("/foo/bar/bar.txt"), true);
-        trie.insert(Path::new("/foo/baz/foo.txt"), true);
-        trie.insert(Path::new("/foo/baz/bar.txt"), true);
-        trie.insert(Path::new("/bar/foo/foo.txt"), true);
-        trie.insert(Path::new("/bar/foo/bar.txt"), true);
-        trie.insert(Path::new("/baz"), true);
+        // The important part of the guest paths are:
+        // 1) The guest file name should be the same (or `.root` if the path is
+        //    considered to be root)
+        // 2) Paths with the same parent should have the same guest parent
+        let paths = trie.calculate_guest_paths("/mnt/").unwrap();
+        let paths: Vec<_> = paths
+            .iter()
+            .map(|(index, guest)| (inputs[*index].path().to_str().unwrap(), guest.as_str()))
+            .collect();
 
-        let mounts = trie.into_mounts("/mnt");
-
-        // Note: the mounts are always in lexical order
-        let collected: Vec<_> = mounts.iter().collect();
         assert_eq!(
-            collected,
+            paths,
             [
-                &Mount::new("/bar/foo/bar.txt", "/mnt/9/bar.txt", true),
-                &Mount::new("/bar/foo/foo.txt", "/mnt/9/foo.txt", true),
-                &Mount::new("/baz", "/mnt/0/baz", true),
-                &Mount::new("/foo/bar/bar.txt", "/mnt/2/bar.txt", true),
-                &Mount::new("/foo/bar/foo.txt", "/mnt/2/foo.txt", true),
-                &Mount::new("/foo/baz/bar.txt", "/mnt/5/bar.txt", true),
-                &Mount::new("/foo/baz/foo.txt", "/mnt/5/foo.txt", true),
+                ("https://example.com/", "/mnt/16/.root"),
+                ("https://example.com/bar/foo/bar.txt", "/mnt/26/bar.txt"),
+                ("https://example.com/bar/foo/foo.txt", "/mnt/26/foo.txt"),
+                ("https://example.com/foo/bar/bar.txt", "/mnt/19/bar.txt"),
+                ("https://example.com/foo/bar/foo.txt", "/mnt/19/foo.txt"),
+                ("https://example.com/foo/baz/bar.txt", "/mnt/22/bar.txt"),
+                ("https://example.com/foo/baz/foo.txt", "/mnt/22/foo.txt"),
+                ("https://foo.com/bar", "/mnt/29/bar"),
+                ("C:\\", "/mnt/1/.root"),
+                ("C:\\bar\\foo\\bar.txt", "/mnt/11/bar.txt"),
+                ("C:\\bar\\foo\\foo.txt", "/mnt/11/foo.txt"),
+                ("C:\\baz", "/mnt/2/baz"),
+                ("C:\\foo\\bar\\bar.txt", "/mnt/4/bar.txt"),
+                ("C:\\foo\\bar\\foo.txt", "/mnt/4/foo.txt"),
+                ("C:\\foo\\baz\\bar.txt", "/mnt/7/bar.txt"),
+                ("C:\\foo\\baz\\foo.txt", "/mnt/7/foo.txt"),
             ]
         );
-
-        for (host, guest) in [
-            ("/foo/bar/foo.txt", "/mnt/2/foo.txt"),
-            ("/foo/bar/bar.txt", "/mnt/2/bar.txt"),
-            ("/foo/baz/foo.txt", "/mnt/5/foo.txt"),
-            ("/foo/baz/bar.txt", "/mnt/5/bar.txt"),
-            ("/bar/foo/foo.txt", "/mnt/9/foo.txt"),
-            ("/bar/foo/bar.txt", "/mnt/9/bar.txt"),
-            ("/baz", "/mnt/0/baz"),
-            ("/baz/any/other/path", "/mnt/0/baz/any/other/path"),
-        ] {
-            assert_eq!(
-                mounts.guest(host).as_deref(),
-                Some(Path::new(guest)),
-                "unexpected guest path for host path `{host}`"
-            );
-            assert_eq!(
-                mounts.host(guest).as_deref(),
-                Some(Path::new(host)),
-                "unexpected host path for guest path `{guest}`"
-            );
-        }
-
-        // Check for paths not in the host or guest mapping
-        assert!(mounts.guest("/tmp/foo.txt").is_none());
-        assert!(mounts.host("/tmp/bar.txt").is_none());
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn trie_with_common_paths_windows() {
-        let mut trie = PathTrie::default();
-        trie.insert(Path::new("C:\\foo\\bar\\foo.txt"), true);
-        trie.insert(Path::new("C:\\foo\\bar\\bar.txt"), true);
-        trie.insert(Path::new("C:\\foo\\baz\\foo.txt"), true);
-        trie.insert(Path::new("C:\\foo\\baz\\bar.txt"), true);
-        trie.insert(Path::new("C:\\bar\\foo\\foo.txt"), true);
-        trie.insert(Path::new("C:\\bar\\foo\\bar.txt"), true);
-        trie.insert(Path::new("C:\\baz"), true);
-
-        let mounts = trie.into_mounts("/mnt");
-
-        // Note: the mounts are always in lexical order
-        let collected: Vec<_> = mounts.iter().collect();
-        assert_eq!(
-            collected,
-            [
-                &Mount::new("C:\\bar\\foo\\bar.txt", "/mnt/10/bar.txt", true),
-                &Mount::new("C:\\bar\\foo\\foo.txt", "/mnt/10/foo.txt", true),
-                &Mount::new("C:\\baz", "/mnt/1/baz", true),
-                &Mount::new("C:\\foo\\bar\\bar.txt", "/mnt/3/bar.txt", true),
-                &Mount::new("C:\\foo\\bar\\foo.txt", "/mnt/3/foo.txt", true),
-                &Mount::new("C:\\foo\\baz\\bar.txt", "/mnt/6/bar.txt", true),
-                &Mount::new("C:\\foo\\baz\\foo.txt", "/mnt/6/foo.txt", true),
-            ]
-        );
-
-        for (host, guest) in [
-            ("C:\\foo\\bar\\foo.txt", "/mnt/3/foo.txt"),
-            ("C:\\foo\\bar\\bar.txt", "/mnt/3/bar.txt"),
-            ("C:\\foo\\baz\\foo.txt", "/mnt/6/foo.txt"),
-            ("C:\\foo\\baz\\bar.txt", "/mnt/6/bar.txt"),
-            ("C:\\bar\\foo\\foo.txt", "/mnt/10/foo.txt"),
-            ("C:\\bar\\foo\\bar.txt", "/mnt/10/bar.txt"),
-            ("C:\\baz", "/mnt/1/baz"),
-            ("C:\\baz\\any\\other\\path", "/mnt/1/baz/any/other/path"),
-        ] {
-            assert_eq!(
-                mounts.guest(host).as_deref(),
-                Some(Path::new(guest)),
-                "unexpected guest path for host path `{host}`"
-            );
-            assert_eq!(
-                mounts.host(guest).as_deref(),
-                Some(Path::new(host)),
-                "unexpected host path for guest path `{guest}`"
-            );
-        }
-
-        // Check for paths not in the host or guest mapping
-        assert!(mounts.guest("/tmp/foo.txt").is_none());
-        assert!(mounts.host("/tmp/bar.txt").is_none());
     }
 }

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -3,7 +3,6 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::fmt;
 use std::fs;
 use std::path::Component;
 use std::path::MAIN_SEPARATOR;
@@ -413,24 +412,6 @@ impl EvaluatedTask {
     }
 }
 
-/// Represents the access for an input.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum InputAccess {
-    /// The input will be read-only.
-    ReadOnly,
-    /// The input will be read-write.
-    ReadWrite,
-}
-
-impl fmt::Display for InputAccess {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ReadOnly => write!(f, "read-only"),
-            Self::ReadWrite => write!(f, "read-write"),
-        }
-    }
-}
-
 /// Represents a `File` or `Directory` input to a task.
 #[derive(Debug, Clone)]
 pub struct Input {
@@ -442,18 +423,15 @@ pub struct Input {
     location: Option<Location<'static>>,
     /// The guest path for the input.
     guest_path: Option<String>,
-    /// The access for the input.
-    access: InputAccess,
 }
 
 impl Input {
     /// Creates a new input with the given path and access.
-    pub fn new(path: EvaluationPath, access: InputAccess) -> Self {
+    pub fn new(path: EvaluationPath) -> Self {
         Self {
             path,
             location: None,
             guest_path: None,
-            access,
         }
     }
 
@@ -480,11 +458,6 @@ impl Input {
     /// Sets the guest path for the input.
     pub fn set_guest_path(&mut self, path: impl Into<String>) {
         self.guest_path = Some(path.into());
-    }
-
-    /// Gets the access for the input.
-    pub fn access(&self) -> InputAccess {
-        self.access
     }
 }
 
@@ -724,46 +697,22 @@ mod test {
     fn non_empty_trie_unix() {
         let mut trie = InputTrie::default();
         let inputs = [
-            Input::new("/".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new("/foo/bar/foo.txt".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new("/foo/bar/bar.txt".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new("/foo/baz/foo.txt".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new("/foo/baz/bar.txt".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new("/bar/foo/foo.txt".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new("/bar/foo/bar.txt".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new("/baz".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new(
-                "https://example.com/".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/bar/foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/bar/bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/baz/foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/baz/bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/bar/foo/foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/bar/foo/bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://foo.com/bar".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
+            Input::new("/".parse().unwrap()),
+            Input::new("/foo/bar/foo.txt".parse().unwrap()),
+            Input::new("/foo/bar/bar.txt".parse().unwrap()),
+            Input::new("/foo/baz/foo.txt".parse().unwrap()),
+            Input::new("/foo/baz/bar.txt".parse().unwrap()),
+            Input::new("/bar/foo/foo.txt".parse().unwrap()),
+            Input::new("/bar/foo/bar.txt".parse().unwrap()),
+            Input::new("/baz".parse().unwrap()),
+            Input::new("https://example.com/".parse().unwrap()),
+            Input::new("https://example.com/foo/bar/foo.txt".parse().unwrap()),
+            Input::new("https://example.com/foo/bar/bar.txt".parse().unwrap()),
+            Input::new("https://example.com/foo/baz/foo.txt".parse().unwrap()),
+            Input::new("https://example.com/foo/baz/bar.txt".parse().unwrap()),
+            Input::new("https://example.com/bar/foo/foo.txt".parse().unwrap()),
+            Input::new("https://example.com/bar/foo/bar.txt".parse().unwrap()),
+            Input::new("https://foo.com/bar".parse().unwrap()),
         ];
 
         for input in &inputs {
@@ -808,64 +757,22 @@ mod test {
     fn non_empty_trie_windows() {
         let mut trie = InputTrie::default();
         let inputs = [
-            Input::new("C:\\".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new(
-                "C:\\foo\\bar\\foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "C:\\foo\\bar\\bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "C:\\foo\\baz\\foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "C:\\foo\\baz\\bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "C:\\bar\\foo\\foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "C:\\bar\\foo\\bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new("C:\\baz".parse().unwrap(), InputAccess::ReadOnly),
-            Input::new(
-                "https://example.com/".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/bar/foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/bar/bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/baz/foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/foo/baz/bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/bar/foo/foo.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://example.com/bar/foo/bar.txt".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
-            Input::new(
-                "https://foo.com/bar".parse().unwrap(),
-                InputAccess::ReadOnly,
-            ),
+            Input::new("C:\\".parse().unwrap()),
+            Input::new("C:\\foo\\bar\\foo.txt".parse().unwrap()),
+            Input::new("C:\\foo\\bar\\bar.txt".parse().unwrap()),
+            Input::new("C:\\foo\\baz\\foo.txt".parse().unwrap()),
+            Input::new("C:\\foo\\baz\\bar.txt".parse().unwrap()),
+            Input::new("C:\\bar\\foo\\foo.txt".parse().unwrap()),
+            Input::new("C:\\bar\\foo\\bar.txt".parse().unwrap()),
+            Input::new("C:\\baz".parse().unwrap()),
+            Input::new("https://example.com/".parse().unwrap()),
+            Input::new("https://example.com/foo/bar/foo.txt".parse().unwrap()),
+            Input::new("https://example.com/foo/bar/bar.txt".parse().unwrap()),
+            Input::new("https://example.com/foo/baz/foo.txt".parse().unwrap()),
+            Input::new("https://example.com/foo/baz/bar.txt".parse().unwrap()),
+            Input::new("https://example.com/bar/foo/foo.txt".parse().unwrap()),
+            Input::new("https://example.com/bar/foo/bar.txt".parse().unwrap()),
+            Input::new("https://foo.com/bar".parse().unwrap()),
         ];
 
         for input in &inputs {

--- a/wdl-engine/src/eval/v1.rs
+++ b/wdl-engine/src/eval/v1.rs
@@ -12,6 +12,7 @@ pub use workflow::*;
 use super::EvaluatedTask;
 use super::EvaluationResult;
 use crate::Outputs;
+use crate::TaskExecutionResult;
 
 /// Represents the kind of progress made during evaluation.
 #[derive(Debug, Clone, Copy)]
@@ -38,10 +39,10 @@ pub enum ProgressKind<'a> {
     TaskExecutionCompleted {
         /// The identifier of the task.
         id: &'a str,
-        /// The status code from the task's execution.
+        /// The result from the task's execution.
         ///
-        /// This may be `Err` if the task failed to spawn.
-        status_code: &'a Result<i32>,
+        /// This may be `Err` if the task failed to complete.
+        result: &'a Result<TaskExecutionResult>,
     },
     /// A task with the given id has completed evaluation.
     TaskCompleted {

--- a/wdl-engine/src/eval/v1/expr.rs
+++ b/wdl-engine/src/eval/v1/expr.rs
@@ -3,7 +3,6 @@
 use std::cmp::Ordering;
 use std::fmt::Write;
 use std::iter::once;
-use std::path::Path;
 use std::sync::Arc;
 
 use futures::FutureExt;
@@ -356,7 +355,7 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                 }
                 Value::Primitive(PrimitiveValue::File(path))
                 | Value::Primitive(PrimitiveValue::Directory(path)) => {
-                    match evaluator.context.translate_path(Path::new(path.as_str())) {
+                    match evaluator.context.translate_path(&path) {
                         Some(path) => write!(buffer, "{path}", path = path.display()).unwrap(),
                         _ => {
                             write!(buffer, "{path}").unwrap();
@@ -1442,6 +1441,7 @@ pub(crate) mod test {
     use crate::eval::Scope;
     use crate::http::Downloader;
     use crate::http::Location;
+    use crate::path::EvaluationPath;
 
     /// Represents a test environment.
     pub struct TestEnv {
@@ -1451,6 +1451,8 @@ pub(crate) mod test {
         structs: HashMap<&'static str, Type>,
         /// The working directory.
         work_dir: TempDir,
+        /// The working directory path.
+        work_dir_path: EvaluationPath,
         /// The current directory.
         temp_dir: TempDir,
     }
@@ -1468,8 +1470,8 @@ pub(crate) mod test {
             self.structs.insert(name, ty.into());
         }
 
-        pub fn work_dir(&self) -> &Path {
-            self.work_dir.path()
+        pub fn work_dir(&self) -> Option<&EvaluationPath> {
+            Some(&self.work_dir_path)
         }
 
         pub fn temp_dir(&self) -> &Path {
@@ -1477,17 +1479,21 @@ pub(crate) mod test {
         }
 
         pub fn write_file(&self, name: &str, bytes: impl AsRef<[u8]>) {
-            fs::write(self.work_dir().join(name), bytes).expect("failed to create temp file");
+            fs::write(self.work_dir.path().join(name), bytes).expect("failed to create temp file");
         }
     }
 
     impl Default for TestEnv {
         fn default() -> Self {
+            let work_dir = TempDir::new().expect("failed to create work directory");
+            let work_dir_path = EvaluationPath::Local(work_dir.path().to_path_buf());
+
             Self {
                 scopes: vec![Scope::default()],
                 structs: Default::default(),
                 temp_dir: TempDir::new().expect("failed to create temp directory"),
-                work_dir: TempDir::new().expect("failed to create work directory"),
+                work_dir,
+                work_dir_path,
             }
         }
     }
@@ -1495,29 +1501,25 @@ pub(crate) mod test {
     impl Downloader for TestEnv {
         fn download<'a, 'b, 'c>(
             &'a self,
-            url: &'b str,
-        ) -> BoxFuture<'c, Result<Option<crate::http::Location>, Arc<anyhow::Error>>>
+            url: &'b Url,
+        ) -> BoxFuture<'c, Result<crate::http::Location<'static>, Arc<anyhow::Error>>>
         where
             'a: 'c,
             'b: 'c,
             Self: 'c,
         {
             async {
-                let url: Url = match url.parse() {
-                    Ok(url) => url,
-                    Err(_) => return Ok(None),
-                };
-
                 // For tests, redirect requests to example.com to files relative to the work dir
                 if url.authority() == "example.com" {
-                    return Ok(Some(Location::Path(
+                    return Ok(Location::Path(
                         self.work_dir
                             .path()
-                            .join(url.path().strip_prefix('/').unwrap_or(url.path())),
-                    )));
+                            .join(url.path().strip_prefix('/').unwrap_or(url.path()))
+                            .into(),
+                    ));
                 }
 
-                Ok(None)
+                panic!("expected test to use example.com URL");
             }
             .boxed()
         }
@@ -1578,7 +1580,7 @@ pub(crate) mod test {
                 .ok_or_else(|| unknown_type(name, span))
         }
 
-        fn work_dir(&self) -> &Path {
+        fn work_dir(&self) -> Option<&EvaluationPath> {
             self.env.work_dir()
         }
 
@@ -1598,7 +1600,7 @@ pub(crate) mod test {
             None
         }
 
-        fn translate_path(&self, _path: &Path) -> Option<Cow<'_, Path>> {
+        fn translate_path(&self, _path: &str) -> Option<Cow<'_, Path>> {
             None
         }
 

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -62,7 +62,6 @@ use crate::Coercible;
 use crate::EvaluationContext;
 use crate::EvaluationResult;
 use crate::Input;
-use crate::InputAccess;
 use crate::Outputs;
 use crate::PrimitiveValue;
 use crate::Scope;
@@ -1106,19 +1105,15 @@ impl TaskEvaluator {
         // Discover every input that's visible to the scope
         ScopeRef::new(&state.scopes, TASK_SCOPE_INDEX.0).for_each(|_, v| {
             v.visit_paths(false, &mut |_, value| {
-                inputs.push(Input::new(
-                    EvaluationPath::from_primitive_value(value)?,
-                    InputAccess::ReadOnly,
-                ));
+                inputs.push(Input::new(EvaluationPath::from_primitive_value(value)?));
                 Ok(())
             })
         })?;
 
         // The temp directory should always be an input
-        inputs.push(Input::new(
-            EvaluationPath::Local(state.root.temp_dir().to_path_buf()),
-            InputAccess::ReadOnly,
-        ));
+        inputs.push(Input::new(EvaluationPath::Local(
+            state.root.temp_dir().to_path_buf(),
+        )));
 
         // Localize the inputs
         self.backend
@@ -1133,22 +1128,19 @@ impl TaskEvaluator {
                         task_id = id,
                         task_name = state.task.name(),
                         document = state.document.uri().as_str(),
-                        "task input `{path}` (downloaded to `{location}`) mapped to \
-                         `{guest_path}` ({access})",
+                        "task input `{path}` (downloaded to `{location}`) mapped to `{guest_path}`",
                         path = input.path().display(),
                         location = location.display(),
                         guest_path = input.guest_path().unwrap_or(""),
-                        access = input.access
                     );
                 } else {
                     debug!(
                         task_id = id,
                         task_name = state.task.name(),
                         document = state.document.uri().as_str(),
-                        "task input `{path}` mapped to `{guest_path}` ({access})",
+                        "task input `{path}` mapped to `{guest_path}`",
                         path = input.path().display(),
                         guest_path = input.guest_path().unwrap_or(""),
-                        access = input.access
                     );
                 }
             }

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -11,7 +11,6 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use indexmap::IndexMap;
-use path_clean::clean;
 use petgraph::algo::toposort;
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
@@ -62,8 +61,10 @@ use super::ProgressKind;
 use crate::Coercible;
 use crate::EvaluationContext;
 use crate::EvaluationResult;
+use crate::Input;
+use crate::InputAccess;
 use crate::Outputs;
-use crate::PathTrie;
+use crate::PrimitiveValue;
 use crate::Scope;
 use crate::ScopeIndex;
 use crate::ScopeRef;
@@ -78,10 +79,12 @@ use crate::config::MAX_RETRIES;
 use crate::convert_unit_string;
 use crate::diagnostics::output_evaluation_failed;
 use crate::diagnostics::runtime_type_mismatch;
+use crate::diagnostics::task_localization_failed;
 use crate::eval::EvaluatedTask;
-use crate::eval::Mounts;
 use crate::http::Downloader;
 use crate::http::HttpDownloader;
+use crate::path;
+use crate::path::EvaluationPath;
 use crate::tree::SyntaxNode;
 use crate::v1::ExprEvaluator;
 
@@ -221,16 +224,20 @@ struct TaskEvaluationContext<'a, 'b> {
     downloader: &'a HttpDownloader,
     /// The current evaluation scope.
     scope: ScopeIndex,
-    /// The working directory to use for evaluation.
-    work_dir: &'a Path,
-    /// The temp directory to use for evaluation.
-    temp_dir: &'a Path,
+    /// The work directory.
+    ///
+    /// This field is only available after task execution.
+    work_dir: Option<&'a EvaluationPath>,
     /// The standard out value to use.
+    ///
+    /// This field is only available after task execution.
     stdout: Option<&'a Value>,
     /// The standard error value to use.
+    ///
+    /// This field is only available after task execution.
     stderr: Option<&'a Value>,
-    /// The mounts for the evaluation.
-    mounts: Option<&'a Mounts>,
+    /// The inputs for the evaluation.
+    inputs: Option<&'a [Input]>,
     /// Whether or not the evaluation has associated task information.
     ///
     /// This is `true` when evaluating hints sections.
@@ -239,23 +246,23 @@ struct TaskEvaluationContext<'a, 'b> {
 
 impl<'a, 'b> TaskEvaluationContext<'a, 'b> {
     /// Constructs a new expression evaluation context.
-    pub fn new(
-        state: &'a State<'b>,
-        downloader: &'a HttpDownloader,
-        temp_dir: &'a Path,
-        scope: ScopeIndex,
-    ) -> Self {
+    pub fn new(state: &'a State<'b>, downloader: &'a HttpDownloader, scope: ScopeIndex) -> Self {
         Self {
             state,
             downloader,
             scope,
-            work_dir: state.root.work_dir(),
+            work_dir: None,
             stdout: None,
-            temp_dir,
             stderr: None,
-            mounts: None,
+            inputs: None,
             task: false,
         }
+    }
+
+    /// Sets the working directory to use for the evaluation context.
+    pub fn with_work_dir(mut self, work_dir: &'a EvaluationPath) -> Self {
+        self.work_dir = Some(work_dir);
+        self
     }
 
     /// Sets the stdout value to use for the evaluation context.
@@ -270,9 +277,9 @@ impl<'a, 'b> TaskEvaluationContext<'a, 'b> {
         self
     }
 
-    /// Sets the mounts associated with the evaluation context.
-    pub fn with_mounts(mut self, mounts: &'a Mounts) -> Self {
-        self.mounts = Some(mounts);
+    /// Sets the inputs associated with the evaluation context.
+    pub fn with_inputs(mut self, inputs: &'a [Input]) -> Self {
+        self.inputs = Some(inputs);
         self
     }
 
@@ -304,12 +311,12 @@ impl EvaluationContext for TaskEvaluationContext<'_, '_> {
         crate::resolve_type_name(self.state.document, name, span)
     }
 
-    fn work_dir(&self) -> &Path {
+    fn work_dir(&self) -> Option<&EvaluationPath> {
         self.work_dir
     }
 
     fn temp_dir(&self) -> &Path {
-        self.temp_dir
+        self.state.root.temp_dir()
     }
 
     fn stdout(&self) -> Option<&Value> {
@@ -328,8 +335,49 @@ impl EvaluationContext for TaskEvaluationContext<'_, '_> {
         }
     }
 
-    fn translate_path(&self, path: &Path) -> Option<Cow<'_, Path>> {
-        self.mounts.and_then(|m| m.guest(path))
+    fn translate_path(&self, path: &str) -> Option<Cow<'_, Path>> {
+        let inputs = self.inputs?;
+        let is_url = path::is_url(path);
+
+        // We cannot translate a relative path
+        if !is_url && Path::new(path).is_relative() {
+            return None;
+        }
+
+        // The most specific (i.e. shortest stripped path) wins
+        let (guest_path, stripped) = inputs
+            .iter()
+            .filter_map(|i| {
+                match i.path() {
+                    EvaluationPath::Local(base) if !is_url => {
+                        let stripped = Path::new(path).strip_prefix(base).ok()?;
+                        Some((i.guest_path()?, stripped.to_str()?))
+                    }
+                    EvaluationPath::Remote(url) if is_url => {
+                        let url = url.as_str();
+                        let stripped = path.strip_prefix(url.strip_suffix('/').unwrap_or(url))?;
+
+                        // Strip off the query string or fragment
+                        let stripped = if let Some(pos) = stripped.find('?') {
+                            &stripped[..pos]
+                        } else if let Some(pos) = stripped.find('#') {
+                            &stripped[..pos]
+                        } else {
+                            stripped.strip_prefix('/').unwrap_or(stripped)
+                        };
+
+                        Some((i.guest_path()?, stripped))
+                    }
+                    _ => None,
+                }
+            })
+            .min_by(|(_, a), (_, b)| a.len().cmp(&b.len()))?;
+
+        if stripped.is_empty() {
+            return Some(Path::new(guest_path).into());
+        }
+
+        Some(Path::new(guest_path).join(stripped).into())
     }
 
     fn downloader(&self) -> &dyn Downloader {
@@ -398,8 +446,8 @@ struct EvaluatedSections {
     requirements: Arc<HashMap<String, Value>>,
     /// The evaluated hints.
     hints: Arc<HashMap<String, Value>>,
-    /// The calculated mounts based on the inputs and declarations.
-    mounts: Arc<Mounts>,
+    /// The inputs to the task.
+    inputs: Arc<[Input]>,
 }
 
 /// Represents a WDL V1 task evaluator.
@@ -622,7 +670,7 @@ impl TaskEvaluator {
                 command,
                 requirements,
                 hints,
-                mounts,
+                inputs,
             } = self
                 .evaluate_sections(id, &mut state, &definition, inputs, attempt)
                 .await?;
@@ -651,10 +699,10 @@ impl TaskEvaluator {
                 requirements.clone(),
                 hints.clone(),
                 env.clone(),
-                mounts.clone(),
+                inputs.clone(),
             );
 
-            let (spawned_rx, completed_rx) = self
+            let events = self
                 .backend
                 .spawn(request, self.token.clone())
                 .with_context(|| {
@@ -666,20 +714,21 @@ impl TaskEvaluator {
                 })?;
 
             // Await the spawned notification first
-            spawned_rx.await.ok();
+            events.spawned.await.ok();
 
             progress(ProgressKind::TaskExecutionStarted { id, attempt });
 
-            let status_code = completed_rx
+            let result = events
+                .completed
                 .await
                 .expect("failed to receive response from spawned task");
 
             progress(ProgressKind::TaskExecutionCompleted {
                 id,
-                status_code: &status_code,
+                result: &result,
             });
 
-            let status_code = status_code.with_context(|| {
+            let result = result.with_context(|| {
                 format!(
                     "task execution failed for task `{name}` in `{path}` (task id `{id}`)",
                     name = task.name(),
@@ -688,7 +737,7 @@ impl TaskEvaluator {
             })?;
 
             // Update the task variable
-            let evaluated = EvaluatedTask::new(&state.root, status_code)?;
+            let evaluated = EvaluatedTask::new(state.root.clone(), result)?;
             if version >= SupportedVersion::V1(V1::Two) {
                 let task = state.scopes[TASK_SCOPE_INDEX.0]
                     .get_mut(TASK_VAR_NAME)
@@ -702,7 +751,7 @@ impl TaskEvaluator {
                         task = state.task.name()
                     )
                 })?);
-                task.set_return_code(evaluated.status_code);
+                task.set_return_code(evaluated.exit_code);
             }
 
             if let Err(e) = evaluated.handle_exit(&requirements) {
@@ -728,7 +777,7 @@ impl TaskEvaluator {
                 continue;
             }
 
-            break (evaluated, mounts);
+            break (evaluated, inputs);
         };
 
         // Evaluate the remaining inputs (unused), and decls, and outputs
@@ -751,6 +800,7 @@ impl TaskEvaluator {
 
         // Take the output scope and return it
         let mut outputs: Outputs = mem::take(&mut state.scopes[OUTPUT_SCOPE_INDEX.0]).into();
+        drop(state);
         if let Some(section) = definition.output() {
             let indexes: HashMap<_, _> = section
                 .declarations()
@@ -791,7 +841,6 @@ impl TaskEvaluator {
                     let mut evaluator = ExprEvaluator::new(TaskEvaluationContext::new(
                         state,
                         &self.downloader,
-                        state.root.temp_dir(),
                         ROOT_SCOPE_INDEX,
                     ));
                     let value = evaluator.evaluate_expr(&expr).await?;
@@ -846,7 +895,6 @@ impl TaskEvaluator {
         let mut evaluator = ExprEvaluator::new(TaskEvaluationContext::new(
             state,
             &self.downloader,
-            state.root.temp_dir(),
             ROOT_SCOPE_INDEX,
         ));
 
@@ -914,7 +962,6 @@ impl TaskEvaluator {
             let mut evaluator = ExprEvaluator::new(TaskEvaluationContext::new(
                 state,
                 &self.downloader,
-                state.root.temp_dir(),
                 ROOT_SCOPE_INDEX,
             ));
 
@@ -979,7 +1026,6 @@ impl TaskEvaluator {
             let mut evaluator = ExprEvaluator::new(TaskEvaluationContext::new(
                 state,
                 &self.downloader,
-                state.root.temp_dir(),
                 ROOT_SCOPE_INDEX,
             ));
 
@@ -1027,13 +1073,7 @@ impl TaskEvaluator {
             }
 
             let mut evaluator = ExprEvaluator::new(
-                TaskEvaluationContext::new(
-                    state,
-                    &self.downloader,
-                    state.root.temp_dir(),
-                    ROOT_SCOPE_INDEX,
-                )
-                .with_task(),
+                TaskEvaluationContext::new(state, &self.downloader, ROOT_SCOPE_INDEX).with_task(),
             );
 
             let value = evaluator.evaluate_hints_item(&name, &item.expr()).await?;
@@ -1052,7 +1092,7 @@ impl TaskEvaluator {
         id: &str,
         state: &State<'_>,
         section: &CommandSection<SyntaxNode>,
-    ) -> EvaluationResult<(String, Mounts)> {
+    ) -> EvaluationResult<(String, Vec<Input>)> {
         debug!(
             task_id = id,
             task_name = state.task.name(),
@@ -1060,62 +1100,60 @@ impl TaskEvaluator {
             "evaluating command section",
         );
 
-        // Determine the mounts needed to evaluate the command properly
-        let mounts = match self.backend.container_root_dir() {
-            Some(root_dir) => {
-                // For every file or directory value in scope, we need to insert into the tree
-                let mut paths = Vec::new();
+        // Determine the inputs to the task
+        let mut inputs = Vec::new();
 
-                // Discover every path and directory that's visible to the scope
-                ScopeRef::new(&state.scopes, TASK_SCOPE_INDEX.0).for_each(|_, v| {
-                    v.visit_paths(&mut |p| {
-                        paths.push((clean(state.root.work_dir().join(p.as_ref())), true));
-                    });
-                });
+        // Discover every input that's visible to the scope
+        ScopeRef::new(&state.scopes, TASK_SCOPE_INDEX.0).for_each(|_, v| {
+            v.visit_paths(false, &mut |_, value| {
+                inputs.push(Input::new(
+                    EvaluationPath::from_primitive_value(value)?,
+                    InputAccess::ReadOnly,
+                ));
+                Ok(())
+            })
+        })?;
 
-                // Insert the paths into the trie
-                let mut trie = PathTrie::default();
-                for (path, read_only) in &paths {
-                    trie.insert(path, *read_only);
+        // Localize the inputs
+        self.backend
+            .localize_inputs(&self.downloader, &mut inputs)
+            .await
+            .map_err(|e| task_localization_failed(e, state.task.name(), state.task.name_span()))?;
+
+        if enabled!(Level::DEBUG) {
+            for input in inputs.iter() {
+                if let Some(location) = input.location() {
+                    debug!(
+                        task_id = id,
+                        task_name = state.task.name(),
+                        document = state.document.uri().as_str(),
+                        "task input `{path}` (downloaded to `{location}`) mapped to \
+                         `{guest_path}` ({access})",
+                        path = input.path().display(),
+                        location = location.display(),
+                        guest_path = input.guest_path().unwrap_or(""),
+                        access = input.access
+                    );
+                } else {
+                    debug!(
+                        task_id = id,
+                        task_name = state.task.name(),
+                        document = state.document.uri().as_str(),
+                        "task input `{path}` mapped to `{guest_path}` ({access})",
+                        path = input.path().display(),
+                        guest_path = input.guest_path().unwrap_or(""),
+                        access = input.access
+                    );
                 }
-
-                trie.insert(state.root.work_dir(), false);
-                trie.insert(state.root.temp_dir(), true);
-                trie.insert(state.root.attempt_temp_dir(), true);
-                trie.insert(state.root.command(), true);
-
-                // Convert the trie into mounts
-                let mounts = trie.into_mounts(root_dir.join("inputs"));
-                if enabled!(Level::DEBUG) {
-                    for mount in mounts.iter() {
-                        debug!(
-                            task_id = id,
-                            task_name = state.task.name(),
-                            document = state.document.uri().as_str(),
-                            "mounting `{host}` as `{guest}`{ro}",
-                            host = mount.host.display(),
-                            guest = mount.guest.display(),
-                            ro = if mount.read_only { " (read-only)" } else { "" }
-                        );
-                    }
-                }
-
-                mounts
             }
-            _ => Default::default(),
-        };
+        }
 
         let mut command = String::new();
         match section.strip_whitespace() {
             Some(parts) => {
                 let mut evaluator = ExprEvaluator::new(
-                    TaskEvaluationContext::new(
-                        state,
-                        &self.downloader,
-                        state.root.attempt_temp_dir(),
-                        TASK_SCOPE_INDEX,
-                    )
-                    .with_mounts(&mounts),
+                    TaskEvaluationContext::new(state, &self.downloader, TASK_SCOPE_INDEX)
+                        .with_inputs(&inputs),
                 );
 
                 for part in parts {
@@ -1140,13 +1178,8 @@ impl TaskEvaluator {
                 );
 
                 let mut evaluator = ExprEvaluator::new(
-                    TaskEvaluationContext::new(
-                        state,
-                        &self.downloader,
-                        state.root.attempt_temp_dir(),
-                        TASK_SCOPE_INDEX,
-                    )
-                    .with_mounts(&mounts),
+                    TaskEvaluationContext::new(state, &self.downloader, TASK_SCOPE_INDEX)
+                        .with_inputs(&inputs),
                 );
 
                 let heredoc = section.is_heredoc();
@@ -1165,7 +1198,7 @@ impl TaskEvaluator {
             }
         }
 
-        Ok((command, mounts))
+        Ok((command, inputs))
     }
 
     /// Evaluates sections prior to spawning the command.
@@ -1243,7 +1276,7 @@ impl TaskEvaluator {
             }
         }
 
-        let (command, mounts) = self
+        let (command, inputs) = self
             .evaluate_command(
                 id,
                 state,
@@ -1255,7 +1288,7 @@ impl TaskEvaluator {
             command,
             requirements: Arc::new(requirements),
             hints: Arc::new(hints),
-            mounts: Arc::new(mounts),
+            inputs: inputs.into(),
         })
     }
 
@@ -1266,7 +1299,7 @@ impl TaskEvaluator {
         state: &mut State<'_>,
         decl: &Decl<SyntaxNode>,
         evaluated: &EvaluatedTask,
-        mounts: &Mounts,
+        inputs: &[Input],
     ) -> EvaluationResult<()> {
         let name = decl.name();
         debug!(
@@ -1280,14 +1313,10 @@ impl TaskEvaluator {
         let decl_ty = decl.ty();
         let ty = crate::convert_ast_type_v1(state.document, &decl_ty)?;
         let mut evaluator = ExprEvaluator::new(
-            TaskEvaluationContext::new(
-                state,
-                &self.downloader,
-                state.root.temp_dir(),
-                TASK_SCOPE_INDEX,
-            )
-            .with_stdout(&evaluated.stdout)
-            .with_stderr(&evaluated.stderr),
+            TaskEvaluationContext::new(state, &self.downloader, TASK_SCOPE_INDEX)
+                .with_work_dir(&evaluated.work_dir)
+                .with_stdout(&evaluated.stdout)
+                .with_stderr(&evaluated.stderr),
         );
 
         let expr = decl.expr().expect("outputs should have expressions");
@@ -1298,27 +1327,76 @@ impl TaskEvaluator {
             .coerce(&ty)
             .map_err(|e| runtime_type_mismatch(e, &ty, name.span(), &value.ty(), expr.span()))?;
 
-        // Finally, join the path with the working directory, checking for existence
-        value
-            .join_paths(&evaluated.work_dir, true, ty.is_optional(), &|p| {
-                let host = mounts.host(p);
+        let result = if let Some(guest_work_dir) = self.backend.guest_work_dir() {
+            // Perform guest to host path translation and check for existence
+            value.visit_paths_mut(ty.is_optional(), &mut |optional, value| {
+                let path = match value {
+                    PrimitiveValue::File(path) => path,
+                    PrimitiveValue::Directory(path) => path,
+                    _ => unreachable!("only file and directory values should be visited"),
+                };
 
-                // If the path was absolute, it must map to a host path otherwise the file
-                // exists only within the container
-                if p.is_absolute() && !p.starts_with(state.root.path()) {
-                    return Ok(Some(host.ok_or_else(|| {
-                        anyhow!(
-                            "guest path `{p}` is not within a container mount",
-                            p = p.display()
-                        )
-                    })?));
+                // It's a file scheme'd URL, treat it as an absolute guest path
+                let guest = if path::is_file_url(path) {
+                    path::parse_url(path)
+                        .and_then(|u| u.to_file_path().ok())
+                        .ok_or_else(|| anyhow!("guest path `{path}` is not a valid file URI"))?
+                } else if path::is_url(path) {
+                    // Treat other URLs as if they exist
+                    // TODO: should probably issue a HEAD request to verify
+                    return Ok(true);
+                } else {
+                    // Otherwise, treat as relative to the guest working directory
+                    guest_work_dir.join(path.as_str())
+                };
+
+                // If the path is inside of the working directory, join with the task's working
+                // directory
+                let host = if let Ok(stripped) = guest.strip_prefix(guest_work_dir) {
+                    Cow::Owned(
+                        evaluated.work_dir.join(
+                            stripped
+                                .to_str()
+                                .with_context(|| format!("output path `{path}` is not UTF-8"))?,
+                        )?,
+                    )
+                } else {
+                    inputs
+                        .iter()
+                        .filter_map(|i| Some((i.path(), guest.strip_prefix(i.guest_path()?).ok()?)))
+                        .min_by(|(_, a), (_, b)| a.as_os_str().len().cmp(&b.as_os_str().len()))
+                        .and_then(|(path, stripped)| {
+                            if stripped.as_os_str().is_empty() {
+                                return Some(Cow::Borrowed(path));
+                            }
+
+                            Some(Cow::Owned(path.join(stripped.to_str()?).ok()?))
+                        })
+                        .ok_or_else(|| {
+                            anyhow!("guest path `{path}` is not within a container mount")
+                        })?
+                };
+
+                // Update the value to the host path
+                *Arc::make_mut(path) = host.into_owned().try_into()?;
+
+                // Finally, ensure the value exists
+                value.ensure_path_exists(optional)
+            })
+        } else {
+            // Backend isn't containerized, just join host paths and check for existence
+            value.visit_paths_mut(ty.is_optional(), &mut |optional, value| {
+                if let Some(work_dir) = evaluated.work_dir.as_local() {
+                    value.join_path_to(work_dir);
                 }
 
-                Ok(host)
+                value.ensure_path_exists(optional)
             })
-            .map_err(|e| {
-                output_evaluation_failed(e, state.task.name(), true, name.text(), name.span())
-            })?;
+        };
+
+        result.map_err(|e| {
+            output_evaluation_failed(e, state.task.name(), true, name.text(), name.span())
+        })?;
 
         state.scopes[OUTPUT_SCOPE_INDEX.0].insert(name.text(), value);
         Ok(())

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -1114,6 +1114,12 @@ impl TaskEvaluator {
             })
         })?;
 
+        // The temp directory should always be an input
+        inputs.push(Input::new(
+            EvaluationPath::Local(state.root.temp_dir().to_path_buf()),
+            InputAccess::ReadOnly,
+        ));
+
         // Localize the inputs
         self.backend
             .localize_inputs(&self.downloader, &mut inputs)

--- a/wdl-engine/src/http.rs
+++ b/wdl-engine/src/http.rs
@@ -5,13 +5,13 @@ use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref;
 use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
+use anyhow::anyhow;
 use anyhow::bail;
 use futures::FutureExt;
 use futures::StreamExt;
@@ -43,16 +43,14 @@ mod s3;
 const DEFAULT_CACHE_SUBDIR: &str = "wdl";
 /// A trait implemented by types responsible for downloading remote files over
 /// HTTP for evaluation.
-pub trait Downloader {
+pub trait Downloader: Send + Sync {
     /// Downloads a file from a given URL.
     ///
-    /// Returns `Ok(None)` if the provided string is not a valid URL.
-    ///
-    /// Returns `Ok(Some)` if the file was downloaded successfully.
+    /// Returns the location of the downloaded file.
     fn download<'a, 'b, 'c>(
         &'a self,
-        url: &'b str,
-    ) -> BoxFuture<'c, Result<Option<Location>, Arc<Error>>>
+        url: &'b Url,
+    ) -> BoxFuture<'c, Result<Location<'static>, Arc<Error>>>
     where
         'a: 'c,
         'b: 'c,
@@ -61,25 +59,41 @@ pub trait Downloader {
 
 /// Represents a location of a downloaded file.
 #[derive(Debug, Clone)]
-pub enum Location {
+pub enum Location<'a> {
     /// The file exists as a temporary file.
     ///
     /// This is used whenever a response body cannot be cached.
     Temp(Arc<TempPath>),
     /// The location is a path to a non-temporary file.
-    Path(PathBuf),
-    /// The location is a shared path to a non-temporary file.
-    SharedPath(Arc<PathBuf>),
+    Path(Cow<'a, Path>),
 }
 
-impl Deref for Location {
+impl Location<'_> {
+    /// Converts the location into an owned representation.
+    pub fn into_owned(self) -> Location<'static> {
+        match self {
+            Self::Temp(path) => Location::Temp(path),
+            Self::Path(path) => Location::Path(Cow::Owned(path.into_owned())),
+        }
+    }
+}
+
+impl Deref for Location<'_> {
     type Target = Path;
 
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Temp(p) => p,
             Self::Path(p) => p,
-            Self::SharedPath(p) => p,
+        }
+    }
+}
+
+impl AsRef<Path> for Location<'_> {
+    fn as_ref(&self) -> &Path {
+        match self {
+            Self::Temp(path) => path.as_ref(),
+            Self::Path(cow) => cow.as_ref(),
         }
     }
 }
@@ -91,7 +105,7 @@ pub enum Status {
     /// The specified `Notify` will be notified when the download completes.
     Downloading(Arc<Notify>),
     /// The requested resource has already been downloaded.
-    Downloaded(Result<Location, Arc<anyhow::Error>>),
+    Downloaded(Result<Location<'static>, Arc<anyhow::Error>>),
 }
 
 /// Responsible for downloading and caching remote files using HTTP.
@@ -140,7 +154,7 @@ impl HttpDownloader {
     /// Gets the file at the given URL.
     ///
     /// Returns the file's local location upon success.
-    async fn get(&self, url: &Url) -> Result<Location> {
+    async fn get(&self, url: &Url) -> Result<Location<'static>> {
         struct DisplayUrl<'a>(&'a Url);
 
         impl fmt::Display for DisplayUrl<'_> {
@@ -191,7 +205,7 @@ impl HttpDownloader {
             );
 
             // The file is in the cache
-            return Ok(Location::SharedPath(path.into()));
+            return Ok(Location::Path(path.into()));
         }
 
         // The file is not in the cache, we need to download it to a temporary path
@@ -228,58 +242,58 @@ impl HttpDownloader {
     }
 
     /// Applies authentication to the given URL.
-    fn apply_auth(&self, url: &mut Url) {
+    fn apply_auth<'a>(&self, url: Cow<'a, Url>) -> Cow<'a, Url> {
         // Attempt to apply auth for Azure storage
-        if azure::apply_auth(&self.config.storage.azure, url) {
-            return;
+        let (matched, url) = azure::apply_auth(&self.config.storage.azure, url);
+        if matched {
+            return url;
         }
 
         // Attempt to apply auth for S3 storage
-        if s3::apply_auth(&self.config.storage.s3, url) {
-            return;
+        let (matched, url) = s3::apply_auth(&self.config.storage.s3, url);
+        if matched {
+            return url;
         }
 
         // Finally, attempt to apply auth for Google Cloud Storage
-        google::apply_auth(&self.config.storage.google, url);
+        let (matched, url) = google::apply_auth(&self.config.storage.google, url);
+        if matched {
+            return url;
+        }
+
+        url
     }
 }
 
 impl Downloader for HttpDownloader {
     fn download<'a, 'b, 'c>(
         &'a self,
-        url: &'b str,
-    ) -> BoxFuture<'c, Result<Option<Location>, Arc<Error>>>
+        url: &'b Url,
+    ) -> BoxFuture<'c, Result<Location<'static>, Arc<Error>>>
     where
         'a: 'c,
         'b: 'c,
         Self: 'c,
     {
         async move {
-            // If the given string is not a URL, return `None`
-            let url: Url = match url.parse() {
-                Ok(url) => url,
-                Err(_) => return Ok(None),
-            };
-
-            let mut url = match url.scheme() {
+            let url: Cow<'_, Url> = match url.scheme() {
                 "file" => {
-                    // If it can be converted to a path, return the path; otherwise `None`
-                    return Ok(match url.to_file_path() {
-                        Ok(p) => Some(Location::Path(p)),
-                        Err(_) => None,
-                    });
+                    return Ok(Location::Path(Cow::Owned(
+                        url.to_file_path()
+                            .map_err(|_| anyhow!("invalid file URL `{url}`"))?,
+                    )));
                 }
-                "http" | "https" => url,
-                "az" => azure::rewrite_url(&url)?,
-                "s3" => s3::rewrite_url(&self.config.storage.s3, &url)?,
-                "gs" => google::rewrite_url(&url)?,
-                _ => return Ok(None),
+                "http" | "https" => Cow::Borrowed(url),
+                "az" => Cow::Owned(azure::rewrite_url(url)?),
+                "s3" => Cow::Owned(s3::rewrite_url(&self.config.storage.s3, url)?),
+                "gs" => Cow::Owned(google::rewrite_url(url)?),
+                _ => return Err(anyhow!("cannot download unsupported URL `{url}`").into()),
             };
 
             // TODO: support downloading "directories" for cloud storage URLs
 
             // Apply any authentication to the URL based on configuration
-            self.apply_auth(&mut url);
+            let url = self.apply_auth(url);
 
             // This loop exists so that all requests to download the same URL will block
             // waiting for a notification that the download has completed.
@@ -299,7 +313,7 @@ impl Downloader for HttpDownloader {
                             notify.clone()
                         }
                         Some(Status::Downloaded(r)) => {
-                            return r.clone().map(Into::into);
+                            return r.clone();
                         }
                         None => {
                             assert!(
@@ -308,7 +322,10 @@ impl Downloader for HttpDownloader {
                             );
 
                             // Insert an entry and break out of the loop to download
-                            downloads.insert(url.clone(), Status::Downloading(Arc::default()));
+                            downloads.insert(
+                                url.clone().into_owned(),
+                                Status::Downloading(Arc::default()),
+                            );
                             break;
                         }
                     }
@@ -333,7 +350,7 @@ impl Downloader for HttpDownloader {
             };
 
             notify.notify_waiters();
-            res.map(Some)
+            res
         }
         .boxed()
     }

--- a/wdl-engine/src/http.rs
+++ b/wdl-engine/src/http.rs
@@ -242,6 +242,8 @@ impl HttpDownloader {
     }
 
     /// Applies authentication to the given URL.
+    ///
+    /// Returns the provided URL unchanged if there was no auth to apply.
     fn apply_auth<'a>(&self, url: Cow<'a, Url>) -> Cow<'a, Url> {
         // Attempt to apply auth for Azure storage
         let (matched, url) = azure::apply_auth(&self.config.storage.azure, url);

--- a/wdl-engine/src/http/azure.rs
+++ b/wdl-engine/src/http/azure.rs
@@ -51,7 +51,12 @@ pub(crate) fn rewrite_url(url: &Url) -> Result<Url> {
 
 /// Applies Azure SAS token authentication to the given URL.
 ///
-/// Returns `(false, _)` if the URL is not for Azure Blob Storage.
+/// Returns `(false, _)` if the URL is not for Azure Blob Storage; the returned
+/// URL is unmodified.
+///
+/// Returns `(true, _)` if the URL is for Azure Blob Storage. If auth was
+/// applied, the returned URL is modified to include it; otherwise the original
+/// URL is returned unmodified.
 pub(crate) fn apply_auth<'a>(
     config: &AzureStorageConfig,
     url: Cow<'a, Url>,

--- a/wdl-engine/src/http/azure.rs
+++ b/wdl-engine/src/http/azure.rs
@@ -1,5 +1,7 @@
 //! Implementation of support for Azure Blob Storage URLs.
 
+use std::borrow::Cow;
+
 use anyhow::Context;
 use anyhow::Result;
 use tracing::warn;
@@ -49,46 +51,56 @@ pub(crate) fn rewrite_url(url: &Url) -> Result<Url> {
 
 /// Applies Azure SAS token authentication to the given URL.
 ///
-/// Returns `true` if the URL was for Azure or `false` if it was not.
-pub(crate) fn apply_auth(config: &AzureStorageConfig, url: &mut Url) -> bool {
-    if let Some(url::Host::Domain(domain)) = url.host() {
-        if let Some(account) = domain.strip_suffix(AZURE_STORAGE_DOMAIN_SUFFIX) {
-            // If the URL already has a query string, don't modify it
-            if url.query().is_some() {
-                return true;
-            }
+/// Returns `(false, _)` if the URL is not for Azure Blob Storage.
+pub(crate) fn apply_auth<'a>(
+    config: &AzureStorageConfig,
+    url: Cow<'a, Url>,
+) -> (bool, Cow<'a, Url>) {
+    // Attempt to extract the account from the domain
+    let account = match url.host().and_then(|host| match host {
+        url::Host::Domain(domain) => domain.strip_suffix(AZURE_STORAGE_DOMAIN_SUFFIX),
+        _ => None,
+    }) {
+        Some(account) => account,
+        None => return (false, url),
+    };
 
-            if let Some(mut segments) = url.path_segments() {
-                // Determine the container name; if there's only one path segment, then use the
-                // root container name
-                let container = match (segments.next(), segments.next()) {
-                    (Some(_), None) => ROOT_CONTAINER_NAME,
-                    (Some(container), Some(_)) => container,
-                    _ => return true,
-                };
-
-                if let Some(containers) = config.auth.get(account) {
-                    if let Some(token) = containers.get(container) {
-                        // Warn if the scheme isn't https, as we won't be applying the auth.
-                        if url.scheme() != "https" {
-                            warn!(
-                                "Azure Blob Storage URL `{url}` is not using HTTPS: \
-                                 authentication will not be used"
-                            );
-                            return true;
-                        }
-
-                        let token = token.strip_prefix('?').unwrap_or(token);
-                        url.set_query(Some(token));
-                    }
-                }
-            }
-
-            return true;
-        }
+    // If the URL already has a query string, don't modify it
+    if url.query().is_some() {
+        return (true, url);
     }
 
-    false
+    // Determine the container name; if there's only one path segment, then use the
+    // root container name
+    let container = match url.path_segments().and_then(|mut segments| {
+        match (segments.next(), segments.next()) {
+            (Some(_), None) => Some(ROOT_CONTAINER_NAME),
+            (Some(container), Some(_)) => Some(container),
+            _ => None,
+        }
+    }) {
+        Some(container) => container,
+        None => return (true, url),
+    };
+
+    // Apply the auth token if there is one
+    if let Some(token) = config
+        .auth
+        .get(account)
+        .and_then(|containers| containers.get(container))
+    {
+        if url.scheme() == "https" {
+            let token = token.strip_prefix('?').unwrap_or(token);
+            let mut url = url.into_owned();
+            url.set_query(Some(token));
+            return (true, Cow::Owned(url));
+        }
+
+        // Warn if the scheme isn't https, as we won't be applying the auth.
+        warn!("Azure Blob Storage URL `{url}` is not using HTTPS: authentication will not be used");
+    }
+
+    (true, url)
 }
 
 #[cfg(test)]
@@ -126,6 +138,17 @@ mod test {
 
     #[test]
     fn it_applies_auth() {
+        fn assert_auth(
+            config: &AzureStorageConfig,
+            url: &str,
+            expected_match: bool,
+            expected: &str,
+        ) {
+            let (matches, url) = apply_auth(config, Cow::Owned(url.parse().unwrap()));
+            assert_eq!(matches, expected_match);
+            assert_eq!(url.as_str(), expected);
+        }
+
         let mut config = AzureStorageConfig::default();
         config.auth.insert(
             "account".to_string(),
@@ -137,71 +160,67 @@ mod test {
         );
 
         // Not an Azure URL
-        let mut url = "https://example.com/bar/baz".parse().unwrap();
-        assert!(!apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://example.com/bar/baz");
+        assert_auth(
+            &config,
+            "https://example.com/bar/baz",
+            false,
+            "https://example.com/bar/baz",
+        );
 
         // Not using HTTPS
-        let mut url = "http://account.blob.core.windows.net/container1/foo"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "http://account.blob.core.windows.net/container1/foo"
+        assert_auth(
+            &config,
+            "http://account.blob.core.windows.net/container1/foo",
+            true,
+            "http://account.blob.core.windows.net/container1/foo",
         );
 
         // Azure URL but unknown account
-        let mut url = "https://foo.blob.core.windows.net/bar/baz".parse().unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://foo.blob.core.windows.net/bar/baz");
+        assert_auth(
+            &config,
+            "https://foo.blob.core.windows.net/bar/baz",
+            true,
+            "https://foo.blob.core.windows.net/bar/baz",
+        );
 
         // Azure URL but unknown container
-        let mut url = "https://account.blob.core.windows.net/bar/baz"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://account.blob.core.windows.net/bar/baz"
+        assert_auth(
+            &config,
+            "https://account.blob.core.windows.net/bar/baz",
+            true,
+            "https://account.blob.core.windows.net/bar/baz",
         );
 
         // Matching with first auth token
-        let mut url = "https://account.blob.core.windows.net/container1/foo"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://account.blob.core.windows.net/container1/foo?token1=foo"
+        assert_auth(
+            &config,
+            "https://account.blob.core.windows.net/container1/foo",
+            true,
+            "https://account.blob.core.windows.net/container1/foo?token1=foo",
         );
 
         // Matching with second auth token
-        let mut url = "https://account.blob.core.windows.net/container2/foo"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://account.blob.core.windows.net/container2/foo?token2=bar"
+        assert_auth(
+            &config,
+            "https://account.blob.core.windows.net/container2/foo",
+            true,
+            "https://account.blob.core.windows.net/container2/foo?token2=bar",
         );
 
         // Matching with third auth token
-        let mut url = "https://account.blob.core.windows.net/foo".parse().unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://account.blob.core.windows.net/foo?token3=qux"
+        assert_auth(
+            &config,
+            "https://account.blob.core.windows.net/foo",
+            true,
+            "https://account.blob.core.windows.net/foo?token3=qux",
         );
 
         // Matching with query params already present
-        let mut url = "https://account.blob.core.windows.net/container1/foo?a=b"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://account.blob.core.windows.net/container1/foo?a=b"
+        assert_auth(
+            &config,
+            "https://account.blob.core.windows.net/container1/foo?a=b",
+            true,
+            "https://account.blob.core.windows.net/container1/foo?a=b",
         );
     }
 }

--- a/wdl-engine/src/http/google.rs
+++ b/wdl-engine/src/http/google.rs
@@ -1,5 +1,7 @@
 //! Implementation of support for Google Cloud Storage URLs.
 
+use std::borrow::Cow;
+
 use anyhow::Context;
 use anyhow::Result;
 use tracing::warn;
@@ -46,66 +48,58 @@ pub(crate) fn rewrite_url(url: &Url) -> Result<Url> {
 
 /// Applies Google Cloud Storage presigned signatures to the given URL.
 ///
-/// Returns `true` if the URL was for Google Cloud Storage or `false` if it was
-/// not.
-pub(crate) fn apply_auth(config: &GoogleStorageConfig, url: &mut Url) -> bool {
-    if let Some(url::Host::Domain(domain)) = url.host() {
-        if let Some(domain) = domain.strip_suffix(GOOGLE_STORAGE_DOMAIN) {
-            // If the URL already has a query string, don't modify it
-            if url.query().is_some() {
-                return true;
-            }
+/// Returns `(false, _)` if the URL is not for Google Cloud Storage.
+pub(crate) fn apply_auth<'a>(
+    config: &GoogleStorageConfig,
+    url: Cow<'a, Url>,
+) -> (bool, Cow<'a, Url>) {
+    // Find the prefix of the domain; if empty, it indicates a path style URL
+    let prefix = match url.host().and_then(|host| match host {
+        url::Host::Domain(domain) => domain.strip_suffix(GOOGLE_STORAGE_DOMAIN),
+        _ => None,
+    }) {
+        Some(prefix) => prefix,
+        None => return (false, url),
+    };
 
-            // There are two supported URL formats:
-            // 1) Path style e.g. `https://storage.googleapis.com/<bucket>/<object>`
-            // 2) Virtual-host style, e.g. `https://<bucket>.storage.googleapis.com/<object>`.
-            let bucket = if domain.is_empty() {
-                // This is a path style URL; bucket is first path segment
-                let mut segments = match url.path_segments() {
-                    Some(segments) => segments,
-                    None => return true,
-                };
-
-                match segments.next() {
-                    Some(bucket) => bucket,
-                    None => return true,
-                }
-            } else {
-                // This is a virtual-host style URL; bucket is first subdomain
-                let mut subdomains = domain.split('.');
-                let bucket = match subdomains.next() {
-                    Some(bucket) => bucket,
-                    None => return true,
-                };
-
-                // Ensure there is nothing between the subdomain and the GCS domain
-                match subdomains.next() {
-                    Some("") => {}
-                    _ => return true,
-                }
-
-                bucket
-            };
-
-            if let Some(sig) = config.auth.get(bucket) {
-                // Warn if the scheme isn't https, as we won't be applying the auth.
-                if url.scheme() != "https" {
-                    warn!(
-                        "Google Cloud Storage URL `{url}` is not using HTTPS: authentication will \
-                         not be used"
-                    );
-                    return true;
-                }
-
-                let sig = sig.strip_prefix('?').unwrap_or(sig);
-                url.set_query(Some(sig));
-            }
-
-            return true;
-        }
+    // If the URL already has a query string, don't modify it
+    if url.query().is_some() {
+        return (true, url);
     }
 
-    false
+    // There are two supported URL formats:
+    // 1) Path style e.g. `https://storage.googleapis.com/<bucket>/<object>`
+    // 2) Virtual-host style, e.g. `https://<bucket>.storage.googleapis.com/<object>`.
+    let bucket = if prefix.is_empty() {
+        // This is a path style URL; bucket is first path segment
+        match url.path_segments().and_then(|mut segments| segments.next()) {
+            Some(bucket) => bucket,
+            None => return (true, url),
+        }
+    } else {
+        // This is a virtual-host style URL; bucket should be followed with a single dot
+        let mut iter = prefix.split('.');
+        match (iter.next(), iter.next(), iter.next()) {
+            (Some(bucket), Some(""), None) => bucket,
+            _ => return (true, url),
+        }
+    };
+
+    if let Some(sig) = config.auth.get(bucket) {
+        if url.scheme() == "https" {
+            let sig = sig.strip_prefix('?').unwrap_or(sig);
+            let mut url = url.into_owned();
+            url.set_query(Some(sig));
+            return (true, Cow::Owned(url));
+        }
+
+        // Warn if the scheme isn't https, as we won't be applying the auth.
+        warn!(
+            "Google Cloud Storage URL `{url}` is not using HTTPS: authentication will not be used"
+        );
+    }
+
+    (true, url)
 }
 
 #[cfg(test)]
@@ -141,6 +135,17 @@ mod test {
 
     #[test]
     fn it_applies_auth() {
+        fn assert_auth(
+            config: &GoogleStorageConfig,
+            url: &str,
+            expected_match: bool,
+            expected: &str,
+        ) {
+            let (matches, url) = apply_auth(config, Cow::Owned(url.parse().unwrap()));
+            assert_eq!(matches, expected_match);
+            assert_eq!(url.as_str(), expected);
+        }
+
         let mut config = GoogleStorageConfig::default();
         config
             .auth
@@ -151,82 +156,75 @@ mod test {
             .insert("bucket2".to_string(), "?token2=bar".to_string());
 
         // Not an GS URL
-        let mut url = "https://example.com/bar/baz".parse().unwrap();
-        assert!(!apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://example.com/bar/baz");
+        assert_auth(
+            &config,
+            "https://example.com/bar/baz",
+            false,
+            "https://example.com/bar/baz",
+        );
 
         // Not using HTTPS
-        let mut url = "http://storage.googleapis.com/bucket1/foo/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "http://storage.googleapis.com/bucket1/foo/bar"
+        assert_auth(
+            &config,
+            "http://storage.googleapis.com/bucket1/foo/bar",
+            true,
+            "http://storage.googleapis.com/bucket1/foo/bar",
         );
 
         // Unknown bucket (path)
-        let mut url = "https://storage.googleapis.com/foo/bar/baz"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://storage.googleapis.com/foo/bar/baz");
+        assert_auth(
+            &config,
+            "https://storage.googleapis.com/foo/bar/baz",
+            true,
+            "https://storage.googleapis.com/foo/bar/baz",
+        );
 
         // Unknown bucket (vhost)
-        let mut url = "https://foo.storage.googleapis.com/bar/baz"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://foo.storage.googleapis.com/bar/baz");
+        assert_auth(
+            &config,
+            "https://foo.storage.googleapis.com/bar/baz",
+            true,
+            "https://foo.storage.googleapis.com/bar/baz",
+        );
 
         // Matching with first auth token (path)
-        let mut url = "https://storage.googleapis.com/bucket1/foo/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://storage.googleapis.com/bucket1/foo/bar?token1=foo"
+        assert_auth(
+            &config,
+            "https://storage.googleapis.com/bucket1/foo/bar",
+            true,
+            "https://storage.googleapis.com/bucket1/foo/bar?token1=foo",
         );
 
         // Matching with first auth token (vhost)
-        let mut url = "https://bucket1.storage.googleapis.com/foo/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://bucket1.storage.googleapis.com/foo/bar?token1=foo"
+        assert_auth(
+            &config,
+            "https://bucket1.storage.googleapis.com/foo/bar",
+            true,
+            "https://bucket1.storage.googleapis.com/foo/bar?token1=foo",
         );
 
         // Matching with second auth token (path)
-        let mut url = "https://storage.googleapis.com/bucket2/foo/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://storage.googleapis.com/bucket2/foo/bar?token2=bar"
+        assert_auth(
+            &config,
+            "https://storage.googleapis.com/bucket2/foo/bar",
+            true,
+            "https://storage.googleapis.com/bucket2/foo/bar?token2=bar",
         );
 
         // Matching with second auth token (vhost)
-        let mut url = "https://bucket2.storage.googleapis.com/foo/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://bucket2.storage.googleapis.com/foo/bar?token2=bar"
+        assert_auth(
+            &config,
+            "https://bucket2.storage.googleapis.com/foo/bar",
+            true,
+            "https://bucket2.storage.googleapis.com/foo/bar?token2=bar",
         );
 
         // Matching with query params already present
-        let mut url = "https://storage.googleapis.com/bucket2/foo/bar?a=b"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://storage.googleapis.com/bucket2/foo/bar?a=b"
+        assert_auth(
+            &config,
+            "https://storage.googleapis.com/bucket2/foo/bar?a=b",
+            true,
+            "https://storage.googleapis.com/bucket2/foo/bar?a=b",
         );
     }
 }

--- a/wdl-engine/src/http/google.rs
+++ b/wdl-engine/src/http/google.rs
@@ -48,7 +48,12 @@ pub(crate) fn rewrite_url(url: &Url) -> Result<Url> {
 
 /// Applies Google Cloud Storage presigned signatures to the given URL.
 ///
-/// Returns `(false, _)` if the URL is not for Google Cloud Storage.
+/// Returns `(false, _)` if the URL is not for Google Cloud Storage; the
+/// returned URL is unmodified.
+///
+/// Returns `(true, _)` if the URL is for Google Cloud Storage. If auth was
+/// applied, the returned URL is modified to include it; otherwise the original
+/// URL is returned unmodified.
 pub(crate) fn apply_auth<'a>(
     config: &GoogleStorageConfig,
     url: Cow<'a, Url>,

--- a/wdl-engine/src/http/s3.rs
+++ b/wdl-engine/src/http/s3.rs
@@ -55,7 +55,12 @@ pub(crate) fn rewrite_url(config: &S3StorageConfig, url: &Url) -> Result<Url> {
 
 /// Applies S3 presigned signatures to the given URL.
 ///
-/// Returns `(false, _)` if the URL was for S3.
+/// Returns `(false, _)` if the URL is not for S3; the returned URL is
+/// unmodified.
+///
+/// Returns `(true, _)` if the URL is for S3. If auth was applied, the returned
+/// URL is modified to include it; otherwise the original URL is returned
+/// unmodified.
 pub(crate) fn apply_auth<'a>(config: &S3StorageConfig, url: Cow<'a, Url>) -> (bool, Cow<'a, Url>) {
     // Find the prefix of the domain
     let prefix = match url.host().and_then(|host| match host {

--- a/wdl-engine/src/http/s3.rs
+++ b/wdl-engine/src/http/s3.rs
@@ -1,5 +1,7 @@
 //! Implementation of support for Amazon AWS S3 URLs.
 
+use std::borrow::Cow;
+
 use anyhow::Context;
 use anyhow::Result;
 use tracing::warn;
@@ -7,8 +9,8 @@ use url::Url;
 
 use crate::config::S3StorageConfig;
 
-/// The S3 storage domain suffix.
-const S3_STORAGE_DOMAIN_SUFFIX: &str = ".amazonaws.com";
+/// The AWS domain suffix.
+const AWS_DOMAIN_SUFFIX: &str = ".amazonaws.com";
 
 /// The default S3 URL region.
 const DEFAULT_REGION: &str = "us-east-1";
@@ -25,24 +27,24 @@ pub(crate) fn rewrite_url(config: &S3StorageConfig, url: &Url) -> Result<Url> {
 
     match (url.query(), url.fragment()) {
         (None, None) => format!(
-            "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}",
+            "https://{bucket}.s3.{region}{AWS_DOMAIN_SUFFIX}{path}",
             path = url.path()
         ),
         (None, Some(fragment)) => {
             format!(
-                "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}#{fragment}",
+                "https://{bucket}.s3.{region}{AWS_DOMAIN_SUFFIX}{path}#{fragment}",
                 path = url.path()
             )
         }
         (Some(query), None) => {
             format!(
-                "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}?{query}",
+                "https://{bucket}.s3.{region}{AWS_DOMAIN_SUFFIX}{path}?{query}",
                 path = url.path()
             )
         }
         (Some(query), Some(fragment)) => {
             format!(
-                "https://{bucket}.s3.{region}{S3_STORAGE_DOMAIN_SUFFIX}{path}?{query}#{fragment}",
+                "https://{bucket}.s3.{region}{AWS_DOMAIN_SUFFIX}{path}?{query}#{fragment}",
                 path = url.path()
             )
         }
@@ -53,67 +55,58 @@ pub(crate) fn rewrite_url(config: &S3StorageConfig, url: &Url) -> Result<Url> {
 
 /// Applies S3 presigned signatures to the given URL.
 ///
-/// Returns `true` if the URL was for S3 or `false` if it was not.
-pub(crate) fn apply_auth(config: &S3StorageConfig, url: &mut Url) -> bool {
-    if let Some(url::Host::Domain(domain)) = url.host() {
-        if let Some(domain) = domain.strip_suffix(S3_STORAGE_DOMAIN_SUFFIX) {
-            // If the URL already has a query string, don't modify it
-            if url.query().is_some() {
-                return true;
-            }
+/// Returns `(false, _)` if the URL was for S3.
+pub(crate) fn apply_auth<'a>(config: &S3StorageConfig, url: Cow<'a, Url>) -> (bool, Cow<'a, Url>) {
+    // Find the prefix of the domain
+    let prefix = match url.host().and_then(|host| match host {
+        url::Host::Domain(domain) => domain.strip_suffix(AWS_DOMAIN_SUFFIX),
+        _ => None,
+    }) {
+        Some(prefix) => prefix,
+        None => return (false, url),
+    };
 
-            // There are three supported URL formats:
-            // 1) Path style without region, e.g. `https://s3.amazonaws.com/<bucket>/<object>`
-            // 2) Path style with region, e.g. `https://s3.<region>.amazonaws.com/<bucket>/<object>`.
-            // 3) Virtual-host style, e.g. `https://<bucket>.s3.<region>.amazonaws.com/<object>`.
-            let bucket = if domain == "s3"
-                || domain == "S3"
-                || domain.starts_with("s3.")
-                || domain.starts_with("S3.")
-            {
-                // This is a path style URL; bucket is first path segment
-                let mut segments = match url.path_segments() {
-                    Some(segments) => segments,
-                    None => return true,
-                };
-
-                match segments.next() {
-                    Some(bucket) => bucket,
-                    None => return true,
-                }
-            } else {
-                // This is a virtual-host style URL; bucket is first subdomain
-                let mut subdomains = domain.split('.');
-                let bucket = match subdomains.next() {
-                    Some(bucket) => bucket,
-                    None => return true,
-                };
-
-                // Ensure the URL is for the S3 service
-                match subdomains.next() {
-                    Some("s3") | Some("S3") => {}
-                    _ => return true,
-                }
-
-                bucket
-            };
-
-            if let Some(sig) = config.auth.get(bucket) {
-                // Warn if the scheme isn't https, as we won't be applying the auth.
-                if url.scheme() != "https" {
-                    warn!("S3 URL `{url}` is not using HTTPS: authentication will not be used");
-                    return true;
-                }
-
-                let sig = sig.strip_prefix('?').unwrap_or(sig);
-                url.set_query(Some(sig));
-            }
-
-            return true;
-        }
+    // If the URL already has a query string, don't modify it
+    if url.query().is_some() {
+        return (true, url);
     }
 
-    false
+    // There are three supported URL formats:
+    // 1) Path style without region, e.g. `https://s3.amazonaws.com/<bucket>/<object>`
+    // 2) Path style with region, e.g. `https://s3.<region>.amazonaws.com/<bucket>/<object>`.
+    // 3) Virtual-host style, e.g. `https://<bucket>.s3.<region>.amazonaws.com/<object>`.
+    let bucket = if prefix == "s3"
+        || prefix == "S3"
+        || prefix.starts_with("s3.")
+        || prefix.starts_with("S3.")
+    {
+        // This is a path style URL; bucket is first path segment
+        match url.path_segments().and_then(|mut segments| segments.next()) {
+            Some(bucket) => bucket,
+            None => return (true, url),
+        }
+    } else {
+        // This is a virtual-host style URL; bucket should be followed with `s3`.
+        let mut iter = prefix.split('.');
+        match (iter.next(), iter.next()) {
+            (Some(bucket), Some("s3")) | (Some(bucket), Some("S3")) => bucket,
+            _ => return (true, url),
+        }
+    };
+
+    if let Some(sig) = config.auth.get(bucket) {
+        if url.scheme() == "https" {
+            let sig = sig.strip_prefix('?').unwrap_or(sig);
+            let mut url = url.into_owned();
+            url.set_query(Some(sig));
+            return (true, Cow::Owned(url));
+        }
+
+        // Warn if the scheme isn't https, as we won't be applying the auth.
+        warn!("S3 URL `{url}` is not using HTTPS: authentication will not be used");
+    }
+
+    (true, url)
 }
 
 #[cfg(test)]
@@ -161,6 +154,12 @@ mod test {
 
     #[test]
     fn it_applies_auth() {
+        fn assert_auth(config: &S3StorageConfig, url: &str, expected_match: bool, expected: &str) {
+            let (matches, url) = apply_auth(config, Cow::Owned(url.parse().unwrap()));
+            assert_eq!(matches, expected_match);
+            assert_eq!(url.as_str(), expected);
+        }
+
         let mut config = S3StorageConfig::default();
         config
             .auth
@@ -171,103 +170,99 @@ mod test {
             .insert("bucket2".to_string(), "?token2=bar".to_string());
 
         // Not an S3 URL
-        let mut url = "https://example.com/bar/baz".parse().unwrap();
-        assert!(!apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://example.com/bar/baz");
+        assert_auth(
+            &config,
+            "https://example.com/bar/baz",
+            false,
+            "https://example.com/bar/baz",
+        );
 
         // Not using HTTPS
-        let mut url = "http://s3.us-east-1.amazonaws.com/bucket1/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "http://s3.us-east-1.amazonaws.com/bucket1/bar"
+        assert_auth(
+            &config,
+            "http://s3.us-east-1.amazonaws.com/bucket1/bar",
+            true,
+            "http://s3.us-east-1.amazonaws.com/bucket1/bar",
         );
 
         // Unknown bucket (path without region)
-        let mut url = "https://s3.amazonaws.com/foo/bar".parse().unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://s3.amazonaws.com/foo/bar");
+        assert_auth(
+            &config,
+            "https://s3.amazonaws.com/foo/bar",
+            true,
+            "https://s3.amazonaws.com/foo/bar",
+        );
 
         // Unknown bucket (path with region)
-        let mut url = "https://s3.us-east-1.amazonaws.com/foo/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://s3.us-east-1.amazonaws.com/foo/bar");
+        assert_auth(
+            &config,
+            "https://s3.us-east-1.amazonaws.com/foo/bar",
+            true,
+            "https://s3.us-east-1.amazonaws.com/foo/bar",
+        );
 
         // Unknown bucket (vhost)
-        let mut url = "https://foo.s3.us-east-1.amazonaws.com/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(url.as_str(), "https://foo.s3.us-east-1.amazonaws.com/bar");
+        assert_auth(
+            &config,
+            "https://foo.s3.us-east-1.amazonaws.com/bar",
+            true,
+            "https://foo.s3.us-east-1.amazonaws.com/bar",
+        );
 
         // Matching with first token (path without region)
-        let mut url = "https://s3.amazonaws.com/bucket1/bar".parse().unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://s3.amazonaws.com/bucket1/bar?token1=foo"
+        assert_auth(
+            &config,
+            "https://s3.amazonaws.com/bucket1/bar",
+            true,
+            "https://s3.amazonaws.com/bucket1/bar?token1=foo",
         );
 
         // Matching with first token(path with region)
-        let mut url = "https://s3.us-east-1.amazonaws.com/bucket1/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://s3.us-east-1.amazonaws.com/bucket1/bar?token1=foo"
+        assert_auth(
+            &config,
+            "https://s3.us-east-1.amazonaws.com/bucket1/bar",
+            true,
+            "https://s3.us-east-1.amazonaws.com/bucket1/bar?token1=foo",
         );
 
         // Matching with first token (vhost)
-        let mut url = "https://bucket1.s3.us-east-1.amazonaws.com/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://bucket1.s3.us-east-1.amazonaws.com/bar?token1=foo"
+        assert_auth(
+            &config,
+            "https://bucket1.s3.us-east-1.amazonaws.com/bar",
+            true,
+            "https://bucket1.s3.us-east-1.amazonaws.com/bar?token1=foo",
         );
 
         // Matching with second token (path without region)
-        let mut url = "https://s3.amazonaws.com/bucket2/bar".parse().unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://s3.amazonaws.com/bucket2/bar?token2=bar"
+        assert_auth(
+            &config,
+            "https://s3.amazonaws.com/bucket2/bar",
+            true,
+            "https://s3.amazonaws.com/bucket2/bar?token2=bar",
         );
 
         // Matching with second token(path with region)
-        let mut url = "https://s3.us-east-1.amazonaws.com/bucket2/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://s3.us-east-1.amazonaws.com/bucket2/bar?token2=bar"
+        assert_auth(
+            &config,
+            "https://s3.us-east-1.amazonaws.com/bucket2/bar",
+            true,
+            "https://s3.us-east-1.amazonaws.com/bucket2/bar?token2=bar",
         );
 
         // Matching with second token (vhost)
-        let mut url = "https://bucket2.s3.us-east-1.amazonaws.com/bar"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://bucket2.s3.us-east-1.amazonaws.com/bar?token2=bar"
+        assert_auth(
+            &config,
+            "https://bucket2.s3.us-east-1.amazonaws.com/bar",
+            true,
+            "https://bucket2.s3.us-east-1.amazonaws.com/bar?token2=bar",
         );
 
         // Matching with query params already present
-        let mut url = "https://bucket2.s3.us-east-1.amazonaws.com/bar?a=b"
-            .parse()
-            .unwrap();
-        assert!(apply_auth(&config, &mut url));
-        assert_eq!(
-            url.as_str(),
-            "https://bucket2.s3.us-east-1.amazonaws.com/bar?a=b"
+        assert_auth(
+            &config,
+            "https://bucket2.s3.us-east-1.amazonaws.com/bar?a=b",
+            true,
+            "https://bucket2.s3.us-east-1.amazonaws.com/bar?a=b",
         );
     }
 }

--- a/wdl-engine/src/lib.rs
+++ b/wdl-engine/src/lib.rs
@@ -23,6 +23,7 @@ use sysinfo::MemoryRefreshKind;
 use sysinfo::System;
 pub use units::*;
 pub use value::*;
+mod path;
 use wdl_analysis::diagnostics::unknown_type;
 use wdl_analysis::document::Document;
 use wdl_analysis::types::Type;

--- a/wdl-engine/src/path.rs
+++ b/wdl-engine/src/path.rs
@@ -251,44 +251,36 @@ mod test {
     fn test_url_parsing() {
         assert_eq!(
             parse_url("http://example.com/foo/bar/baz")
-                .map(|u| String::from(u))
+                .map(String::from)
                 .as_deref(),
             Some("http://example.com/foo/bar/baz")
         );
         assert_eq!(
             parse_url("https://example.com/foo/bar/baz")
-                .map(|u| String::from(u))
+                .map(String::from)
                 .as_deref(),
             Some("https://example.com/foo/bar/baz")
         );
         assert_eq!(
             parse_url("file:///foo/bar/baz")
-                .map(|u| String::from(u))
+                .map(String::from)
                 .as_deref(),
             Some("file:///foo/bar/baz")
         );
         assert_eq!(
-            parse_url("az://foo/bar/baz")
-                .map(|u| String::from(u))
-                .as_deref(),
+            parse_url("az://foo/bar/baz").map(String::from).as_deref(),
             Some("az://foo/bar/baz")
         );
         assert_eq!(
-            parse_url("s3://foo/bar/baz")
-                .map(|u| String::from(u))
-                .as_deref(),
+            parse_url("s3://foo/bar/baz").map(String::from).as_deref(),
             Some("s3://foo/bar/baz")
         );
         assert_eq!(
-            parse_url("gs://foo/bar/baz")
-                .map(|u| String::from(u))
-                .as_deref(),
+            parse_url("gs://foo/bar/baz").map(String::from).as_deref(),
             Some("gs://foo/bar/baz")
         );
         assert_eq!(
-            parse_url("foo://foo/bar/baz")
-                .map(|u| String::from(u))
-                .as_deref(),
+            parse_url("foo://foo/bar/baz").map(String::from).as_deref(),
             None
         );
     }
@@ -296,13 +288,19 @@ mod test {
     #[test]
     fn test_evaluation_path_parsing() {
         let p: EvaluationPath = "/foo/bar/baz".parse().expect("should parse");
-        assert_eq!(p.unwrap_local().as_os_str(), "/foo/bar/baz");
+        assert_eq!(
+            p.unwrap_local().to_str().unwrap().replace("\\", "/"),
+            "/foo/bar/baz"
+        );
 
         let p: EvaluationPath = "foo".parse().expect("should parse");
         assert_eq!(p.unwrap_local().as_os_str(), "foo");
 
         let p: EvaluationPath = "file:///foo/bar/baz".parse().expect("should parse");
-        assert_eq!(p.unwrap_local().as_os_str(), "/foo/bar/baz");
+        assert_eq!(
+            p.unwrap_local().to_str().unwrap().replace("\\", "/"),
+            "/foo/bar/baz"
+        );
 
         let p: EvaluationPath = "https://example.com/foo/bar/baz"
             .parse()
@@ -329,7 +327,9 @@ mod test {
             p.join("qux/../quux")
                 .expect("should join")
                 .unwrap_local()
-                .as_os_str(),
+                .to_str()
+                .unwrap()
+                .replace("\\", "/"),
             "/foo/bar/baz/quux"
         );
 
@@ -338,7 +338,9 @@ mod test {
             p.join("qux/../quux")
                 .expect("should join")
                 .unwrap_local()
-                .as_os_str(),
+                .to_str()
+                .unwrap()
+                .replace("\\", "/"),
             "foo/quux"
         );
 

--- a/wdl-engine/src/path.rs
+++ b/wdl-engine/src/path.rs
@@ -296,11 +296,17 @@ mod test {
         let p: EvaluationPath = "foo".parse().expect("should parse");
         assert_eq!(p.unwrap_local().as_os_str(), "foo");
 
-        let p: EvaluationPath = "file:///foo/bar/baz".parse().expect("should parse");
-        assert_eq!(
-            p.unwrap_local().to_str().unwrap().replace("\\", "/"),
-            "/foo/bar/baz"
-        );
+        #[cfg(unix)]
+        {
+            let p: EvaluationPath = "file:///foo/bar/baz".parse().expect("should parse");
+            assert_eq!(p.unwrap_local().as_os_str(), "/foo/bar/baz");
+        }
+
+        #[cfg(windows)]
+        {
+            let p: EvaluationPath = "file:///C:/foo/bar/baz".parse().expect("should parse");
+            assert_eq!(p.unwrap_local().as_os_str(), "C:\\foo\\bar\\baz");
+        }
 
         let p: EvaluationPath = "https://example.com/foo/bar/baz"
             .parse()
@@ -344,14 +350,29 @@ mod test {
             "foo/quux"
         );
 
-        let p: EvaluationPath = "file:///foo/bar/baz".parse().expect("should parse");
-        assert_eq!(
-            p.join("qux/../quux")
-                .expect("should join")
-                .unwrap_local()
-                .as_os_str(),
-            "/foo/bar/baz/quux"
-        );
+        #[cfg(unix)]
+        {
+            let p: EvaluationPath = "file:///foo/bar/baz".parse().expect("should parse");
+            assert_eq!(
+                p.join("qux/../quux")
+                    .expect("should join")
+                    .unwrap_local()
+                    .as_os_str(),
+                "/foo/bar/baz/quux"
+            );
+        }
+
+        #[cfg(windows)]
+        {
+            let p: EvaluationPath = "file:///C:/foo/bar/baz".parse().expect("should parse");
+            assert_eq!(
+                p.join("qux/../quux")
+                    .expect("should join")
+                    .unwrap_local()
+                    .as_os_str(),
+                "C:\\foo\\bar\\baz\\quux"
+            );
+        }
 
         let p: EvaluationPath = "https://example.com/foo/bar/baz"
             .parse()

--- a/wdl-engine/src/path.rs
+++ b/wdl-engine/src/path.rs
@@ -1,0 +1,211 @@
+//! Representation of evaluation paths that support URLs.
+
+use std::fmt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use path_clean::clean;
+use url::Url;
+
+use crate::PrimitiveValue;
+
+/// Determines if the given string is prefixed with a `file` URL scheme.
+pub fn is_file_url(s: &str) -> bool {
+    s.get(0..7)
+        .map(|s| s.eq_ignore_ascii_case("file://"))
+        .unwrap_or(false)
+}
+
+/// Determines if the given string is prefixed with a supported URL scheme.
+pub fn is_url(s: &str) -> bool {
+    ["http://", "https://", "file://", "az://", "s3://", "gs://"]
+        .iter()
+        .any(|prefix| {
+            s.get(0..prefix.len())
+                .map(|s| s.eq_ignore_ascii_case(prefix))
+                .unwrap_or(false)
+        })
+}
+
+/// Parses a string into a URL.
+///
+/// Returns `None` if the string is not a supported scheme or not a valid URL.
+pub fn parse_url(s: &str) -> Option<Url> {
+    if !is_url(s) {
+        return None;
+    }
+
+    s.parse().ok()
+}
+
+/// Represents a path used in evaluation that may be either local or remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvaluationPath {
+    /// The path is local (i.e. on the host).
+    Local(PathBuf),
+    /// The path is remote.
+    Remote(Url),
+}
+
+impl EvaluationPath {
+    /// Joins the given path to this path.
+    pub fn join(&self, path: &str) -> Result<Self> {
+        // URLs are absolute, so they can't be joined
+        if is_url(path) {
+            return path.parse();
+        }
+
+        // We can't join an absolute local path either
+        if Path::new(path).is_absolute() {
+            return Ok(Self::Local(clean(path)));
+        }
+
+        match self {
+            Self::Local(dir) => Ok(Self::Local(dir.join(clean(path)))),
+            Self::Remote(dir) => dir
+                .join(path)
+                .map(Self::Remote)
+                .with_context(|| format!("failed to join `{path}` to URL `{dir}`")),
+        }
+    }
+
+    /// Creates a path from a primitive `File` or `Directory` value.
+    pub fn from_primitive_value(v: &PrimitiveValue) -> Result<Self> {
+        match v {
+            PrimitiveValue::File(path) | PrimitiveValue::Directory(path) => path.parse(),
+            _ => bail!("primitive value must be a `File` or a `Directory`"),
+        }
+    }
+
+    /// Gets a string representation of the path.
+    ///
+    /// Returns `None` if the path is local and cannot be represented in UTF-8.
+    pub fn to_str(&self) -> Option<&str> {
+        match self {
+            Self::Local(path) => path.to_str(),
+            Self::Remote(url) => Some(url.as_str()),
+        }
+    }
+
+    /// Converts the path to a local path.
+    ///
+    /// Returns `None` if the path is remote.
+    pub fn as_local(&self) -> Option<&Path> {
+        match self {
+            Self::Local(path) => Some(path),
+            Self::Remote(_) => None,
+        }
+    }
+
+    /// Unwraps the path to a local path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the path is remote.
+    pub fn unwrap_local(self) -> PathBuf {
+        match self {
+            Self::Local(path) => path,
+            Self::Remote(_) => panic!("path is remote"),
+        }
+    }
+
+    /// Converts the path to a remote URL.
+    ///
+    /// Returns `None` if the path is local.
+    pub fn as_remote(&self) -> Option<&Url> {
+        match self {
+            Self::Local(_) => None,
+            Self::Remote(url) => Some(url),
+        }
+    }
+
+    /// Unwraps the path to a remote URL.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the path is local.
+    pub fn unwrap_remote(self) -> Url {
+        match self {
+            Self::Local(_) => panic!("path is local"),
+            Self::Remote(url) => url,
+        }
+    }
+
+    /// Gets the file name of the path.
+    ///
+    /// Returns `Ok(None)` if the path does not contain a file name (i.e. is
+    /// root).
+    ///
+    /// Returns an error if the file name is not UTF-8.
+    pub fn file_name(&self) -> Result<Option<&str>> {
+        match self {
+            Self::Local(path) => path
+                .file_name()
+                .map(|n| {
+                    n.to_str().with_context(|| {
+                        format!("path `{path}` is not UTF-8", path = path.display())
+                    })
+                })
+                .transpose(),
+            Self::Remote(url) => Ok(url.path_segments().and_then(|mut s| s.next_back())),
+        }
+    }
+
+    /// Returns a display implementation for the path.
+    pub fn display(&self) -> impl fmt::Display {
+        struct Display<'a>(&'a EvaluationPath);
+
+        impl fmt::Display for Display<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    EvaluationPath::Local(path) => write!(f, "{path}", path = path.display()),
+                    EvaluationPath::Remote(url) => write!(f, "{url}"),
+                }
+            }
+        }
+
+        Display(self)
+    }
+}
+
+impl FromStr for EvaluationPath {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Store `file` schemed URLs as local paths.
+        if is_file_url(s) {
+            let url = s
+                .parse::<Url>()
+                .with_context(|| format!("invalid `file` schemed URL `{s}`"))?;
+            return url
+                .to_file_path()
+                .map(|p| Self::Local(clean(p)))
+                .map_err(|_| anyhow!("URL `{s}` cannot be represented as a local file path"));
+        }
+
+        if let Some(url) = parse_url(s) {
+            return Ok(Self::Remote(url));
+        }
+
+        Ok(Self::Local(clean(s)))
+    }
+}
+
+impl TryFrom<EvaluationPath> for String {
+    type Error = anyhow::Error;
+
+    fn try_from(value: EvaluationPath) -> Result<Self, Self::Error> {
+        match value {
+            EvaluationPath::Local(path) => path
+                .into_os_string()
+                .into_string()
+                .map_err(|_| anyhow!("path cannot be represented as a UTF-8 string")),
+            EvaluationPath::Remote(url) => Ok(url.into()),
+        }
+    }
+}

--- a/wdl-engine/src/stdlib/read_boolean.rs
+++ b/wdl-engine/src/stdlib/read_boolean.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_boolean` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::fs;
@@ -17,6 +14,7 @@ use super::Function;
 use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_boolean";
@@ -38,30 +36,20 @@ fn read_boolean(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
@@ -76,7 +64,7 @@ fn read_boolean(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
         };
 
         let mut lines =
-            BufReader::new(fs::File::open(&cache_path).await.map_err(read_error)?).lines();
+            BufReader::new(fs::File::open(&file_path).await.map_err(read_error)?).lines();
         let mut line = lines
             .next_line()
             .await

--- a/wdl-engine/src/stdlib/read_float.rs
+++ b/wdl-engine/src/stdlib/read_float.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_float` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::fs;
@@ -17,6 +14,7 @@ use super::Function;
 use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_float";
@@ -37,30 +35,20 @@ fn read_float(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
@@ -75,7 +63,7 @@ fn read_float(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
         };
 
         let mut lines =
-            BufReader::new(fs::File::open(&cache_path).await.map_err(read_error)?).lines();
+            BufReader::new(fs::File::open(&file_path).await.map_err(read_error)?).lines();
         let line = lines
             .next_line()
             .await

--- a/wdl-engine/src/stdlib/read_int.rs
+++ b/wdl-engine/src/stdlib/read_int.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_int` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::fs;
@@ -17,6 +14,7 @@ use super::Function;
 use super::Signature;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_int";
@@ -37,30 +35,20 @@ fn read_int(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
@@ -75,7 +63,7 @@ fn read_int(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
         };
 
         let mut lines =
-            BufReader::new(fs::File::open(&cache_path).await.map_err(read_error)?).lines();
+            BufReader::new(fs::File::open(&file_path).await.map_err(read_error)?).lines();
         let line = lines
             .next_line()
             .await

--- a/wdl-engine/src/stdlib/read_lines.rs
+++ b/wdl-engine/src/stdlib/read_lines.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_lines` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::fs;
@@ -20,6 +17,7 @@ use crate::Array;
 use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_lines";
@@ -44,36 +42,26 @@ fn read_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnosti
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
         };
 
-        let file = fs::File::open(&cache_path).await.map_err(read_error)?;
+        let file = fs::File::open(&file_path).await.map_err(read_error)?;
         let mut lines = BufReader::new(file).lines();
         let mut elements = Vec::new();
         while let Some(line) = lines.next_line().await.map_err(read_error)? {

--- a/wdl-engine/src/stdlib/read_map.rs
+++ b/wdl-engine/src/stdlib/read_map.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_map` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
@@ -21,6 +18,7 @@ use crate::Map;
 use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_map";
@@ -48,36 +46,26 @@ fn read_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
         };
 
-        let file = fs::File::open(&cache_path).await.map_err(read_error)?;
+        let file = fs::File::open(&file_path).await.map_err(read_error)?;
 
         let mut i = 1;
         let mut lines = BufReader::new(file).lines();

--- a/wdl-engine/src/stdlib/read_objects.rs
+++ b/wdl-engine/src/stdlib/read_objects.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_objects` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
@@ -25,6 +22,7 @@ use crate::Object;
 use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_objects";
@@ -56,36 +54,26 @@ fn read_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnos
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
         };
 
-        let file = fs::File::open(&cache_path).await.map_err(read_error)?;
+        let file = fs::File::open(&file_path).await.map_err(read_error)?;
 
         let mut lines = BufReader::new(file).lines();
         let names = match lines.next_line().await.map_err(read_error)? {

--- a/wdl-engine/src/stdlib/read_string.rs
+++ b/wdl-engine/src/stdlib/read_string.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_string` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::fs;
@@ -16,6 +13,7 @@ use super::Signature;
 use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_string";
@@ -35,36 +33,26 @@ fn read_string(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
         };
 
-        let mut contents = fs::read_to_string(&cache_path).await.map_err(read_error)?;
+        let mut contents = fs::read_to_string(&file_path).await.map_err(read_error)?;
         let trimmed = contents.trim_end_matches(['\r', '\n']);
         contents.truncate(trimmed.len());
         Ok(PrimitiveValue::new_string(contents).into())
@@ -101,7 +89,10 @@ mod test {
             "file",
             PrimitiveValue::new_file(
                 env.work_dir()
+                    .unwrap()
                     .join("foo")
+                    .unwrap()
+                    .unwrap_local()
                     .to_str()
                     .expect("should be UTF-8"),
             ),

--- a/wdl-engine/src/stdlib/read_tsv.rs
+++ b/wdl-engine/src/stdlib/read_tsv.rs
@@ -1,8 +1,5 @@
 //! Implements the `read_tsv` function from the WDL standard library.
 
-use std::borrow::Cow;
-use std::path::Path;
-
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
@@ -26,6 +23,7 @@ use crate::CompoundValue;
 use crate::PrimitiveValue;
 use crate::Value;
 use crate::diagnostics::function_call_failed;
+use crate::stdlib::download_file;
 
 /// The name of the function defined in this file for use in diagnostics.
 const FUNCTION_NAME: &str = "read_tsv";
@@ -75,36 +73,26 @@ fn read_tsv_simple(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diag
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
         };
 
-        let file = fs::File::open(&cache_path).await.map_err(read_error)?;
+        let file = fs::File::open(&file_path).await.map_err(read_error)?;
         let mut lines = BufReader::new(file).lines();
         let mut rows: Vec<Value> = Vec::new();
         while let Some(line) = lines.next_line().await.map_err(read_error)? {
@@ -151,36 +139,26 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
             .coerce_argument(0, PrimitiveType::File)
             .unwrap_file();
 
-        let location = context
-            .context
-            .downloader()
-            .download(&path)
-            .await
-            .map_err(|e| {
-                function_call_failed(
-                    FUNCTION_NAME,
-                    format!("failed to download file `{path}`: {e:?}"),
-                    context.call_site,
-                )
-            })?;
-
-        let cache_path: Cow<'_, Path> = location
-            .as_deref()
-            .map(Into::into)
-            .unwrap_or_else(|| context.work_dir().join(path.as_str()).into());
+        let file_path = download_file(
+            context.context.downloader(),
+            context.work_dir(),
+            path.as_str(),
+        )
+        .await
+        .map_err(|e| function_call_failed(FUNCTION_NAME, e, context.arguments[0].span))?;
 
         let read_error = |e: std::io::Error| {
             function_call_failed(
                 FUNCTION_NAME,
                 format!(
                     "failed to read file `{path}`: {e}",
-                    path = cache_path.display()
+                    path = file_path.display()
                 ),
                 context.call_site,
             )
         };
 
-        let file = fs::File::open(&cache_path).await.map_err(read_error)?;
+        let file = fs::File::open(&file_path).await.map_err(read_error)?;
 
         let mut lines = BufReader::new(file).lines();
 

--- a/wdl-engine/tests/inputs.rs
+++ b/wdl-engine/tests/inputs.rs
@@ -111,7 +111,12 @@ fn compare_result(path: &Path, result: &str) -> Result<()> {
     }
 
     let expected = fs::read_to_string(path)
-        .with_context(|| format!("failed to read result file `{path}`", path = path.display()))?
+        .with_context(|| {
+            format!(
+                "failed to read result file `{path}`: expected contents to be `{result}`",
+                path = path.display()
+            )
+        })?
         .replace("\r\n", "\n");
 
     if expected != result {

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -149,7 +149,12 @@ fn compare_result(path: &Path, result: &str) -> Result<()> {
     }
 
     let expected = fs::read_to_string(path)
-        .with_context(|| format!("failed to read result file `{path}`", path = path.display()))?
+        .with_context(|| {
+            format!(
+                "failed to read result file `{path}`: expected contents to be `{result}`",
+                path = path.display()
+            )
+        })?
         .replace("\r\n", "\n");
 
     if expected != result {

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -64,7 +64,7 @@ use wdl_engine::v1::TaskEvaluator;
 
 /// Regex used to remove both host and guest path prefixes.
 static PATH_PREFIX_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(attempts[\/\\]\d+[\/\\]|\/mnt\/task\/inputs\/\d+\/)"#).expect("invalid regex")
+    Regex::new(r#"(attempts[\/\\]\d+[\/\\]|\/mnt\/inputs\/\d+\/)"#).expect("invalid regex")
 });
 
 /// Regex used to replace temporary file names in task command files with
@@ -277,10 +277,10 @@ fn compare_evaluation_results(
     temp_dir: &Path,
     evaluated: &EvaluatedTask,
 ) -> Result<()> {
-    let command = fs::read_to_string(evaluated.command()).with_context(|| {
+    let command = fs::read_to_string(evaluated.root().command()).with_context(|| {
         format!(
             "failed to read task command file `{path}`",
-            path = evaluated.command().display()
+            path = evaluated.root().command().display()
         )
     })?;
     let stdout =
@@ -324,7 +324,12 @@ fn compare_evaluation_results(
     // Compare expected output files
     let mut had_files = false;
     let files_dir = test_dir.join("files");
-    for entry in WalkDir::new(evaluated.work_dir()) {
+    for entry in WalkDir::new(
+        evaluated
+            .work_dir()
+            .as_local()
+            .expect("work dir should be local"),
+    ) {
         let entry = entry.with_context(|| {
             format!(
                 "failed to read directory `{path}`",
@@ -352,7 +357,12 @@ fn compare_evaluation_results(
         let expected_path = files_dir.join(
             entry
                 .path()
-                .strip_prefix(evaluated.work_dir())
+                .strip_prefix(
+                    evaluated
+                        .work_dir()
+                        .as_local()
+                        .expect("should be local path"),
+                )
                 .unwrap_or(entry.path()),
         );
         fs::create_dir_all(
@@ -387,7 +397,10 @@ fn compare_evaluation_results(
                 .path()
                 .strip_prefix(&files_dir)
                 .unwrap_or(entry.path());
-            let expected_path = evaluated.work_dir().join(relative_path);
+            let expected_path = evaluated
+                .work_dir()
+                .join(relative_path.to_str().unwrap())?
+                .unwrap_local();
             if !expected_path.is_file() {
                 bail!(
                     "task did not produce expected output file `{path}`",

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -288,20 +288,18 @@ fn compare_evaluation_results(
             path = evaluated.root().command().display()
         )
     })?;
-    let stdout =
-        fs::read_to_string(evaluated.stdout().as_file().unwrap().as_str()).with_context(|| {
-            format!(
-                "failed to read task stdout file `{path}`",
-                path = evaluated.stdout().as_file().unwrap()
-            )
-        })?;
-    let stderr =
-        fs::read_to_string(evaluated.stderr().as_file().unwrap().as_str()).with_context(|| {
-            format!(
-                "failed to read task stderr file `{path}`",
-                path = evaluated.stderr().as_file().unwrap()
-            )
-        })?;
+    let stdout = fs::read_to_string(evaluated.root().stdout()).with_context(|| {
+        format!(
+            "failed to read task stdout file `{path}`",
+            path = evaluated.root().stdout().display()
+        )
+    })?;
+    let stderr = fs::read_to_string(evaluated.root().stderr()).with_context(|| {
+        format!(
+            "failed to read task stderr file `{path}`",
+            path = evaluated.root().stderr().display()
+        )
+    })?;
 
     // Strip both temp paths and test dir (input file) paths from the outputs
     let command = strip_paths(temp_dir, &command);

--- a/wdl-engine/tests/tasks/task-fail/error.txt
+++ b/wdl-engine/tests/tasks/task-fail/error.txt
@@ -1,4 +1,8 @@
 task execution failed for task `test` in `tests/tasks/task-fail/source.wdl` (task id `test`)
 
 Caused by:
-    task process has terminated with status code 1; see the `stdout` and `stderr` files in execution directory `attempts/0/` for task command output
+    task process has terminated with exit code 1: see the `stdout` and `stderr` files in execution directory `attempts/0/` for task command output
+    
+    task stderr output:
+    this task is going to fail!
+    

--- a/wdl-engine/tests/workflows.rs
+++ b/wdl-engine/tests/workflows.rs
@@ -131,7 +131,12 @@ fn compare_result(path: &Path, result: &str) -> Result<()> {
     }
 
     let expected = fs::read_to_string(path)
-        .with_context(|| format!("failed to read result file `{path}`", path = path.display()))?
+        .with_context(|| {
+            format!(
+                "failed to read result file `{path}`: expected contents to be `{result}`",
+                path = path.display()
+            )
+        })?
         .replace("\r\n", "\n");
 
     if expected != result {

--- a/wdl-engine/tests/workflows/localization/foo.txt
+++ b/wdl-engine/tests/workflows/localization/foo.txt
@@ -1,0 +1,1 @@
+This is a local input file.

--- a/wdl-engine/tests/workflows/localization/inputs.json
+++ b/wdl-engine/tests/workflows/localization/inputs.json
@@ -1,0 +1,5 @@
+{
+    "test.one": "https://jsonplaceholder.typicode.com/todos/1",
+    "test.two": "https://jsonplaceholder.typicode.com/todos/2",
+    "test.local": "foo.txt"
+}

--- a/wdl-engine/tests/workflows/localization/outputs.json
+++ b/wdl-engine/tests/workflows/localization/outputs.json
@@ -1,0 +1,15 @@
+{
+  "test.o1": {
+    "userId": 1,
+    "id": 1,
+    "title": "delectus aut autem",
+    "completed": false
+  },
+  "test.o2": {
+    "userId": 1,
+    "id": 2,
+    "title": "quis ut nam facilis et officia qui",
+    "completed": false
+  },
+  "test.s": "This is a local input file."
+}

--- a/wdl-engine/tests/workflows/localization/source.wdl
+++ b/wdl-engine/tests/workflows/localization/source.wdl
@@ -1,0 +1,43 @@
+## This is a test of localizing remote files for task execution.
+
+version 1.1
+
+task t {
+    # This path should not be localized or translated to a guest path
+    File relative_path = "relative.txt"
+
+    input {
+        File one
+        File two
+        File local
+    }
+
+    command <<<
+        set -euo pipefail
+        cat ~{local} > ~{relative_path}
+        cat ~{one} > one
+        cat ~{two} > two
+    >>>
+
+    output {
+        File one_out = "one"
+        File two_out = "two"
+        File relative_out = relative_path
+    }
+}
+
+workflow test {
+    input {
+        File one
+        File two
+        File local
+    }
+
+    call t { input: one, two, local }
+
+    output {
+        Object o1 = read_json(t.one_out)
+        Object o2 = read_json(t.two_out)
+        String s = read_string(t.relative_out)
+    }
+}

--- a/wdl-engine/tests/workflows/localization/source.wdl
+++ b/wdl-engine/tests/workflows/localization/source.wdl
@@ -14,9 +14,9 @@ task t {
 
     command <<<
         set -euo pipefail
-        cat ~{local} > ~{relative_path}
-        cat ~{one} > one
-        cat ~{two} > two
+        cat '~{local}' > ~{relative_path}
+        cat '~{one}' > one
+        cat '~{two}' > two
     >>>
 
     output {


### PR DESCRIPTION
This PR implements localization of remote files for task execution.

For both the Docker and local backends, remote paths (i.e. by URL) that are visible to command evaluation are localized by downloading them to the file cache.

To implement this feature, `PathTrie` has been renamed to `InputTrie` and the representation of "mounts" has changed to "inputs".

Input paths may be either local (a file path) or remote (a URL).

This feature will also soon enable a new TES backend that executes tasks remotely, where inputs should _not_ be localized and the task working directory is actually stored remotely.

Additional refactoring of the stdlib functions was required to properly handle remote paths.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
