### PR TITLE
fix: change event type for labels CI to run in base context

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,7 +1,7 @@
 name: Adds labels
 
 on:
-  pull_request:
+  pull_request_target:
 
 env:
   GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The current labels CI step fails when the PR originates in a public fork. This is because the GitHub token that the CI steps use is limited to read-only access (see the last column in this table: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token). This PR changes the event type to `pull_request_target`, which causes the job to run in the base context (e.g. our repo)(documentation: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token). This allows the permissions to be elevated, since it prevents unknowingly running potentially malicious code.

Quoting from the docs:

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.



Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.