### PR TITLE
chore: fix clippy warnings.

### DIFF
--- a/wdl-ast/src/v1/import.rs
+++ b/wdl-ast/src/v1/import.rs
@@ -67,7 +67,7 @@ impl<N: TreeNode> ImportStatement<N> {
         let text = uri.text()?;
         let stem = match Url::parse(text.text()) {
             Ok(url) => Path::new(
-                urlencoding::decode(url.path_segments()?.last()?)
+                urlencoding::decode(url.path_segments()?.next_back()?)
                     .ok()?
                     .as_ref(),
             )

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -169,7 +169,7 @@ impl Visitor for CommentWhitespaceRule {
                     let this_whitespace = leading_whitespace.text();
                     let this_indentation = this_whitespace
                         .split('\n')
-                        .last()
+                        .next_back()
                         .expect("should have prior whitespace");
                     if this_indentation != expected_indentation {
                         // Report a diagnostic if the comment is not indented properly

--- a/wdl-lint/src/rules/key_value_pairs.rs
+++ b/wdl-lint/src/rules/key_value_pairs.rs
@@ -144,7 +144,10 @@ impl Visitor for KeyValuePairsRule {
             .into_token()
             .expect("should have a token")
             .to_string();
-        let parent_ws = tmp.split('\n').last().expect("should have indentation");
+        let parent_ws = tmp
+            .split('\n')
+            .next_back()
+            .expect("should have indentation");
 
         if !item.inner().to_string().contains('\n') {
             state.exceptable_add(
@@ -197,7 +200,10 @@ impl Visitor for KeyValuePairsRule {
                 {
                     // If there was no newline, that is already reported
                     let ws = prior_ws.to_string();
-                    let ws = ws.split('\n').last().expect("should have a last element");
+                    let ws = ws
+                        .split('\n')
+                        .next_back()
+                        .expect("should have a last element");
                     let expected_ws = parent_ws.to_owned() + INDENT;
 
                     if ws != expected_ws {
@@ -218,7 +224,7 @@ impl Visitor for KeyValuePairsRule {
                 let ws = prior_ws.to_string();
                 let ws = ws
                     .split('\n')
-                    .last()
+                    .next_back()
                     .expect("there should be a last element");
                 let expected_ws = parent_ws.to_owned();
 
@@ -259,7 +265,10 @@ impl Visitor for KeyValuePairsRule {
             .into_token()
             .expect("should have a token")
             .to_string();
-        let parent_ws = tmp.split('\n').last().expect("should have indentation");
+        let parent_ws = tmp
+            .split('\n')
+            .next_back()
+            .expect("should have indentation");
 
         // If the array is all on one line, report that
         if !item.inner().to_string().contains('\n') {
@@ -315,7 +324,7 @@ impl Visitor for KeyValuePairsRule {
                     let ws = prior_ws.to_string();
                     let ws = ws
                         .split('\n')
-                        .last()
+                        .next_back()
                         .expect("there should be a last element");
                     let expected_ws = parent_ws.to_owned() + INDENT;
 
@@ -337,7 +346,7 @@ impl Visitor for KeyValuePairsRule {
                 let ws = prior_ws.to_string();
                 let ws = ws
                     .split('\n')
-                    .last()
+                    .next_back()
                     .expect("there should be a last element");
                 let expected_ws = parent_ws.to_owned();
 


### PR DESCRIPTION
A new Rust version was released today with a helpful lint of calling `next_back` instead of `last` on double-ended iterators.

This fixes those calls.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
