### PR TITLE
feat: add support for lsp `goto_definitions`

### DIFF
--- a/wdl-analysis/CHANGELOG.md
+++ b/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added `goto_definition` support for WDL Language Server ([#468](https://github.com/stjude-rust-labs/wdl/pull/468)).
+
 ## 0.9.0 - 05-27-2025
 
 #### Dependencies

--- a/wdl-analysis/Cargo.toml
+++ b/wdl-analysis/Cargo.toml
@@ -31,7 +31,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 walkdir = { workspace = true }
-lsp-types = "0.97.0"
+lsp-types = "0.94.1"
 
 [dev-dependencies]
 codespan-reporting = { workspace = true }

--- a/wdl-analysis/Cargo.toml
+++ b/wdl-analysis/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 walkdir = { workspace = true }
+lsp-types = "0.97.0"
 
 [dev-dependencies]
 codespan-reporting = { workspace = true }

--- a/wdl-analysis/src/analyzer.rs
+++ b/wdl-analysis/src/analyzer.rs
@@ -21,6 +21,7 @@ use line_index::LineCol;
 use line_index::LineIndex;
 use line_index::WideEncoding;
 use line_index::WideLineCol;
+use lsp_types::GotoDefinitionResponse;
 use path_clean::clean;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
@@ -425,15 +426,6 @@ impl DiagnosticsConfig {
     }
 }
 
-/// Represents a location for goto definition results.
-#[derive(Debug, Clone)]
-pub struct GotoDefinitionLocation {
-    /// The URI of the document containing the definition.
-    pub uri: Url,
-    /// The range of the definition in the document.
-    pub range: Range<SourcePosition>,
-}
-
 /// Represents a Workflow Description Language (WDL) document analyzer.
 ///
 /// By default, analysis parses documents, performs validation checks, resolves
@@ -735,7 +727,7 @@ where
         document: Url,
         position: SourcePosition,
         encoding: SourcePositionEncoding,
-    ) -> Result<Option<GotoDefinitionLocation>> {
+    ) -> Result<Option<GotoDefinitionResponse>> {
         let (tx, rx) = oneshot::channel();
         self.sender
             .send(Request::GotoDefinition(GotoDefinitionRequest {

--- a/wdl-analysis/src/analyzer.rs
+++ b/wdl-analysis/src/analyzer.rs
@@ -61,15 +61,6 @@ pub enum ProgressKind {
     Analyzing,
 }
 
-/// Represents a location for goto definition results.
-#[derive(Debug, Clone)]
-pub struct GotoDefinitionLocation {
-    /// The URI of the document containing the definition.
-    pub uri: Url,
-    /// The range of the definition in the document.
-    pub range: Range<SourcePosition>,
-}
-
 impl fmt::Display for ProgressKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -432,6 +423,15 @@ impl DiagnosticsConfig {
             unnecessary_function_call: None,
         }
     }
+}
+
+/// Represents a location for goto definition results.
+#[derive(Debug, Clone)]
+pub struct GotoDefinitionLocation {
+    /// The URI of the document containing the definition.
+    pub uri: Url,
+    /// The range of the definition in the document.
+    pub range: Range<SourcePosition>,
 }
 
 /// Represents a Workflow Description Language (WDL) document analyzer.

--- a/wdl-analysis/src/analyzer.rs
+++ b/wdl-analysis/src/analyzer.rs
@@ -721,7 +721,7 @@ where
         })
     }
 
-    /// Performs a `goto definition` for a symbol at the current position.
+    /// Performs a "goto definition" for a symbol at the current position.
     pub async fn goto_definition(
         &self,
         document: Url,

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -69,11 +69,13 @@ impl Namespace {
 /// Represents a struct in a document.
 #[derive(Debug, Clone)]
 pub struct Struct {
+    /// The name of the struct.
+    name: String,
     /// The span that introduced the struct.
     ///
     /// This is either the name of a struct definition (local) or an import's
     /// URI or alias (imported).
-    span: Span,
+    name_span: Span,
     /// The offset of the CST node from the start of the document.
     ///
     /// This is used to adjust diagnostics resulting from traversing the struct
@@ -94,6 +96,16 @@ pub struct Struct {
 }
 
 impl Struct {
+    /// Gets the name of the struct.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Gets the span of the name.
+    pub fn name_span(&self) -> Span {
+        self.name_span
+    }
+
     /// Gets the namespace that defines this struct.
     ///
     /// Returns `None` for structs defined in the containing document or `Some`

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -106,6 +106,16 @@ impl Struct {
         self.name_span
     }
 
+    /// Gets the offset of the struct
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Gets the node of the struct.
+    pub fn node(&self) -> &rowan::GreenNode {
+        &self.node
+    }
+
     /// Gets the namespace that defines this struct.
     ///
     /// Returns `None` for structs defined in the containing document or `Some`
@@ -120,16 +130,6 @@ impl Struct {
     /// the struct; this may happen if the struct definition is recursive.
     pub fn ty(&self) -> Option<&Type> {
         self.ty.as_ref()
-    }
-
-    /// Gets the node of the struct.
-    pub fn node(&self) -> &rowan::GreenNode {
-        &self.node
-    }
-
-    /// Gets the offset of the struct
-    pub fn offset(&self) -> usize {
-        self.offset
     }
 }
 
@@ -324,7 +324,7 @@ impl Input {
 pub struct Output {
     /// The type of the output.
     ty: Type,
-    /// The span of the output.
+    /// The span of the output name.
     name_span: Span,
 }
 

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -121,6 +121,17 @@ impl Struct {
     pub fn ty(&self) -> Option<&Type> {
         self.ty.as_ref()
     }
+
+    /// Gets the node of the struct.
+    pub fn node(&self) -> &rowan::GreenNode {
+        &self.node
+    }
+
+    /// Gets the offset of the struct
+    pub fn offset(&self) -> usize {
+        self.offset
+
+    }
 }
 
 /// Represents information about a name in a scope.
@@ -314,17 +325,24 @@ impl Input {
 pub struct Output {
     /// The type of the output.
     ty: Type,
+    /// The span of the output.
+    name_span: Span,
 }
 
 impl Output {
     /// Creates a new output with the given type.
-    pub(crate) fn new(ty: Type) -> Self {
-        Self { ty }
+    pub(crate) fn new(ty: Type, name_span: Span) -> Self {
+        Self { ty, name_span }
     }
 
     /// Gets the type of the output.
     pub fn ty(&self) -> &Type {
         &self.ty
+    }
+
+    /// Gets the span of output's name.
+    pub fn name_span(&self) -> Span {
+        self.name_span
     }
 }
 

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -130,7 +130,6 @@ impl Struct {
     /// Gets the offset of the struct
     pub fn offset(&self) -> usize {
         self.offset
-
     }
 }
 

--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -332,14 +332,14 @@ fn add_namespace(
                     if prev.namespace.is_none() {
                         document.diagnostics.push(struct_conflicts_with_import(
                             aliased_name,
-                            prev.span,
+                            prev.name_span,
                             span,
                         ));
                     } else {
                         document.diagnostics.push(imported_struct_conflict(
                             aliased_name,
                             span,
-                            prev.span,
+                            prev.name_span,
                             !aliased,
                         ));
                     }
@@ -350,7 +350,8 @@ fn add_namespace(
                 document.structs.insert(
                     aliased_name.to_string(),
                     Struct {
-                        span,
+                        name_span: span,
+                        name: aliased_name.to_string(),
                         offset: s.offset,
                         node: s.node.clone(),
                         namespace: Some(ns.clone()),
@@ -388,14 +389,14 @@ fn add_struct(document: &mut DocumentData, definition: &StructDefinition) {
                 document.diagnostics.push(struct_conflicts_with_import(
                     name.text(),
                     name.span(),
-                    prev.span,
+                    prev.name_span,
                 ))
             }
         } else {
             document.diagnostics.push(name_conflict(
                 name.text(),
                 Context::Struct(name.span()),
-                Context::Struct(prev.span),
+                Context::Struct(prev.name_span),
             ));
         }
         return;
@@ -422,7 +423,8 @@ fn add_struct(document: &mut DocumentData, definition: &StructDefinition) {
     document.structs.insert(
         name.text().to_string(),
         Struct {
-            span: name.span(),
+            name_span: name.span(),
+            name: name.text().to_string(),
             namespace: None,
             offset: definition.span().start(),
             node: definition.inner().green().into(),

--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -506,7 +506,7 @@ fn create_output_type_map(
         }
 
         let ty = convert_ast_type(document, &decl.ty());
-        map.insert(name.text().to_string(), Output { ty });
+        map.insert(name.text().to_string(), Output::new(ty, name.span()));
     }
 
     map.into()

--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -1442,6 +1442,8 @@ fn set_struct_types(document: &mut DocumentData) {
         return;
     }
 
+    /// Recursively finds all nested struct type dependencies to build
+    /// dependency graphs
     fn find_deps_in_ty(ty: &wdl_ast::v1::Type, deps: &mut Vec<String>) {
         match ty {
             wdl_ast::v1::Type::Ref(r) => {

--- a/wdl-analysis/src/handlers.rs
+++ b/wdl-analysis/src/handlers.rs
@@ -1,0 +1,5 @@
+//! Language server protocol handlers.
+
+mod goto_definition;
+
+pub use goto_definition::*;

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -11,7 +11,6 @@ use lsp_types::GotoDefinitionResponse;
 use lsp_types::Location;
 use lsp_types::Position;
 use rowan::TextSize;
-use tracing::debug;
 use url::Url;
 use wdl_ast::AstNode;
 use wdl_ast::AstToken;
@@ -155,18 +154,6 @@ impl GotoDefinitionHandler {
                 lines,
                 graph,
             ),
-
-            // TODO:
-            SyntaxKind::BoundDeclNode
-            | SyntaxKind::UnboundDeclNode
-            | SyntaxKind::ScatterStatementNode
-            | SyntaxKind::ImportAliasNode
-            | SyntaxKind::StructDefinitionNode
-            | SyntaxKind::TaskDefinitionNode
-            | SyntaxKind::WorkflowDefinitionNode => {
-                debug!("NOT YET IMPLEMENTED: {kind:?}", kind = parent_node.kind());
-                Ok(None)
-            }
 
             // handled by scope resolution
             SyntaxKind::NameRefExprNode => Ok(None),

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -392,7 +392,8 @@ impl GotoDefinitionHandler {
     /// # Supports:
     /// - Struct member access (`person.name`)
     /// - Call output access (`call_result.output`)
-    /// - TODO: Arrays
+    /// - Arrays (persons[0].name)
+    /// - Chained Access Expressions (documents.persons[0].address.street)
     fn resolve_access_expression(
         &self,
         parent_node: &SyntaxNode,

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -130,7 +130,7 @@ impl GotoDefinitionHandler {
         graph: &DocumentGraph,
     ) -> Result<Option<GotoDefinitionResponse>> {
         match parent_node.kind() {
-            SyntaxKind::TypeRefNode => {
+            SyntaxKind::TypeRefNode | SyntaxKind::LiteralStructNode => {
                 self.resolve_type_reference(analysis_doc, token, document_uri, lines, graph)
             }
 

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -43,11 +43,6 @@ impl Default for GotoDefinitionHandler {
 }
 
 impl GotoDefinitionHandler {
-    /// Creates a new goto definition handler.
-    pub fn new() -> Self {
-        Self
-    }
-
     /// Finds the definition location for an identifier at the given position.
     ///
     /// Searches the document and its imports for the definition of the

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -1,0 +1,606 @@
+//! Implements goto definition functionality.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use line_index::LineIndex;
+use line_index::WideEncoding;
+use lsp_types::GotoDefinitionResponse;
+use lsp_types::Location;
+use lsp_types::Position;
+use rowan::TextSize;
+use tracing::debug;
+use url::Url;
+use wdl_ast::AstNode;
+use wdl_ast::AstToken;
+use wdl_ast::Span;
+use wdl_ast::SyntaxKind;
+use wdl_ast::SyntaxNode;
+use wdl_ast::SyntaxToken;
+use wdl_ast::TreeNode;
+use wdl_ast::TreeToken;
+use wdl_ast::v1;
+
+use crate::DiagnosticsConfig;
+use crate::SourcePosition;
+use crate::SourcePositionEncoding;
+use crate::diagnostics;
+use crate::document::Document;
+use crate::document::ScopeRef;
+use crate::graph::DocumentGraph;
+use crate::graph::ParseState;
+use crate::types::v1::EvaluationContext;
+use crate::types::v1::ExprTypeEvaluator;
+
+/// Handler for goto definition requests.
+#[derive(Debug)]
+pub struct GotoDefinitionHandler;
+
+impl Default for GotoDefinitionHandler {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl GotoDefinitionHandler {
+    /// Creates a new goto definition handler
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Finds the definition location for an identifier at the given position.
+    ///
+    /// Searches the document and its imports for the definition of the
+    /// identifier at the specified position, returning the location if
+    /// found.
+    ///
+    /// * If a definition is found for the identifier then a
+    ///   [`GotoDefinitionResponse`] containing the URI and range is returned
+    ///   wrapped in [`Some`].
+    ///
+    /// * Else, [`None`] is returned.
+    pub fn goto_definition(
+        &self,
+        graph: &DocumentGraph,
+        document_uri: Url,
+        position: SourcePosition,
+        encoding: SourcePositionEncoding,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let index = graph
+            .get_index(&document_uri)
+            .ok_or_else(|| anyhow!("document not found in graph"))?;
+
+        let (root, lines, analysis_doc) = {
+            let node = graph.get(index);
+
+            let (root, lines) = match node.parse_state() {
+                ParseState::Parsed { lines, root, .. } => {
+                    (SyntaxNode::new_root(root.clone()), lines.clone())
+                }
+                _ => {
+                    debug!("document not yet parsed: {}", document_uri);
+                    return Ok(None);
+                }
+            };
+
+            let analysis_doc = match node.document() {
+                Some(doc) => doc.clone(),
+                None => {
+                    debug!("document analysis data not available for {}", document_uri);
+                    return Ok(None);
+                }
+            };
+
+            (root, lines, analysis_doc)
+        };
+
+        let offset = position_to_offset(&lines, position, encoding)?;
+        let token = match find_identifier_token_at_offset(&root, offset) {
+            Some(tok) => tok,
+            None => {
+                // WARN: if we throw an error the lsp crashes on other editors
+                // vscode extension kicks in and restarts the lsp automatically
+                //
+                debug!("no identifier found at position");
+                return Ok(None);
+            }
+        };
+
+        let ident_text = token.text();
+        let parent_node = token
+            .parent()
+            .ok_or_else(|| anyhow!("identifier token has no parent"))?;
+
+        debug!("resolving location for {token:?}");
+
+        // context based resolution
+        if let Some(location) = self.resolve_by_context(
+            &parent_node,
+            &token,
+            &analysis_doc,
+            &document_uri,
+            &lines,
+            graph,
+        )? {
+            return Ok(Some(location));
+        }
+
+        // scope based resolution
+        if let Some(scope_ref) = analysis_doc.find_scope_by_position(token.span().start()) {
+            if let Some(name_def) = scope_ref.lookup(ident_text) {
+                return Ok(Some(location(&document_uri, name_def.span(), &lines)?));
+            }
+        }
+
+        // global resolution
+        self.resolve_global_identifier(&analysis_doc, ident_text, &document_uri, &lines, graph)
+    }
+
+    /// Resolves identifier definition based on their parent node's syntax kind
+    fn resolve_by_context(
+        &self,
+        parent_node: &SyntaxNode,
+        token: &SyntaxToken,
+        analysis_doc: &Document,
+        document_uri: &Url,
+        lines: &Arc<LineIndex>,
+        graph: &DocumentGraph,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        match parent_node.kind() {
+            SyntaxKind::TypeRefNode => {
+                self.resolve_type_reference(analysis_doc, token.text(), document_uri, lines, graph)
+            }
+
+            SyntaxKind::CallTargetNode => self.resolve_call_target(
+                parent_node,
+                token,
+                analysis_doc,
+                document_uri,
+                lines,
+                graph,
+            ),
+            SyntaxKind::ImportStatementNode => {
+                self.resolve_import_namespace(parent_node, token, document_uri, lines)
+            }
+
+            SyntaxKind::AccessExprNode => self.resolve_access_expression(
+                parent_node,
+                token,
+                analysis_doc,
+                document_uri,
+                lines,
+                graph,
+            ),
+
+            // TODO:
+            SyntaxKind::BoundDeclNode
+            | SyntaxKind::UnboundDeclNode
+            | SyntaxKind::ScatterStatementNode
+            | SyntaxKind::ImportAliasNode
+            | SyntaxKind::StructDefinitionNode
+            | SyntaxKind::TaskDefinitionNode
+            | SyntaxKind::WorkflowDefinitionNode => {
+                debug!("NOT YET IMPLEMENTED: {kind:?}", kind = parent_node.kind());
+                Ok(None)
+            }
+
+            // handled by scope resolution
+            SyntaxKind::NameRefExprNode => Ok(None),
+            _ => Ok(None),
+        }
+    }
+
+    /// Resolves type references to their definition locations.
+    ///
+    /// Searches for struct definitions in the current document and imported
+    /// namespaces
+    fn resolve_type_reference(
+        &self,
+        analysis_doc: &Document,
+        ident_text: &str,
+        document_uri: &Url,
+        lines: &Arc<LineIndex>,
+        graph: &DocumentGraph,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        // NOTE: local structs
+        if let Some(struct_info) = analysis_doc.struct_by_name(ident_text) {
+            let (uri, def_lines) = if let Some(ns_name) = struct_info.namespace() {
+                let ns = analysis_doc.namespace(ns_name).unwrap();
+                let imported_lines = graph
+                    .get(graph.get_index(ns.source()).unwrap())
+                    .parse_state()
+                    .lines()
+                    .unwrap()
+                    .clone();
+
+                (ns.source().as_ref(), imported_lines)
+            } else {
+                (document_uri, lines.clone())
+            };
+            return Ok(Some(location(uri, struct_info.name_span(), &def_lines)?));
+        };
+
+        // NOTE: imported structs
+        for (_ns_name_str, ns_info) in analysis_doc.namespaces() {
+            if let Some(imported_doc) = graph
+                .get(graph.get_index(ns_info.source()).unwrap())
+                .document()
+            {
+                if let Some(struct_info) = imported_doc.struct_by_name(ident_text) {
+                    let imported_lines = graph
+                        .get(graph.get_index(ns_info.source()).unwrap())
+                        .parse_state()
+                        .lines()
+                        .unwrap()
+                        .clone();
+
+                    return Ok(Some(location(
+                        ns_info.source(),
+                        struct_info.name_span(),
+                        &imported_lines,
+                    )?));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Resolves call targets to their definition locations.
+    ///
+    /// Handles both local and namespaced function calls, resolving them to task
+    /// and workflow definition in the current document or imported
+    /// namespaces.
+    fn resolve_call_target(
+        &self,
+        parent_node: &SyntaxNode,
+        token: &SyntaxToken,
+        analysis_doc: &Document,
+        document_uri: &Url,
+        lines: &Arc<LineIndex>,
+        graph: &DocumentGraph,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let ident_text = token.text();
+        let target = wdl_ast::v1::CallTarget::cast(parent_node.clone()).unwrap();
+        let target_names: Vec<_> = target.names().collect();
+        let is_callee_name_clicked = target_names.last().is_some_and(|n| n.text() == ident_text);
+
+        if is_callee_name_clicked {
+            let callee_name_str = token.text();
+
+            // NOTE: namespaced (foo.bar)
+            if target_names.len() > 1 {
+                let namespaced_name_str = target_names.first().unwrap().text();
+                if let Some(ns_info) = analysis_doc.namespace(namespaced_name_str) {
+                    if let Some(imported_doc) = graph
+                        .get(graph.get_index(ns_info.source()).unwrap())
+                        .document()
+                    {
+                        let imported_lines = graph
+                            .get(graph.get_index(ns_info.source()).unwrap())
+                            .parse_state()
+                            .lines()
+                            .unwrap()
+                            .clone();
+
+                        if let Some(task_def) = imported_doc.task_by_name(callee_name_str) {
+                            return Ok(Some(location(
+                                ns_info.source(),
+                                task_def.name_span(),
+                                &imported_lines,
+                            )?));
+                        }
+
+                        if let Some(wf_def) = imported_doc
+                            .workflow()
+                            .filter(|w| w.name() == callee_name_str)
+                        {
+                            return Ok(Some(location(
+                                ns_info.source(),
+                                wf_def.name_span(),
+                                &imported_lines,
+                            )?));
+                        }
+                    }
+                }
+            } else {
+                // NOTE: local calls
+                if let Some(task_def) = analysis_doc.task_by_name(callee_name_str) {
+                    return Ok(Some(location(document_uri, task_def.name_span(), lines)?));
+                }
+
+                if let Some(wf_def) = analysis_doc
+                    .workflow()
+                    .filter(|w| w.name() == callee_name_str)
+                {
+                    return Ok(Some(location(document_uri, wf_def.name_span(), lines)?));
+                }
+            }
+        } else if let Some(ns_info) = analysis_doc.namespace(token.text()) {
+            return Ok(Some(location(document_uri, ns_info.span(), lines)?));
+        }
+
+        Ok(None)
+    }
+
+    /// Resolves import namespace identifier to their definition locations.
+    fn resolve_import_namespace(
+        &self,
+        parent_node: &SyntaxNode,
+        token: &SyntaxToken,
+        document_uri: &Url,
+        lines: &Arc<LineIndex>,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let import_stmt = wdl_ast::v1::ImportStatement::cast(parent_node.clone()).unwrap();
+        let ident_text = token.text();
+
+        if import_stmt
+            .explicit_namespace()
+            .is_some_and(|ns_ident| ns_ident.text() == ident_text)
+        {
+            return Ok(Some(location(document_uri, token.span(), lines)?));
+        }
+
+        Ok(None)
+    }
+
+    /// Searches for global definitions(structs, tasks, workflows) in the
+    /// current document and all imported namespaces
+    fn resolve_global_identifier(
+        &self,
+        analysis_doc: &Document,
+        ident_text: &str,
+        document_uri: &Url,
+        lines: &Arc<LineIndex>,
+        graph: &DocumentGraph,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        if let Some(location) =
+            find_global_definition_in_doc(analysis_doc, ident_text, document_uri, lines)?
+        {
+            return Ok(Some(location));
+        }
+
+        for (_, ns_info) in analysis_doc.namespaces() {
+            if let Some(imported_doc) = graph
+                .get(graph.get_index(ns_info.source()).unwrap())
+                .document()
+            {
+                let imported_lines = graph
+                    .get(graph.get_index(ns_info.source()).unwrap())
+                    .parse_state()
+                    .lines()
+                    .unwrap()
+                    .clone();
+
+                if let Some(location) = find_global_definition_in_doc(
+                    imported_doc,
+                    ident_text,
+                    ns_info.source().as_ref(),
+                    &imported_lines,
+                )? {
+                    return Ok(Some(location));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Resolves access expressions to their member definition locations.
+    ///
+    /// Evaluates the target expression's type and resolves member access to the
+    /// appropriate def. location.
+    ///
+    /// # Supports:
+    /// - Struct member access (`person.name`)
+    /// - Call output access (`call_result.output`)
+    /// - TODO: Arrays
+    fn resolve_access_expression(
+        &self,
+        parent_node: &SyntaxNode,
+        token: &SyntaxToken,
+        analysis_doc: &Document,
+        document_uri: &Url,
+        lines: &Arc<LineIndex>,
+        graph: &DocumentGraph,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let access_expr = wdl_ast::v1::AccessExpr::cast(parent_node.clone()).unwrap();
+        let (target_expr, member_ident) = access_expr.operands();
+
+        if member_ident.span() != token.span() {
+            return Ok(None);
+        }
+
+        let scope = analysis_doc
+            .find_scope_by_position(parent_node.span().start())
+            .ok_or_else(|| anyhow!("could not find scope for access expression"))?;
+
+        let mut ctx = GotoDefEvalContext {
+            scope,
+            document: analysis_doc,
+        };
+        let mut evaluator = ExprTypeEvaluator::new(&mut ctx);
+        let target_type = evaluator
+            .evaluate_expr(&target_expr)
+            .unwrap_or(crate::types::Type::Union);
+
+        if let Some(struct_ty) = target_type.as_struct() {
+            let struct_def = analysis_doc
+                .struct_by_name(struct_ty.name())
+                .ok_or_else(|| anyhow!("struct definition not found for {}", struct_ty.name()))?;
+
+            let (uri, def_lines) = if let Some(ns_name) = struct_def.namespace() {
+                let ns = analysis_doc.namespace(ns_name).unwrap();
+                let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
+                let lines = imported_node.parse_state().lines().unwrap().clone();
+                (ns.source().as_ref(), lines)
+            } else {
+                (document_uri, lines.clone())
+            };
+
+            let struct_node =
+                v1::StructDefinition::cast(SyntaxNode::new_root(struct_def.node().clone()))
+                    .expect("should cast to struct definition");
+
+            if let Some(member) = struct_node
+                .members()
+                .find(|m| m.name().text() == member_ident.text())
+            {
+                let member_span = member.name().span();
+                let span = Span::new(member_span.start() + struct_def.offset(), member_span.len());
+                return Ok(Some(location(uri, span, &def_lines)?));
+            }
+        }
+
+        if let Some(call_ty) = target_type.as_call() {
+            if let Some(output) = call_ty.outputs().get(member_ident.text()) {
+                let (uri, callee_lines) = if let Some(ns_name) = call_ty.namespace() {
+                    let ns = analysis_doc.namespace(ns_name).unwrap();
+                    let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
+                    let lines = imported_node.parse_state().lines().unwrap().clone();
+                    (ns.source().as_ref(), lines.clone())
+                } else {
+                    (document_uri, lines.clone())
+                };
+
+                return Ok(Some(location(uri, output.name_span(), &callee_lines)?));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+/// Finds an identifier token at the specified `TextSize` offset in the concrete
+/// syntax tree.
+fn find_identifier_token_at_offset(node: &SyntaxNode, offset: TextSize) -> Option<SyntaxToken> {
+    node.token_at_offset(offset)
+        .find(|t| t.kind() == SyntaxKind::Ident)
+}
+
+/// Converts a text size offset to LSP position.
+fn position(index: &LineIndex, offset: TextSize) -> Result<Position> {
+    let line_col = index.line_col(offset);
+    let line_col = index
+        .to_wide(WideEncoding::Utf16, line_col)
+        .with_context(|| {
+            format!(
+                "invalid line column: {line}:{column}",
+                line = line_col.line,
+                column = line_col.col
+            )
+        })?;
+
+    Ok(Position::new(line_col.line, line_col.col))
+}
+
+/// Converts a `Span` to an LSP location
+fn location(uri: &Url, span: Span, lines: &Arc<LineIndex>) -> Result<GotoDefinitionResponse> {
+    let start_offset = TextSize::from(span.start() as u32);
+    let end_offset = TextSize::from(span.end() as u32);
+    let range = lsp_types::Range {
+        start: position(lines, start_offset)?,
+        end: position(lines, end_offset)?,
+    };
+
+    Ok(GotoDefinitionResponse::Scalar(Location::new(
+        uri.clone(),
+        range,
+    )))
+}
+
+/// Finds global structs, tasks and workflow definition in a document
+fn find_global_definition_in_doc(
+    analysis_doc: &Document,
+    ident_text: &str,
+    document_uri: &Url,
+    lines: &Arc<LineIndex>,
+) -> Result<Option<GotoDefinitionResponse>> {
+    if let Some(s) = analysis_doc.struct_by_name(ident_text) {
+        return Ok(Some(location(document_uri, s.name_span(), lines)?));
+    }
+    if let Some(t) = analysis_doc.task_by_name(ident_text) {
+        return Ok(Some(location(document_uri, t.name_span(), lines)?));
+    }
+    if let Some(w) = analysis_doc
+        .workflow()
+        .filter(|w_def| w_def.name() == ident_text)
+    {
+        return Ok(Some(location(document_uri, w.name_span(), lines)?));
+    }
+
+    Ok(None)
+}
+
+/// Converts a source postion to a text offset based on the specified encoding.
+fn position_to_offset(
+    lines: &Arc<LineIndex>,
+    position: SourcePosition,
+    encoding: SourcePositionEncoding,
+) -> Result<TextSize> {
+    let line_col = match encoding {
+        SourcePositionEncoding::UTF8 => line_index::LineCol {
+            line: position.line,
+            col: position.character,
+        },
+        SourcePositionEncoding::UTF16 => lines
+            .to_utf8(
+                line_index::WideEncoding::Utf16,
+                line_index::WideLineCol {
+                    line: position.line,
+                    col: position.character,
+                },
+            )
+            .ok_or_else(|| anyhow!("invalid utf-16 position: {position:?}"))?,
+    };
+
+    lines
+        .offset(line_col)
+        .ok_or_else(|| anyhow!("line_col is invalid"))
+}
+
+/// Context for evaluating expressions during goto definition resolution.
+struct GotoDefEvalContext<'a> {
+    /// The scope reference containing the variable and name bindings at the
+    /// current position
+    scope: ScopeRef<'a>,
+
+    /// The document being analyzed.
+    document: &'a Document,
+}
+
+impl EvaluationContext for GotoDefEvalContext<'_> {
+    fn version(&self) -> wdl_ast::SupportedVersion {
+        self.document
+            .version()
+            .expect("document should have a version")
+    }
+
+    fn resolve_name(&self, name: &str, _span: Span) -> Option<crate::types::Type> {
+        self.scope.lookup(name).map(|n| n.ty().clone())
+    }
+
+    fn resolve_type_name(
+        &mut self,
+        name: &str,
+        span: Span,
+    ) -> std::result::Result<crate::types::Type, wdl_ast::Diagnostic> {
+        if let Some(s) = self.document.struct_by_name(name) {
+            if let Some(ty) = s.ty() {
+                return Ok(ty.clone());
+            }
+        }
+        Err(diagnostics::unknown_type(name, span))
+    }
+
+    fn task(&self) -> Option<&crate::document::Task> {
+        None
+    }
+
+    fn diagnostics_config(&self) -> DiagnosticsConfig {
+        DiagnosticsConfig::default()
+    }
+
+    fn add_diagnostic(&mut self, _: wdl_ast::Diagnostic) {}
+}

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -423,28 +423,6 @@ impl GotoDefinitionHandler {
             let struct_def = analysis_doc
                 .structs()
                 .find(|(_, s)| {
-                    // When structs imported and aliased to a different name,they are checked
-                    // using their Type
-                    //
-                    // Eg:
-                    // `person.wdl`:
-                    //
-                    // sturct Person {
-                    //  Sting name
-                    // }
-                    //
-                    // `main.wdl`:
-                    //
-                    // import "person.wdl" as lib alias Person as person
-                    //
-                    // workflow main {
-                    //  peson a = person {
-                    //      name = "wdl"
-                    //  }
-                    //
-                    //  a.name
-                    //    ^^^^ this has a struct name as person but Type is `Person`
-                    // }
                     if let Some(s_ty) = s.ty() {
                         if let Some(s_struct_ty) = s_ty.as_struct() {
                             return s_struct_ty.name() == struct_ty.name();

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -420,7 +420,6 @@ impl GotoDefinitionHandler {
             .unwrap_or(crate::types::Type::Union);
 
         if let Some(struct_ty) = target_type.as_struct() {
-            debug!("found a struct type: {}", struct_ty);
             let struct_def = analysis_doc
                 .structs()
                 .find(|(_, s)| {

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use anyhow::bail;
 use line_index::LineIndex;
 use line_index::WideEncoding;
 use lsp_types::Location;
@@ -32,489 +33,466 @@ use crate::graph::ParseState;
 use crate::types::v1::EvaluationContext;
 use crate::types::v1::ExprTypeEvaluator;
 
-/// Handler for goto definition requests.
-#[derive(Debug)]
-pub struct GotoDefinitionHandler;
+/// Finds the definition location for an identifier at the given position.
+///
+/// Searches the document and its imports for the definition of the
+/// identifier at the specified position, returning the location if
+/// found.
+///
+/// * If a definition is found for the identifier then a [`Location`] containing
+///   the URI and range is returned wrapped in [`Some`].
+///
+/// * Else, [`None`] is returned.
+pub fn goto_definition(
+    graph: &DocumentGraph,
+    document_uri: Url,
+    position: SourcePosition,
+    encoding: SourcePositionEncoding,
+) -> Result<Option<Location>> {
+    let index = graph
+        .get_index(&document_uri)
+        .ok_or_else(|| anyhow!("document `{uri}` not found in graph", uri = document_uri))?;
 
-impl Default for GotoDefinitionHandler {
-    fn default() -> Self {
-        Self
+    let node = graph.get(index);
+    let (root, lines) = match node.parse_state() {
+        ParseState::Parsed { lines, root, .. } => {
+            (SyntaxNode::new_root(root.clone()), lines.clone())
+        }
+        _ => bail!("document `{uri}` has not been parsed", uri = document_uri),
+    };
+
+    let Some(analysis_doc) = node.document() else {
+        bail!("document analysis data not available for {}", document_uri);
+    };
+
+    let offset = position_to_offset(&lines, position, encoding)?;
+    let Some(token) = find_identifier_token_at_offset(&root, offset) else {
+        bail!("no identifier found at position");
+    };
+
+    let ident_text = token.text();
+    let parent_node = token.parent().expect("identifier has not parent");
+
+    // Context based resolution
+    if let Some(location) = resolve_by_context(
+        &parent_node,
+        &token,
+        analysis_doc,
+        &document_uri,
+        &lines,
+        graph,
+    )? {
+        return Ok(Some(location));
+    }
+
+    // Scope based resolution
+    if let Some(scope_ref) = analysis_doc.find_scope_by_position(token.span().start()) {
+        if let Some(name_def) = scope_ref.lookup(ident_text) {
+            return Ok(Some(location_from_span(
+                &document_uri,
+                name_def.span(),
+                &lines,
+            )?));
+        }
+    }
+
+    // Global resolution
+    resolve_global_identifier(analysis_doc, ident_text, &document_uri, &lines, graph)
+}
+
+/// Resolves identifier definition based on their parent node's syntax kind.
+fn resolve_by_context(
+    parent_node: &SyntaxNode,
+    token: &SyntaxToken,
+    analysis_doc: &Document,
+    document_uri: &Url,
+    lines: &Arc<LineIndex>,
+    graph: &DocumentGraph,
+) -> Result<Option<Location>> {
+    match parent_node.kind() {
+        SyntaxKind::TypeRefNode | SyntaxKind::LiteralStructNode => {
+            resolve_type_reference(analysis_doc, token, document_uri, lines, graph)
+        }
+
+        SyntaxKind::CallTargetNode => {
+            resolve_call_target(parent_node, token, analysis_doc, document_uri, lines, graph)
+        }
+        SyntaxKind::ImportStatementNode => {
+            resolve_import_namespace(parent_node, token, document_uri, lines)
+        }
+
+        SyntaxKind::AccessExprNode => {
+            resolve_access_expression(parent_node, token, analysis_doc, document_uri, lines, graph)
+        }
+
+        // This case is handled by scope resolution.
+        SyntaxKind::NameRefExprNode => Ok(None),
+        _ => Ok(None),
     }
 }
 
-impl GotoDefinitionHandler {
-    /// Finds the definition location for an identifier at the given position.
-    ///
-    /// Searches the document and its imports for the definition of the
-    /// identifier at the specified position, returning the location if
-    /// found.
-    ///
-    /// * If a definition is found for the identifier then a [`Location`]
-    ///   containing the URI and range is returned wrapped in [`Some`].
-    ///
-    /// * Else, [`None`] is returned.
-    pub fn goto_definition(
-        &self,
-        graph: &DocumentGraph,
-        document_uri: Url,
-        position: SourcePosition,
-        encoding: SourcePositionEncoding,
-    ) -> Result<Option<Location>> {
-        let index = graph
-            .get_index(&document_uri)
-            .ok_or_else(|| anyhow!("document not found in graph"))?;
-
-        let node = graph.get(index);
-        let (root, lines) = match node.parse_state() {
-            ParseState::Parsed { lines, root, .. } => {
-                (SyntaxNode::new_root(root.clone()), lines.clone())
-            }
-            _ => return Err(anyhow!("document not yet parsed: {}", document_uri)),
-        };
-
-        let Some(analysis_doc) = node.document() else {
-            return Err(anyhow!(
-                "document analysis data not available for {}",
-                document_uri
-            ));
-        };
-
-        let offset = position_to_offset(&lines, position, encoding)?;
-        let Some(token) = find_identifier_token_at_offset(&root, offset) else {
-            return Err(anyhow!("no identifier found at position"));
-        };
-
-        let ident_text = token.text();
-        let parent_node = token
-            .parent()
-            .ok_or_else(|| anyhow!("identifier token has no parent"))?;
-
-        // Context based resolution
-        if let Some(location) = self.resolve_by_context(
-            &parent_node,
-            &token,
-            analysis_doc,
-            &document_uri,
-            &lines,
-            graph,
-        )? {
-            return Ok(Some(location));
-        }
-
-        // Scope based resolution
-        if let Some(scope_ref) = analysis_doc.find_scope_by_position(token.span().start()) {
-            if let Some(name_def) = scope_ref.lookup(ident_text) {
-                return Ok(Some(location_from_span(
-                    &document_uri,
-                    name_def.span(),
-                    &lines,
-                )?));
-            }
-        }
-
-        // Global resolution
-        self.resolve_global_identifier(analysis_doc, ident_text, &document_uri, &lines, graph)
-    }
-
-    /// Resolves identifier definition based on their parent node's syntax kind.
-    fn resolve_by_context(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        analysis_doc: &Document,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<Location>> {
-        match parent_node.kind() {
-            SyntaxKind::TypeRefNode | SyntaxKind::LiteralStructNode => {
-                self.resolve_type_reference(analysis_doc, token, document_uri, lines, graph)
-            }
-
-            SyntaxKind::CallTargetNode => self.resolve_call_target(
-                parent_node,
-                token,
-                analysis_doc,
-                document_uri,
-                lines,
-                graph,
-            ),
-            SyntaxKind::ImportStatementNode => {
-                self.resolve_import_namespace(parent_node, token, document_uri, lines)
-            }
-
-            SyntaxKind::AccessExprNode => self.resolve_access_expression(
-                parent_node,
-                token,
-                analysis_doc,
-                document_uri,
-                lines,
-                graph,
-            ),
-
-            // This case is handled by scope resolution.
-            SyntaxKind::NameRefExprNode => Ok(None),
-            _ => Ok(None),
-        }
-    }
-
-    /// Resolves type references to their definition locations.
-    ///
-    /// Searches for struct definitions in the current document and imported
-    /// namespaces.
-    fn resolve_type_reference(
-        &self,
-        analysis_doc: &Document,
-        token: &SyntaxToken,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<Location>> {
-        let ident_text = token.text();
-        if let Some(struct_info) = analysis_doc.struct_by_name(ident_text) {
-            if struct_info.namespace().is_none() {
-                // Handle struct defined in local document.
-                return Ok(Some(location_from_span(
-                    document_uri,
-                    struct_info.name_span(),
-                    lines,
-                )?));
-            }
-
-            let is_aliased_import = struct_info
-                .ty()
-                .and_then(|t| t.as_struct())
-                .map(|st| st.name().as_str() != ident_text)
-                .unwrap_or(false);
-
-            if is_aliased_import {
-                // Returns the location where alias import was defined.
-                return Ok(Some(location_from_span(
-                    document_uri,
-                    struct_info.name_span(),
-                    lines,
-                )?));
-            } else {
-                // Return the location in the imported file.
-                let ns_name = struct_info.namespace().unwrap();
-
-                // SAFETY: we just found a struct_info with this namespace name and the document
-                // gurantees that `analysis_doc.namespaces` contains a corresponding entry for
-                // `ns_name`.
-                let ns = analysis_doc
-                    .namespace(ns_name)
-                    .expect("namespace should be present");
-                let node = graph.get(graph.get_index(ns.source()).unwrap());
-                let imported_lines = node.parse_state().lines().unwrap().clone();
-                let imported_doc = node.document().expect("document should exist");
-
-                if let Some(original_struct) = imported_doc.struct_by_name(ident_text) {
-                    return Ok(Some(location_from_span(
-                        ns.source(),
-                        original_struct.name_span(),
-                        &imported_lines,
-                    )?));
-                }
-            }
-        }
-
-        // Fallback search in case the struct is not in the current document's analysis
-        // map
-        for (_, ns) in analysis_doc.namespaces() {
-            let node = graph.get(graph.get_index(ns.source()).unwrap());
-            let Some(imported_doc) = node.document() else {
-                continue;
-            };
-
-            let Some(struct_info) = imported_doc.struct_by_name(ident_text) else {
-                continue;
-            };
-
-            let imported_lines = node.parse_state().lines().unwrap().clone();
+/// Resolves type references to their definition locations.
+///
+/// Searches for struct definitions in the current document and imported
+/// namespaces.
+fn resolve_type_reference(
+    analysis_doc: &Document,
+    token: &SyntaxToken,
+    document_uri: &Url,
+    lines: &Arc<LineIndex>,
+    graph: &DocumentGraph,
+) -> Result<Option<Location>> {
+    let ident_text = token.text();
+    if let Some(struct_info) = analysis_doc.struct_by_name(ident_text) {
+        if struct_info.namespace().is_none() {
+            // Handle struct defined in local document.
             return Ok(Some(location_from_span(
-                ns.source(),
+                document_uri,
                 struct_info.name_span(),
-                &imported_lines,
-            )?));
-        }
-
-        Err(anyhow!(
-            "could not resolve type reference for `{}`",
-            ident_text
-        ))
-    }
-
-    /// Resolves call targets to their definition locations.
-    ///
-    /// Handles both local and namespaced function calls, resolving them to task
-    /// and workflow definition in the current document or imported
-    /// namespaces.
-    fn resolve_call_target(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        analysis_doc: &Document,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<Location>> {
-        let ident_text = token.text();
-        let target = wdl_ast::v1::CallTarget::cast(parent_node.clone()).unwrap();
-        let target_names: Vec<_> = target.names().collect();
-        let is_callee_name_clicked = target_names.last().is_some_and(|n| n.text() == ident_text);
-
-        if is_callee_name_clicked {
-            let callee_name_str = token.text();
-
-            // NOTE: Namespaced (foo.bar)
-            if target_names.len() > 1 {
-                let namespaced_name_str = target_names.first().unwrap().text();
-                let Some(ns_info) = analysis_doc.namespace(namespaced_name_str) else {
-                    return Ok(None);
-                };
-
-                let node = graph.get(graph.get_index(ns_info.source()).unwrap());
-                let Some(imported_doc) = node.document() else {
-                    return Ok(None);
-                };
-                let imported_lines = node.parse_state().lines().unwrap().clone();
-
-                if let Some(task_def) = imported_doc.task_by_name(callee_name_str) {
-                    return Ok(Some(location_from_span(
-                        ns_info.source(),
-                        task_def.name_span(),
-                        &imported_lines,
-                    )?));
-                }
-
-                if let Some(wf_def) = imported_doc
-                    .workflow()
-                    .filter(|w| w.name() == callee_name_str)
-                {
-                    return Ok(Some(location_from_span(
-                        ns_info.source(),
-                        wf_def.name_span(),
-                        &imported_lines,
-                    )?));
-                }
-            } else {
-                // NOTE: Local calls
-                if let Some(task_def) = analysis_doc.task_by_name(callee_name_str) {
-                    return Ok(Some(location_from_span(
-                        document_uri,
-                        task_def.name_span(),
-                        lines,
-                    )?));
-                }
-
-                if let Some(wf_def) = analysis_doc
-                    .workflow()
-                    .filter(|w| w.name() == callee_name_str)
-                {
-                    return Ok(Some(location_from_span(
-                        document_uri,
-                        wf_def.name_span(),
-                        lines,
-                    )?));
-                }
-            }
-        } else if let Some(ns_info) = analysis_doc.namespace(token.text()) {
-            return Ok(Some(location_from_span(
-                document_uri,
-                ns_info.span(),
                 lines,
             )?));
         }
 
-        Ok(None)
-    }
+        let is_aliased_import = struct_info
+            .ty()
+            .and_then(|t| t.as_struct())
+            .map(|st| st.name().as_str() != ident_text)
+            .unwrap_or(false);
 
-    /// Resolves import namespace identifier to their definition locations.
-    fn resolve_import_namespace(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-    ) -> Result<Option<Location>> {
-        let import_stmt = wdl_ast::v1::ImportStatement::cast(parent_node.clone()).unwrap();
-        let ident_text = token.text();
+        if is_aliased_import {
+            // Returns the location where alias import was defined.
+            return Ok(Some(location_from_span(
+                document_uri,
+                struct_info.name_span(),
+                lines,
+            )?));
+        } else {
+            // Return the location in the imported file.
+            let ns_name = struct_info.namespace().unwrap();
 
-        if import_stmt
-            .explicit_namespace()
-            .is_some_and(|ns_ident| ns_ident.text() == ident_text)
-        {
-            return Ok(Some(location_from_span(document_uri, token.span(), lines)?));
-        }
-
-        Ok(None)
-    }
-
-    /// Searches for global definitions(structs, tasks, workflows) in the
-    /// current document and all imported namespaces.
-    fn resolve_global_identifier(
-        &self,
-        analysis_doc: &Document,
-        ident_text: &str,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<Location>> {
-        if let Some(location) =
-            find_global_definition_in_doc(analysis_doc, ident_text, document_uri, lines)?
-        {
-            return Ok(Some(location));
-        }
-
-        for (_, ns) in analysis_doc.namespaces() {
-            // SAFETY: we know `get_index` will return `Some` as `ns.source` comes from
-            // `analysis_doc.namespaces` which only contains namespaces for documents that
-            // are guranteed to be present in the graph.
+            // SAFETY: we just found a struct_info with this namespace name and the document
+            // gurantees that `analysis_doc.namespaces` contains a corresponding entry for
+            // `ns_name`.
+            let ns = analysis_doc
+                .namespace(ns_name)
+                .expect("namespace should be present");
             let node = graph.get(graph.get_index(ns.source()).unwrap());
-            let Some(imported_doc) = node.document() else {
-                continue;
-            };
-
-            // SAFETY: we know `lines` will return Some as we only reach here when
-            // `node.document` is fully parsed.
             let imported_lines = node.parse_state().lines().unwrap().clone();
+            let imported_doc = node.document().expect("document should exist");
 
-            if let Some(location) = find_global_definition_in_doc(
-                imported_doc,
-                ident_text,
-                ns.source().as_ref(),
-                &imported_lines,
-            )? {
-                return Ok(Some(location));
+            if let Some(original_struct) = imported_doc.struct_by_name(ident_text) {
+                return Ok(Some(location_from_span(
+                    ns.source(),
+                    original_struct.name_span(),
+                    &imported_lines,
+                )?));
             }
         }
-
-        Ok(None)
     }
 
-    /// Resolves access expressions to their member definition locations.
-    ///
-    /// Evaluates the target expression's type and resolves member access to the
-    /// appropriate def. location.
-    ///
-    /// # Supports:
-    /// - Struct member access (`person.name`)
-    /// - Call output access (`call_result.output`)
-    /// - Arrays (persons[0].name)
-    /// - Chained Access Expressions (documents.persons[0].address.street)
-    fn resolve_access_expression(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        analysis_doc: &Document,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<Location>> {
-        // SAFETY: we already checked `parent_node.kind()` is
-        // `SyntaxKind::AccessExprNode` in the `resolve_by_context` before
-        // calling this function.
-        let access_expr = wdl_ast::v1::AccessExpr::cast(parent_node.clone()).unwrap();
-        let (target_expr, member_ident) = access_expr.operands();
-
-        if member_ident.span() != token.span() {
-            return Ok(None);
-        }
-
-        let scope = analysis_doc
-            .find_scope_by_position(parent_node.span().start())
-            .ok_or_else(|| anyhow!("could not find scope for access expression"))?;
-
-        let mut ctx = GotoDefEvalContext {
-            scope,
-            document: analysis_doc,
+    // Fallback search in case the struct is not in the current document's analysis
+    // map
+    for (_, ns) in analysis_doc.namespaces() {
+        let node = graph.get(graph.get_index(ns.source()).unwrap());
+        let Some(imported_doc) = node.document() else {
+            continue;
         };
-        let mut evaluator = ExprTypeEvaluator::new(&mut ctx);
-        let target_type = evaluator
-            .evaluate_expr(&target_expr)
-            .unwrap_or(crate::types::Type::Union);
 
-        if let Some(struct_ty) = target_type.as_struct() {
-            let struct_def = analysis_doc
-                .structs()
-                .find(|(_, s)| {
-                    if let Some(s_ty) = s.ty() {
-                        if let Some(s_struct_ty) = s_ty.as_struct() {
-                            return s_struct_ty.name() == struct_ty.name();
-                        }
-                    }
-                    s.name() == struct_ty.name().as_str()
-                })
-                .map(|(_, s)| s)
-                .ok_or_else(|| anyhow!("struct definition not found for {}", struct_ty.name()))?;
+        let Some(struct_info) = imported_doc.struct_by_name(ident_text) else {
+            continue;
+        };
 
-            let (uri, def_lines) = match struct_def.namespace() {
-                Some(ns_name) => {
-                    // SAFETY: `namepsace` returns `Some` only when struct was imported from a
-                    // namepsace that exists in the document.
-                    let ns = analysis_doc.namespace(ns_name).unwrap();
+        let imported_lines = node.parse_state().lines().unwrap().clone();
+        return Ok(Some(location_from_span(
+            ns.source(),
+            struct_info.name_span(),
+            &imported_lines,
+        )?));
+    }
 
-                    // SAFETY: `ns.source` comes from a valid namepsace entry which gurantees the
-                    // document exists in the graph.
-                    let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
+    Err(anyhow!(
+        "could not resolve type reference for `{}`",
+        ident_text
+    ))
+}
 
-                    // SAFETY: we successfully got the document above, it's in
-                    // `ParseState::Parsed` which always has a valid lines field.
-                    let lines = imported_node.parse_state().lines().unwrap().clone();
-                    (ns.source().as_ref(), lines)
-                }
-                None => (document_uri, lines.clone()),
-            };
+/// Resolves call targets to their definition locations.
+///
+/// Handles both local and namespaced function calls, resolving them to task
+/// and workflow definition in the current document or imported
+/// namespaces.
+fn resolve_call_target(
+    parent_node: &SyntaxNode,
+    token: &SyntaxToken,
+    analysis_doc: &Document,
+    document_uri: &Url,
+    lines: &Arc<LineIndex>,
+    graph: &DocumentGraph,
+) -> Result<Option<Location>> {
+    let target = wdl_ast::v1::CallTarget::cast(parent_node.clone()).unwrap();
+    let target_names: Vec<_> = target.names().collect();
+    let is_callee_name_clicked = target_names
+        .last()
+        .is_some_and(|n| n.span() == token.span());
 
-            let struct_node =
-                v1::StructDefinition::cast(SyntaxNode::new_root(struct_def.node().clone()))
-                    .expect("should cast to struct definition");
+    if is_callee_name_clicked {
+        let callee_name_str = token.text();
 
-            if let Some(member) = struct_node
-                .members()
-                .find(|m| m.name().text() == member_ident.text())
-            {
-                let member_span = member.name().span();
-                let span = Span::new(member_span.start() + struct_def.offset(), member_span.len());
-                // Returns found struct member definition location.
-                return Ok(Some(location_from_span(uri, span, &def_lines)?));
-            }
-        }
-
-        if let Some(call_ty) = target_type.as_call() {
-            let Some(output) = call_ty.outputs().get(member_ident.text()) else {
-                // Call output not found for the requested member.
+        // NOTE: Namespaced (foo.bar)
+        if target_names.len() == 2 {
+            let namespaced_name_str = target_names.first().unwrap().text();
+            let Some(ns_info) = analysis_doc.namespace(namespaced_name_str) else {
                 return Ok(None);
             };
 
-            let (uri, callee_lines) = match call_ty.namespace() {
-                Some(ns_name) => {
-                    // SAFETY: `namespace` returns `Some` only when the call type references
-                    // a namespace that exists in document.
-                    let ns = analysis_doc.namespace(ns_name).unwrap();
-
-                    // SAFETY: `ns.source` comes from a valid namepsace entry which gurantees the
-                    // document exists in the graph.
-                    let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
-
-                    // SAFETY: we successfully got the document above, it's in
-                    // `ParseState::Parsed` which always has a valid lines field.
-                    let lines = imported_node.parse_state().lines().unwrap().clone();
-                    (ns.source().as_ref(), lines.clone())
-                }
-                None => (document_uri, lines.clone()),
+            let node = graph.get(graph.get_index(ns_info.source()).unwrap());
+            let Some(imported_doc) = node.document() else {
+                return Ok(None);
             };
+            let imported_lines = node.parse_state().lines().unwrap().clone();
 
-            // Returns found call output definition location.
-            return Ok(Some(location_from_span(
-                uri,
-                output.name_span(),
-                &callee_lines,
-            )?));
+            if let Some(task_def) = imported_doc.task_by_name(callee_name_str) {
+                return Ok(Some(location_from_span(
+                    ns_info.source(),
+                    task_def.name_span(),
+                    &imported_lines,
+                )?));
+            }
+
+            if let Some(wf_def) = imported_doc
+                .workflow()
+                .filter(|w| w.name() == callee_name_str)
+            {
+                return Ok(Some(location_from_span(
+                    ns_info.source(),
+                    wf_def.name_span(),
+                    &imported_lines,
+                )?));
+            }
+        } else if target_names.len() == 1 {
+            // NOTE: Local calls
+            if let Some(task_def) = analysis_doc.task_by_name(callee_name_str) {
+                return Ok(Some(location_from_span(
+                    document_uri,
+                    task_def.name_span(),
+                    lines,
+                )?));
+            }
+
+            if let Some(wf_def) = analysis_doc
+                .workflow()
+                .filter(|w| w.name() == callee_name_str)
+            {
+                return Ok(Some(location_from_span(
+                    document_uri,
+                    wf_def.name_span(),
+                    lines,
+                )?));
+            }
+        } else {
+            // More than 2 names (e.g. foo.bar.baz) - invalid expression.
+            return Ok(None);
         }
-
-        Ok(None)
+    } else if let Some(ns_info) = analysis_doc.namespace(token.text()) {
+        return Ok(Some(location_from_span(
+            document_uri,
+            ns_info.span(),
+            lines,
+        )?));
     }
+
+    Ok(None)
+}
+
+/// Resolves import namespace identifier to their definition locations.
+fn resolve_import_namespace(
+    parent_node: &SyntaxNode,
+    token: &SyntaxToken,
+    document_uri: &Url,
+    lines: &Arc<LineIndex>,
+) -> Result<Option<Location>> {
+    let import_stmt = wdl_ast::v1::ImportStatement::cast(parent_node.clone()).unwrap();
+    let ident_text = token.text();
+
+    if import_stmt
+        .explicit_namespace()
+        .is_some_and(|ns_ident| ns_ident.text() == ident_text)
+    {
+        return Ok(Some(location_from_span(document_uri, token.span(), lines)?));
+    }
+
+    Ok(None)
+}
+
+/// Searches for global definitions(structs, tasks, workflows) in the
+/// current document and all imported namespaces.
+fn resolve_global_identifier(
+    analysis_doc: &Document,
+    ident_text: &str,
+    document_uri: &Url,
+    lines: &Arc<LineIndex>,
+    graph: &DocumentGraph,
+) -> Result<Option<Location>> {
+    if let Some(location) =
+        find_global_definition_in_doc(analysis_doc, ident_text, document_uri, lines)?
+    {
+        return Ok(Some(location));
+    }
+
+    for (_, ns) in analysis_doc.namespaces() {
+        // SAFETY: we know `get_index` will return `Some` as `ns.source` comes from
+        // `analysis_doc.namespaces` which only contains namespaces for documents that
+        // are guranteed to be present in the graph.
+        let node = graph.get(graph.get_index(ns.source()).unwrap());
+        let Some(imported_doc) = node.document() else {
+            continue;
+        };
+
+        // SAFETY: we know `lines` will return Some as we only reach here when
+        // `node.document` is fully parsed.
+        let imported_lines = node.parse_state().lines().unwrap().clone();
+
+        if let Some(location) = find_global_definition_in_doc(
+            imported_doc,
+            ident_text,
+            ns.source().as_ref(),
+            &imported_lines,
+        )? {
+            return Ok(Some(location));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Resolves access expressions to their member definition locations.
+///
+/// Evaluates the target expression's type and resolves member access to the
+/// appropriate def. location.
+///
+/// # Supports:
+/// - Struct member access (`person.name`)
+/// - Call output access (`call_result.output`)
+/// - Arrays (persons[0].name)
+/// - Chained Access Expressions (documents.persons[0].address.street)
+fn resolve_access_expression(
+    parent_node: &SyntaxNode,
+    token: &SyntaxToken,
+    analysis_doc: &Document,
+    document_uri: &Url,
+    lines: &Arc<LineIndex>,
+    graph: &DocumentGraph,
+) -> Result<Option<Location>> {
+    // SAFETY: we already checked `parent_node.kind()` is
+    // `SyntaxKind::AccessExprNode` in the `resolve_by_context` before
+    // calling this function.
+    let access_expr = wdl_ast::v1::AccessExpr::cast(parent_node.clone()).unwrap();
+    let (target_expr, member_ident) = access_expr.operands();
+
+    if member_ident.span() != token.span() {
+        return Ok(None);
+    }
+
+    let scope = analysis_doc
+        .find_scope_by_position(parent_node.span().start())
+        .context("could not find scope for access expression")?;
+
+    let mut ctx = GotoDefEvalContext {
+        scope,
+        document: analysis_doc,
+    };
+    let mut evaluator = ExprTypeEvaluator::new(&mut ctx);
+    let target_type = evaluator
+        .evaluate_expr(&target_expr)
+        .unwrap_or(crate::types::Type::Union);
+
+    if let Some(struct_ty) = target_type.as_struct() {
+        let struct_def = analysis_doc
+            .structs()
+            .find(|(_, s)| {
+                if let Some(s_ty) = s.ty() {
+                    if let Some(s_struct_ty) = s_ty.as_struct() {
+                        return s_struct_ty.name() == struct_ty.name();
+                    }
+                }
+                s.name() == struct_ty.name().as_str()
+            })
+            .map(|(_, s)| s)
+            .ok_or_else(|| {
+                anyhow!(
+                    "definition not found for struct `{name}`",
+                    name = struct_ty.name()
+                )
+            })?;
+
+        let (uri, def_lines) = match struct_def.namespace() {
+            Some(ns_name) => {
+                // SAFETY: `namepsace` returns `Some` only when struct was imported from a
+                // namepsace that exists in the document.
+                let ns = analysis_doc.namespace(ns_name).unwrap();
+
+                // SAFETY: `ns.source` comes from a valid namepsace entry which gurantees the
+                // document exists in the graph.
+                let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
+
+                // SAFETY: we successfully got the document above, it's in
+                // `ParseState::Parsed` which always has a valid lines field.
+                let lines = imported_node.parse_state().lines().unwrap().clone();
+                (ns.source().as_ref(), lines)
+            }
+            None => (document_uri, lines.clone()),
+        };
+
+        let struct_node =
+            v1::StructDefinition::cast(SyntaxNode::new_root(struct_def.node().clone()))
+                .expect("should cast to struct definition");
+
+        let Some(member) = struct_node
+            .members()
+            .find(|m| m.name().text() == member_ident.text())
+        else {
+            return Ok(None);
+        };
+
+        let member_span = member.name().span();
+        let span = Span::new(member_span.start() + struct_def.offset(), member_span.len());
+        // Returns found struct member definition location.
+        return Ok(Some(location_from_span(uri, span, &def_lines)?));
+    }
+
+    if let Some(call_ty) = target_type.as_call() {
+        let Some(output) = call_ty.outputs().get(member_ident.text()) else {
+            // Call output not found for the requested member.
+            return Ok(None);
+        };
+
+        let (uri, callee_lines) = match call_ty.namespace() {
+            Some(ns_name) => {
+                // SAFETY: `namespace` returns `Some` only when the call type references
+                // a namespace that exists in document.
+                let ns = analysis_doc.namespace(ns_name).unwrap();
+
+                // SAFETY: `ns.source` comes from a valid namepsace entry which gurantees the
+                // document exists in the graph.
+                let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
+
+                // SAFETY: we successfully got the document above, it's in
+                // `ParseState::Parsed` which always has a valid lines field.
+                let lines = imported_node.parse_state().lines().unwrap().clone();
+                (ns.source().as_ref(), lines.clone())
+            }
+            None => (document_uri, lines.clone()),
+        };
+
+        // Returns found call output definition location.
+        return Ok(Some(location_from_span(
+            uri,
+            output.name_span(),
+            &callee_lines,
+        )?));
+    }
+
+    Ok(None)
 }
 
 /// Finds an identifier token at the specified `TextSize` offset in the concrete

--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -56,6 +56,7 @@ pub use document::Document;
 pub use rules::*;
 pub use validation::*;
 pub use visitor::*;
+pub mod handlers;
 
 /// The prefix of `except` comments.
 pub const EXCEPT_COMMENT_PREFIX: &str = "#@ except:";

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -354,7 +354,8 @@ where
                                 elapsed = start.elapsed()
                             );
 
-                            completed.send(result).ok();
+                            let location = result.map(GotoDefinitionResponse::Scalar);
+                            completed.send(location).ok();
                         }
                         Err(err) => {
                             debug!(

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -357,7 +357,7 @@ where
                             completed.send(location).ok();
                         }
                         Err(err) => {
-                            debug!(
+                            error!(
                                 "error occurred while completing the goto definition request: \
                                  {err:?}"
                             );

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -44,7 +44,7 @@ use crate::document::Document;
 use crate::graph::DfsSpace;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
-use crate::handlers::GotoDefinitionHandler;
+use crate::handlers;
 use crate::rayon::RayonHandle;
 
 /// The minimum number of milliseconds between analysis progress reports.
@@ -346,8 +346,7 @@ where
                     );
 
                     let graph = self.graph.read();
-                    let handler = GotoDefinitionHandler;
-                    match handler.goto_definition(&graph, document, position, encoding) {
+                    match handlers::goto_definition(&graph, document, position, encoding) {
                         Ok(result) => {
                             debug!(
                                 "goto definition request completed in {elapsed:?}",

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -346,7 +346,7 @@ where
                     );
 
                     let graph = self.graph.read();
-                    let handler = GotoDefinitionHandler::new();
+                    let handler = GotoDefinitionHandler;
                     match handler.goto_definition(&graph, document, position, encoding) {
                         Ok(result) => {
                             debug!(

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -15,16 +15,11 @@ use futures::Future;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use indexmap::IndexSet;
-use line_index::LineIndex;
-use line_index::WideEncoding;
 use lsp_types::GotoDefinitionResponse;
-use lsp_types::Location;
-use lsp_types::Position;
 use parking_lot::RwLock;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 use reqwest::Client;
-use rowan::TextSize;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::oneshot;
@@ -33,17 +28,9 @@ use tracing::error;
 use tracing::info;
 use url::Url;
 use wdl_ast::Ast;
-use wdl_ast::AstNode;
 use wdl_ast::AstToken;
 use wdl_ast::Node;
 use wdl_ast::Severity;
-use wdl_ast::Span;
-use wdl_ast::SyntaxKind;
-use wdl_ast::SyntaxNode;
-use wdl_ast::SyntaxToken;
-use wdl_ast::TreeNode;
-use wdl_ast::TreeToken;
-use wdl_ast::v1;
 use wdl_format::Formatter;
 use wdl_format::element::node::AstNodeFormatExt as _;
 
@@ -53,15 +40,12 @@ use crate::IncrementalChange;
 use crate::ProgressKind;
 use crate::SourcePosition;
 use crate::SourcePositionEncoding;
-use crate::diagnostics;
 use crate::document::Document;
-use crate::document::ScopeRef;
 use crate::graph::DfsSpace;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
+use crate::handlers::GotoDefinitionHandler;
 use crate::rayon::RayonHandle;
-use crate::types::v1::EvaluationContext;
-use crate::types::v1::ExprTypeEvaluator;
 
 /// The minimum number of milliseconds between analysis progress reports.
 const MINIMUM_PROGRESS_MILLIS: u128 = 50;
@@ -356,12 +340,14 @@ where
                 }) => {
                     let start = Instant::now();
                     debug!(
-                        "received request for goto definition at {document}: {line}{char}",
+                        "received request for goto definition at {document}: {line}:{char}",
                         line = position.line,
                         char = position.character
                     );
 
-                    match self.goto_definition(document, position, encoding) {
+                    let graph = self.graph.read();
+                    let handler = GotoDefinitionHandler::new();
+                    match handler.goto_definition(&graph, document, position, encoding) {
                         Ok(result) => {
                             debug!(
                                 "goto definition request completed in {elapsed:?}",
@@ -374,7 +360,8 @@ where
                             debug!(
                                 "error occurred while completing the goto definition request: \
                                  {err:?}"
-                            )
+                            );
+                            completed.send(None).ok();
                         }
                     }
                 }
@@ -787,448 +774,6 @@ where
 
         (index, document)
     }
-
-    /// Finds the definition location for an identifier at the given position.
-    ///
-    /// Searches the document and its imports for the definition of the
-    /// identifier at the specified position, returning the location if
-    /// found.
-    ///
-    /// * If a definition is found for the identifier then a
-    ///   [`GotoDefinitionLocation`] contanining the URI and range is returned
-    ///   wrapped in [`Some`].
-    /// * Else, [`None`] is returned.
-    fn goto_definition(
-        &self,
-        document_uri: Url,
-        position: SourcePosition,
-        encoding: SourcePositionEncoding,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        let graph = self.graph.read();
-        let index = graph
-            .get_index(&document_uri)
-            .ok_or_else(|| anyhow!("document not found in graph"))?;
-
-        let (root, lines, analysis_doc) = {
-            let node = graph.get(index);
-
-            let (root, lines) = match node.parse_state() {
-                ParseState::Parsed { lines, root, .. } => {
-                    (SyntaxNode::new_root(root.clone()), lines.clone())
-                }
-                _ => {
-                    debug!("document not yet parsed: {}", document_uri);
-                    return Ok(None);
-                }
-            };
-
-            let analysis_doc = match node.document() {
-                Some(doc) => doc.clone(),
-                None => {
-                    debug!("document analysis data not available for {}", document_uri);
-                    if graph.is_rooted(index) {
-                        debug!("marking document for reanalysis: {}", document_uri);
-                        drop(graph);
-                        let mut write_graph = self.graph.write();
-                        write_graph.get_mut(index).reanalyze();
-                    }
-                    return Ok(None);
-                }
-            };
-
-            (root, lines, analysis_doc)
-        };
-
-        let offset = position_to_offset(&lines, position, encoding)?;
-        let token = match find_identifier_token_at_offset(&root, offset) {
-            Some(tok) => tok,
-            None => {
-                // TODO: if we throw an error the lsp crashes on other editors
-                // vscode extension kicks in and restarts the lsp automatically
-                //
-                // anyhow!("no identifier found at position")
-                debug!("no identifier found at position");
-                return Ok(None);
-            }
-        };
-
-        let ident_text = token.text();
-        let parent_node = token
-            .parent()
-            .ok_or_else(|| anyhow!("identifier token has no parent"))?;
-
-        debug!("resolving location for {token:?}");
-
-        // TODO: context
-        if let Some(location) = self.resolve_by_context(
-            &parent_node,
-            &token,
-            &analysis_doc,
-            &document_uri,
-            &lines,
-            &graph,
-        )? {
-            return Ok(Some(location));
-        }
-
-        // TODO: scope
-        if let Some(scope_ref) = analysis_doc.find_scope_by_position(token.span().start()) {
-            if let Some(name_def) = scope_ref.lookup(ident_text) {
-                return Ok(Some(location(&document_uri, name_def.span(), &lines)?));
-            }
-        }
-
-        self.resolve_global_identifier(&analysis_doc, ident_text, &document_uri, &lines, &graph)
-    }
-
-    /// Resolves identifier definition based on their parent node's syntax kind
-    fn resolve_by_context(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        analysis_doc: &Document,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        match parent_node.kind() {
-            SyntaxKind::TypeRefNode => {
-                self.resolve_type_reference(analysis_doc, token.text(), document_uri, lines, graph)
-            }
-
-            SyntaxKind::CallTargetNode => self.resolve_call_target(
-                parent_node,
-                token,
-                analysis_doc,
-                document_uri,
-                lines,
-                graph,
-            ),
-            SyntaxKind::ImportStatementNode => {
-                self.resolve_import_namespace(parent_node, token, document_uri, lines)
-            }
-
-            SyntaxKind::AccessExprNode => self.resolve_access_expression(
-                parent_node,
-                token,
-                analysis_doc,
-                document_uri,
-                lines,
-                graph,
-            ),
-
-            // TODO:
-            SyntaxKind::BoundDeclNode
-            | SyntaxKind::UnboundDeclNode
-            | SyntaxKind::ScatterStatementNode
-            | SyntaxKind::ImportAliasNode
-            | SyntaxKind::StructDefinitionNode
-            | SyntaxKind::TaskDefinitionNode
-            | SyntaxKind::WorkflowDefinitionNode => {
-                debug!("NOT YET IMPLEMENTED: {kind:?}", kind = parent_node.kind());
-                Ok(None)
-            }
-
-            // handled by scope resolution
-            SyntaxKind::NameRefExprNode => Ok(None),
-            _ => Ok(None),
-        }
-    }
-
-    /// Resolves type references to their definition locations.
-    ///
-    /// Searches for struct definitions in the current document and imported
-    /// namespaces
-    fn resolve_type_reference(
-        &self,
-        analysis_doc: &Document,
-        ident_text: &str,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        // NOTE: local structs
-        if let Some(struct_info) = analysis_doc.struct_by_name(ident_text) {
-            let (uri, def_lines) = if let Some(ns_name) = struct_info.namespace() {
-                let ns = analysis_doc.namespace(ns_name).unwrap();
-                let imported_lines = graph
-                    .get(graph.get_index(ns.source()).unwrap())
-                    .parse_state()
-                    .lines()
-                    .unwrap()
-                    .clone();
-
-                (ns.source().as_ref(), imported_lines)
-            } else {
-                (document_uri, lines.clone())
-            };
-            return Ok(Some(location(uri, struct_info.name_span(), &def_lines)?));
-        };
-
-        // NOTE: imported structs
-        for (_ns_name_str, ns_info) in analysis_doc.namespaces() {
-            if let Some(imported_doc) = graph
-                .get(graph.get_index(ns_info.source()).unwrap())
-                .document()
-            {
-                if let Some(struct_info) = imported_doc.struct_by_name(ident_text) {
-                    let imported_lines = graph
-                        .get(graph.get_index(ns_info.source()).unwrap())
-                        .parse_state()
-                        .lines()
-                        .unwrap()
-                        .clone();
-
-                    return Ok(Some(location(
-                        ns_info.source(),
-                        struct_info.name_span(),
-                        &imported_lines,
-                    )?));
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    /// Resolves call targets to their definition locations.
-    ///
-    /// Handles both local and namespaced function calls, resolving them to task
-    /// and workflow definition in the current document or imported
-    /// namespaces.
-    fn resolve_call_target(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        analysis_doc: &Document,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        let ident_text = token.text();
-        let target = wdl_ast::v1::CallTarget::cast(parent_node.clone()).unwrap();
-        let target_names: Vec<_> = target.names().collect();
-        let is_callee_name_clicked = target_names.last().is_some_and(|n| n.text() == ident_text);
-
-        if is_callee_name_clicked {
-            let callee_name_str = token.text();
-
-            // NOTE: namespaced (foo.bar)
-            if target_names.len() > 1 {
-                let namespaced_name_str = target_names.first().unwrap().text();
-                if let Some(ns_info) = analysis_doc.namespace(namespaced_name_str) {
-                    if let Some(imported_doc) = graph
-                        .get(graph.get_index(ns_info.source()).unwrap())
-                        .document()
-                    {
-                        let imported_lines = graph
-                            .get(graph.get_index(ns_info.source()).unwrap())
-                            .parse_state()
-                            .lines()
-                            .unwrap()
-                            .clone();
-
-                        if let Some(task_def) = imported_doc.task_by_name(callee_name_str) {
-                            return Ok(Some(location(
-                                ns_info.source(),
-                                task_def.name_span(),
-                                &imported_lines,
-                            )?));
-                        }
-
-                        if let Some(wf_def) = imported_doc
-                            .workflow()
-                            .filter(|w| w.name() == callee_name_str)
-                        {
-                            return Ok(Some(location(
-                                ns_info.source(),
-                                wf_def.name_span(),
-                                &imported_lines,
-                            )?));
-                        }
-                    }
-                }
-            } else {
-                // NOTE: local calls
-                if let Some(task_def) = analysis_doc.task_by_name(callee_name_str) {
-                    return Ok(Some(location(
-                        &Arc::new(document_uri.clone()),
-                        task_def.name_span(),
-                        lines,
-                    )?));
-                }
-
-                if let Some(wf_def) = analysis_doc
-                    .workflow()
-                    .filter(|w| w.name() == callee_name_str)
-                {
-                    return Ok(Some(location(
-                        &Arc::new(document_uri.clone()),
-                        wf_def.name_span(),
-                        lines,
-                    )?));
-                }
-            }
-        } else if let Some(ns_info) = analysis_doc.namespace(token.text()) {
-            return Ok(Some(location(
-                &Arc::new(document_uri.clone()),
-                ns_info.span(),
-                lines,
-            )?));
-        }
-
-        Ok(None)
-    }
-
-    /// Resolves import namespace identifier to their definition locations.
-    fn resolve_import_namespace(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        let import_stmt = wdl_ast::v1::ImportStatement::cast(parent_node.clone()).unwrap();
-        let ident_text = token.text();
-
-        if import_stmt
-            .explicit_namespace()
-            .is_some_and(|ns_ident| ns_ident.text() == ident_text)
-        {
-            return Ok(Some(location(
-                &Arc::new(document_uri.clone()),
-                token.span(),
-                lines,
-            )?));
-        }
-
-        Ok(None)
-    }
-
-    /// Searches for global definitions(structs, tasks, workflows) in the
-    /// current document and all imported namespaces
-    fn resolve_global_identifier(
-        &self,
-        analysis_doc: &Document,
-        ident_text: &str,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        if let Some(location) =
-            find_global_definition_in_doc(analysis_doc, ident_text, document_uri, lines)?
-        {
-            return Ok(Some(location));
-        }
-
-        for (_, ns_info) in analysis_doc.namespaces() {
-            if let Some(imported_doc) = graph
-                .get(graph.get_index(ns_info.source()).unwrap())
-                .document()
-            {
-                let imported_lines = graph
-                    .get(graph.get_index(ns_info.source()).unwrap())
-                    .parse_state()
-                    .lines()
-                    .unwrap()
-                    .clone();
-
-                if let Some(location) = find_global_definition_in_doc(
-                    imported_doc,
-                    ident_text,
-                    ns_info.source().as_ref(),
-                    &imported_lines,
-                )? {
-                    return Ok(Some(location));
-                }
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Resolves access expressions to their member definition locations.
-    ///
-    /// Evaluates the target expression's type and resolves member access to the
-    /// appropriate def. location.
-    ///
-    /// # Supports:
-    /// - Struct member access (`person.name`)
-    /// - Call output access (`call_result.output`)
-    /// - TODO: Arrays
-    fn resolve_access_expression(
-        &self,
-        parent_node: &SyntaxNode,
-        token: &SyntaxToken,
-        analysis_doc: &Document,
-        document_uri: &Url,
-        lines: &Arc<LineIndex>,
-        graph: &DocumentGraph,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        let access_expr = wdl_ast::v1::AccessExpr::cast(parent_node.clone()).unwrap();
-        let (target_expr, member_ident) = access_expr.operands();
-
-        if member_ident.span() != token.span() {
-            return Ok(None);
-        }
-
-        let scope = analysis_doc
-            .find_scope_by_position(parent_node.span().start())
-            .ok_or_else(|| anyhow!("could not find scope for access expression"))?;
-
-        let mut ctx = GotoDefEvalContext {
-            scope,
-            document: analysis_doc,
-        };
-        let mut evaluator = ExprTypeEvaluator::new(&mut ctx);
-        let target_type = evaluator
-            .evaluate_expr(&target_expr)
-            .unwrap_or(crate::types::Type::Union);
-
-        if let Some(struct_ty) = target_type.as_struct() {
-            let struct_def = analysis_doc
-                .struct_by_name(struct_ty.name())
-                .ok_or_else(|| anyhow!("struct definition not found for {}", struct_ty.name()))?;
-
-            let (uri, def_lines) = if let Some(ns_name) = struct_def.namespace() {
-                let ns = analysis_doc.namespace(ns_name).unwrap();
-                let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
-                let lines = imported_node.parse_state().lines().unwrap().clone();
-                (ns.source().as_ref(), lines)
-            } else {
-                (document_uri, lines.clone())
-            };
-
-            let struct_node =
-                v1::StructDefinition::cast(SyntaxNode::new_root(struct_def.node().clone()))
-                    .expect("should cast to struct definition");
-
-            if let Some(member) = struct_node
-                .members()
-                .find(|m| m.name().text() == member_ident.text())
-            {
-                let member_span = member.name().span();
-                let span = Span::new(member_span.start() + struct_def.offset(), member_span.len());
-                return Ok(Some(location(uri, span, &def_lines)?));
-            }
-        }
-
-        if let Some(call_ty) = target_type.as_call() {
-            if let Some(output) = call_ty.outputs().get(member_ident.text()) {
-                let (uri, callee_lines) = if let Some(ns_name) = call_ty.namespace() {
-                    let ns = analysis_doc.namespace(ns_name).unwrap();
-                    let imported_node = graph.get(graph.get_index(ns.source()).unwrap());
-                    let lines = imported_node.parse_state().lines().unwrap().clone();
-                    (ns.source().as_ref(), lines.clone())
-                } else {
-                    (document_uri, lines.clone())
-                };
-
-                return Ok(Some(location(uri, output.name_span(), &callee_lines)?));
-            }
-        }
-
-        Ok(None)
-    }
 }
 
 /// Formats the panic payload for display.
@@ -1240,137 +785,4 @@ pub(crate) fn format_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> S
     } else {
         "unknown panic payload".to_string()
     }
-}
-
-/// Finds an identifier token at the specified `TextSize` offset in the concrete
-/// syntax tree.
-fn find_identifier_token_at_offset(node: &SyntaxNode, offset: TextSize) -> Option<SyntaxToken> {
-    node.token_at_offset(offset)
-        .find(|t| t.kind() == SyntaxKind::Ident)
-}
-
-/// Converts a text size offset to LSP position.
-fn position(index: &LineIndex, offset: TextSize) -> Result<Position> {
-    let line_col = index.line_col(offset);
-    let line_col = index
-        .to_wide(WideEncoding::Utf16, line_col)
-        .with_context(|| {
-            format!(
-                "invalid line column: {line}:{column}",
-                line = line_col.line,
-                column = line_col.col
-            )
-        })?;
-
-    Ok(Position::new(line_col.line, line_col.col))
-}
-
-/// Converts a `Span` to an LSP location
-fn location(uri: &Url, span: Span, lines: &Arc<LineIndex>) -> Result<GotoDefinitionResponse> {
-    let start_offset = TextSize::from(span.start() as u32);
-    let end_offset = TextSize::from(span.end() as u32);
-    let range = lsp_types::Range {
-        start: position(lines, start_offset)?,
-        end: position(lines, end_offset)?,
-    };
-
-    Ok(GotoDefinitionResponse::Scalar(Location::new(
-        uri.clone(),
-        range,
-    )))
-}
-
-/// Finds global structs, tasks and workflow definition in a document
-fn find_global_definition_in_doc(
-    analysis_doc: &Document,
-    ident_text: &str,
-    document_uri: &Url,
-    lines: &Arc<LineIndex>,
-) -> Result<Option<GotoDefinitionResponse>> {
-    if let Some(s) = analysis_doc.struct_by_name(ident_text) {
-        return Ok(Some(location(document_uri, s.name_span(), lines)?));
-    }
-    if let Some(t) = analysis_doc.task_by_name(ident_text) {
-        return Ok(Some(location(document_uri, t.name_span(), lines)?));
-    }
-    if let Some(w) = analysis_doc
-        .workflow()
-        .filter(|w_def| w_def.name() == ident_text)
-    {
-        return Ok(Some(location(document_uri, w.name_span(), lines)?));
-    }
-
-    Ok(None)
-}
-
-/// Converts a source postion to a text offset based on the specified encoding.
-fn position_to_offset(
-    lines: &Arc<LineIndex>,
-    position: SourcePosition,
-    encoding: SourcePositionEncoding,
-) -> Result<TextSize> {
-    let line_col = match encoding {
-        SourcePositionEncoding::UTF8 => line_index::LineCol {
-            line: position.line,
-            col: position.character,
-        },
-        SourcePositionEncoding::UTF16 => lines
-            .to_utf8(
-                line_index::WideEncoding::Utf16,
-                line_index::WideLineCol {
-                    line: position.line,
-                    col: position.character,
-                },
-            )
-            .ok_or_else(|| anyhow!("invalid utf-16 position: {position:?}"))?,
-    };
-
-    lines
-        .offset(line_col)
-        .ok_or_else(|| anyhow!("line_col is invalid"))
-}
-
-/// Context for evaluating expressions during goto definition resolution.
-struct GotoDefEvalContext<'a> {
-    /// The scope reference containing the variable and name bindings at the
-    /// current position
-    scope: ScopeRef<'a>,
-
-    /// The document being analyzed.
-    document: &'a Document,
-}
-
-impl EvaluationContext for GotoDefEvalContext<'_> {
-    fn version(&self) -> wdl_ast::SupportedVersion {
-        self.document
-            .version()
-            .expect("document should have a version")
-    }
-
-    fn resolve_name(&self, name: &str, _span: Span) -> Option<crate::types::Type> {
-        self.scope.lookup(name).map(|n| n.ty().clone())
-    }
-
-    fn resolve_type_name(
-        &mut self,
-        name: &str,
-        span: Span,
-    ) -> std::result::Result<crate::types::Type, wdl_ast::Diagnostic> {
-        if let Some(s) = self.document.struct_by_name(name) {
-            if let Some(ty) = s.ty() {
-                return Ok(ty.clone());
-            }
-        }
-        Err(diagnostics::unknown_type(name, span))
-    }
-
-    fn task(&self) -> Option<&crate::document::Task> {
-        None
-    }
-
-    fn diagnostics_config(&self) -> DiagnosticsConfig {
-        DiagnosticsConfig::default()
-    }
-
-    fn add_diagnostic(&mut self, _: wdl_ast::Diagnostic) {}
 }

--- a/wdl-analysis/src/queue.rs
+++ b/wdl-analysis/src/queue.rs
@@ -898,17 +898,13 @@ pub(crate) fn format_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> S
 
 /// Finds an identifier token at the specified `TextSize` offset in the CST.
 fn find_identifier_at_offset(node: &SyntaxNode, offset: TextSize) -> Result<Option<String>> {
-    if let Some(token) = node
+    match node
         .token_at_offset(offset)
         .find(|t| t.kind() == SyntaxKind::Ident)
     {
-        let range = token.text_range();
-        if !range.is_empty() && range.contains_inclusive(offset) {
-            return Ok(Some(token.text().to_string()));
-        }
+        None => Ok(None),
+        Some(token) => Ok(Some(token.text().to_string())),
     }
-
-    Ok(None)
 }
 
 /// Searches for a definition of the given identifier in the AST.
@@ -968,7 +964,7 @@ fn source_position(index: &LineIndex, offset: TextSize) -> Result<SourcePosition
     Ok(SourcePosition::new(line_col.line, line_col.col))
 }
 
-/// Converts a AST `Span` to LSP source position range.
+/// Converts an AST `Span` to LSP source position range.
 fn range_from_span(span: Span, index: &Arc<LineIndex>) -> Result<Range<SourcePosition>> {
     let start_offset = TextSize::from(span.start() as u32);
     let end_offset = TextSize::from(span.end() as u32);

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -233,6 +233,16 @@ impl Type {
         }
     }
 
+    /// Converts the type to a call type
+    ///
+    /// Returns `None` if the type if not a call type.
+    pub fn as_call(&self) -> Option<&CallType> {
+        match self {
+            Self::Call(ty) => Some(ty),
+            _ => None,
+        }
+    }
+
     /// Determines if the type is `Union`.
     pub fn is_union(&self) -> bool {
         matches!(self, Type::Union)
@@ -983,7 +993,7 @@ impl CallType {
     pub fn promote(&self, kind: PromotionKind) -> Self {
         let mut ty = self.clone();
         for output in Arc::make_mut(&mut ty.outputs).values_mut() {
-            *output = Output::new(output.ty().promote(kind));
+            *output = Output::new(output.ty().promote(kind), output.name_span());
         }
 
         ty

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -383,6 +383,7 @@ impl LanguageServer for Server {
                     },
                 )),
                 document_formatting_provider: Some(OneOf::Left(true)),
+                definition_provider: Some(OneOf::Left(true)),
                 ..Default::default()
             },
             server_info: Some(ServerInfo {
@@ -709,5 +710,49 @@ impl LanguageServer for Server {
             });
 
         Ok(result)
+    }
+
+    async fn goto_definition(
+        &self,
+        mut params: GotoDefinitionParams,
+    ) -> RpcResult<Option<GotoDefinitionResponse>> {
+        normalize_uri_path(&mut params.text_document_position_params.text_document.uri);
+
+        debug!("received `textDocument/gotoDefinition` request: {params:#?}");
+
+        let position = SourcePosition::new(
+            params.text_document_position_params.position.line,
+            params.text_document_position_params.position.character,
+        );
+
+        let result = self
+            .analyzer
+            .goto_definition(
+                params.text_document_position_params.text_document.uri,
+                position,
+                SourcePositionEncoding::UTF16,
+            )
+            .await
+            .map_err(|e| RpcError {
+                code: ErrorCode::InternalError,
+                message: e.to_string().into(),
+                data: None,
+            })?;
+
+        Ok(result.map(|location| {
+            GotoDefinitionResponse::Scalar(Location {
+                uri: location.uri,
+                range: Range {
+                    start: Position {
+                        line: location.range.start.line,
+                        character: location.range.start.character,
+                    },
+                    end: Position {
+                        line: location.range.end.line,
+                        character: location.range.end.character,
+                    },
+                },
+            })
+        }))
     }
 }

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -739,20 +739,6 @@ impl LanguageServer for Server {
                 data: None,
             })?;
 
-        Ok(result.map(|location| {
-            GotoDefinitionResponse::Scalar(Location {
-                uri: location.uri,
-                range: Range {
-                    start: Position {
-                        line: location.range.start.line,
-                        character: location.range.start.character,
-                    },
-                    end: Position {
-                        line: location.range.end.line,
-                        character: location.range.end.character,
-                    },
-                },
-            })
-        }))
+        Ok(result)
     }
 }


### PR DESCRIPTION
Added:

- `Struct definitions`
- `Call definitions`
  - Tasks
  - Workflows
- `Namespaced calls`
- `Namespace usage → import declaration`
- `Access expressions`
  - Struct member access
  - Call output access
  - Array element access
  - Chained access expressions
- `Scope-based resolution`
  - Variable references
  - Scatter variables
  - Conditional variables
  - Task inputs/outputs
  - Workflow inputs/outputs
- `Cross document navigation`
- `Aliased imports`
- `Global document resolution`

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
