### PR TITLE
chore: run `wdl-engine` tests with the Docker backend on macOS and Windows.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,8 +54,7 @@ jobs:
           brew install colima
           brew install lima-additional-guestagents
           # M1 and M2 Macs that the Github Actions supplies don't support nested virtualization. This forces x86 emulation to get around this
-          #--mount /private is necessary here in order to give docker access to mac's temp directory for tests
-          colima start --mount /private --memory 4 --network-address --arch x86_64
+          colima start --mount $TMPDIR:w --mount $(pwd) --mount $HOME/Library/Caches/wdl:w --memory 4 --network-address --arch x86_64
           echo "DOCKER_HOST=unix:///Users/runner/.colima/docker.sock" >> $GITHUB_ENV
       - name: Setup WSL (Windows)
         if: ${{'windows-latest' == matrix.os}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,8 +45,8 @@ jobs:
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - name: Setup Docker (Mac)
-        if: ${{'macos-latest' == matrix.os}}
+      - name: Setup Docker (macOS)
+        if: ${{ matrix.os == 'macos-latest' }}
         run: |
           brew update
           brew install docker
@@ -57,22 +57,23 @@ jobs:
           colima start --mount $TMPDIR:w --mount $(pwd) --mount $HOME/Library/Caches/wdl:w --memory 4 --network-address --arch x86_64
           echo "DOCKER_HOST=unix:///Users/runner/.colima/docker.sock" >> $GITHUB_ENV
       - name: Setup WSL (Windows)
-        if: ${{'windows-latest' == matrix.os}}
+        if: ${{ matrix.os == 'windows-latest' }}
         uses: Vampire/setup-wsl@v5
       - name: Install Podman (Windows)
-        if: ${{'windows-latest' == matrix.os}}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: |
           curl -L --url "https://github.com/containers/podman/releases/download/v5.5.1/podman-5.5.1-setup.exe" -o Podman.exe
           Start-Process Podman.exe -Wait -ArgumentList "/norestart /passive" -Verb runAs;
           Add-Content $env:GITHUB_PATH "C:\Program Files\RedHat\Podman\"
       - name: Startup Docker (Windows)
-        if: ${{'windows-latest' == matrix.os}}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          podman machine init
+          podman machine init -v $env:TEMP:/tmp/win
           podman machine set --rootful
           podman machine start
           Add-Content $env:GITHUB_ENV "DOCKER_HOST=npipe:////./pipe/podman-machine-default"
       - name: Run tests
+        if: ${{ matrix.os != 'windows-latest' }}
         run: cargo test --all-features
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,36 @@ jobs:
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
         run: rustup update stable && rustup default stable
+      - name: Setup Docker (Mac)
+        if: ${{'macos-latest' == matrix.os}}
+        run: |
+          brew update
+          brew install docker
+          brew install qemu
+          brew install colima
+          brew install lima-additional-guestagents
+          # M1 and M2 Macs that the Github Actions supplies don't support nested virtualization. This forces x86 emulation to get around this
+          #--mount /private is necessary here in order to give docker access to mac's temp directory for tests
+          colima start --mount /private --memory 4 --network-address --arch x86_64
+          echo "DOCKER_HOST=unix:///Users/runner/.colima/docker.sock" >> $GITHUB_ENV
+      - name: Setup WSL (Windows)
+        if: ${{'windows-latest' == matrix.os}}
+        uses: Vampire/setup-wsl@v5
+      - name: Install Podman (Windows)
+        if: ${{'windows-latest' == matrix.os}}
+        run: |
+          curl -L --url "https://github.com/containers/podman/releases/download/v5.5.1/podman-5.5.1-setup.exe" -o Podman.exe
+          Start-Process Podman.exe -Wait -ArgumentList "/norestart /passive" -Verb runAs;
+          Add-Content $env:GITHUB_PATH "C:\Program Files\RedHat\Podman\"
+      - name: Startup Docker (Windows)
+        if: ${{'windows-latest' == matrix.os}}
+        run: |
+          podman machine init
+          podman machine set --rootful
+          podman machine start
+          Add-Content $env:GITHUB_ENV "DOCKER_HOST=npipe:////./pipe/podman-machine-default"
+      - name: Run tests
+        run: cargo test --all-features
       - uses: actions/cache@v4
         with:
           path: |

--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the macOS and Windows CI jobs to run tests with the Docker backend ([#478](https://github.com/stjude-rust-labs/wdl/pull/478)).
 * Fixed guest paths for redirected stdio for both the Docker and TES backends ([#470](https://github.com/stjude-rust-labs/wdl/pull/470)).
 
 ### Changed

--- a/wdl-engine/tests/tasks.rs
+++ b/wdl-engine/tests/tasks.rs
@@ -174,10 +174,6 @@ fn configs() -> Vec<config::Config> {
                 ..Default::default()
             }
         },
-        // Currently we limit running the Docker backend to Linux as GitHub does not have Docker
-        // installed on macOS hosted runners and the Windows hosted runners are configured to use
-        // Windows containers
-        #[cfg(target_os = "linux")]
         {
             config::Config {
                 backends: [(

--- a/wdl-engine/tests/workflows.rs
+++ b/wdl-engine/tests/workflows.rs
@@ -156,10 +156,6 @@ fn configs() -> Vec<config::Config> {
                 ..Default::default()
             }
         },
-        // Currently we limit running the Docker backend to Linux as GitHub does not have Docker
-        // installed on macOS hosted runners and the Windows hosted runners are configured to use
-        // Windows containers
-        #[cfg(target_os = "linux")]
         {
             config::Config {
                 backends: [(


### PR DESCRIPTION
This PR copies what is done in stjude-rust-labs/sprocket#119 for setting up a Docker daemon that can be used from the `wdl-engine` tests.

It removes the `#[cfg(target_os = "linux")]` that previously prevented the tests from running on macOS and Windows for CI.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
