### PR TITLE
fix: use `/var/log` directory for stdout/stderr guest paths.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * TES input and outputs now include authentication query parameters ([#466](https://github.com/stjude-rust-labs/wdl/pull/466)).
 
+### Fixed
+
+* Fixed guest paths for redirected stdio for both the Docker and TES backends ([#470](https://github.com/stjude-rust-labs/wdl/pull/470)).
+
 ## 0.4.0 - 05-27-2025
 
 #### Added

--- a/wdl-engine/src/backend/docker.rs
+++ b/wdl-engine/src/backend/docker.rs
@@ -66,19 +66,19 @@ use crate::v1::memory;
 const INITIAL_EXPECTED_NAMES: usize = 1000;
 
 /// The root guest path for inputs.
-const GUEST_INPUTS_DIR: &str = "/mnt/inputs";
+const GUEST_INPUTS_DIR: &str = "/mnt/task/inputs";
 
 /// The guest working directory.
-const GUEST_WORK_DIR: &str = "/mnt/work";
+const GUEST_WORK_DIR: &str = "/mnt/task/work";
 
 /// The guest path for the command file.
-const GUEST_COMMAND_PATH: &str = "/mnt/command";
+const GUEST_COMMAND_PATH: &str = "/mnt/task/command";
 
 /// The path to the container's stdout.
-const GUEST_STDOUT_PATH: &str = "/var/log/stdout";
+const GUEST_STDOUT_PATH: &str = "/mnt/task/stdout";
 
 /// The path to the container's stderr.
-const GUEST_STDERR_PATH: &str = "/var/log/stderr";
+const GUEST_STDERR_PATH: &str = "/mnt/task/stderr";
 
 /// This request contains the requested cpu and memory reservations for the task
 /// as well as the result receiver channel.

--- a/wdl-engine/src/backend/docker.rs
+++ b/wdl-engine/src/backend/docker.rs
@@ -75,10 +75,10 @@ const GUEST_WORK_DIR: &str = "/mnt/work";
 const GUEST_COMMAND_PATH: &str = "/mnt/command";
 
 /// The path to the container's stdout.
-const GUEST_STDOUT_PATH: &str = "/stdout";
+const GUEST_STDOUT_PATH: &str = "/var/log/stdout";
 
 /// The path to the container's stderr.
-const GUEST_STDERR_PATH: &str = "/stderr";
+const GUEST_STDERR_PATH: &str = "/var/log/stderr";
 
 /// This request contains the requested cpu and memory reservations for the task
 /// as well as the result receiver channel.

--- a/wdl-engine/src/backend/tes.rs
+++ b/wdl-engine/src/backend/tes.rs
@@ -81,10 +81,10 @@ const GUEST_WORK_DIR: &str = "/mnt/work";
 const GUEST_COMMAND_PATH: &str = "/mnt/command";
 
 /// The path to the container's stdout.
-const GUEST_STDOUT_PATH: &str = "/stdout";
+const GUEST_STDOUT_PATH: &str = "/var/log/stdout";
 
 /// The path to the container's stderr.
-const GUEST_STDERR_PATH: &str = "/stderr";
+const GUEST_STDERR_PATH: &str = "/var/log/stderr";
 
 /// The default poll interval, in seconds, for the TES backend.
 const DEFAULT_TES_INTERVAL: u64 = 60;

--- a/wdl-engine/src/backend/tes.rs
+++ b/wdl-engine/src/backend/tes.rs
@@ -72,19 +72,19 @@ use crate::v1::preemptible;
 const INITIAL_EXPECTED_NAMES: usize = 1000;
 
 /// The root guest path for inputs.
-const GUEST_INPUTS_DIR: &str = "/mnt/inputs";
+const GUEST_INPUTS_DIR: &str = "/mnt/task/inputs";
 
 /// The guest working directory.
-const GUEST_WORK_DIR: &str = "/mnt/work";
+const GUEST_WORK_DIR: &str = "/mnt/task/work";
 
 /// The guest path for the command file.
-const GUEST_COMMAND_PATH: &str = "/mnt/command";
+const GUEST_COMMAND_PATH: &str = "/mnt/task/command";
 
 /// The path to the container's stdout.
-const GUEST_STDOUT_PATH: &str = "/var/log/stdout";
+const GUEST_STDOUT_PATH: &str = "/mnt/task/stdout";
 
 /// The path to the container's stderr.
-const GUEST_STDERR_PATH: &str = "/var/log/stderr";
+const GUEST_STDERR_PATH: &str = "/mnt/task/stderr";
 
 /// The default poll interval, in seconds, for the TES backend.
 const DEFAULT_TES_INTERVAL: u64 = 60;

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -57,7 +57,7 @@ use wdl_engine::v1::TaskEvaluator;
 
 /// Regex used to remove both host and guest path prefixes.
 static PATH_PREFIX_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(attempts[\/\\]\d+[\/\\]|\/mnt\/inputs\/\d+\/)"#).expect("invalid regex")
+    Regex::new(r#"(attempts[\/\\]\d+[\/\\]|\/mnt\/task\/inputs\/\d+\/)"#).expect("invalid regex")
 });
 
 /// Regex used to replace temporary file names in task command files with

--- a/wdl-engine/tests/tasks/path-translation/source.wdl
+++ b/wdl-engine/tests/tasks/path-translation/source.wdl
@@ -11,25 +11,25 @@ task test {
         set -euo pipefail
 
         # Test for the `sep` option
-        echo '~{if task.container == "ubuntu:latest" then if find("~{sep=',' files}", "/mnt/inputs") != None then "ok!" else "bad :(" else "ok!" }'
+        echo '~{if task.container == "ubuntu:latest" then if find("~{sep=',' files}", "/mnt/task/inputs") != None then "ok!" else "bad :(" else "ok!" }'
 
         # Test for the `sep` function
-        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', files), "/mnt/inputs") != None then "ok!" else "bad :(" else "ok!" }'
+        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', files), "/mnt/task/inputs") != None then "ok!" else "bad :(" else "ok!" }'
 
         # Test for the `prefix` function
-        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', prefix("foo", files)), "/mnt/inputs") != None then "ok!" else "bad :(" else "ok!" }'
+        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', prefix("foo", files)), "/mnt/task/inputs") != None then "ok!" else "bad :(" else "ok!" }'
 
         # Test for the `quote` function
-        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', quote(files)), "/mnt/inputs") != None then "ok!" else "bad :(" else "ok!" }'
+        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', quote(files)), "/mnt/task/inputs") != None then "ok!" else "bad :(" else "ok!" }'
 
         # Test for the `squote` function
-        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', squote(files)), "/mnt/inputs") != None then "ok!" else "bad :(" else "ok!" }'
+        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', squote(files)), "/mnt/task/inputs") != None then "ok!" else "bad :(" else "ok!" }'
 
         # Test for the `suffix` function
-        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', suffix("bar", files)), "/mnt/inputs") != None then "ok!" else "bad :(" else "ok!" }'
+        echo '~{if task.container == "ubuntu:latest" then if find(sep(',', suffix("bar", files)), "/mnt/task/inputs") != None then "ok!" else "bad :(" else "ok!" }'
 
         # Test for string concatenation
-        echo '~{if task.container == "ubuntu:latest" then if find("test" + files[1], "/mnt/inputs") != None then "ok!" else "bad :(" else "ok!" }'
+        echo '~{if task.container == "ubuntu:latest" then if find("test" + files[1], "/mnt/task/inputs") != None then "ok!" else "bad :(" else "ok!" }'
 
         # Ensure we can read each file
         cat '~{files[0]}'


### PR DESCRIPTION
This PR fixes the guest paths used for logging the command's stdout and stderr to for both the Docker and TES backends.

For the TES backend, creating files at root do not work for some TES server implementations.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
