### PR TITLE
ci: move `wdl-lint` to match topological order

### DIFF
--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -53,10 +53,10 @@ use toml_edit::DocumentMut;
 const SORTED_CRATES_TO_PUBLISH: &[&str] = &[
     "wdl-grammar",
     "wdl-ast",
-    "wdl-lint",
     "wdl-format",
     "wdl-analysis",
     "wdl-doc",
+    "wdl-lint",
     "wdl-engine",
     "wdl-lsp",
     "wdl-cli",


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

this is inconsequential due to the retry logic in the `ci` bin, but if we want our release time to shorten by 30 seconds, we can merge this 😅 

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [ ] Your commit messages follow the [conventional commit] style.
- [ ] Your PR title follows the [conventional commit] style.

END SECTION -->

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
