### PR TITLE
chore: change github CODEOWNER name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @stjude-rust-labs/wdl-review
+* @stjude-rust-labs/sprocket


### PR DESCRIPTION
Updating the CODEOWNERS file for the new Github team name

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
