### PR TITLE
fix: removes unused `shellcheck` option

### DIFF
--- a/wdl-cli/CHANGELOG.md
+++ b/wdl-cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 * JSON and YAML files are now correctly parsed ([#440](https://github.com/stjude-rust-labs/wdl/pull/440)).
+* Removes the unused `shellcheck` option in `wdl::cli::Analysis` ([#441](https://github.com/stjude-rust-labs/wdl/pull/441)).
 
 ## 0.1.1 - 05-02-2025
 

--- a/wdl-cli/src/analysis.rs
+++ b/wdl-cli/src/analysis.rs
@@ -39,9 +39,6 @@ pub struct Analysis {
     /// Whether or not to enable linting.
     lint: bool,
 
-    /// Whether or not to enable `shellcheck`.
-    shellcheck: bool,
-
     /// The initialization callback.
     init: InitCb,
 
@@ -77,12 +74,6 @@ impl Analysis {
     /// Sets whether linting is enabled.
     pub fn lint(mut self, value: bool) -> Self {
         self.lint = value;
-        self
-    }
-
-    /// Sets whether `shellcheck` is enabled.
-    pub fn shellcheck(mut self, value: bool) -> Self {
-        self.shellcheck = value;
         self
     }
 
@@ -149,7 +140,6 @@ impl Default for Analysis {
             sources: Default::default(),
             exceptions: Default::default(),
             lint: Default::default(),
-            shellcheck: Default::default(),
             init: Box::new(|| {}),
             progress: Box::new(|_, _, _| Box::pin(async {})),
         }


### PR DESCRIPTION
This PR fixes the bug where the `shellcheck` option is still provided on `wdl-cli::Analysis`.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
