### PR TITLE
fix: ensure server is fully initialized before responding

### DIFF
--- a/wdl-lsp/CHANGELOG.md
+++ b/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Ensure the server is fully initialized before responding ([#487](https://github.com/stjude-rust-labs/wdl/pull/487)).
+
 ## 0.9.0 - 05-27-2025
 
 #### Dependencies


### PR DESCRIPTION
Hi, so i was working on lsp tests and i found out they were flaky. The LSP server was responding to the `initialize` request before its initial workspace analysis was complete which created a race condition where a client could send a feature request (e.g., `textDocument/gotoDefinition`) before the server had the necessary data to handle it.

This was most visible in the integration test suite, which would fail with errors like `"document not found in graph"` or `"document has not been parsed"`.

This pr fixes it by making the server's `initialize` handler `await` the completion of the initial workspace analysis.

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

END SECTION -->

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
