### PR TITLE
fix: fixes the calculation of an unlimited state

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 * Placeholder options are now type checked at runtime ([#345](https://github.com/stjude-rust-labs/wdl/pull/345)).
+* Whether or not a task manager state represents unlimited resources is now correctly calculated ([#397](https://github.com/stjude-rust-labs/wdl/pull/397)).
 
 ## 0.2.0 - 04-01-2025
 

--- a/wdl-engine/src/backend.rs
+++ b/wdl-engine/src/backend.rs
@@ -377,7 +377,7 @@ impl<Req> TaskManagerState<Req> {
 
     /// Determines if the resources are unlimited.
     fn unlimited(&self) -> bool {
-        self.cpu == f64::MAX && self.memory == u64::MAX
+        self.cpu == u64::MAX as f64 && self.memory == u64::MAX
     }
 }
 
@@ -834,5 +834,11 @@ mod test {
         assert!(s[r.end..].contains(&8));
         assert!(s[r.end..].contains(&4));
         assert!(s[r.end..].contains(&3));
+    }
+
+    #[test]
+    fn unlimited_state() {
+        let manager_state = TaskManagerState::<()>::new(u64::MAX, u64::MAX);
+        assert!(manager_state.unlimited());
     }
 }


### PR DESCRIPTION
This PR fixes a bug where a task manager state is unlimited is incorrectly calculated.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
