### PR TITLE
refactor: rename `crankshaft` backend to `docker`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ clap-verbosity-flag = { version = "3.0.2", features = ["tracing"] }
 codespan-reporting = "0.12.0"
 colored = "3.0.0"
 convert_case = "0.8.0"
-crankshaft = { git = "https://github.com/stjude-rust-labs/crankshaft", rev = "4975725f4" }
+crankshaft = "0.2.0"
 dirs = "6.0.0"
 faster-hex = "0.10.0"
 ftree = "1.2.0"

--- a/wdl-ast/CHANGELOG.md
+++ b/wdl-ast/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `braced_scope_span` and `heredoc_scope_span` methods to `AstNodeExt` ([#292](https://github.com/stjude-rust-labs/wdl/pull/292))
 * Added constants for the task variable fields, task requirement names, and
   task hint names ([#265](https://github.com/stjude-rust-labs/wdl/pull/265)).
-* Added `allows_nested_inputs` function to `Workflow` (#[241](https://github.com/stjude-rust-labs/wdl/pull/241)).
+* Added `allows_nested_inputs` function to `Workflow` ([#241](https://github.com/stjude-rust-labs/wdl/pull/241)).
 * `strip_whitespace()` method to `LiteralString` and `CommandSection` AST nodes ([#238](https://github.com/stjude-rust-labs/wdl/pull/238)).
 
 #### Changed

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,36 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-* Implemented remote file localization for task execution (#[386](https://github.com/stjude-rust-labs/wdl/pull/386)).
-* Implemented concurrent file downloads for localization for task execution (#[424](https://github.com/stjude-rust-labs/wdl/pull/424)).
+* Implemented remote file localization for task execution ([#386](https://github.com/stjude-rust-labs/wdl/pull/386)).
+* Implemented concurrent file downloads for localization for task execution ([#424](https://github.com/stjude-rust-labs/wdl/pull/424)).
 
 #### Fixed
 
 * Fix overly verbose call stacks in task failure messages ([#435](https://github.com/stjude-rust-labs/wdl/pull/435))
-* Fix `sub` replacement of multiple instances (#[426](https://github.com/stjude-rust-labs/wdl/pull/426)).
-* Fix path translation in more expressions (#[422](https://github.com/stjude-rust-labs/wdl/pull/422)).
-* The `sep` placeholder option was not performing guest path translation (#[417](https://github.com/stjude-rust-labs/wdl/pull/417)).
+* Fix `sub` replacement of multiple instances ([#426](https://github.com/stjude-rust-labs/wdl/pull/426)).
+* Fix path translation in more expressions ([#422](https://github.com/stjude-rust-labs/wdl/pull/422)).
+* The `sep` placeholder option was not performing guest path translation ([#417](https://github.com/stjude-rust-labs/wdl/pull/417)).
 * Placeholder options are now type checked at runtime ([#345](https://github.com/stjude-rust-labs/wdl/pull/345)).
 * Whether or not a task manager state represents unlimited resources is now correctly calculated ([#397](https://github.com/stjude-rust-labs/wdl/pull/397)).
 * Fixed environment variable values are not using guest paths for Docker backend ([#398](https://github.com/stjude-rust-labs/wdl/pull/398)).
 * Ensure output files created by Docker tasks running as root have correct host user permissions ([#379](https://github.com/stjude-rust-labs/wdl/pull/379)).
-* Fixes `chown` functionlity by making the path absolute ([#428](https://github.com/stjude-rust-labs/wdl/pull/379)).
+* Fixes `chown` functionality by making the path absolute ([#428](https://github.com/stjude-rust-labs/wdl/pull/379)).
 
 #### Changed
 
-* Evaluation errors now contain a "backtrace" containing call locations (#[432](https://github.com/stjude-rust-labs/wdl/pull/432)).
-* Changed origin path resolution in inputs to accomodate incremental command line parsing ([#430](https://github.com/stjude-rust-labs/wdl/pull/430)).
+* Refactored `crankshaft` backend to the `docker` backend ()
+* Evaluation errors now contain a "backtrace" containing call locations ([#432](https://github.com/stjude-rust-labs/wdl/pull/432)).
+* Changed origin path resolution in inputs to accommodate incremental command line parsing ([#430](https://github.com/stjude-rust-labs/wdl/pull/430)).
 
 ## 0.2.0 - 04-01-2025
 
 #### Added
 
-* Added support for cloud storage URIs (#[367](https://github.com/stjude-rust-labs/wdl/pull/367)).
-* Added support reading of remote files from the stdlib file functions (#[364](https://github.com/stjude-rust-labs/wdl/pull/364))
+* Added support for cloud storage URIs ([#367](https://github.com/stjude-rust-labs/wdl/pull/367)).
+* Added support reading of remote files from the stdlib file functions ([#364](https://github.com/stjude-rust-labs/wdl/pull/364))
 * Added support for YAML input files (.yml and .yaml) alongside JSON ([#352](https://github.com/stjude-rust-labs/wdl/pull/352)).
-* Added support for graceful cancellation of evaluation (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
-* Added support for `max_cpu` and `max_memory` hints in task evaluation (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
-* Added a Crankshaft backend with initial support for Docker (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Added support for graceful cancellation of evaluation ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Added support for `max_cpu` and `max_memory` hints in task evaluation ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Added a Crankshaft backend with initial support for Docker ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Added calculation for mounting input files for future backends that use
   containers ([#323](https://github.com/stjude-rust-labs/wdl/pull/323)).
 * Added retry logic for task execution ([#320](https://github.com/stjude-rust-labs/wdl/pull/320)).
@@ -47,11 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-* Fixed support for URLs in file stdlib functions (#[369](https://github.com/stjude-rust-labs/wdl/pull/369)).
-* Fixed panic when an input path in a complex type did not exist (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
-* Fixed path translation in nested placeholder evaluation (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
-* Fixed path translation to mount inputs individually (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
-* Fixed not including task temp directories in mounts (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Fixed support for URLs in file stdlib functions ([#369](https://github.com/stjude-rust-labs/wdl/pull/369)).
+* Fixed panic when an input path in a complex type did not exist ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Fixed path translation in nested placeholder evaluation ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Fixed path translation to mount inputs individually ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Fixed not including task temp directories in mounts ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Fixed an incorrect type being used for scatter statement outputs ([#316](https://github.com/stjude-rust-labs/wdl/pull/316)).
 * Fixed handling of input dependencies in workflow graph evaluation ([#360](https://github.com/stjude-rust-labs/wdl/pull/360)).
 
@@ -62,9 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated for refactored `wdl-ast` API so that evaluation can now operate
   directly on AST nodes in `async` context ([#355](https://github.com/stjude-rust-labs/wdl/pull/355)).
 * Updated to Rust 2024 edition ([#353](https://github.com/stjude-rust-labs/wdl/pull/353)).
-* Docker backend is now the default backend (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Docker backend is now the default backend ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Refactored a common task management implementation to use in task execution
-  backends (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+  backends ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Workflow evaluation now uses `tokio::spawn` internally for running graph
   evaluation concurrently ([#320](https://github.com/stjude-rust-labs/wdl/pull/320)).
 * Improved evaluation reporting to include how many tasks are ready for
@@ -101,12 +102,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Implemented WDL expression evaluation ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
 * Refactored API to remove reliance on the engine for creating values ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
 * Split value representation into primitive and compound values ([#249](https://github.com/stjude-rust-labs/wdl/pull/249)).
-* Added `InputFiles` type for parsing WDL input JSON files (#[241](https://github.com/stjude-rust-labs/wdl/pull/241)).
+* Added `InputFiles` type for parsing WDL input JSON files ([#241](https://github.com/stjude-rust-labs/wdl/pull/241)).
 * Added the `wdl-engine` crate that will eventually implement a WDL execution
-  engine (#[225](https://github.com/stjude-rust-labs/wdl/pull/225)).
+  engine ([#225](https://github.com/stjude-rust-labs/wdl/pull/225)).
 
 #### Changed
 
 * Removed the `Engine` type in favor of direct use of a `WorkflowEvaluator` or
   `TaskEvaluator` ([#292](https://github.com/stjude-rust-labs/wdl/pull/292))
-* Require file existence for a successul validation parse of inputs ([#281](https://github.com/stjude-rust-labs/wdl/pull/281)).
+* Require file existence for a successful validation parse of inputs ([#281](https://github.com/stjude-rust-labs/wdl/pull/281)).

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-* Refactored `crankshaft` backend to the `docker` backend ()
+* Refactored `crankshaft` backend to the `docker` backend ([#436](https://github.com/stjude-rust-labs/wdl/pull/436)).
 * Evaluation errors now contain a "backtrace" containing call locations ([#432](https://github.com/stjude-rust-labs/wdl/pull/432)).
 * Changed origin path resolution in inputs to accommodate incremental command line parsing ([#430](https://github.com/stjude-rust-labs/wdl/pull/430)).
 

--- a/wdl-engine/src/backend/docker.rs
+++ b/wdl-engine/src/backend/docker.rs
@@ -1,4 +1,4 @@
-//! Implementation of the crankshaft backend.
+//! Implementation of the Docker backend.
 
 use std::collections::HashMap;
 use std::fs;
@@ -10,6 +10,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
+use crankshaft::config::backend;
 use crankshaft::engine::Task;
 use crankshaft::engine::service::name::GeneratorIterator;
 use crankshaft::engine::service::name::UniqueAlphanumeric;
@@ -17,9 +18,11 @@ use crankshaft::engine::service::runner::Backend;
 use crankshaft::engine::service::runner::backend::docker;
 use crankshaft::engine::task::Execution;
 use crankshaft::engine::task::Input;
+use crankshaft::engine::task::Output;
 use crankshaft::engine::task::Resources;
 use crankshaft::engine::task::input::Contents;
-use crankshaft::engine::task::input::Type;
+use crankshaft::engine::task::input::Type as InputType;
+use crankshaft::engine::task::output::Type as OutputType;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use nonempty::NonEmpty;
@@ -27,6 +30,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
+use url::Url;
 
 use super::TaskExecutionBackend;
 use super::TaskExecutionConstraints;
@@ -35,13 +39,16 @@ use super::TaskExecutionResult;
 use super::TaskManager;
 use super::TaskManagerRequest;
 use super::TaskSpawnRequest;
+use crate::COMMAND_FILE_NAME;
 use crate::InputTrie;
 use crate::ONE_GIBIBYTE;
+use crate::PrimitiveValue;
+use crate::STDERR_FILE_NAME;
+use crate::STDOUT_FILE_NAME;
 use crate::Value;
 use crate::WORK_DIR_NAME;
-use crate::config::CrankshaftBackendConfig;
-use crate::config::CrankshaftBackendKind;
 use crate::config::DEFAULT_TASK_SHELL;
+use crate::config::DockerBackendConfig;
 use crate::config::TaskConfig;
 use crate::http::Downloader;
 use crate::http::HttpDownloader;
@@ -68,34 +75,26 @@ const GUEST_WORK_DIR: &str = "/mnt/work";
 /// The guest path for the command file.
 const GUEST_COMMAND_PATH: &str = "/mnt/command";
 
-/// The guest path for the output directory.
-#[cfg(unix)]
-const GUEST_OUT_DIR: &str = "/workflow_output";
+/// The path to the container's stdout.
+const GUEST_STDOUT_PATH: &str = "/stdout";
 
-/// Amount of CPU to reserve for the cleanup task.
-#[cfg(unix)]
-const CLEANUP_CPU: f64 = 0.1;
+/// The path to the container's stderr.
+const GUEST_STDERR_PATH: &str = "/stderr";
 
-/// Amount of memory to reserve for the cleanup task.
-#[cfg(unix)]
-const CLEANUP_MEMORY: f64 = 0.05;
-
-/// Represents a crankshaft task request.
-///
 /// This request contains the requested cpu and memory reservations for the task
 /// as well as the result receiver channel.
 #[derive(Debug)]
-struct CrankshaftTaskRequest {
+struct DockerTaskRequest {
     /// The inner task spawn request.
     inner: TaskSpawnRequest,
-    /// The Crankshaft backend to use.
-    backend: Arc<dyn Backend>,
+    /// The underlying Crankshaft backend.
+    backend: Arc<docker::Backend>,
     /// The name of the task.
     name: String,
+    /// The optional shell to use.
+    shell: Arc<Option<String>>,
     /// The requested container for the task.
     container: String,
-    /// The requested shell to use for the task.
-    shell: Option<Arc<String>>,
     /// The requested CPU reservation for the task.
     cpu: f64,
     /// The requested memory reservation for the task, in bytes.
@@ -108,7 +107,7 @@ struct CrankshaftTaskRequest {
     token: CancellationToken,
 }
 
-impl TaskManagerRequest for CrankshaftTaskRequest {
+impl TaskManagerRequest for DockerTaskRequest {
     fn cpu(&self) -> f64 {
         self.cpu
     }
@@ -119,8 +118,7 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
 
     async fn run(self, spawned: oneshot::Sender<()>) -> Result<TaskExecutionResult> {
         // Create the working directory
-        // TODO: this should only be done for local task execution
-        let work_dir = self.inner.root.attempt_dir().join(WORK_DIR_NAME);
+        let work_dir = self.inner.attempt_dir().join(WORK_DIR_NAME);
         fs::create_dir_all(&work_dir).with_context(|| {
             format!(
                 "failed to create directory `{path}`",
@@ -130,8 +128,8 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
 
         // Write the evaluated command to disk
         // This is done even for remote execution so that a copy exists locally
-        let command_path = self.inner.root.command();
-        fs::write(command_path, self.inner.command()).with_context(|| {
+        let command_path = self.inner.attempt_dir().join(COMMAND_FILE_NAME);
+        fs::write(&command_path, self.inner.command()).with_context(|| {
             format!(
                 "failed to write command contents to `{path}`",
                 path = command_path.display()
@@ -143,76 +141,63 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
         let mut inputs = Vec::with_capacity(self.inner.inputs().len() + 2);
         for input in self.inner.inputs().iter() {
             if let Some(guest_path) = input.guest_path() {
-                let (exists, is_dir) = input
-                    .location()
-                    .map(|p| {
-                        p.metadata()
-                            .map(|m| (true, m.is_dir()))
-                            .unwrap_or((false, false))
-                    })
-                    .unwrap_or_else(|| match input.path() {
-                        EvaluationPath::Local(p) => p
-                            .metadata()
-                            .map(|m| (true, m.is_dir()))
-                            .unwrap_or((false, false)),
-                        EvaluationPath::Remote(url) => (true, url.as_str().ends_with('/')),
-                    });
+                let location = input.location().expect("all inputs should have localized");
 
-                if exists {
-                    inputs.push(Arc::new(
+                if location.exists() {
+                    inputs.push(
                         Input::builder()
                             .path(guest_path)
-                            .contents(
-                                input
-                                    .location()
-                                    .map(|l| Contents::Path(l.to_path_buf()))
-                                    .unwrap_or_else(|| match input.path() {
-                                        EvaluationPath::Local(path) => Contents::Path(path.clone()),
-                                        EvaluationPath::Remote(url) => Contents::Url(url.clone()),
-                                    }),
-                            )
-                            .ty(if is_dir { Type::Directory } else { Type::File })
+                            .contents(Contents::Path(location.into()))
+                            .ty(input.kind())
                             .read_only(true)
                             .build(),
-                    ));
+                    );
                 }
             }
         }
 
         // Add an input for the work directory
-        // TODO: we should not do this for remote backends
-        inputs.push(Arc::new(
+        inputs.push(
             Input::builder()
                 .path(GUEST_WORK_DIR)
                 .contents(Contents::Path(work_dir.to_path_buf()))
-                .ty(Type::Directory)
+                .ty(InputType::Directory)
                 .read_only(false)
                 .build(),
-        ));
+        );
 
         // Add an input for the command
-        inputs.push(Arc::new(
+        inputs.push(
             Input::builder()
                 .path(GUEST_COMMAND_PATH)
                 .contents(Contents::Path(command_path.to_path_buf()))
-                .ty(Type::File)
+                .ty(InputType::File)
                 .read_only(true)
                 .build(),
-        ));
+        );
 
-        // TODO: for remote backends, add an output for the working directory
+        let stdout_path = self.inner.attempt_dir().join(STDOUT_FILE_NAME);
+        let stderr_path = self.inner.attempt_dir().join(STDERR_FILE_NAME);
+
+        let outputs = vec![
+            Output::builder()
+                .path(GUEST_STDOUT_PATH)
+                .url(Url::from_file_path(&stdout_path).expect("path should be absolute"))
+                .ty(OutputType::File)
+                .build(),
+            Output::builder()
+                .path(GUEST_STDERR_PATH)
+                .url(Url::from_file_path(&stderr_path).expect("path should be absolute"))
+                .ty(OutputType::File)
+                .build(),
+        ];
 
         let task = Task::builder()
             .name(self.name)
             .executions(NonEmpty::new(
                 Execution::builder()
                     .image(&self.container)
-                    .program(
-                        self.shell
-                            .as_ref()
-                            .map(|s| s.as_str())
-                            .unwrap_or(DEFAULT_TASK_SHELL),
-                    )
+                    .program(self.shell.as_deref().unwrap_or(DEFAULT_TASK_SHELL))
                     .args(["-C".to_string(), GUEST_COMMAND_PATH.to_string()])
                     .work_dir(GUEST_WORK_DIR)
                     .env({
@@ -229,9 +214,12 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
                         }
                         final_env
                     })
+                    .stdout(GUEST_STDOUT_PATH)
+                    .stderr(GUEST_STDERR_PATH)
                     .build(),
             ))
             .inputs(inputs)
+            .outputs(outputs)
             .resources(
                 Resources::builder()
                     .cpu(self.cpu)
@@ -242,49 +230,46 @@ impl TaskManagerRequest for CrankshaftTaskRequest {
             )
             .build();
 
-        let outputs = self
+        let statuses = self
             .backend
             .run(task, Some(spawned), self.token.clone())
             .map_err(|e| anyhow!("{e:#}"))?
             .await
             .map_err(|e| anyhow!("{e:#}"))?;
 
-        assert_eq!(outputs.len(), 1, "there should only be one output");
-        let output = outputs.first();
-
-        // TODO: in the future it would be nice if Crankshaft wrote the output directly
-        // to the files rather than buffering it in memory
-        fs::write(self.inner.root.stdout(), &output.stdout).with_context(|| {
-            format!(
-                "failed to write to stdout file `{path}`",
-                path = self.inner.root.stdout().display()
-            )
-        })?;
-        fs::write(self.inner.root.stderr(), &output.stderr).with_context(|| {
-            format!(
-                "failed to write to stderr file `{path}`",
-                path = self.inner.root.stderr().display()
-            )
-        })?;
+        assert_eq!(statuses.len(), 1, "there should only be one output");
+        let status = statuses.first();
 
         Ok(TaskExecutionResult {
-            exit_code: output.status.code().expect("should have exit code"),
-            // TODO: fix this for remote execution
+            inputs: self.inner.info.inputs,
+            exit_code: status.code().expect("should have exit code"),
             work_dir: EvaluationPath::Local(work_dir),
+            stdout: PrimitiveValue::new_file(
+                stdout_path
+                    .into_os_string()
+                    .into_string()
+                    .expect("path should be UTF-8"),
+            )
+            .into(),
+            stderr: PrimitiveValue::new_file(
+                stderr_path
+                    .into_os_string()
+                    .into_string()
+                    .expect("path should be UTF-8"),
+            )
+            .into(),
         })
     }
 }
 
-/// Represents the crankshaft backend.
-pub struct CrankshaftBackend {
+/// Represents the Docker backend.
+pub struct DockerBackend {
     /// The underlying Crankshaft backend.
-    inner: Arc<dyn Backend>,
-    /// The kind of backend to use.
-    kind: CrankshaftBackendKind,
-    /// The default container to use for tasks.
+    inner: Arc<docker::Backend>,
+    /// The shell to use.
+    shell: Arc<Option<String>>,
+    /// The default container to use.
     container: Option<String>,
-    /// The default shell to use for tasks.
-    shell: Option<Arc<String>>,
     /// The maximum amount of concurrency supported.
     max_concurrency: u64,
     /// The maximum CPUs for any of one node.
@@ -292,54 +277,49 @@ pub struct CrankshaftBackend {
     /// The maximum memory for any of one node.
     max_memory: u64,
     /// The task manager for the backend.
-    manager: TaskManager<CrankshaftTaskRequest>,
+    manager: TaskManager<DockerTaskRequest>,
     /// The name generator for tasks.
     generator: Arc<Mutex<GeneratorIterator<UniqueAlphanumeric>>>,
 }
 
-impl CrankshaftBackend {
-    /// Constructs a new crankshaft task execution backend with the given
+impl DockerBackend {
+    /// Constructs a new Docker task execution backend with the given
     /// configuration.
-    pub async fn new(task: &TaskConfig, config: &CrankshaftBackendConfig) -> Result<Self> {
+    pub async fn new(task: &TaskConfig, config: &DockerBackendConfig) -> Result<Self> {
         task.validate()?;
         config.validate()?;
 
-        let kind = config.default.clone();
+        info!("initializing Docker backend");
 
-        let (inner, max_concurrency, manager, max_cpu, max_memory) = match &kind {
-            CrankshaftBackendKind::Docker => {
-                info!("initializing Docker backend");
+        let backend = docker::Backend::initialize_default_with(
+            backend::docker::Config::builder()
+                .cleanup(config.cleanup)
+                .build(),
+        )
+        .await
+        .map_err(|e| anyhow!("{e:#}"))
+        .context("failed to initialize Docker backend")?;
 
-                let backend = docker::Backend::initialize_default_with(config.docker.clone())
-                    .await
-                    .map_err(|e| anyhow!("{e:#}"))
-                    .context("failed to initialize Docker backend")?;
+        let resources = *backend.resources();
+        let cpu = resources.cpu();
+        let max_cpu = resources.max_cpu();
+        let memory = resources.memory();
+        let max_memory = resources.max_memory();
 
-                let resources = *backend.resources();
-                let cpu = resources.cpu();
-                let max_cpu = resources.max_cpu();
-                let memory = resources.memory();
-                let max_memory = resources.max_memory();
-
-                // If a service is being used, then we're going to be spawning into a cluster
-                // For the purposes of resource tracking, treat it as unlimited resources and
-                // let Docker handle resource allocation
-                let manager = if resources.use_service() {
-                    TaskManager::new_unlimited(max_cpu, max_memory)
-                } else {
-                    TaskManager::new(cpu, max_cpu, memory, max_memory)
-                };
-
-                (Arc::new(backend), cpu, manager, max_cpu, max_memory)
-            }
+        // If a service is being used, then we're going to be spawning into a cluster
+        // For the purposes of resource tracking, treat it as unlimited resources and
+        // let Docker handle resource allocation
+        let manager = if resources.use_service() {
+            TaskManager::new_unlimited(max_cpu, max_memory)
+        } else {
+            TaskManager::new(cpu, max_cpu, memory, max_memory)
         };
 
         Ok(Self {
-            inner,
-            kind,
-            container: task.container.clone(),
-            shell: task.shell.clone().map(Into::into),
-            max_concurrency,
+            inner: Arc::new(backend),
+            shell: Arc::new(task.shell.clone()),
+            container: task.shell.clone(),
+            max_concurrency: cpu,
             max_cpu,
             max_memory,
             manager,
@@ -351,7 +331,7 @@ impl CrankshaftBackend {
     }
 }
 
-impl TaskExecutionBackend for CrankshaftBackend {
+impl TaskExecutionBackend for DockerBackend {
     fn max_concurrency(&self) -> u64 {
         self.max_concurrency
     }
@@ -426,9 +406,7 @@ impl TaskExecutionBackend for CrankshaftBackend {
             }
 
             // Localize all inputs
-            // TODO: only do this for local task execution
-            let mut download_futs = JoinSet::new();
-
+            let mut downloads = JoinSet::new();
             for (idx, input) in inputs.iter_mut().enumerate() {
                 match input.path() {
                     EvaluationPath::Local(path) => {
@@ -437,7 +415,7 @@ impl TaskExecutionBackend for CrankshaftBackend {
                     EvaluationPath::Remote(url) => {
                         let downloader = downloader.clone();
                         let url = url.clone();
-                        download_futs.spawn(async move {
+                        downloads.spawn(async move {
                             let location_result = downloader.download(&url).await;
 
                             match location_result {
@@ -449,7 +427,7 @@ impl TaskExecutionBackend for CrankshaftBackend {
                 }
             }
 
-            while let Some(result) = download_futs.join_next().await {
+            while let Some(result) = downloads.join_next().await {
                 match result {
                     Ok(Ok((idx, location))) => {
                         inputs
@@ -501,12 +479,12 @@ impl TaskExecutionBackend for CrankshaftBackend {
                 .expect("generator should never be exhausted")
         );
         self.manager.send(
-            CrankshaftTaskRequest {
+            DockerTaskRequest {
                 inner: request,
+                shell: self.shell.clone(),
                 backend: self.inner.clone(),
                 name,
                 container,
-                shell: self.shell.clone(),
                 cpu,
                 memory,
                 max_cpu,
@@ -523,6 +501,7 @@ impl TaskExecutionBackend for CrankshaftBackend {
         })
     }
 
+    #[cfg(unix)]
     fn cleanup<'a, 'b, 'c>(
         &'a self,
         output_dir: &'b Path,
@@ -533,149 +512,110 @@ impl TaskExecutionBackend for CrankshaftBackend {
         'b: 'c,
         Self: 'c,
     {
-        if self.kind != CrankshaftBackendKind::Docker {
+        /// The guest path for the output directory.
+        const GUEST_OUT_DIR: &str = "/workflow_output";
+
+        /// Amount of CPU to reserve for the cleanup task.
+        const CLEANUP_CPU: f64 = 0.1;
+
+        /// Amount of memory to reserve for the cleanup task.
+        const CLEANUP_MEMORY: f64 = 0.05;
+
+        let backend = self.inner.clone();
+        let generator = self.generator.clone();
+        let output_path = std::path::absolute(output_dir).expect("failed to get absolute path");
+        if !output_path.is_dir() {
+            info!("output directory does not exist: skipping cleanup");
             return None;
         }
 
-        #[cfg(unix)]
-        {
-            let inner_backend = self.inner.clone();
-            let generator = self.generator.clone();
-            let output_path = std::path::absolute(output_dir).expect("failed to get absolute path");
-            Some(
-                async move {
-                    let result = async {
-                        let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
-                        let ownership = format!("{uid}:{gid}");
-                        info!(
-                            "cleanup target: '{}', attempting to set ownership to: {}",
-                            output_path.display(),
-                            ownership
+        Some(
+            async move {
+                let result = async {
+                    let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
+                    let ownership = format!("{uid}:{gid}");
+                    let output_mount = Input::builder()
+                        .path(GUEST_OUT_DIR)
+                        .contents(Contents::Path(output_path.clone()))
+                        .ty(InputType::Directory)
+                        // need write access
+                        .read_only(false)
+                        .build();
+
+                    let name = format!(
+                        "docker-backend-cleanup-{id}",
+                        id = generator
+                            .lock()
+                            .expect("generator should always acquire")
+                            .next()
+                            .expect("generator should never be exhausted")
+                    );
+
+                    let task = Task::builder()
+                        .name(&name)
+                        .executions(NonEmpty::new(
+                            Execution::builder()
+                                .image("alpine:latest")
+                                .program("chown")
+                                .args([
+                                    "-R".to_string(),
+                                    ownership.clone(),
+                                    GUEST_OUT_DIR.to_string(),
+                                ])
+                                .work_dir("/")
+                                .build(),
+                        ))
+                        .inputs([output_mount])
+                        .resources(
+                            Resources::builder()
+                                .cpu(CLEANUP_CPU)
+                                .ram(CLEANUP_MEMORY)
+                                .build(),
+                        )
+                        .build();
+
+                    info!(
+                        "running cleanup task `{name}` to change ownership of `{path}` to \
+                         `{ownership}`",
+                        path = output_path.display(),
+                    );
+
+                    let (spawned_tx, _) = oneshot::channel();
+                    let output_rx = backend
+                        .run(task, Some(spawned_tx), token)
+                        .map_err(|e| anyhow!("failed to submit cleanup task: {e}"))?;
+
+                    let statuses = output_rx
+                        .await
+                        .map_err(|e| anyhow!("failed to run cleanup task: {e}"))?;
+                    let status = statuses.first();
+                    if status.success() {
+                        Ok(())
+                    } else {
+                        bail!(
+                            "failed to chown output directory `{path}`",
+                            path = output_path.display()
                         );
-
-                        if !output_path.exists() {
-                            info!("output directory does not exist, skipping cleanup");
-                            return Ok(());
-                        }
-                        if !output_path.is_dir() {
-                            bail!(
-                                "output directory `{path}` is not a directory",
-                                path = output_path.display()
-                            );
-                        }
-
-                        let output_mount = Input::builder()
-                            .path(GUEST_OUT_DIR)
-                            .contents(Contents::Path(output_path.clone()))
-                            .ty(Type::Directory)
-                            // need write access
-                            .read_only(false)
-                            .build();
-
-                        let cleanup_task_name = format!(
-                            "wdl-engine-chown-cleanup-{}",
-                            generator
-                                .lock()
-                                .expect("generator should always acquire")
-                                .next()
-                                .expect("generator should never be exhausted")
-                        );
-
-                        let cleanup_resources = Resources::builder()
-                            .cpu(CLEANUP_CPU)
-                            .ram(CLEANUP_MEMORY)
-                            .build();
-
-                        let cleanup_task = Task::builder()
-                            .name(&cleanup_task_name)
-                            .executions(NonEmpty::new(
-                                Execution::builder()
-                                    .image("alpine:latest")
-                                    .program("chown")
-                                    .args([
-                                        "-R".to_string(),
-                                        ownership.clone(),
-                                        GUEST_OUT_DIR.to_string(),
-                                    ])
-                                    .work_dir("/")
-                                    .build(),
-                            ))
-                            .inputs([Arc::new(output_mount)])
-                            .resources(cleanup_resources)
-                            .build();
-
-                        info!(
-                            "running cleanup task '{}' to chown '{}' to '{}'",
-                            cleanup_task_name,
-                            output_path.display(),
-                            ownership
-                        );
-
-                        let (spawned_tx, _) = oneshot::channel();
-
-                        let output_rx = inner_backend
-                            .run(cleanup_task, Some(spawned_tx), token)
-                            .map_err(|e| anyhow!("failed to submit cleanup task: {e}"))?;
-
-                        match output_rx.await {
-                            Ok(outputs) => {
-                                if outputs.is_empty() {
-                                    bail!(
-                                        "cleanup task '{}' did not produce any outputs",
-                                        cleanup_task_name
-                                    );
-                                }
-                                let output = outputs.first();
-                                if output.status.success() {
-                                    info!(
-                                        "cleanup task '{}' completed successfully",
-                                        cleanup_task_name
-                                    );
-                                    Ok(())
-                                } else {
-                                    let stderr = String::from_utf8_lossy(&output.stderr);
-                                    tracing::error!(
-                                        "failed to chown output directory: '{}'. Exit status: \
-                                         '{}'. Stderr: '{}'",
-                                        output_path.display(),
-                                        output.status,
-                                        stderr
-                                    );
-                                    bail!(
-                                        "failed to chown output directory: '{}'",
-                                        output_path.display()
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "receiving result for cleanup task '{}' failed: {e}",
-                                    cleanup_task_name
-                                );
-                                bail!(
-                                    "receiving result for cleanup task '{}' failed: {e}",
-                                    cleanup_task_name
-                                );
-                            }
-                        }
-                    }
-                    .await;
-
-                    if let Err(e) = result {
-                        tracing::error!("cleanup task failed: {e:#}");
                     }
                 }
-                .boxed(),
-            )
-        }
+                .await;
 
-        #[cfg(not(unix))]
-        {
-            let _ = token;
-            let _ = output_dir;
-            info!("cleanup task is not supported on this platform");
+                if let Err(e) = result {
+                    tracing::error!("cleanup task failed: {e:#}");
+                }
+            }
+            .boxed(),
+        )
+    }
 
-            None
-        }
+    #[cfg(not(unix))]
+    fn cleanup<'a, 'b, 'c>(&'a self, _: &'b Path, _: CancellationToken) -> Option<BoxFuture<'c, ()>>
+    where
+        'a: 'c,
+        'b: 'c,
+        Self: 'c,
+    {
+        tracing::debug!("cleanup task is not supported on this platform");
+        None
     }
 }

--- a/wdl-engine/src/backend/docker.rs
+++ b/wdl-engine/src/backend/docker.rs
@@ -237,7 +237,7 @@ impl TaskManagerRequest for DockerTaskRequest {
             .await
             .map_err(|e| anyhow!("{e:#}"))?;
 
-        assert_eq!(statuses.len(), 1, "there should only be one output");
+        assert_eq!(statuses.len(), 1, "there should only be one exit status");
         let status = statuses.first();
 
         Ok(TaskExecutionResult {

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -865,22 +865,40 @@ mod test {
     fn non_empty_trie_windows() {
         let mut trie = InputTrie::default();
         let inputs = [
-            Input::new("C:\\".parse().unwrap()),
-            Input::new("C:\\foo\\bar\\foo.txt".parse().unwrap()),
-            Input::new("C:\\foo\\bar\\bar.txt".parse().unwrap()),
-            Input::new("C:\\foo\\baz\\foo.txt".parse().unwrap()),
-            Input::new("C:\\foo\\baz\\bar.txt".parse().unwrap()),
-            Input::new("C:\\bar\\foo\\foo.txt".parse().unwrap()),
-            Input::new("C:\\bar\\foo\\bar.txt".parse().unwrap()),
-            Input::new("C:\\baz".parse().unwrap()),
-            Input::new("https://example.com/".parse().unwrap()),
-            Input::new("https://example.com/foo/bar/foo.txt".parse().unwrap()),
-            Input::new("https://example.com/foo/bar/bar.txt".parse().unwrap()),
-            Input::new("https://example.com/foo/baz/foo.txt".parse().unwrap()),
-            Input::new("https://example.com/foo/baz/bar.txt".parse().unwrap()),
-            Input::new("https://example.com/bar/foo/foo.txt".parse().unwrap()),
-            Input::new("https://example.com/bar/foo/bar.txt".parse().unwrap()),
-            Input::new("https://foo.com/bar".parse().unwrap()),
+            Input::new(InputKind::Directory, "C:\\".parse().unwrap()),
+            Input::new(InputKind::File, "C:\\foo\\bar\\foo.txt".parse().unwrap()),
+            Input::new(InputKind::File, "C:\\foo\\bar\\bar.txt".parse().unwrap()),
+            Input::new(InputKind::File, "C:\\foo\\baz\\foo.txt".parse().unwrap()),
+            Input::new(InputKind::File, "C:\\foo\\baz\\bar.txt".parse().unwrap()),
+            Input::new(InputKind::File, "C:\\bar\\foo\\foo.txt".parse().unwrap()),
+            Input::new(InputKind::File, "C:\\bar\\foo\\bar.txt".parse().unwrap()),
+            Input::new(InputKind::Directory, "C:\\baz".parse().unwrap()),
+            Input::new(InputKind::File, "https://example.com/".parse().unwrap()),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/bar/foo.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/bar/bar.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/baz/foo.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/baz/bar.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/bar/foo/foo.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/bar/foo/bar.txt".parse().unwrap(),
+            ),
+            Input::new(InputKind::File, "https://foo.com/bar".parse().unwrap()),
         ];
 
         for input in &inputs {

--- a/wdl-engine/src/eval.rs
+++ b/wdl-engine/src/eval.rs
@@ -6,9 +6,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::BufRead;
 use std::path::Component;
-use std::path::MAIN_SEPARATOR;
 use std::path::Path;
-use std::sync::Arc;
+use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -29,11 +28,11 @@ use crate::CompoundValue;
 use crate::Outputs;
 use crate::PrimitiveValue;
 use crate::TaskExecutionResult;
-use crate::TaskExecutionRoot;
 use crate::Value;
 use crate::http::Downloader;
 use crate::http::Location;
 use crate::path::EvaluationPath;
+use crate::stdlib::download_file;
 
 pub mod v1;
 
@@ -296,16 +295,10 @@ impl<'a> ScopeRef<'a> {
 /// Represents an evaluated task.
 #[derive(Debug)]
 pub struct EvaluatedTask {
-    /// The evaluated task's exit code.
-    exit_code: i32,
-    /// The task execution root.
-    root: Arc<TaskExecutionRoot>,
-    /// The working directory of the executed task.
-    work_dir: EvaluationPath,
-    /// The value to return from the `stdout` function.
-    stdout: Value,
-    /// The value to return from the `stderr` function.
-    stderr: Value,
+    /// The task attempt directory.
+    attempt_dir: PathBuf,
+    /// The task execution result.
+    result: TaskExecutionResult,
     /// The evaluated outputs of the task.
     ///
     /// This is `Ok` when the task executes successfully and all of the task's
@@ -320,55 +313,42 @@ impl EvaluatedTask {
     /// Constructs a new evaluated task.
     ///
     /// Returns an error if the stdout or stderr paths are not UTF-8.
-    fn new(root: Arc<TaskExecutionRoot>, result: TaskExecutionResult) -> anyhow::Result<Self> {
-        let stdout = PrimitiveValue::new_file(root.stdout().to_str().with_context(|| {
-            format!(
-                "path to stdout file `{path}` is not UTF-8",
-                path = root.stdout().display()
-            )
-        })?)
-        .into();
-        let stderr = PrimitiveValue::new_file(root.stderr().to_str().with_context(|| {
-            format!(
-                "path to stderr file `{path}` is not UTF-8",
-                path = root.stderr().display()
-            )
-        })?)
-        .into();
-
+    fn new(attempt_dir: PathBuf, result: TaskExecutionResult) -> anyhow::Result<Self> {
         Ok(Self {
-            exit_code: result.exit_code,
-            root,
-            work_dir: result.work_dir,
-            stdout,
-            stderr,
+            result,
+            attempt_dir,
             outputs: Ok(Default::default()),
         })
     }
 
     /// Gets the exit code of the evaluated task.
     pub fn exit_code(&self) -> i32 {
-        self.exit_code
+        self.result.exit_code
     }
 
-    /// Gets the task execution root for the evaluated task.
-    pub fn root(&self) -> &TaskExecutionRoot {
-        &self.root
+    /// Gets the attempt directory of the task.
+    pub fn attempt_dir(&self) -> &Path {
+        &self.attempt_dir
+    }
+
+    /// Gets the inputs that were given to the task.
+    pub fn inputs(&self) -> &[Input] {
+        &self.result.inputs
     }
 
     /// Gets the working directory of the evaluated task.
     pub fn work_dir(&self) -> &EvaluationPath {
-        &self.work_dir
+        &self.result.work_dir
     }
 
     /// Gets the stdout value of the evaluated task.
     pub fn stdout(&self) -> &Value {
-        &self.stdout
+        &self.result.stdout
     }
 
     /// Gets the stderr value of the evaluated task.
     pub fn stderr(&self) -> &Value {
-        &self.stderr
+        &self.result.stderr
     }
 
     /// Gets the outputs of the evaluated task.
@@ -394,7 +374,11 @@ impl EvaluatedTask {
     /// Handles the exit of a task execution.
     ///
     /// Returns an error if the task failed.
-    fn handle_exit(&self, requirements: &HashMap<String, Value>) -> anyhow::Result<()> {
+    async fn handle_exit(
+        &self,
+        requirements: &HashMap<String, Value>,
+        downloader: &dyn Downloader,
+    ) -> anyhow::Result<()> {
         let mut error = true;
         if let Some(return_codes) = requirements
             .get(TASK_REQUIREMENT_RETURN_CODES)
@@ -411,52 +395,58 @@ impl EvaluatedTask {
                     );
                 }
                 Value::Primitive(PrimitiveValue::Integer(ok)) => {
-                    if self.exit_code == i32::try_from(*ok).unwrap_or_default() {
+                    if self.result.exit_code == i32::try_from(*ok).unwrap_or_default() {
                         error = false;
                     }
                 }
                 Value::Compound(CompoundValue::Array(codes)) => {
                     error = !codes.as_slice().iter().any(|v| {
                         v.as_integer()
-                            .map(|i| i32::try_from(i).unwrap_or_default() == self.exit_code)
+                            .map(|i| i32::try_from(i).unwrap_or_default() == self.result.exit_code)
                             .unwrap_or(false)
                     });
                 }
                 _ => unreachable!("unexpected return codes value"),
             }
         } else {
-            error = self.exit_code != 0;
+            error = self.result.exit_code != 0;
         }
 
         if error {
             // Read the last `MAX_STDERR_LINES` number of lines from stderr
             // If there's a problem reading stderr, don't output it
-            let stderr = fs::File::open(self.root.stderr())
+            let stderr = download_file(downloader, None, self.stderr().as_file().unwrap())
+                .await
                 .ok()
-                .map(|f| {
-                    // Buffer the last N number of lines
-                    let reader = RevBufReader::new(f);
-                    let lines: Vec<_> = reader
-                        .lines()
-                        .take(MAX_STDERR_LINES)
-                        .map_while(|l| l.ok())
-                        .collect();
+                .and_then(|l| {
+                    fs::File::open(l).ok().map(|f| {
+                        // Buffer the last N number of lines
+                        let reader = RevBufReader::new(f);
+                        let lines: Vec<_> = reader
+                            .lines()
+                            .take(MAX_STDERR_LINES)
+                            .map_while(|l| l.ok())
+                            .collect();
 
-                    // Iterate the lines in reverse order as we read them in reverse
-                    lines
-                        .iter()
-                        .rev()
-                        .format_with("\n", |l, f| f(&format_args!("  {l}")))
-                        .to_string()
+                        // Iterate the lines in reverse order as we read them in reverse
+                        lines
+                            .iter()
+                            .rev()
+                            .format_with("\n", |l, f| f(&format_args!("  {l}")))
+                            .to_string()
+                    })
                 })
                 .unwrap_or_default();
 
+            // If the work directory is remote,
             bail!(
-                "task process terminated with exit code {code}: see the `stdout` and `stderr` \
-                 files in execution directory `{dir}{MAIN_SEPARATOR}` for task command \
-                 output{header}{stderr}{trailer}",
-                code = self.exit_code,
-                dir = self.root().attempt_dir().display(),
+                "process terminated with exit code {code}: see `{stdout_path}` and \
+                 `{stderr_path}` for task output and the related files in \
+                 `{dir}`{header}{stderr}{trailer}",
+                code = self.result.exit_code,
+                dir = self.attempt_dir().display(),
+                stdout_path = self.stdout().as_file().expect("must be file"),
+                stderr_path = self.stderr().as_file().expect("must be file"),
                 header = if stderr.is_empty() {
                     Cow::Borrowed("")
                 } else {
@@ -470,9 +460,29 @@ impl EvaluatedTask {
     }
 }
 
+/// Gets the kind of an input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InputKind {
+    /// The input is a single file.
+    File,
+    /// The input is a directory.
+    Directory,
+}
+
+impl From<InputKind> for crankshaft::engine::task::input::Type {
+    fn from(value: InputKind) -> Self {
+        match value {
+            InputKind::File => Self::File,
+            InputKind::Directory => Self::Directory,
+        }
+    }
+}
+
 /// Represents a `File` or `Directory` input to a task.
 #[derive(Debug, Clone)]
 pub struct Input {
+    /// The input kind.
+    kind: InputKind,
     /// The path for the input.
     path: EvaluationPath,
     /// The download location for the input.
@@ -485,12 +495,34 @@ pub struct Input {
 
 impl Input {
     /// Creates a new input with the given path and access.
-    pub fn new(path: EvaluationPath) -> Self {
+    pub fn new(kind: InputKind, path: EvaluationPath) -> Self {
         Self {
+            kind,
             path,
             location: None,
             guest_path: None,
         }
+    }
+
+    /// Creates an input from a primitive value.
+    pub fn from_primitive(value: &PrimitiveValue) -> Result<Self> {
+        let (kind, path) = match value {
+            PrimitiveValue::File(path) => (InputKind::File, path),
+            PrimitiveValue::Directory(path) => (InputKind::Directory, path),
+            _ => bail!("value is not a `File` or `Directory`"),
+        };
+
+        Ok(Self {
+            kind,
+            path: path.parse()?,
+            location: None,
+            guest_path: None,
+        })
+    }
+
+    /// Gets the kind of the input.
+    pub fn kind(&self) -> InputKind {
+        self.kind
     }
 
     /// Gets the path to the input.
@@ -755,22 +787,40 @@ mod test {
     fn non_empty_trie_unix() {
         let mut trie = InputTrie::default();
         let inputs = [
-            Input::new("/".parse().unwrap()),
-            Input::new("/foo/bar/foo.txt".parse().unwrap()),
-            Input::new("/foo/bar/bar.txt".parse().unwrap()),
-            Input::new("/foo/baz/foo.txt".parse().unwrap()),
-            Input::new("/foo/baz/bar.txt".parse().unwrap()),
-            Input::new("/bar/foo/foo.txt".parse().unwrap()),
-            Input::new("/bar/foo/bar.txt".parse().unwrap()),
-            Input::new("/baz".parse().unwrap()),
-            Input::new("https://example.com/".parse().unwrap()),
-            Input::new("https://example.com/foo/bar/foo.txt".parse().unwrap()),
-            Input::new("https://example.com/foo/bar/bar.txt".parse().unwrap()),
-            Input::new("https://example.com/foo/baz/foo.txt".parse().unwrap()),
-            Input::new("https://example.com/foo/baz/bar.txt".parse().unwrap()),
-            Input::new("https://example.com/bar/foo/foo.txt".parse().unwrap()),
-            Input::new("https://example.com/bar/foo/bar.txt".parse().unwrap()),
-            Input::new("https://foo.com/bar".parse().unwrap()),
+            Input::new(InputKind::Directory, "/".parse().unwrap()),
+            Input::new(InputKind::File, "/foo/bar/foo.txt".parse().unwrap()),
+            Input::new(InputKind::File, "/foo/bar/bar.txt".parse().unwrap()),
+            Input::new(InputKind::File, "/foo/baz/foo.txt".parse().unwrap()),
+            Input::new(InputKind::File, "/foo/baz/bar.txt".parse().unwrap()),
+            Input::new(InputKind::File, "/bar/foo/foo.txt".parse().unwrap()),
+            Input::new(InputKind::File, "/bar/foo/bar.txt".parse().unwrap()),
+            Input::new(InputKind::Directory, "/baz".parse().unwrap()),
+            Input::new(InputKind::File, "https://example.com/".parse().unwrap()),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/bar/foo.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/bar/bar.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/baz/foo.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/foo/baz/bar.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/bar/foo/foo.txt".parse().unwrap(),
+            ),
+            Input::new(
+                InputKind::File,
+                "https://example.com/bar/foo/bar.txt".parse().unwrap(),
+            ),
+            Input::new(InputKind::File, "https://foo.com/bar".parse().unwrap()),
         ];
 
         for input in &inputs {

--- a/wdl-engine/src/eval/v1.rs
+++ b/wdl-engine/src/eval/v1.rs
@@ -22,6 +22,16 @@ pub enum ProgressKind<'a> {
         /// The identifier of the task.
         id: &'a str,
     },
+    /// A task has been retried.
+    TaskRetried {
+        /// The identifier of the task.
+        id: &'a str,
+        /// The retry number for the task's execution, starting at 0 to indicate
+        /// first retry.
+        ///
+        /// This value is incremented upon each retry.
+        retry: u64,
+    },
     /// A task with the given id has started execution.
     ///
     /// Note that a task may have multiple executions as a result of retrying
@@ -29,11 +39,6 @@ pub enum ProgressKind<'a> {
     TaskExecutionStarted {
         /// The identifier of the task.
         id: &'a str,
-        /// The attempt number for the task's execution, starting at 0 to
-        /// indicate the first attempt.
-        ///
-        /// This value is incremented upon each retry.
-        attempt: u64,
     },
     /// A task with the given id has completed execution.
     TaskExecutionCompleted {
@@ -70,6 +75,7 @@ impl ProgressKind<'_> {
     pub fn id(&self) -> &str {
         match self {
             Self::TaskStarted { id, .. }
+            | Self::TaskRetried { id, .. }
             | Self::TaskExecutionStarted { id, .. }
             | Self::TaskExecutionCompleted { id, .. }
             | Self::TaskCompleted { id, .. }

--- a/wdl-engine/src/stdlib.rs
+++ b/wdl-engine/src/stdlib.rs
@@ -106,7 +106,7 @@ fn ensure_local_path<'a>(
 }
 
 /// Helper for downloading files in stdlib functions.
-async fn download_file<'a>(
+pub(crate) async fn download_file<'a>(
     downloader: &dyn Downloader,
     work_dir: Option<&EvaluationPath>,
     path: &'a str,

--- a/wdl-engine/tests/tasks/task-fail/error.txt
+++ b/wdl-engine/tests/tasks/task-fail/error.txt
@@ -1,4 +1,4 @@
-error: task execution failed for task `test`: task process terminated with exit code 1: see the `stdout` and `stderr` files in execution directory `attempts/0/` for task command output
+error: task execution failed for task `test`: process terminated with exit code 1: see `attempts/0/stdout` and `attempts/0/stderr` for task output and the related files in `attempts/0`
 
 task stderr output (last 10 lines):
 

--- a/wdl-engine/tests/workflows.rs
+++ b/wdl-engine/tests/workflows.rs
@@ -52,7 +52,7 @@ use wdl_ast::Severity;
 use wdl_engine::EvaluationError;
 use wdl_engine::Inputs;
 use wdl_engine::config;
-use wdl_engine::config::BackendKind;
+use wdl_engine::config::BackendConfig;
 use wdl_engine::v1::WorkflowEvaluator;
 
 /// Finds tests to run as part of the analysis test suite.
@@ -155,19 +155,20 @@ fn compare_result(path: &Path, result: &str) -> Result<()> {
 fn configs() -> Vec<config::Config> {
     vec![
         {
-            let mut config = config::Config::default();
-            config.backend.default = BackendKind::Local;
-            config
+            config::Config {
+                backend: BackendConfig::Local(Default::default()),
+                ..Default::default()
+            }
         },
         // Currently we limit running the Docker backend to Linux as GitHub does not have Docker
         // installed on macOS hosted runners and the Windows hosted runners are configured to use
         // Windows containers
         #[cfg(target_os = "linux")]
         {
-            let mut config = config::Config::default();
-            config.backend.crankshaft.default = config::CrankshaftBackendKind::Docker;
-            config.backend.default = BackendKind::Crankshaft;
-            config
+            config::Config {
+                backend: BackendConfig::Docker(Default::default()),
+                ..Default::default()
+            }
         },
     ]
 }

--- a/wdl-engine/tests/workflows/callstack/error.txt
+++ b/wdl-engine/tests/workflows/callstack/error.txt
@@ -1,4 +1,4 @@
-error: task execution failed for task `my_task`: task process terminated with exit code 1: see the `stdout` and `stderr` files in execution directory `calls/test/calls/test/calls/my_task/attempts/0/` for task command output
+error: task execution failed for task `my_task`: process terminated with exit code 1: see `calls/test/calls/test/calls/my_task/attempts/0/stdout` and `calls/test/calls/test/calls/my_task/attempts/0/stderr` for task output and the related files in `calls/test/calls/test/calls/my_task/attempts/0`
 
 task stderr output (last 10 lines):
 

--- a/wdl-grammar/CHANGELOG.md
+++ b/wdl-grammar/CHANGELOG.md
@@ -221,7 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 * Adds initial version of parsing WDL 1.x grammar.
-* Adds `wdl-grammar` tool, a tool that is useful in creating and exhausitvely
+* Adds `wdl-grammar` tool, a tool that is useful in creating and exhaustively
   testing the `wdl-grammar` crate.
     * The following subcommands are included in the initial release:
         * `wdl-grammar create-test`: scaffolds otherwise arduous Rust tests that

--- a/wdl/CHANGELOG.md
+++ b/wdl/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-* Added ability to compile and watch a CSS style directory for `wdl doc` (#[262](https://github.com/stjude-rust-labs/wdl/pull/262)).
-* Added ability to skip CSS compilation using a precompiled stylesheet for `wdl doc` (#[262](https://github.com/stjude-rust-labs/wdl/pull/262)).
-* Added graceful cancellation on SIGINT (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
-* Added `--config` option to the `run` command (#[327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Added ability to compile and watch a CSS style directory for `wdl doc` ([#262](https://github.com/stjude-rust-labs/wdl/pull/262)).
+* Added ability to skip CSS compilation using a precompiled stylesheet for `wdl doc` ([#262](https://github.com/stjude-rust-labs/wdl/pull/262)).
+* Added graceful cancellation on SIGINT ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
+* Added `--config` option to the `run` command ([#327](https://github.com/stjude-rust-labs/wdl/pull/327)).
 * Added executing task information to the `wdl run` progress bar ([#310](https://github.com/stjude-rust-labs/wdl/pull/310)).
 
 #### Fixed


### PR DESCRIPTION
This commit renames the `crankshaft` backend to simply the `docker` backend and removes the TODOs that were in place for the upcoming TES backend, which will now be introduced as a separate backend given the number of differences between the two backends (mostly due to how it handles inputs, outputs, and localization).

Additionally, this updates `wdl-engine` to use `crankshaft` version `0.2.0`, which required some changes in the (now) docker backend for handling stdout and stderr.

Additionally, the backend configuration for the engine has subsequently changed so that it no longer just wraps a Crankshaft configuration verbatim, allowing for a stable configuration format driven by `wdl-engine`. The backend configuration is now an enumeration rather than a set of structs, allowing for a future where multiple backends might be used simultaneously or as fallbacks.

A number of the changes here are needed to support the upcoming TES backend as well.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
