### PR TITLE
refactor: check push date rather than update date

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
 
           for label in $awaiting_labels; do
             pr_numbers=$(
-              gh pr list --label "$label" --json "number,updatedAt" --jq '.[] | select(.updatedAt < "$date") | .number')
+              gh api /repos/${{ github.repository }}/pulls --jq '.[] | select ((.labels | any(.name == "$label")) and .head.repo.pushed_at < "$date") | .number')
             prs="$prs $pr_numbers"
           done
 


### PR DESCRIPTION
The `stale` CI action currently checks the last update date. Based on experience, that date doesn't reflect the last visible action on a PR. This PR switches that to check the last push date for a PR.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.