### PR TITLE
ci: ignore PRs against non-main branches

### DIFF
--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -37,7 +37,9 @@ jobs:
             echo "No valid author found."
           fi
       - name: Add reviewers
-        if: github.event.pull_request.draft == false
+        if: |
+          github.event.pull_request.draft == false &&
+          github.base_ref = 'main'
         run: |
           # The gh cli silently drops a reviewer if they are the author.
           # So no need to clean the list here.


### PR DESCRIPTION
This updates the assignment CI step to skip adding assignees if the target of the pull request is not `main`.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.
- [ ] Your PR title follows the [conventional commit] style.
