### PR TITLE
fix: severity downgrade from error to note

### DIFF
--- a/Arena.toml
+++ b/Arena.toml
@@ -542,6 +542,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:10:1: note[PreambleCommentPlacement]: preamble comment after the version statement"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L10"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:110:26: note[CallInputSpacing]: call input not properly spaced"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L110"
 
@@ -884,6 +889,11 @@ permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f87
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
 message = "ww-vc-trio.wdl:299:3: note[InputSorted]: input not sorted"
 permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L299"
+
+[[diagnostics]]
+document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"
+message = "ww-vc-trio.wdl:2:1: note[PreambleCommentPlacement]: preamble comment after the version statement"
+permalink = "https://github.com/getwilds/ww-vc-trio/blob/c2c13e85efda8ac7aca7f8765fbaa7c2cacb08b2/ww-vc-trio.wdl/#L2"
 
 [[diagnostics]]
 document = "getwilds/ww-vc-trio:/ww-vc-trio.wdl"

--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Renamed lint rules to be more consistent ([#408](https://github.com/stjude-rust-labs/wdl/pull/408)).
 
+#### Fixed
+
+* Downgraded `PreambleCommentPlacement` severity from `error` to `note` ([#418](https://github.com/stjude-rust-labs/wdl/pull/418)).
+
 ## 0.10.0 - 04-01-2025
 
 #### Added

--- a/wdl-lint/src/rules/preamble_comment_placement.rs
+++ b/wdl-lint/src/rules/preamble_comment_placement.rs
@@ -20,7 +20,7 @@ const ID: &str = "PreambleCommentPlacement";
 
 /// Creates a diagnostic for a comment outside the preamble.
 fn preamble_comment_outside_preamble(span: Span) -> Diagnostic {
-    Diagnostic::error("preamble comment after the version statement")
+    Diagnostic::note("preamble comment after the version statement")
         .with_rule(ID)
         .with_highlight(span)
         .with_fix("do not use `##` comments outside the preamble")

--- a/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
+++ b/wdl-lint/tests/lints/preamble-comment-after-version/source.errors
@@ -6,7 +6,7 @@ note[PreambleFormatted]: unnecessary whitespace in document preamble
   │
   = fix: remove the leading whitespace
 
-error[PreambleCommentPlacement]: preamble comment after the version statement
+note[PreambleCommentPlacement]: preamble comment after the version statement
    ┌─ tests/lints/preamble-comment-after-version/source.wdl:6:1
    │  
  6 │ ╭ ## This is a preamble comment after the version
@@ -18,7 +18,7 @@ error[PreambleCommentPlacement]: preamble comment after the version statement
    │  
    = fix: do not use `##` comments outside the preamble
 
-error[PreambleCommentPlacement]: preamble comment after the version statement
+note[PreambleCommentPlacement]: preamble comment after the version statement
    ┌─ tests/lints/preamble-comment-after-version/source.wdl:19:5
    │
 19 │     ## This one is bad!


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

`wdl-lint` should never emit errors, but the `PreambleCommentPlacement` rule was configured at error severity.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
