### PR TITLE
ci: checkout repo for assignee

### DIFF
--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number }}
     steps:
+      - uses: actions/checkout@v4
       - name: Add assignee
         run: |
           # Get the PR author


### PR DESCRIPTION
Adds a step to checkout the repository, which seems to be a prerequisite for running `gh` commands.

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
      (If you are an external contributor without permissions, leave this
      unchecked and someone else will do it for you.)
- [ ] You have added at least one relevant code reviewer to the PR.
      (If you are an external contributor without permissions, leave this
      unchecked and someone else will do it for you.)
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.
- [ ] Your PR title follows the [conventional commit] style.

