### PR TITLE
feat: add authentication to TES input and output URLs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ clap-verbosity-flag = { version = "3.0.3", features = ["tracing"] }
 codespan-reporting = "0.12.0"
 colored = "3.0.0"
 convert_case = "0.8.0"
-crankshaft = "0.3.0"
+crankshaft = { version = "0.3.0", git = "https://github.com/peterhuene/crankshaft", branch = "fix-tes" }
 dirs = "6.0.0"
 faster-hex = "0.10.0"
 ftree = "1.2.0"

--- a/wdl-engine/src/backend/docker.rs
+++ b/wdl-engine/src/backend/docker.rs
@@ -47,9 +47,8 @@ use crate::STDERR_FILE_NAME;
 use crate::STDOUT_FILE_NAME;
 use crate::Value;
 use crate::WORK_DIR_NAME;
+use crate::config::Config;
 use crate::config::DEFAULT_TASK_SHELL;
-use crate::config::DockerBackendConfig;
-use crate::config::TaskConfig;
 use crate::http::Downloader;
 use crate::http::HttpDownloader;
 use crate::http::Location;
@@ -85,14 +84,14 @@ const GUEST_STDERR_PATH: &str = "/stderr";
 /// as well as the result receiver channel.
 #[derive(Debug)]
 struct DockerTaskRequest {
+    /// The engine configuration.
+    config: Arc<Config>,
     /// The inner task spawn request.
     inner: TaskSpawnRequest,
     /// The underlying Crankshaft backend.
     backend: Arc<docker::Backend>,
     /// The name of the task.
     name: String,
-    /// The optional shell to use.
-    shell: Arc<Option<String>>,
     /// The requested container for the task.
     container: String,
     /// The requested CPU reservation for the task.
@@ -197,7 +196,13 @@ impl TaskManagerRequest for DockerTaskRequest {
             .executions(NonEmpty::new(
                 Execution::builder()
                     .image(&self.container)
-                    .program(self.shell.as_deref().unwrap_or(DEFAULT_TASK_SHELL))
+                    .program(
+                        self.config
+                            .task
+                            .shell
+                            .as_deref()
+                            .unwrap_or(DEFAULT_TASK_SHELL),
+                    )
                     .args(["-C".to_string(), GUEST_COMMAND_PATH.to_string()])
                     .work_dir(GUEST_WORK_DIR)
                     .env({
@@ -264,12 +269,10 @@ impl TaskManagerRequest for DockerTaskRequest {
 
 /// Represents the Docker backend.
 pub struct DockerBackend {
+    /// The engine configuration
+    config: Arc<Config>,
     /// The underlying Crankshaft backend.
     inner: Arc<docker::Backend>,
-    /// The shell to use.
-    shell: Arc<Option<String>>,
-    /// The default container to use.
-    container: Option<String>,
     /// The maximum amount of concurrency supported.
     max_concurrency: u64,
     /// The maximum CPUs for any of one node.
@@ -285,15 +288,21 @@ pub struct DockerBackend {
 impl DockerBackend {
     /// Constructs a new Docker task execution backend with the given
     /// configuration.
-    pub async fn new(task: &TaskConfig, config: &DockerBackendConfig) -> Result<Self> {
-        task.validate()?;
-        config.validate()?;
-
+    ///
+    /// The provided configuration is expected to have already been validated.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given configuration is not configured to use the docker
+    /// backend.
+    pub async fn new(config: Arc<Config>) -> Result<Self> {
         info!("initializing Docker backend");
+
+        let backend_config = config.backend.as_docker().expect("expected docker backend");
 
         let backend = docker::Backend::initialize_default_with(
             backend::docker::Config::builder()
-                .cleanup(config.cleanup)
+                .cleanup(backend_config.cleanup)
                 .build(),
         )
         .await
@@ -316,9 +325,8 @@ impl DockerBackend {
         };
 
         Ok(Self {
+            config,
             inner: Arc::new(backend),
-            shell: Arc::new(task.shell.clone()),
-            container: task.shell.clone(),
             max_concurrency: cpu,
             max_cpu,
             max_memory,
@@ -341,7 +349,7 @@ impl TaskExecutionBackend for DockerBackend {
         requirements: &HashMap<String, Value>,
         _: &HashMap<String, Value>,
     ) -> Result<TaskExecutionConstraints> {
-        let container = container(requirements, self.container.as_deref());
+        let container = container(requirements, self.config.task.container.as_deref());
 
         let cpu = cpu(requirements);
         if (self.max_cpu as f64) < cpu {
@@ -462,7 +470,7 @@ impl TaskExecutionBackend for DockerBackend {
         let requirements = request.requirements();
         let hints = request.hints();
 
-        let container = container(requirements, self.container.as_deref()).into_owned();
+        let container = container(requirements, self.config.task.container.as_deref()).into_owned();
         let cpu = cpu(requirements);
         let memory = memory(requirements)? as u64;
         let max_cpu = max_cpu(hints);
@@ -480,8 +488,8 @@ impl TaskExecutionBackend for DockerBackend {
         );
         self.manager.send(
             DockerTaskRequest {
+                config: self.config.clone(),
                 inner: request,
-                shell: self.shell.clone(),
                 backend: self.inner.clone(),
                 name,
                 container,

--- a/wdl-engine/src/backend/tes.rs
+++ b/wdl-engine/src/backend/tes.rs
@@ -1,5 +1,6 @@
 //! Implementation of the TES backend.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
@@ -50,11 +51,11 @@ use crate::STDERR_FILE_NAME;
 use crate::STDOUT_FILE_NAME;
 use crate::Value;
 use crate::WORK_DIR_NAME;
+use crate::config::Config;
 use crate::config::DEFAULT_TASK_SHELL;
-use crate::config::TaskConfig;
 use crate::config::TesBackendAuthConfig;
-use crate::config::TesBackendConfig;
 use crate::http::HttpDownloader;
+use crate::http::rewrite_url;
 use crate::path::EvaluationPath;
 use crate::v1::DEFAULT_TASK_REQUIREMENT_DISKS;
 use crate::v1::container;
@@ -95,18 +96,16 @@ const DEFAULT_TES_INTERVAL: u64 = 60;
 /// as well as the result receiver channel.
 #[derive(Debug)]
 struct TesTaskRequest {
+    /// The engine configuration.
+    config: Arc<Config>,
     /// The inner task spawn request.
     inner: TaskSpawnRequest,
     /// The Crankshaft TES backend to use.
     backend: Arc<tes::Backend>,
     /// The name of the task.
     name: String,
-    /// The optional shell to use.
-    shell: Arc<Option<String>>,
     /// The requested container for the task.
     container: String,
-    /// The associated engine configuration.
-    config: Arc<TesBackendConfig>,
     /// The requested CPU reservation for the task.
     cpu: f64,
     /// The requested memory reservation for the task, in bytes.
@@ -224,7 +223,9 @@ impl TaskManagerRequest for TesTaskRequest {
                     .path(input.guest_path().expect("should have guest path"))
                     .contents(match input.path() {
                         EvaluationPath::Local(path) => Contents::Path(path.clone()),
-                        EvaluationPath::Remote(url) => Contents::Url(url.clone()),
+                        EvaluationPath::Remote(url) => Contents::Url(
+                            rewrite_url(&self.config, Cow::Borrowed(url))?.into_owned(),
+                        ),
                     })
                     .ty(input.kind())
                     .read_only(true)
@@ -236,15 +237,30 @@ impl TaskManagerRequest for TesTaskRequest {
         // should always unwrap
         let outputs_url = self
             .config
+            .backend
+            .as_tes()
+            .unwrap()
             .outputs
             .as_ref()
             .expect("should have outputs URL")
             .join(&task_dir)
             .expect("should join");
 
-        let mut work_dir_url = outputs_url.join(WORK_DIR_NAME).expect("should join");
-        let stdout_url = outputs_url.join(STDOUT_FILE_NAME).expect("should join");
-        let stderr_url = outputs_url.join(STDERR_FILE_NAME).expect("should join");
+        let mut work_dir_url = rewrite_url(
+            &self.config,
+            Cow::Owned(outputs_url.join(WORK_DIR_NAME).expect("should join")),
+        )?
+        .into_owned();
+        let stdout_url = rewrite_url(
+            &self.config,
+            Cow::Owned(outputs_url.join(STDOUT_FILE_NAME).expect("should join")),
+        )?
+        .into_owned();
+        let stderr_url = rewrite_url(
+            &self.config,
+            Cow::Owned(outputs_url.join(STDERR_FILE_NAME).expect("should join")),
+        )?
+        .into_owned();
 
         // The TES backend will output three things: the working directory contents,
         // stdout, and stderr.
@@ -274,7 +290,13 @@ impl TaskManagerRequest for TesTaskRequest {
                 .executions(NonEmpty::new(
                     Execution::builder()
                         .image(&self.container)
-                        .program(self.shell.as_deref().unwrap_or(DEFAULT_TASK_SHELL))
+                        .program(
+                            self.config
+                                .task
+                                .shell
+                                .as_deref()
+                                .unwrap_or(DEFAULT_TASK_SHELL),
+                        )
                         .args(["-C".to_string(), GUEST_COMMAND_PATH.to_string()])
                         .work_dir(GUEST_WORK_DIR)
                         .env(self.inner.env().clone())
@@ -333,14 +355,10 @@ impl TaskManagerRequest for TesTaskRequest {
 
 /// Represents the Task Execution Service (TES) backend.
 pub struct TesBackend {
+    /// The engine configuration.
+    config: Arc<Config>,
     /// The underlying Crankshaft backend.
     inner: Arc<tes::Backend>,
-    /// The shell to use.
-    shell: Arc<Option<String>>,
-    /// The default container to use.
-    container: Option<String>,
-    /// The associated backend configuration.
-    config: Arc<TesBackendConfig>,
     /// The maximum amount of concurrency supported.
     max_concurrency: u64,
     /// The maximum CPUs for any of one node.
@@ -356,11 +374,17 @@ pub struct TesBackend {
 impl TesBackend {
     /// Constructs a new TES task execution backend with the given
     /// configuration.
-    pub async fn new(task: &TaskConfig, config: &TesBackendConfig) -> Result<Self> {
-        task.validate()?;
-        config.validate()?;
-
+    ///
+    /// The provided configuration is expected to have already been validated.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given configuration is not configured to use the TES
+    /// backend.
+    pub async fn new(config: Arc<Config>) -> Result<Self> {
         info!("initializing TES backend");
+
+        let backend_config = config.backend.as_tes().expect("expected TES backend");
 
         // There's no way to ask the TES service for its limits, so use the maximums
         // allowed
@@ -369,7 +393,7 @@ impl TesBackend {
         let manager = TaskManager::new_unlimited(max_cpu, max_memory);
 
         let mut http = backend::tes::http::Config::default();
-        if let Some(TesBackendAuthConfig::Basic(auth)) = &config.auth {
+        if let Some(TesBackendAuthConfig::Basic(auth)) = &backend_config.auth {
             http.basic_auth_token = Some(STANDARD.encode(format!(
                 "{user}:{pass}",
                 user = auth.username.as_ref().expect("should have user name"),
@@ -379,18 +403,18 @@ impl TesBackend {
 
         let backend = tes::Backend::initialize(
             backend::tes::Config::builder()
-                .url(config.url.clone().expect("should have URL"))
+                .url(backend_config.url.clone().expect("should have URL"))
                 .http(http)
-                .interval(config.interval.unwrap_or(DEFAULT_TES_INTERVAL))
+                .interval(backend_config.interval.unwrap_or(DEFAULT_TES_INTERVAL))
                 .build(),
         );
 
+        let max_concurrency = backend_config.max_concurrency.unwrap_or(u64::MAX);
+
         Ok(Self {
+            config,
             inner: Arc::new(backend),
-            shell: Arc::new(task.shell.clone()),
-            container: task.container.clone(),
-            config: Arc::new(config.clone()),
-            max_concurrency: config.max_concurrency.unwrap_or(u64::MAX),
+            max_concurrency,
             max_cpu,
             max_memory,
             manager,
@@ -412,7 +436,7 @@ impl TaskExecutionBackend for TesBackend {
         requirements: &HashMap<String, Value>,
         hints: &HashMap<String, Value>,
     ) -> Result<TaskExecutionConstraints> {
-        let container = container(requirements, self.container.as_deref());
+        let container = container(requirements, self.config.task.container.as_deref());
 
         let cpu = cpu(requirements);
         if (self.max_cpu as f64) < cpu {
@@ -494,7 +518,7 @@ impl TaskExecutionBackend for TesBackend {
         let requirements = request.requirements();
         let hints = request.hints();
 
-        let container = container(requirements, self.container.as_deref()).into_owned();
+        let container = container(requirements, self.config.task.container.as_deref()).into_owned();
         let cpu = cpu(requirements);
         let memory = memory(requirements)? as u64;
         let max_cpu = max_cpu(hints);
@@ -513,12 +537,11 @@ impl TaskExecutionBackend for TesBackend {
         );
         self.manager.send(
             TesTaskRequest {
+                config: self.config.clone(),
                 inner: request,
                 backend: self.inner.clone(),
                 name,
-                shell: self.shell.clone(),
                 container,
-                config: self.config.clone(),
                 cpu,
                 memory,
                 max_cpu,

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -691,22 +691,10 @@ impl TaskEvaluator {
     ///
     /// Returns an error if the configuration isn't valid.
     pub async fn new(config: Config, token: CancellationToken) -> Result<Self> {
-        let backend = config.create_backend().await?;
-        Self::new_with_backend(config, backend, token)
-    }
-
-    /// Constructs a new task evaluator with the given evaluation
-    /// configuration, task execution backend, and cancellation token.
-    ///
-    /// Returns an error if the configuration isn't valid.
-    pub fn new_with_backend(
-        config: Config,
-        backend: Arc<dyn TaskExecutionBackend>,
-        token: CancellationToken,
-    ) -> Result<Self> {
         config.validate()?;
 
         let config = Arc::new(config);
+        let backend = config.create_backend().await?;
         let downloader = HttpDownloader::new(config.clone())?;
 
         Ok(Self {

--- a/wdl-engine/src/eval/v1/workflow.rs
+++ b/wdl-engine/src/eval/v1/workflow.rs
@@ -612,22 +612,10 @@ impl WorkflowEvaluator {
     ///
     /// Returns an error if the configuration isn't valid.
     pub async fn new(config: Config, token: CancellationToken) -> Result<Self> {
-        let backend = config.create_backend().await?;
-        Self::new_with_backend(config, backend, token)
-    }
-
-    /// Constructs a new workflow evaluator with the given evaluation
-    /// configuration, task execution backend, and cancellation token.
-    ///
-    /// Returns an error if the configuration isn't valid.
-    pub fn new_with_backend(
-        config: Config,
-        backend: Arc<dyn TaskExecutionBackend>,
-        token: CancellationToken,
-    ) -> Result<Self> {
         config.validate()?;
 
         let config = Arc::new(config);
+        let backend = config.create_backend().await?;
         let downloader = HttpDownloader::new(config.clone())?;
 
         Ok(Self {


### PR DESCRIPTION
This PR adds authentication to TES input and output URLs.

Previously the backend worked with TES on Azure where the input and output URLs did not need the authentication in the URLs because the TES server used its own authentication.

To make the TES backend more generic, it should be sending the authentication along with the inputs and outputs.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
