### PR TITLE
chore: add a Default implementation for Source

### DIFF
--- a/wdl-cli/src/analysis/source.rs
+++ b/wdl-cli/src/analysis/source.rs
@@ -85,6 +85,13 @@ impl std::str::FromStr for Source {
     }
 }
 
+impl Default for Source {
+    fn default() -> Self {
+        // Default to the current directory.
+        Source::Directory(std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds a `Default` implementation to `Source`. In Sprocket, we want to enable running without specifying a location (similar to `cargo`).

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.
- [ ] Your PR title follows the [conventional commit] style.
