### PR TITLE
fix: treat if statements that evaluate to string as string

### DIFF
--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -34,6 +34,8 @@ use wdl_ast::SyntaxElement;
 use wdl_ast::SyntaxKind;
 use wdl_ast::v1::CommandPart;
 use wdl_ast::v1::CommandSection;
+use wdl_ast::v1::Expr;
+use wdl_ast::v1::LiteralExpr;
 use wdl_ast::v1::Placeholder;
 use wdl_ast::v1::StrippedCommandPart;
 
@@ -395,6 +397,18 @@ fn to_bash_var(placeholder: &Placeholder, ty: Option<Type>) -> (String, bool) {
                     format!("true{}", " ".repeat(placeholder_len.saturating_sub(4))),
                     true,
                 );
+            }
+            PrimitiveType::String => {
+                if let Expr::If(i) = placeholder.expr() {
+                    let (_, if_expr, else_expr) = i.exprs();
+                    if let (
+                        Expr::Literal(LiteralExpr::String(_)),
+                        Expr::Literal(LiteralExpr::String(_)),
+                    ) = (if_expr, else_expr)
+                    {
+                        return ("a".repeat(placeholder_len), true);
+                    }
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
The current `shellcheck` implementation yields warnings that aren't truly applicable.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.
- [ ] Your PR title follows the [conventional commit] style.
