### PR TITLE
ci: switch reviewers assignment to use API and always succeed

### DIFF
--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -36,5 +36,14 @@ jobs:
         run: |
           # The gh cli silently drops a reviewer if they are the author.
           # So no need to clean the list here.
-          reviewers=$(yq -o csv ".reviewers" .github/reviewers.yml)
-          gh pr edit $PR_NUMBER --add-reviewer "$reviewers"
+          reviewers=$(yq -o tsv ".reviewers" .github/reviewers.yml)
+          for reviewer in "$reviewers"
+          do
+            # gh pr edit $PR_NUMBER --add-reviewer "$reviewers"
+            # Adding a duplicate reviewer returns an error hence "|| true"
+            gh api /repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -f "reviewers[]=$reviewer" || true
+          done


### PR DESCRIPTION
The GitHub command line utility requires permissions on the organization to set reviewers because it attempts to do a union with any existing reviewers. This is documented in: https://github.com/cli/cli/issues/4844. It doesn't appear that it will be resolved anytime soon. Instead of creating a PAT with the elevated permissions, this PR avoids the issue by using the API directly and not attempting to do any reconciliation. It simply loops over the reviewers and requests them one at a time. It intentionally silences any errors as this shouldn't cause the CI to be red on new PRs.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.
