### PR TITLE
feat: write inputs and outputs to task/workflow root directories.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added writing `inputs.json` and `outputs.json` for each task and workflow
+  that was evaluated ([#437](https://github.com/stjude-rust-labs/wdl/pull/437)).
 * Implemented remote file localization for task execution ([#386](https://github.com/stjude-rust-labs/wdl/pull/386)).
 * Implemented concurrent file downloads for localization for task execution ([#424](https://github.com/stjude-rust-labs/wdl/pull/424)).
 

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -90,6 +90,9 @@ use crate::path;
 use crate::path::EvaluationPath;
 use crate::tree::SyntaxNode;
 use crate::v1::ExprEvaluator;
+use crate::v1::INPUTS_FILE;
+use crate::v1::OUTPUTS_FILE;
+use crate::v1::write_json_file;
 
 /// The default container requirement.
 pub const DEFAULT_TASK_REQUIREMENT_CONTAINER: &str = "ubuntu:latest";
@@ -640,6 +643,9 @@ impl TaskEvaluator {
             )
         })?;
 
+        // Write the inputs to the task's root directory
+        write_json_file(root_dir.join(INPUTS_FILE), inputs)?;
+
         let mut state = State::new(&temp_dir, document, task)?;
         let nodes = toposort(&graph, None).expect("graph should be acyclic");
         let mut current = 0;
@@ -832,6 +838,9 @@ impl TaskEvaluator {
                 .collect();
             outputs.sort_by(move |a, b| indexes[a].cmp(&indexes[b]))
         }
+
+        // Write the outputs to the task's root directory
+        write_json_file(root_dir.join(OUTPUTS_FILE), &outputs)?;
 
         evaluated.outputs = Ok(outputs);
         Ok(evaluated)

--- a/wdl-engine/src/eval/v1/workflow.rs
+++ b/wdl-engine/src/eval/v1/workflow.rs
@@ -85,7 +85,10 @@ use crate::path::EvaluationPath;
 use crate::tree::SyntaxNode;
 use crate::tree::SyntaxToken;
 use crate::v1::ExprEvaluator;
+use crate::v1::INPUTS_FILE;
+use crate::v1::OUTPUTS_FILE;
 use crate::v1::TaskEvaluator;
+use crate::v1::write_json_file;
 
 /// Helper for formatting a workflow or task identifier for a call statement.
 fn format_id(namespace: Option<&str>, target: &str, alias: &str, scatter_index: &str) -> String {
@@ -776,6 +779,9 @@ impl WorkflowEvaluator {
             )
         })?;
 
+        // Write the inputs to the workflow's root directory
+        write_json_file(root_dir.join(INPUTS_FILE), &inputs)?;
+
         let calls_dir = root_dir.join("calls");
         fs::create_dir_all(&calls_dir).with_context(|| {
             format!(
@@ -827,6 +833,9 @@ impl WorkflowEvaluator {
                 .collect();
             outputs.sort_by(move |a, b| indexes[a].cmp(&indexes[b]))
         }
+
+        // Write the outputs to the workflow's root directory
+        write_json_file(root_dir.join(OUTPUTS_FILE), &outputs)?;
         Ok(outputs)
     }
 

--- a/wdl-engine/src/eval/v1/workflow.rs
+++ b/wdl-engine/src/eval/v1/workflow.rs
@@ -1764,15 +1764,159 @@ impl WorkflowEvaluator {
 
 #[cfg(test)]
 mod test {
+    use std::fs::read_to_string;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
+    use pretty_assertions::assert_eq;
     use tempfile::TempDir;
     use wdl_analysis::Analyzer;
     use wdl_analysis::DiagnosticsConfig;
 
     use super::*;
     use crate::config::BackendConfig;
+
+    #[tokio::test]
+    async fn it_writes_input_and_output_files() {
+        let root_dir = TempDir::new().expect("failed to create temporary directory");
+        fs::write(
+            root_dir.path().join("source.wdl"),
+            r#"
+version 1.2
+
+task foo {
+    input {
+        String a
+        Int b
+        Array[String] c
+    }
+
+    command <<<>>>
+
+    output {
+        String x = a
+        Int y = b
+        Array[String] z = c
+    }
+}
+
+workflow test {
+    input {
+        String a
+        Int b
+        Array[String] c
+    }
+
+    call foo {
+        a = "foo",
+        b = 10,
+        c = ["foo", "bar", "baz"]
+    }
+
+    call foo as bar {
+        a = "bar",
+        b = 1,
+        c = []
+    }
+
+    output {
+        String x = a
+        Int y = b
+        Array[String] z = c
+    }
+}
+"#,
+        )
+        .expect("failed to write WDL source file");
+
+        // Analyze the source file
+        let analyzer = Analyzer::new(DiagnosticsConfig::except_all(), |(), _, _, _| async {});
+        analyzer
+            .add_directory(root_dir.path().to_path_buf())
+            .await
+            .expect("failed to add directory");
+        let results = analyzer
+            .analyze(())
+            .await
+            .expect("failed to analyze document");
+        assert_eq!(results.len(), 1, "expected only one result");
+
+        let config = Config {
+            backend: BackendConfig::Local(Default::default()),
+            ..Default::default()
+        };
+        let evaluator = WorkflowEvaluator::new(config, CancellationToken::new())
+            .await
+            .unwrap();
+
+        // Evaluate the `test` workflow in `source.wdl` using the default local backend
+        let mut inputs = WorkflowInputs::default();
+        inputs.set("a", "qux".to_string());
+        inputs.set("b", 1234);
+        inputs.set(
+            "c",
+            Array::new(
+                ArrayType::new(PrimitiveType::String),
+                ["jam".to_string(), "cakes".to_string()],
+            )
+            .unwrap(),
+        );
+        let outputs_dir = root_dir.path().join("outputs");
+        let outputs = evaluator
+            .evaluate(
+                results.first().expect("should have result").document(),
+                inputs,
+                &outputs_dir,
+                |_| async {},
+            )
+            .await
+            .expect("failed to evaluate workflow");
+        assert_eq!(outputs.iter().count(), 3, "expected three outputs");
+
+        // Check the workflow inputs.json
+        assert_eq!(
+            read_to_string(outputs_dir.join("inputs.json"))
+                .expect("failed to read workflow `inputs.json`"),
+            "{\n  \"a\": \"qux\",\n  \"b\": 1234,\n  \"c\": [\n    \"jam\",\n    \"cakes\"\n  ]\n}"
+        );
+
+        // Check the workflow outputs.json
+        assert_eq!(
+            read_to_string(outputs_dir.join("outputs.json"))
+                .expect("failed to read workflow `outputs.json`"),
+            "{\n  \"x\": \"qux\",\n  \"y\": 1234,\n  \"z\": [\n    \"jam\",\n    \"cakes\"\n  ]\n}"
+        );
+
+        // Check the `foo` call inputs.json
+        assert_eq!(
+            read_to_string(outputs_dir.join("calls/foo/inputs.json"))
+                .expect("failed to read foo `inputs.json`"),
+            "{\n  \"a\": \"foo\",\n  \"b\": 10,\n  \"c\": [\n    \"foo\",\n    \"bar\",\n    \
+             \"baz\"\n  ]\n}"
+        );
+
+        // Check the `foo` call outputs.json
+        assert_eq!(
+            read_to_string(outputs_dir.join("calls/foo/outputs.json"))
+                .expect("failed to read foo `outputs.json`"),
+            "{\n  \"x\": \"foo\",\n  \"y\": 10,\n  \"z\": [\n    \"foo\",\n    \"bar\",\n    \
+             \"baz\"\n  ]\n}"
+        );
+
+        // Check the `bar` call inputs.json
+        assert_eq!(
+            read_to_string(outputs_dir.join("calls/bar/inputs.json"))
+                .expect("failed to read bar `inputs.json`"),
+            "{\n  \"a\": \"bar\",\n  \"b\": 1,\n  \"c\": []\n}"
+        );
+
+        // Check the `bar` call outputs.json
+        assert_eq!(
+            read_to_string(outputs_dir.join("calls/bar/outputs.json"))
+                .expect("failed to read bar `outputs.json`"),
+            "{\n  \"x\": \"bar\",\n  \"y\": 1,\n  \"z\": []\n}"
+        );
+    }
 
     #[tokio::test]
     async fn it_reports_progress() {

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -30,7 +30,7 @@ use crate::Value;
 /// Helper for replacing input paths with a path derived from joining the
 /// specified path with the input path.
 fn join_paths<'a>(
-    inputs: &mut HashMap<String, Value>,
+    inputs: &mut IndexMap<String, Value>,
     path: impl Fn(&str) -> Result<&'a Path>,
     ty: impl Fn(&str) -> Option<Type>,
 ) -> Result<()> {
@@ -68,7 +68,7 @@ fn join_paths<'a>(
 #[derive(Default, Debug, Clone)]
 pub struct TaskInputs {
     /// The task input values.
-    inputs: HashMap<String, Value>,
+    inputs: IndexMap<String, Value>,
     /// The overridden requirements section values.
     requirements: HashMap<String, Value>,
     /// The overridden hints section values.
@@ -317,7 +317,7 @@ impl Serialize for TaskInputs {
 #[derive(Default, Debug, Clone)]
 pub struct WorkflowInputs {
     /// The workflow input values.
-    inputs: HashMap<String, Value>,
+    inputs: IndexMap<String, Value>,
     /// The nested call inputs.
     calls: HashMap<String, Inputs>,
 }

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -10,6 +10,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
 use indexmap::IndexMap;
+use serde::Serialize;
 use serde_json::Value as JsonValue;
 use serde_yaml_ng::Value as YamlValue;
 use wdl_analysis::document::Document;
@@ -299,6 +300,16 @@ where
             requirements: Default::default(),
             hints: Default::default(),
         }
+    }
+}
+
+impl Serialize for TaskInputs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Only serialize the input values
+        self.inputs.serialize(serializer)
     }
 }
 
@@ -607,6 +618,17 @@ where
                 .collect(),
             calls: Default::default(),
         }
+    }
+}
+
+impl Serialize for WorkflowInputs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Note: for serializing, only serialize the direct inputs, not the nested
+        // inputs
+        self.inputs.serialize(serializer)
     }
 }
 


### PR DESCRIPTION
This commit writes an `inputs.json` and a `outputs.json` for each task and workflow that is evaluated.

The files are present in each root directory for the task/workflow in the `outputs` directory.

Closes #330.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
