### PR TITLE
fix: skip `Expr::NameRef` if already seen as `StringPart::Placeholder`

### DIFF
--- a/wdl-lint/CHANGELOG.md
+++ b/wdl-lint/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Updated shellcheck logic that erroneously flagged placeholders that are quoted ([#541](https://github.com/stjude-rust-labs/wdl/pull/541)).
+
 #### Removed
 
 * Removed the `OutputSection` lint rule ([#532](https://github.com/stjude-rust-labs/wdl/pull/532)).

--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -927,4 +927,11 @@ task test {{
             &parse_placeholder_as_expr(r#"echo ~{sep(" ", quote(arr))}"#)
         ));
     }
+    #[test]
+    fn test_evaluates_to_bash_literal7() {
+        // This contains a quoted placeholder.
+        assert!(!super::evaluates_to_bash_literal(
+            &parse_placeholder_as_expr(r#"echo ~{if 1=1 then "hello '~{foo}' world" else ""}"#)
+        ));
+    }
 }

--- a/wdl-lint/src/rules/shellcheck.rs
+++ b/wdl-lint/src/rules/shellcheck.rs
@@ -393,6 +393,7 @@ fn is_quoted(expr: &Expr) -> bool {
     let mut opened = false;
     let mut name = false;
 
+    let mut placeholders = Vec::new();
     for c in expr.descendants::<Expr>() {
         match c {
             Expr::Literal(LiteralExpr::String(ref s)) => {
@@ -408,7 +409,8 @@ fn is_quoted(expr: &Expr) -> bool {
                                 opened = !opened;
                             });
                         }
-                        StringPart::Placeholder(_placeholder) => {
+                        StringPart::Placeholder(placeholder) => {
+                            placeholders.push(placeholder.expr());
                             if !opened {
                                 return false;
                             }
@@ -418,10 +420,12 @@ fn is_quoted(expr: &Expr) -> bool {
                 }
             }
             Expr::NameRef(_) => {
-                if !opened {
-                    return false;
+                if !placeholders.contains(&c) {
+                    if !opened {
+                        return false;
+                    }
+                    name = true;
                 }
-                name = true;
             }
             _ => {}
         }


### PR DESCRIPTION
The current handling of placeholders is buggy. The tree treats a placeholder as a component of the string, but also as a child expression. The prior logic descends into the string, looking at children, but any additional quotation is not a child node. So we just store the expressions associated with placeholders and then skip those when evaluating child nodes.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.
