### PR TITLE
ci: use API for assignee

### DIFF
--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -27,7 +27,11 @@ jobs:
           # Check if the author is not empty
           if [ -n "$author" ]; then
             # Add the author as an assignee
-            gh pr edit $PR_NUMBER --add-assignee "$author"
+            gh api /repos/${{ github.repository }}/issues/$PR_NUMBER/assignees \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -f assignees[]="$author" || true
           else
             echo "No valid author found."
           fi

--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -43,7 +43,7 @@ jobs:
           reviewers=$(yq -o tsv ".reviewers" .github/reviewers.yml)
           for reviewer in "$reviewers"
           do
-            # gh pr edit $PR_NUMBER --add-reviewer "$reviewers"
+            # gh pr edit $PR_NUMBER --add-reviewer $reviewers
             # Adding a duplicate reviewer returns an error hence "|| true"
             gh api /repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers \
               --method POST \

--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -27,6 +27,7 @@ jobs:
           # Check if the author is not empty
           if [ -n "$author" ]; then
             # Add the author as an assignee
+            echo "adding $author as author of PR #$PR_NUMBER"
             gh api /repos/${{ github.repository }}/issues/$PR_NUMBER/assignees \
               --method POST \
               -H "Accept: application/vnd.github+json" \
@@ -45,6 +46,7 @@ jobs:
           do
             # gh pr edit $PR_NUMBER --add-reviewer $reviewers
             # Adding a duplicate reviewer returns an error hence "|| true"
+            echo "adding $reviewer to PR #$PR_NUMBER"
             gh api /repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers \
               --method POST \
               -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
It appears that the `gh pr` command line utility cannot assign pull requests to an external contributor. This switches to using the API to do it, which works (at least locally). It also adds `|| true` so that the step cannot fail and break the CI.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.
- [ ] Your PR title follows the [conventional commit] style.