### PR TITLE
fix: call locations spans should not span multiple lines.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fix overly verbose call stacks in task failure messages ([#435](https://github.com/stjude-rust-labs/wdl/pull/435))
 * Fix `sub` replacement of multiple instances (#[426](https://github.com/stjude-rust-labs/wdl/pull/426)).
 * Fix path translation in more expressions (#[422](https://github.com/stjude-rust-labs/wdl/pull/422)).
 * The `sep` placeholder option was not performing guest path translation (#[417](https://github.com/stjude-rust-labs/wdl/pull/417)).

--- a/wdl-engine/src/eval/v1/workflow.rs
+++ b/wdl-engine/src/eval/v1/workflow.rs
@@ -51,6 +51,7 @@ use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
 use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
+use wdl_ast::v1::CallKeyword;
 use wdl_ast::v1::CallStatement;
 use wdl_ast::v1::ConditionalStatement;
 use wdl_ast::v1::Decl;
@@ -83,6 +84,7 @@ use crate::http::HttpDownloader;
 use crate::path;
 use crate::path::EvaluationPath;
 use crate::tree::SyntaxNode;
+use crate::tree::SyntaxToken;
 use crate::v1::ExprEvaluator;
 use crate::v1::TaskEvaluator;
 
@@ -1664,7 +1666,10 @@ impl WorkflowEvaluator {
                 if let EvaluationError::Source(e) = &mut e {
                     e.backtrace.push(CallLocation {
                         document: state.document.clone(),
-                        span: stmt.span(),
+                        span: stmt
+                            .token::<CallKeyword<SyntaxToken>>()
+                            .expect("should have call keyword")
+                            .span(),
                     });
                 }
 

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -491,6 +491,21 @@ async fn main() {
             }
         };
 
+        if let Some(e) = result.error() {
+            println!("test {test_name} ... {failed}", failed = "failed".red());
+            errors.push((test_name.to_string(), e.to_string()));
+            continue;
+        }
+
+        if result.document().has_errors() {
+            println!("test {test_name} ... {failed}", failed = "failed".red());
+            errors.push((
+                test_name.to_string(),
+                "test WDL contains errors: run a `check` on `source.wdl`".to_string(),
+            ));
+            continue;
+        }
+
         futures.push(async { (test_name.to_string(), run_test(test, result).await) });
     }
 

--- a/wdl-engine/tests/workflows.rs
+++ b/wdl-engine/tests/workflows.rs
@@ -304,6 +304,21 @@ async fn main() {
             }
         };
 
+        if let Some(e) = result.error() {
+            println!("test {test_name} ... {failed}", failed = "failed".red());
+            errors.push((test_name.to_string(), e.to_string()));
+            continue;
+        }
+
+        if result.document().has_errors() {
+            println!("test {test_name} ... {failed}", failed = "failed".red());
+            errors.push((
+                test_name.to_string(),
+                "test WDL contains errors: run a `check` on `source.wdl`".to_string(),
+            ));
+            continue;
+        }
+
         futures.push(async { (test_name.to_string(), run_test(test, result).await) });
     }
 

--- a/wdl-engine/tests/workflows/callstack/error.txt
+++ b/wdl-engine/tests/workflows/callstack/error.txt
@@ -18,18 +18,18 @@ task stderr output (last 10 lines):
  3 │ task my_task {
    │      ^^^^^^^ this task failed to execute
    │
-   ┌─ tests/workflows/callstack/first.wdl:11:5
+   ┌─ tests/workflows/callstack/first.wdl:17:5
    │
-11 │     call my_task
-   │     ------------ called from this location
+17 │     call my_task {
+   │     ---- called from this location
    │
    ┌─ tests/workflows/callstack/second.wdl:6:5
    │
  6 │     call first.test
-   │     --------------- called from this location
+   │     ---- called from this location
    │
    ┌─ tests/workflows/callstack/source.wdl:6:5
    │
  6 │     call second.test
-   │     ---------------- called from this location
+   │     ---- called from this location
 

--- a/wdl-engine/tests/workflows/callstack/first.wdl
+++ b/wdl-engine/tests/workflows/callstack/first.wdl
@@ -1,6 +1,12 @@
 version 1.2
 
 task my_task {
+    input {
+        String x
+        Int y
+        Float z
+    }
+
     command <<<
         >&2 printf "first! (should not be present)\nsecond!\nthird!\nfourth!\nfifth!\nsixth!\nseventh!\neighth!\nninth!\ntenth!\neleventh!\n"
         exit 1
@@ -8,5 +14,9 @@ task my_task {
 }
 
 workflow test {
-    call my_task
+    call my_task {
+        x = "foo",
+        y = 0,
+        z = 1.0
+    }
 }

--- a/wdl-lint/tests/lints.rs
+++ b/wdl-lint/tests/lints.rs
@@ -166,15 +166,11 @@ async fn main() {
             ),
         ) {
             Ok(()) => {
-                println!(
-                    "{}: {}: {}",
-                    test_name,
-                    "ok".green(),
-                    result.document().uri()
-                );
+                println!("test {test_name} ... {ok}", ok = "ok".green());
             }
             Err(e) => {
-                errors.push(format!("{}: {}: {}", test_name, "error".red(), e));
+                println!("test {test_name} ... {failed}", failed = "failed".red());
+                errors.push((test_name, e));
             }
         }
     }
@@ -186,8 +182,8 @@ async fn main() {
             failed = "failed".red()
         );
 
-        for msg in errors.iter() {
-            eprintln!("{msg}", msg = msg.red());
+        for (name, msg) in errors.iter() {
+            eprintln!("{name}: {msg}", msg = msg.red());
         }
 
         std::process::exit(1);


### PR DESCRIPTION
This fixes call locations in a printed callstack displaying overly verbose diagnostics due to using the entire span of the call statement; call statements typically span many lines due to their inputs, leading to overly verbose output.

The fix is to use the span of the call keyword in the call statement, which guarantees only a single line of source output per call location.

This also includes a change to the evaluation tests so that invalid WDL gets a failure message rather than writing to `errors.txt`. Additionally, the printed output of the lint tests harness has been updated to match what we output for the other test harnesses.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
