### PR TITLE
fix: perform multiple replacements with sub()

### DIFF
--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -42,7 +42,7 @@ jobs:
           # The gh cli silently drops a reviewer if they are the author.
           # So no need to clean the list here.
           reviewers=$(yq -o tsv ".reviewers" .github/reviewers.yml)
-          for reviewer in "$reviewers"
+          for reviewer in $reviewers
           do
             # gh pr edit $PR_NUMBER --add-reviewer $reviewers
             # Adding a duplicate reviewer returns an error hence "|| true"

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-* Fix `sub` replacement of multiple instances (#[426](https://github.com/stjude-rust-labs/wdl/pull/426))
+* Fix `sub` replacement of multiple instances (#[426](https://github.com/stjude-rust-labs/wdl/pull/426)).
 * Fix path translation in more expressions (#[422](https://github.com/stjude-rust-labs/wdl/pull/422)).
 * The `sep` placeholder option was not performing guest path translation (#[417](https://github.com/stjude-rust-labs/wdl/pull/417)).
 * Placeholder options are now type checked at runtime ([#345](https://github.com/stjude-rust-labs/wdl/pull/345)).

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fix `sub` replacement of multiple instances (#[426](https://github.com/stjude-rust-labs/wdl/pull/426))
 * Fix path translation in more expressions (#[422](https://github.com/stjude-rust-labs/wdl/pull/422)).
 * The `sep` placeholder option was not performing guest path translation (#[417](https://github.com/stjude-rust-labs/wdl/pull/417)).
 * Placeholder options are now type checked at runtime ([#345](https://github.com/stjude-rust-labs/wdl/pull/345)).

--- a/wdl-engine/src/stdlib/sub.rs
+++ b/wdl-engine/src/stdlib/sub.rs
@@ -38,7 +38,7 @@ fn sub(context: CallContext<'_>) -> Result<Value, Diagnostic> {
 
     let regex = Regex::new(pattern.as_str())
         .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
-    match regex.replace(input.as_str(), replacement.as_str()) {
+    match regex.replace_all(input.as_str(), replacement.as_str()) {
         Cow::Borrowed(_) => {
             // No replacements, just return the input
             Ok(PrimitiveValue::String(input).into())

--- a/wdl-engine/src/stdlib/sub.rs
+++ b/wdl-engine/src/stdlib/sub.rs
@@ -96,5 +96,10 @@ mod test {
             .await
             .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "hello Bob");
+
+        let value = eval_v1_expr(&env, V1::Two, "sub('hello there world', ' ', '_')")
+            .await
+            .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "hello_there_world");
     }
 }

--- a/wdl-engine/tests/tasks/test-sub/outputs.json
+++ b/wdl-engine/tests/tasks/test-sub/outputs.json
@@ -1,6 +1,6 @@
 {
   "test_sub.chocolove": "I love chocolate when/nit's late",
-  "test_sub.chocoearly": "I like chocoearly when/nit's late",
+  "test_sub.chocoearly": "I like chocoearly when/nit's early",
   "test_sub.chocolate": "I like chocolate when/nit's early",
   "test_sub.chocoearlylate": "I like chocearly when/nit's late",
   "test_sub.choco4": "I 4444 chocolate when/nit's late",


### PR DESCRIPTION
The WDL [spec](https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#sub) specifies replacement of all non-overlapping matches. This PR updates the `regex` function from `replace` to `replace_all` to make it compliant with the spec.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

