### PR TITLE
Fix gauntlet diagnostics windows

### DIFF
--- a/gauntlet/CHANGELOG.md
+++ b/gauntlet/CHANGELOG.md
@@ -7,44 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-#### Added
+### Added
 
 * `--shellcheck` flag to run shellcheck lints in arena mode ([#264](https://github.com/stjude-rust-labs/wdl/pull/264))
 * Full analysis instead of basic validation ([#207](https://github.com/stjude-rust-labs/wdl/pull/172))
 * Checkout submodules ([#207](https://github.com/stjude-rust-labs/wdl/pull/172))
 
-#### Changed
+### Changed
 
 * Use `tracing` events instead of the `log` crate ([#172](https://github.com/stjude-rust-labs/wdl/pull/172))
 * Changed name from `wdl-gauntlet` to just `gauntlet`
 * Set `publish = false` in `Cargo.toml`
 * Break `refresh` option into `bless` and `update` flags ([#261](https://github.com/stjude-rust-labs/wdl/pull/261))
 
+### Fixed
+
+* Added diagnostic message normalization to ensure consistent behavior across platforms ([#385](https://github.com/stjude-rust-labs/wdl/issues/385))
+
 ## 0.5.0 - 08-22-2024
 
-#### Changed
+### Changed
 
 * bump dependency versions
 
 ## 0.4.0 - 06-28-2024
 
-#### Changed
+### Changed
 
 * Upgradted `wdl` crate dependencies
 
-#### Added
+### Added
 
 * Permalinks for each diagnostic
 
 ## 0.3.0 - 06-13-2024
 
-#### Changed
+### Changed
 
 * Migrated `wdl-gauntlet` to use the new parser implementation ([#76](https://github.com/stjude-rust-labs/wdl/pull/76))
 
 ## 0.2.0 - 05-31-2024
 
-#### Changed
+### Changed
 
 * Core goal of crate is split in two:
   * **The goal of** (base) **`wdl-gauntlet` is to ensure the parsing of syntactically valid WDLs never regresses.**
@@ -53,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * uses `libgit2` (via the `git2` crate) instead of the GitHub REST API (via `octocrab` and `reqwest` crates)
 * no more persistent cache (Now uses `temp-dir`)
 
-#### Added
+### Added
 
 * The `--arena` flag and `Arena.toml` for lint rule testing
 * more test repos!
@@ -61,6 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.0 — 12-17-2023
 
-#### Added
+### Added
 
 * Adds the initial version of the crate.

--- a/gauntlet/CHANGELOG.md
+++ b/gauntlet/CHANGELOG.md
@@ -7,48 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
+#### Added
 
 * `--shellcheck` flag to run shellcheck lints in arena mode ([#264](https://github.com/stjude-rust-labs/wdl/pull/264))
 * Full analysis instead of basic validation ([#207](https://github.com/stjude-rust-labs/wdl/pull/172))
 * Checkout submodules ([#207](https://github.com/stjude-rust-labs/wdl/pull/172))
 
-### Changed
+#### Changed
 
 * Use `tracing` events instead of the `log` crate ([#172](https://github.com/stjude-rust-labs/wdl/pull/172))
 * Changed name from `wdl-gauntlet` to just `gauntlet`
 * Set `publish = false` in `Cargo.toml`
 * Break `refresh` option into `bless` and `update` flags ([#261](https://github.com/stjude-rust-labs/wdl/pull/261))
 
-### Fixed
+#### Fixed
 
 * Added diagnostic message normalization to ensure consistent behavior across platforms ([#385](https://github.com/stjude-rust-labs/wdl/issues/385))
 
 ## 0.5.0 - 08-22-2024
 
-### Changed
+#### Changed
 
 * bump dependency versions
 
 ## 0.4.0 - 06-28-2024
 
-### Changed
+#### Changed
 
-* Upgradted `wdl` crate dependencies
+* Upgraded `wdl` crate dependencies
 
-### Added
+#### Added
 
 * Permalinks for each diagnostic
 
 ## 0.3.0 - 06-13-2024
 
-### Changed
+#### Changed
 
 * Migrated `wdl-gauntlet` to use the new parser implementation ([#76](https://github.com/stjude-rust-labs/wdl/pull/76))
 
 ## 0.2.0 - 05-31-2024
 
-### Changed
+#### Changed
 
 * Core goal of crate is split in two:
   * **The goal of** (base) **`wdl-gauntlet` is to ensure the parsing of syntactically valid WDLs never regresses.**
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * uses `libgit2` (via the `git2` crate) instead of the GitHub REST API (via `octocrab` and `reqwest` crates)
 * no more persistent cache (Now uses `temp-dir`)
 
-### Added
+#### Added
 
 * The `--arena` flag and `Arena.toml` for lint rule testing
 * more test repos!
@@ -65,6 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.0 — 12-17-2023
 
-### Added
+#### Added
 
 * Adds the initial version of the crate.

--- a/gauntlet/src/config/inner.rs
+++ b/gauntlet/src/config/inner.rs
@@ -12,6 +12,7 @@ use serde_with::serde_as;
 use crate::document;
 use crate::repository;
 use crate::repository::RawHash;
+use crate::normalize_diagnostic;
 
 /// Represents a diagnostic reported for a document.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -45,7 +46,7 @@ impl Diagnostic {
         };
         Self {
             document,
-            message,
+            message: normalize_diagnostic(&message),
             permalink: url,
         }
     }

--- a/gauntlet/src/config/inner.rs
+++ b/gauntlet/src/config/inner.rs
@@ -10,9 +10,9 @@ use serde::Serialize;
 use serde_with::serde_as;
 
 use crate::document;
+use crate::normalize_diagnostic;
 use crate::repository;
 use crate::repository::RawHash;
-use crate::normalize_diagnostic;
 
 /// Represents a diagnostic reported for a document.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -144,7 +144,7 @@ pub fn normalize_diagnostic(s: &str) -> String {
         "The system cannot find the file specified. (os error 2)",
         "No such file or directory (os error 2)",
     );
-    
+
     // Also handle Windows "path not found" error
     s.replace(
         "The system cannot find the path specified. (os error 3)",

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -133,6 +133,18 @@ pub struct Args {
     pub shellcheck: bool,
 }
 
+/// Normalizes diagnostic message text to handle platform-specific differences.
+/// This ensures the same diagnostic message on different platforms is treated as identical.
+pub fn normalize_diagnostic(s: &str) -> String {
+    let s = s.replace('\\', "/").replace("\r\n", "\n");
+
+    // Handle OS-specific error messages
+    s.replace(
+        "The system cannot find the file specified. (os error 2)",
+        "No such file or directory (os error 2)",
+    )
+}
+
 /// Main function for this subcommand.
 pub async fn gauntlet(args: Args) -> Result<()> {
     let mut config = match args.no_config {
@@ -263,6 +275,9 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .context("diagnostic should be UTF-8")?
                         .trim()
                         .to_string();
+                    
+                    // Normalize the diagnostic message to handle platform-specific differences
+                    let message = normalize_diagnostic(&message);
 
                     if !actual.insert((message.clone(), line_no)) {
                         panic!(
@@ -293,7 +308,8 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .iter()
                         .map_while(|d| {
                             if d.document() == &document_identifier {
-                                Some(d.message().to_string())
+                                // Normalize the diagnostic message from config to handle platform-specific differences
+                                Some(normalize_diagnostic(d.message()))
                             } else {
                                 None
                             }
@@ -412,4 +428,32 @@ pub async fn gauntlet(args: Args) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_diagnostic() {
+        // Test Windows-style path normalization
+        let windows_path = "Failed to import 'C:\\Users\\test\\file.wdl'";
+        let unix_path = "Failed to import 'C:/Users/test/file.wdl'";
+        assert_eq!(normalize_diagnostic(windows_path), unix_path);
+
+        // Test line ending normalization
+        let windows_line_ending = "Error message\r\nSecond line";
+        let unix_line_ending = "Error message\nSecond line";
+        assert_eq!(normalize_diagnostic(windows_line_ending), unix_line_ending);
+
+        // Test OS-specific error message normalization
+        let windows_error = "The system cannot find the file specified. (os error 2)";
+        let unix_error = "No such file or directory (os error 2)";
+        assert_eq!(normalize_diagnostic(windows_error), unix_error);
+
+        // Test that Unix style messages are left unchanged
+        assert_eq!(normalize_diagnostic(unix_path), unix_path);
+        assert_eq!(normalize_diagnostic(unix_line_ending), unix_line_ending);
+        assert_eq!(normalize_diagnostic(unix_error), unix_error);
+    }
 }

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -140,8 +140,14 @@ pub fn normalize_diagnostic(s: &str) -> String {
     let s = s.replace('\\', "/").replace("\r\n", "\n");
 
     // Handle OS-specific error messages
-    s.replace(
+    let s = s.replace(
         "The system cannot find the file specified. (os error 2)",
+        "No such file or directory (os error 2)",
+    );
+    
+    // Also handle Windows "path not found" error
+    s.replace(
+        "The system cannot find the path specified. (os error 3)",
         "No such file or directory (os error 2)",
     )
 }
@@ -449,9 +455,11 @@ mod tests {
         assert_eq!(normalize_diagnostic(windows_line_ending), unix_line_ending);
 
         // Test OS-specific error message normalization
-        let windows_error = "The system cannot find the file specified. (os error 2)";
+        let windows_file_error = "The system cannot find the file specified. (os error 2)";
+        let windows_path_error = "The system cannot find the path specified. (os error 3)";
         let unix_error = "No such file or directory (os error 2)";
-        assert_eq!(normalize_diagnostic(windows_error), unix_error);
+        assert_eq!(normalize_diagnostic(windows_file_error), unix_error);
+        assert_eq!(normalize_diagnostic(windows_path_error), unix_error);
 
         // Test that Unix style messages are left unchanged
         assert_eq!(normalize_diagnostic(unix_path), unix_path);

--- a/gauntlet/src/lib.rs
+++ b/gauntlet/src/lib.rs
@@ -134,7 +134,8 @@ pub struct Args {
 }
 
 /// Normalizes diagnostic message text to handle platform-specific differences.
-/// This ensures the same diagnostic message on different platforms is treated as identical.
+/// This ensures the same diagnostic message on different platforms is treated
+/// as identical.
 pub fn normalize_diagnostic(s: &str) -> String {
     let s = s.replace('\\', "/").replace("\r\n", "\n");
 
@@ -275,7 +276,7 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .context("diagnostic should be UTF-8")?
                         .trim()
                         .to_string();
-                    
+
                     // Normalize the diagnostic message to handle platform-specific differences
                     let message = normalize_diagnostic(&message);
 
@@ -308,7 +309,8 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .iter()
                         .map_while(|d| {
                             if d.document() == &document_identifier {
-                                // Normalize the diagnostic message from config to handle platform-specific differences
+                                // Normalize the diagnostic message from config to handle
+                                // platform-specific differences
                                 Some(normalize_diagnostic(d.message()))
                             } else {
                                 None


### PR DESCRIPTION
<!-- START SECTION: any other pull request -->

This PR fixes an issue in `gauntlet` where diagnostic messages were being handled differently on Windows versus Unix-based systems, causing CI failures. I implemented a normalization function to ensure consistent handling of paths, line endings, and OS-specific error messages across platforms.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

<!-- END SECTION -->

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/