### PR TITLE
chore: apply clippy lints from Rust 1.88

### DIFF
--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -343,16 +343,13 @@ async fn publish(name: &str, version: &str, manifest_path: &Path, dry_run: bool)
     // binary may be re-run and there's no need to re-attempt previous work.
     let client = reqwest::Client::new();
     let req = client
-        .get(format!("https://crates.io/api/v1/crates/{}", name))
+        .get(format!("https://crates.io/api/v1/crates/{name}"))
         .header("User-Agent", "curl/8.7.1"); // crates.io requires a user agent apparently
     let response = req.send().await.expect("failed to get crate info");
     if response.status().is_success() {
         let text = response.text().await.expect("failed to get response text");
-        if text.contains(&format!("\"newest_version\":\"{}\"", version)) {
-            println!(
-                "skip publish {} because {} is latest version",
-                name, version,
-            );
+        if text.contains(&format!("\"newest_version\":\"{version}\"")) {
+            println!("skip publish {name} because {version} is latest version",);
             return true;
         }
     } else {
@@ -375,7 +372,7 @@ async fn publish(name: &str, version: &str, manifest_path: &Path, dry_run: bool)
     };
 
     if !status.success() {
-        println!("FAIL: failed to publish `{}`: {}", name, status);
+        println!("FAIL: failed to publish `{name}`: {status}");
         return false;
     }
 

--- a/gauntlet/src/config.rs
+++ b/gauntlet/src/config.rs
@@ -170,7 +170,7 @@ impl Config {
             let mut file = File::create(path).map_err(Error::InputOutput)?;
             let contents = toml::to_string_pretty(&self.inner).map_err(Error::SerializeToml)?;
 
-            write!(file, "{}", contents).map_err(Error::InputOutput)
+            write!(file, "{contents}").map_err(Error::InputOutput)
         } else {
             Err(Error::SaveOnAnonymousConfig)
         }

--- a/gauntlet/src/config/inner.rs
+++ b/gauntlet/src/config/inner.rs
@@ -40,7 +40,7 @@ impl Diagnostic {
             path = document.path()
         );
         let url = if let Some(line_no) = line_no {
-            format!("{}/#L{}", url, line_no)
+            format!("{url}/#L{line_no}")
         } else {
             url
         };

--- a/gauntlet/src/main.rs
+++ b/gauntlet/src/main.rs
@@ -35,7 +35,7 @@ async fn inner() -> Result<(), Box<dyn std::error::Error>> {
 
     let filter = match args.log_all_modules {
         true => EnvFilter::default().add_directive(level.into()),
-        false => EnvFilter::default().add_directive(format!("wdl_gauntlet={}", level).parse()?),
+        false => EnvFilter::default().add_directive(format!("wdl_gauntlet={level}").parse()?),
     };
 
     tracing_subscriber::fmt().with_env_filter(filter).init();
@@ -49,7 +49,7 @@ async fn inner() -> Result<(), Box<dyn std::error::Error>> {
 async fn main() {
     match inner().await {
         Ok(_) => {}
-        Err(err) => eprintln!("error: {}", err),
+        Err(err) => eprintln!("error: {err}"),
     }
 }
 

--- a/gauntlet/src/report.rs
+++ b/gauntlet/src/report.rs
@@ -270,20 +270,20 @@ impl<T: std::io::Write> Report<T> {
                 counts
             });
 
-        write!(self.inner, "Passed {}/{} tests", passed, considered)?;
+        write!(self.inner, "Passed {passed}/{considered} tests")?;
 
         let mut with = Vec::new();
 
         match missing {
             0 => {}
             1 => with.push(String::from("1 missing diagnostic")),
-            v => with.push(format!("{} missing diagnostics", v)),
+            v => with.push(format!("{v} missing diagnostics")),
         }
 
         match unexpected {
             0 => {}
             1 => with.push(String::from("1 unexpected diagnostic")),
-            v => with.push(format!("{} unexpected diagnostics", v)),
+            v => with.push(format!("{v} unexpected diagnostics")),
         }
 
         if !with.is_empty() {

--- a/gauntlet/src/repository.rs
+++ b/gauntlet/src/repository.rs
@@ -54,7 +54,7 @@ impl<'de> Deserialize<'de> for RawHash {
 impl fmt::Display for RawHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in &self.0 {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -89,7 +89,7 @@ impl Repository {
         let git_repo = RepoBuilder::new()
             .fetch_options(fo)
             .clone(
-                format!("https://github.com/{}.git", identifier).as_str(),
+                format!("https://github.com/{identifier}.git").as_str(),
                 &repo_root,
             )
             .expect("failed to clone repository");

--- a/wdl-ast/tests/registry.rs
+++ b/wdl-ast/tests/registry.rs
@@ -225,7 +225,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, Box<[SyntaxKind]>>> = LazyLock::
     // [`HashMap`] to ensure on the fly that no keys are duplicated.
     for (r#type, kinds) in types {
         if result.contains_key(&r#type) {
-            panic!("the `{:?}` key is duplicated", r#type);
+            panic!("the `{type:?}` key is duplicated");
         }
 
         result.insert(r#type, kinds);
@@ -338,7 +338,7 @@ fn ensures_one_to_one() {
     if !missing.is_empty() {
         let mut missing = missing
             .into_iter()
-            .map(|kind| format!("{:?}", kind))
+            .map(|kind| format!("{kind:?}"))
             .collect::<Vec<_>>();
         missing.sort();
 
@@ -357,7 +357,7 @@ fn ensures_one_to_one() {
                 let mut types = types.clone();
                 types.sort();
 
-                let mut result = format!("== {:?} ==", kind);
+                let mut result = format!("== {kind:?} ==");
                 for r#type in types {
                     result.push_str("\n* ");
                     result.push_str(r#type);

--- a/wdl-cli/src/inputs.rs
+++ b/wdl-cli/src/inputs.rs
@@ -282,7 +282,7 @@ impl Inputs {
         let result = EngineInputs::parse_object(document, values)?;
 
         Ok(result.map(|(callee_name, inputs)| {
-            let callee_prefix = format!("{}.", callee_name);
+            let callee_prefix = format!("{callee_name}.");
 
             let origins = origins
                 .into_iter()

--- a/wdl-doc/src/lib.rs
+++ b/wdl-doc/src/lib.rs
@@ -302,7 +302,7 @@ pub async fn document_workspace(
             match item {
                 DocumentItem::Struct(s) => {
                     let name = s.name().text().to_owned();
-                    let path = cur_dir.join(format!("{}-struct.html", name));
+                    let path = cur_dir.join(format!("{name}-struct.html"));
 
                     let r#struct = r#struct::Struct::new(s.clone());
 
@@ -312,7 +312,7 @@ pub async fn document_workspace(
                 }
                 DocumentItem::Task(t) => {
                     let name = t.name().text().to_owned();
-                    let path = cur_dir.join(format!("{}-task.html", name));
+                    let path = cur_dir.join(format!("{name}-task.html"));
 
                     let task = task::Task::new(
                         name.clone(),
@@ -329,7 +329,7 @@ pub async fn document_workspace(
                 }
                 DocumentItem::Workflow(w) => {
                     let name = w.name().text().to_owned();
-                    let path = cur_dir.join(format!("{}-workflow.html", name));
+                    let path = cur_dir.join(format!("{name}-workflow.html"));
 
                     let workflow = workflow::Workflow::new(
                         name.clone(),

--- a/wdl-doc/tests/doc.rs
+++ b/wdl-doc/tests/doc.rs
@@ -52,7 +52,7 @@ async fn main() {
             println!("Successfully generated docs");
         }
         Err(e) => {
-            eprintln!("Failed to generate docs: {}", e);
+            eprintln!("Failed to generate docs: {e}");
             exit(1);
         }
     }

--- a/wdl-engine/src/http.rs
+++ b/wdl-engine/src/http.rs
@@ -429,10 +429,7 @@ impl Downloader for HttpDownloader {
                 match downloads.insert(url.clone().into_owned(), Status::Downloaded(result.clone()))
                 {
                     Some(Status::Downloading(notify)) => notify,
-                    _ => panic!(
-                        "expected to find a downloading status for `{url}`",
-                        url = url
-                    ),
+                    _ => panic!("expected to find a downloading status for `{url}`"),
                 }
             };
 

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -298,8 +298,8 @@ impl fmt::Debug for SyntaxNode {
                             write!(f, "  ")?;
                         }
                         match element {
-                            NodeOrToken::Node(node) => writeln!(f, "{:?}", node)?,
-                            NodeOrToken::Token(token) => writeln!(f, "{:?}", token)?,
+                            NodeOrToken::Node(node) => writeln!(f, "{node:?}")?,
+                            NodeOrToken::Token(token) => writeln!(f, "{token:?}")?,
                         }
                         level += 1;
                     }
@@ -388,7 +388,7 @@ impl fmt::Debug for SyntaxToken {
         for idx in 21..25 {
             if text.is_char_boundary(idx) {
                 let text = format!("{} ...", &text[..idx]);
-                return write!(f, " {:?}", text);
+                return write!(f, " {text:?}");
             }
         }
         unreachable!()

--- a/wdl-format/src/config/indent.rs
+++ b/wdl-format/src/config/indent.rs
@@ -36,8 +36,8 @@ impl Indent {
             (false, Some(n)) => {
                 if n > MAX_SPACE_INDENT {
                     Err(format!(
-                        "Indentation with spaces cannot have more than {} characters",
-                        MAX_SPACE_INDENT
+                        "Indentation with spaces cannot have more than {MAX_SPACE_INDENT} \
+                         characters"
                     ))
                 } else {
                     Ok(Indent::Spaces(n))

--- a/wdl-format/src/config/max_line_length.rs
+++ b/wdl-format/src/config/max_line_length.rs
@@ -21,8 +21,8 @@ impl MaxLineLength {
             MIN_MAX_LINE_LENGTH..=MAX_MAX_LINE_LENGTH => Self(Some(value)),
             _ => {
                 return Err(format!(
-                    "The maximum line length must be between {} and {} or 0",
-                    MIN_MAX_LINE_LENGTH, MAX_MAX_LINE_LENGTH
+                    "The maximum line length must be between {MIN_MAX_LINE_LENGTH} and \
+                     {MAX_MAX_LINE_LENGTH} or 0"
                 ));
             }
         };

--- a/wdl-format/src/lib.rs
+++ b/wdl-format/src/lib.rs
@@ -254,10 +254,10 @@ workflow bar # This is an inline comment on the workflow ident.
         let result = formatter.format(&document);
         match result {
             Ok(s) => {
-                print!("{}", s);
+                print!("{s}");
             }
             Err(err) => {
-                panic!("failed to format document: {}", err);
+                panic!("failed to format document: {err}");
             }
         }
     }

--- a/wdl-format/src/token/pre.rs
+++ b/wdl-format/src/token/pre.rs
@@ -61,10 +61,10 @@ impl std::fmt::Display for PreToken {
             PreToken::IndentStart => write!(f, "<IndentStart>"),
             PreToken::IndentEnd => write!(f, "<IndentEnd>"),
             PreToken::LineSpacingPolicy(policy) => {
-                write!(f, "<LineSpacingPolicy@{:?}>", policy)
+                write!(f, "<LineSpacingPolicy@{policy:?}>")
             }
             PreToken::Literal(value, kind) => {
-                write!(f, "<Literal-{:?}@{}>", kind, value,)
+                write!(f, "<Literal-{kind:?}@{value}>",)
             }
             PreToken::Trivia(trivia) => match trivia {
                 Trivia::BlankLine => {
@@ -72,10 +72,10 @@ impl std::fmt::Display for PreToken {
                 }
                 Trivia::Comment(comment) => match comment {
                     Comment::Preceding(value) => {
-                        write!(f, "<Comment-Preceding@{}>", value,)
+                        write!(f, "<Comment-Preceding@{value}>",)
                     }
                     Comment::Inline(value) => {
-                        write!(f, "<Comment-Inline@{}>", value,)
+                        write!(f, "<Comment-Inline@{value}>",)
                     }
                 },
             },

--- a/wdl-grammar/tests/parsing.rs
+++ b/wdl-grammar/tests/parsing.rs
@@ -133,7 +133,7 @@ fn run_test(test: &Path, ntests: &AtomicUsize) -> Result<(), String> {
         })?
         .replace("\r\n", "\n");
     let (tree, diagnostics) = SyntaxTree::parse(&source);
-    compare_result(&path.with_extension("tree"), &format!("{:#?}", tree), false)?;
+    compare_result(&path.with_extension("tree"), &format!("{tree:#?}"), false)?;
     compare_result(
         &path.with_extension("errors"),
         &format_diagnostics(&diagnostics, &path, &source),

--- a/wdl-lint/src/lib.rs
+++ b/wdl-lint/src/lib.rs
@@ -154,8 +154,8 @@ pub fn rules() -> Vec<Box<dyn Rule>> {
             for related_id in r.related_rules() {
                 if related_id == self_id {
                     panic!(
-                        "Rule `{id}` refers to itself in its related rules. This is not allowed.",
-                        id = self_id
+                        "Rule `{self_id}` refers to itself in its related rules. This is not \
+                         allowed."
                     );
                 }
             }

--- a/wdl-lint/src/rules/concise_input.rs
+++ b/wdl-lint/src/rules/concise_input.rs
@@ -26,7 +26,7 @@ fn redundant_input_assignment(span: Span, name: &str) -> Diagnostic {
     Diagnostic::note("redundant input assignment")
         .with_rule(ID)
         .with_highlight(span)
-        .with_fix(format!("can be shortened to `{}`", name))
+        .with_fix(format!("can be shortened to `{name}`"))
 }
 
 /// Detects a redundant input assignment.

--- a/wdl-lint/src/rules/import_sorted.rs
+++ b/wdl-lint/src/rules/import_sorted.rs
@@ -25,8 +25,7 @@ fn import_not_sorted(span: Span, sorted_imports: String) -> Diagnostic {
         .with_rule(ID)
         .with_label("imports must be sorted", span)
         .with_fix(format!(
-            "sort the imports lexicographically:\n{}",
-            sorted_imports
+            "sort the imports lexicographically:\n{sorted_imports}"
         ))
 }
 /// Creates an improper comment diagnostic.

--- a/wdl-lint/src/rules/input_sorted.rs
+++ b/wdl-lint/src/rules/input_sorted.rs
@@ -26,7 +26,7 @@ fn input_not_sorted(span: Span, sorted_inputs: String) -> Diagnostic {
     Diagnostic::note("input not sorted")
         .with_rule(ID)
         .with_label("input section must be sorted".to_string(), span)
-        .with_fix(format!("sort input statements as: \n{}", sorted_inputs))
+        .with_fix(format!("sort input statements as: \n{sorted_inputs}"))
 }
 
 /// Define an ordering for declarations.

--- a/wdl-lint/src/rules/line_width.rs
+++ b/wdl-lint/src/rules/line_width.rs
@@ -19,7 +19,7 @@ const ID: &str = "LineWidth";
 
 /// Creates a diagnostic for when a line exceeds the maximum width.
 fn line_too_long(span: Span, max_width: usize) -> Diagnostic {
-    Diagnostic::note(format!("line exceeds maximum width of {}", max_width))
+    Diagnostic::note(format!("line exceeds maximum width of {max_width}"))
         .with_rule(ID)
         .with_highlight(span)
         .with_fix("split the line into multiple lines")

--- a/wdl-lint/src/rules/lint_directive_formatted.rs
+++ b/wdl-lint/src/rules/lint_directive_formatted.rs
@@ -39,8 +39,7 @@ fn invalid_lint_directive(name: &str, span: Span) -> Diagnostic {
         .with_rule(ID)
         .with_highlight(span)
         .with_fix(format!(
-            "use any of the recognized lint directives: [{:#?}]",
-            accepted_directives
+            "use any of the recognized lint directives: [{accepted_directives:#?}]"
         ))
 }
 

--- a/wdl-lint/src/rules/output_section.rs
+++ b/wdl-lint/src/rules/output_section.rs
@@ -45,7 +45,6 @@ fn missing_output_section(name: &str, context: Context, span: Span) -> Diagnosti
         .with_label(format!("this {context} is missing an output section"), span)
         .with_fix(format!(
             "add an output section to the {context} to enable call-caching",
-            context = context,
         ))
 }
 

--- a/wdl-lint/src/rules/parameter_meta_matched.rs
+++ b/wdl-lint/src/rules/parameter_meta_matched.rs
@@ -88,8 +88,7 @@ fn mismatched_param_order(parent: &SectionParent, span: Span, expected_order: &s
         span,
     )
     .with_fix(format!(
-        "based on the current `input` order, order the parameter metadata as:\n{}",
-        expected_order
+        "based on the current `input` order, order the parameter metadata as:\n{expected_order}"
     ))
 }
 

--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -826,11 +826,10 @@ task test {{
         Array[File] arr = ["a", "b", "c"]
     }}
     command {{
-        {}
+        {command}
     }}
 }}
-"#,
-            command
+"#
         );
         let (document, _diagnostics) = Document::parse(&source);
         document

--- a/wdl-lint/src/tags.rs
+++ b/wdl-lint/src/tags.rs
@@ -152,6 +152,6 @@ impl std::fmt::Display for TagSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut tags = self.iter().collect::<Vec<_>>();
         tags.sort();
-        write!(f, "{:?}", tags)
+        write!(f, "{tags:?}")
     }
 }


### PR DESCRIPTION
These are basically all [this new lint](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) for format string arguments

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
