### PR TITLE
refactor: accept case insensitive `--except` args

### DIFF
--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Changed
+
+* Changed the behaviour of `cli` to accept case insensitive `--except` args ([#423](https://github.com/stjude-rust-labs/wdl/pull/423)).
+
 ## 0.12.0 - 04-01-2025
 
 #### Added

--- a/wdl/src/cli.rs
+++ b/wdl/src/cli.rs
@@ -55,7 +55,7 @@ pub async fn analyze(
     let rules = analysis_rules();
     let rules = rules
         .iter()
-        .filter(|rule| !exceptions.iter().any(|e| e == rule.id()));
+        .filter(|rule| !exceptions.iter().any(|e| e.eq_ignore_ascii_case(rule.id())));
     let rules_config = DiagnosticsConfig::new(rules);
 
     let pb = tracing::warn_span!("progress");
@@ -91,7 +91,7 @@ pub async fn analyze(
             if lint {
                 let visitor =
                     wdl_lint::LintVisitor::new(lint_rules().into_iter().filter_map(|rule| {
-                        if exceptions.iter().any(|e| e == rule.id()) {
+                        if exceptions.iter().any(|e| e.eq_ignore_ascii_case(rule.id())) {
                             None
                         } else {
                             Some(rule)


### PR DESCRIPTION
> #@ except lint directives within WDL source should still require an exact case sensitive match, but I think we can relax that requirement on the CLI.

ref: https://github.com/stjude-rust-labs/sprocket/issues/95

Checking of rules were done inside wdl cli crate instead of sprocket.

I think the change should be inside this repository, but do let me know if i have to make changes in `sprocket` instead

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
