### PR TITLE
chore: `cargo clippy --fix`

### DIFF
--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -226,9 +226,10 @@ async fn main() {
 /// Finds crates in a particular directory.
 fn find_crates(dir: &Path, dst: &mut Vec<Rc<RefCell<Crate>>>) {
     if dir.join("Cargo.toml").exists()
-        && let Some(krate) = read_crate(&dir.join("Cargo.toml")) {
-            dst.push(Rc::new(RefCell::new(krate)));
-        }
+        && let Some(krate) = read_crate(&dir.join("Cargo.toml"))
+    {
+        dst.push(Rc::new(RefCell::new(krate)));
+    }
 
     for entry in dir.read_dir().unwrap() {
         let entry = entry.unwrap();
@@ -292,20 +293,20 @@ fn bump_version(krate: &Crate, crates: &[Rc<RefCell<Crate>>], patch: bool) {
         .expect("failed to write new manifest");
 
     if let Some(changelog_path) = &krate.changelog_path
-        && krate.should_bump {
-            let todays_date = chrono::Local::now().format("%m-%d-%Y");
-            let mut changelog =
-                fs::read_to_string(changelog_path).expect("failed to read changelog");
-            changelog = changelog.replace(
-                "## Unreleased",
-                &format!(
-                    "## Unreleased\n\n## {} - {}",
-                    bump(&krate.version, patch),
-                    todays_date
-                ),
-            );
-            fs::write(changelog_path, changelog).expect("failed to write changelog");
-        }
+        && krate.should_bump
+    {
+        let todays_date = chrono::Local::now().format("%m-%d-%Y");
+        let mut changelog = fs::read_to_string(changelog_path).expect("failed to read changelog");
+        changelog = changelog.replace(
+            "## Unreleased",
+            &format!(
+                "## Unreleased\n\n## {} - {}",
+                bump(&krate.version, patch),
+                todays_date
+            ),
+        );
+        fs::write(changelog_path, changelog).expect("failed to write changelog");
+    }
 }
 
 /// Performs a major version bump increment on the semver version `version`.

--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -225,11 +225,10 @@ async fn main() {
 
 /// Finds crates in a particular directory.
 fn find_crates(dir: &Path, dst: &mut Vec<Rc<RefCell<Crate>>>) {
-    if dir.join("Cargo.toml").exists() {
-        if let Some(krate) = read_crate(&dir.join("Cargo.toml")) {
+    if dir.join("Cargo.toml").exists()
+        && let Some(krate) = read_crate(&dir.join("Cargo.toml")) {
             dst.push(Rc::new(RefCell::new(krate)));
         }
-    }
 
     for entry in dir.read_dir().unwrap() {
         let entry = entry.unwrap();
@@ -292,8 +291,8 @@ fn bump_version(krate: &Crate, crates: &[Rc<RefCell<Crate>>], patch: bool) {
     fs::write(&krate.manifest_path, new_manifest.to_string())
         .expect("failed to write new manifest");
 
-    if let Some(changelog_path) = &krate.changelog_path {
-        if krate.should_bump {
+    if let Some(changelog_path) = &krate.changelog_path
+        && krate.should_bump {
             let todays_date = chrono::Local::now().format("%m-%d-%Y");
             let mut changelog =
                 fs::read_to_string(changelog_path).expect("failed to read changelog");
@@ -307,7 +306,6 @@ fn bump_version(krate: &Crate, crates: &[Rc<RefCell<Crate>>], patch: bool) {
             );
             fs::write(changelog_path, changelog).expect("failed to write changelog");
         }
-    }
 }
 
 /// Performs a major version bump increment on the semver version `version`.

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -759,11 +759,10 @@ impl Document {
         }
 
         // Check to see if the position is contained in the workflow
-        if let Some(workflow) = &self.data.workflow {
-            if workflow.scope().span().contains(position) {
+        if let Some(workflow) = &self.data.workflow
+            && workflow.scope().span().contains(position) {
                 return find_scope(&workflow.scopes, position);
             }
-        }
 
         // Search for a task that might contain the position
         let task = match self

--- a/wdl-analysis/src/document.rs
+++ b/wdl-analysis/src/document.rs
@@ -760,9 +760,10 @@ impl Document {
 
         // Check to see if the position is contained in the workflow
         if let Some(workflow) = &self.data.workflow
-            && workflow.scope().span().contains(position) {
-                return find_scope(&workflow.scopes, position);
-            }
+            && workflow.scope().span().contains(position)
+        {
+            return find_scope(&workflow.scopes, position);
+        }
 
         // Search for a task that might contain the position
         let task = match self

--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -542,8 +542,8 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
             return;
         }
         _ => {
-            if let Some(s) = &document.workflow {
-                if s.name == name.text() {
+            if let Some(s) = &document.workflow
+                && s.name == name.text() {
                     document.diagnostics.push(name_conflict(
                         name.text(),
                         Context::Task(name.span()),
@@ -551,7 +551,6 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
                     ));
                     return;
                 }
-            }
         }
     }
 
@@ -602,8 +601,8 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
                 }
 
                 // Check for unused input
-                if let Some(severity) = config.diagnostics_config().unused_input {
-                    if decl.env().is_none() {
+                if let Some(severity) = config.diagnostics_config().unused_input
+                    && decl.env().is_none() {
                         // For any input that isn't an environment variable, check to see if there's
                         // a single implicit dependency edge; if so, it might be unused
                         let mut edges = graph.edges_directed(index, Direction::Outgoing);
@@ -624,7 +623,6 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
                             }
                         }
                     }
-                }
             }
             TaskGraphNode::Decl(decl) => {
                 if !add_decl(
@@ -1637,11 +1635,10 @@ fn type_check_expr(
     }
     // Check to see if we're assigning an empty array literal to a non-empty type; we can statically
     // flag these as errors; otherwise, non-empty array constraints are checked at runtime
-    else if let Type::Compound(CompoundType::Array(ty), _) = expected {
-        if ty.is_non_empty() && expr.is_empty_array_literal() {
+    else if let Type::Compound(CompoundType::Array(ty), _) = expected
+        && ty.is_non_empty() && expr.is_empty_array_literal() {
             document
                 .diagnostics
                 .push(non_empty_array_assignment(expected_span, expr.span()));
         }
-    }
 }

--- a/wdl-analysis/src/document/v1.rs
+++ b/wdl-analysis/src/document/v1.rs
@@ -543,14 +543,15 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
         }
         _ => {
             if let Some(s) = &document.workflow
-                && s.name == name.text() {
-                    document.diagnostics.push(name_conflict(
-                        name.text(),
-                        Context::Task(name.span()),
-                        Context::Workflow(s.name_span),
-                    ));
-                    return;
-                }
+                && s.name == name.text()
+            {
+                document.diagnostics.push(name_conflict(
+                    name.text(),
+                    Context::Task(name.span()),
+                    Context::Workflow(s.name_span),
+                ));
+                return;
+            }
         }
     }
 
@@ -602,27 +603,27 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
 
                 // Check for unused input
                 if let Some(severity) = config.diagnostics_config().unused_input
-                    && decl.env().is_none() {
-                        // For any input that isn't an environment variable, check to see if there's
-                        // a single implicit dependency edge; if so, it might be unused
-                        let mut edges = graph.edges_directed(index, Direction::Outgoing);
+                    && decl.env().is_none()
+                {
+                    // For any input that isn't an environment variable, check to see if there's
+                    // a single implicit dependency edge; if so, it might be unused
+                    let mut edges = graph.edges_directed(index, Direction::Outgoing);
 
-                        if let (Some(true), None) = (edges.next().map(|e| e.weight()), edges.next())
-                        {
-                            let name = decl.name();
+                    if let (Some(true), None) = (edges.next().map(|e| e.weight()), edges.next()) {
+                        let name = decl.name();
 
-                            // Determine if the input is really used based on its name and type
-                            if is_input_used(name.text(), &task.inputs[name.text()].ty) {
-                                continue;
-                            }
+                        // Determine if the input is really used based on its name and type
+                        if is_input_used(name.text(), &task.inputs[name.text()].ty) {
+                            continue;
+                        }
 
-                            if !decl.inner().is_rule_excepted(UNUSED_INPUT_RULE_ID) {
-                                document.diagnostics.push(
-                                    unused_input(name.text(), name.span()).with_severity(severity),
-                                );
-                            }
+                        if !decl.inner().is_rule_excepted(UNUSED_INPUT_RULE_ID) {
+                            document.diagnostics.push(
+                                unused_input(name.text(), name.span()).with_severity(severity),
+                            );
                         }
                     }
+                }
             }
             TaskGraphNode::Decl(decl) => {
                 if !add_decl(
@@ -1636,9 +1637,11 @@ fn type_check_expr(
     // Check to see if we're assigning an empty array literal to a non-empty type; we can statically
     // flag these as errors; otherwise, non-empty array constraints are checked at runtime
     else if let Type::Compound(CompoundType::Array(ty), _) = expected
-        && ty.is_non_empty() && expr.is_empty_array_literal() {
-            document
-                .diagnostics
-                .push(non_empty_array_assignment(expected_span, expr.span()));
-        }
+        && ty.is_non_empty()
+        && expr.is_empty_array_literal()
+    {
+        document
+            .diagnostics
+            .push(non_empty_array_assignment(expected_span, expr.span()));
+    }
 }

--- a/wdl-analysis/src/eval/v1.rs
+++ b/wdl-analysis/src/eval/v1.rs
@@ -822,11 +822,10 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
             match graph[from].clone() {
                 WorkflowGraphNode::Input(decl) => {
                     // Only add edges for default expressions if the input wasn't provided
-                    if !input_present(decl.name().text()) {
-                        if let Some(expr) = decl.expr() {
+                    if !input_present(decl.name().text())
+                        && let Some(expr) = decl.expr() {
                             self.add_expr_edges(from, expr, graph, diagnostics);
                         }
-                    }
                 }
 
                 WorkflowGraphNode::Decl(decl) | WorkflowGraphNode::Output(decl) => {

--- a/wdl-analysis/src/eval/v1.rs
+++ b/wdl-analysis/src/eval/v1.rs
@@ -823,9 +823,10 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
                 WorkflowGraphNode::Input(decl) => {
                     // Only add edges for default expressions if the input wasn't provided
                     if !input_present(decl.name().text())
-                        && let Some(expr) = decl.expr() {
-                            self.add_expr_edges(from, expr, graph, diagnostics);
-                        }
+                        && let Some(expr) = decl.expr()
+                    {
+                        self.add_expr_edges(from, expr, graph, diagnostics);
+                    }
                 }
 
                 WorkflowGraphNode::Decl(decl) | WorkflowGraphNode::Output(decl) => {

--- a/wdl-analysis/src/handlers.rs
+++ b/wdl-analysis/src/handlers.rs
@@ -57,11 +57,10 @@ impl EvaluationContext for TypeEvalContext<'_> {
         name: &str,
         span: Span,
     ) -> std::result::Result<crate::types::Type, wdl_ast::Diagnostic> {
-        if let Some(s) = self.document.struct_by_name(name) {
-            if let Some(ty) = s.ty() {
+        if let Some(s) = self.document.struct_by_name(name)
+            && let Some(ty) = s.ty() {
                 return Ok(ty.clone());
             }
-        }
         Err(diagnostics::unknown_type(name, span))
     }
 

--- a/wdl-analysis/src/handlers.rs
+++ b/wdl-analysis/src/handlers.rs
@@ -58,9 +58,10 @@ impl EvaluationContext for TypeEvalContext<'_> {
         span: Span,
     ) -> std::result::Result<crate::types::Type, wdl_ast::Diagnostic> {
         if let Some(s) = self.document.struct_by_name(name)
-            && let Some(ty) = s.ty() {
-                return Ok(ty.clone());
-            }
+            && let Some(ty) = s.ty()
+        {
+            return Ok(ty.clone());
+        }
         Err(diagnostics::unknown_type(name, span))
     }
 

--- a/wdl-analysis/src/handlers/completions.rs
+++ b/wdl-analysis/src/handlers/completions.rs
@@ -132,11 +132,10 @@ pub fn completion(
         // left of the cursor (ignoring whitespace) is the `version` keyword, we are
         // very likely completing the version number.
         let mut non_trivia = token.clone();
-        if non_trivia.kind().is_trivia() {
-            if let Some(prev) = non_trivia.prev_token() {
+        if non_trivia.kind().is_trivia()
+            && let Some(prev) = non_trivia.prev_token() {
                 non_trivia = prev;
             }
-        }
         if non_trivia.kind() == SyntaxKind::VersionKeyword {
             let _ = add_version_completions(token, &lines, &mut items);
             return Ok(items);
@@ -316,9 +315,9 @@ fn add_member_access_completions(
     };
 
     // Namespace completions
-    if let Some(token) = target_element.as_token() {
-        if token.kind() == SyntaxKind::Ident {
-            if let Some(ns) = document.namespace(token.text()) {
+    if let Some(token) = target_element.as_token()
+        && token.kind() == SyntaxKind::Ident
+            && let Some(ns) = document.namespace(token.text()) {
                 let ns_root = ns.document().root();
                 for task in ns.document().tasks() {
                     items.push(CompletionItem {
@@ -344,8 +343,6 @@ fn add_member_access_completions(
 
                 return Ok(());
             }
-        }
-    }
 
     let Some(target_node) = target_element.as_node() else {
         return Ok(());
@@ -373,13 +370,13 @@ fn add_member_access_completions(
         // Inferred `task.meta.*` and `task.parameter_meta.*` completions.
         // TODO: recurse on `Objects`
         let (expr, member) = access_expr.operands();
-        if let Some(name_ref) = expr.as_name_ref() {
-            if name_ref.name().text() == TASK_VAR_NAME {
+        if let Some(name_ref) = expr.as_name_ref()
+            && name_ref.name().text() == TASK_VAR_NAME {
                 let member_name = member.text();
                 // `task.meta.*` completions.
                 if member_name == TASK_FIELD_META {
-                    if let Some(task_def) = node.ancestors().find_map(TaskDefinition::cast) {
-                        if let Some(meta_section) = task_def.metadata() {
+                    if let Some(task_def) = node.ancestors().find_map(TaskDefinition::cast)
+                        && let Some(meta_section) = task_def.metadata() {
                             for item in meta_section.items() {
                                 items.push(CompletionItem {
                                     label: item.name().text().to_string(),
@@ -390,12 +387,11 @@ fn add_member_access_completions(
                                 });
                             }
                         }
-                    }
                     return Ok(());
                 } else if member_name == TASK_FIELD_PARAMETER_META {
                     // `task.parameter_meta.*` completions.
-                    if let Some(task_def) = node.ancestors().find_map(TaskDefinition::cast) {
-                        if let Some(param_meta_section) = task_def.parameter_metadata() {
+                    if let Some(task_def) = node.ancestors().find_map(TaskDefinition::cast)
+                        && let Some(param_meta_section) = task_def.parameter_metadata() {
                             for item in param_meta_section.items() {
                                 items.push(CompletionItem {
                                     label: item.name().text().to_string(),
@@ -406,11 +402,9 @@ fn add_member_access_completions(
                                 });
                             }
                         }
-                    }
                     return Ok(());
                 }
             }
-        }
     }
 
     // NOTE: we do type evaluation only for non namespaces or complex types
@@ -472,8 +466,7 @@ fn add_member_access_completions(
 
                     if let Some(decl_node) =
                         token_at_decl.and_then(|t| t.parent_ancestors().find_map(BoundDecl::cast))
-                    {
-                        if let Expr::Literal(LiteralExpr::Map(map_literal)) = decl_node.expr() {
+                        && let Expr::Literal(LiteralExpr::Map(map_literal)) = decl_node.expr() {
                             for item in map_literal.items() {
                                 let (key, _) = item.key_value();
                                 if let Expr::Literal(literal_key) = key {
@@ -516,7 +509,6 @@ fn add_member_access_completions(
                                 }
                             }
                         }
-                    }
                 }
             } else if let Expr::Literal(LiteralExpr::Map(map_literal)) = target_expr {
                 for item in map_literal.items() {

--- a/wdl-analysis/src/handlers/find_all_references.rs
+++ b/wdl-analysis/src/handlers/find_all_references.rs
@@ -163,13 +163,13 @@ fn collect_references_from_document(
             .context("failed to resolve token definition")?;
 
             if let Some(location) = resolved_location
-                && location == target.location {
-                    let reference_location =
-                        location_from_span(document.uri(), token.span(), lines)
-                            .context("failed to create reference location")?;
+                && location == target.location
+            {
+                let reference_location = location_from_span(document.uri(), token.span(), lines)
+                    .context("failed to create reference location")?;
 
-                    locations.push(reference_location);
-                }
+                locations.push(reference_location);
+            }
         }
     }
     Ok(())

--- a/wdl-analysis/src/handlers/find_all_references.rs
+++ b/wdl-analysis/src/handlers/find_all_references.rs
@@ -162,15 +162,14 @@ fn collect_references_from_document(
             )
             .context("failed to resolve token definition")?;
 
-            if let Some(location) = resolved_location {
-                if location == target.location {
+            if let Some(location) = resolved_location
+                && location == target.location {
                     let reference_location =
                         location_from_span(document.uri(), token.span(), lines)
                             .context("failed to create reference location")?;
 
                     locations.push(reference_location);
                 }
-            }
         }
     }
     Ok(())

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -97,40 +97,41 @@ pub fn goto_definition(
 
     // Scope based resolution
     if let Some(scope_ref) = analysis_doc.find_scope_by_position(token.span().start())
-        && let Some(name_def) = scope_ref.lookup(ident_text) {
-            if let Type::Call(_) = name_def.ty() {
-                let def_offset = name_def.span().start().try_into()?;
-                let def_token = root
-                    .token_at_offset(def_offset)
-                    .find(|t| t.span() == name_def.span() && t.kind() == SyntaxKind::Ident);
+        && let Some(name_def) = scope_ref.lookup(ident_text)
+    {
+        if let Type::Call(_) = name_def.ty() {
+            let def_offset = name_def.span().start().try_into()?;
+            let def_token = root
+                .token_at_offset(def_offset)
+                .find(|t| t.span() == name_def.span() && t.kind() == SyntaxKind::Ident);
 
-                if let Some(def_token) = def_token
-                    && let Some(call_stmt) = def_token
-                        .parent_ancestors()
-                        .find_map(v1::CallStatement::cast)
-                        && call_stmt.alias().is_none() {
-                            // NOTE: implicit alias found, resolving call target instead of the
-                            // alias
-                            let target = call_stmt.target();
-                            let callee_name =
-                                target.names().last().expect("call target must have a name");
-                            return resolve_call_target(
-                                target.inner(),
-                                callee_name.inner(),
-                                analysis_doc,
-                                &document_uri,
-                                &lines,
-                                graph,
-                            );
-                        }
+            if let Some(def_token) = def_token
+                && let Some(call_stmt) = def_token
+                    .parent_ancestors()
+                    .find_map(v1::CallStatement::cast)
+                && call_stmt.alias().is_none()
+            {
+                // NOTE: implicit alias found, resolving call target instead of the
+                // alias
+                let target = call_stmt.target();
+                let callee_name = target.names().last().expect("call target must have a name");
+                return resolve_call_target(
+                    target.inner(),
+                    callee_name.inner(),
+                    analysis_doc,
+                    &document_uri,
+                    &lines,
+                    graph,
+                );
             }
-
-            return Ok(Some(location_from_span(
-                &document_uri,
-                name_def.span(),
-                &lines,
-            )?));
         }
+
+        return Ok(Some(location_from_span(
+            &document_uri,
+            name_def.span(),
+            &lines,
+        )?));
+    }
 
     // Global resolution
     resolve_global_identifier(analysis_doc, ident_text, &document_uri, &lines, graph)
@@ -509,9 +510,10 @@ fn resolve_access_expression(
             .structs()
             .find(|(_, s)| {
                 if let Some(s_ty) = s.ty()
-                    && let Some(s_struct_ty) = s_ty.as_struct() {
-                        return s_struct_ty.name() == struct_ty.name();
-                    }
+                    && let Some(s_struct_ty) = s_ty.as_struct()
+                {
+                    return s_struct_ty.name() == struct_ty.name();
+                }
                 s.name() == struct_ty.name().as_str()
             })
             .map(|(_, s)| s)
@@ -784,20 +786,23 @@ fn find_target_input_parameter(
     lines: &Arc<LineIndex>,
 ) -> Result<Option<Location>> {
     if let Some(task) = doc.task_by_name(target_name)
-        && task.inputs().contains_key(token.text()) {
-            let scope = task.scope();
-            if let Some(ident) = scope.lookup(token.text()) {
-                return Ok(Some(location_from_span(uri, ident.span(), lines)?));
-            }
+        && task.inputs().contains_key(token.text())
+    {
+        let scope = task.scope();
+        if let Some(ident) = scope.lookup(token.text()) {
+            return Ok(Some(location_from_span(uri, ident.span(), lines)?));
         }
+    }
 
     if let Some(workflow) = doc.workflow()
-        && workflow.name() == target_name && workflow.inputs().contains_key(token.text()) {
-            let scope = workflow.scope();
-            if let Some(ident) = scope.lookup(token.text()) {
-                return Ok(Some(location_from_span(uri, ident.span(), lines)?));
-            }
+        && workflow.name() == target_name
+        && workflow.inputs().contains_key(token.text())
+    {
+        let scope = workflow.scope();
+        if let Some(ident) = scope.lookup(token.text()) {
+            return Ok(Some(location_from_span(uri, ident.span(), lines)?));
         }
+    }
 
     Ok(None)
 }

--- a/wdl-analysis/src/handlers/goto_definition.rs
+++ b/wdl-analysis/src/handlers/goto_definition.rs
@@ -96,20 +96,19 @@ pub fn goto_definition(
     }
 
     // Scope based resolution
-    if let Some(scope_ref) = analysis_doc.find_scope_by_position(token.span().start()) {
-        if let Some(name_def) = scope_ref.lookup(ident_text) {
+    if let Some(scope_ref) = analysis_doc.find_scope_by_position(token.span().start())
+        && let Some(name_def) = scope_ref.lookup(ident_text) {
             if let Type::Call(_) = name_def.ty() {
                 let def_offset = name_def.span().start().try_into()?;
                 let def_token = root
                     .token_at_offset(def_offset)
                     .find(|t| t.span() == name_def.span() && t.kind() == SyntaxKind::Ident);
 
-                if let Some(def_token) = def_token {
-                    if let Some(call_stmt) = def_token
+                if let Some(def_token) = def_token
+                    && let Some(call_stmt) = def_token
                         .parent_ancestors()
                         .find_map(v1::CallStatement::cast)
-                    {
-                        if call_stmt.alias().is_none() {
+                        && call_stmt.alias().is_none() {
                             // NOTE: implicit alias found, resolving call target instead of the
                             // alias
                             let target = call_stmt.target();
@@ -124,8 +123,6 @@ pub fn goto_definition(
                                 graph,
                             );
                         }
-                    }
-                }
             }
 
             return Ok(Some(location_from_span(
@@ -134,7 +131,6 @@ pub fn goto_definition(
                 &lines,
             )?));
         }
-    }
 
     // Global resolution
     resolve_global_identifier(analysis_doc, ident_text, &document_uri, &lines, graph)
@@ -512,11 +508,10 @@ fn resolve_access_expression(
         let struct_def = analysis_doc
             .structs()
             .find(|(_, s)| {
-                if let Some(s_ty) = s.ty() {
-                    if let Some(s_struct_ty) = s_ty.as_struct() {
+                if let Some(s_ty) = s.ty()
+                    && let Some(s_struct_ty) = s_ty.as_struct() {
                         return s_struct_ty.name() == struct_ty.name();
                     }
-                }
                 s.name() == struct_ty.name().as_str()
             })
             .map(|(_, s)| s)
@@ -788,23 +783,21 @@ fn find_target_input_parameter(
     uri: &Url,
     lines: &Arc<LineIndex>,
 ) -> Result<Option<Location>> {
-    if let Some(task) = doc.task_by_name(target_name) {
-        if task.inputs().contains_key(token.text()) {
+    if let Some(task) = doc.task_by_name(target_name)
+        && task.inputs().contains_key(token.text()) {
             let scope = task.scope();
             if let Some(ident) = scope.lookup(token.text()) {
                 return Ok(Some(location_from_span(uri, ident.span(), lines)?));
             }
         }
-    }
 
-    if let Some(workflow) = doc.workflow() {
-        if workflow.name() == target_name && workflow.inputs().contains_key(token.text()) {
+    if let Some(workflow) = doc.workflow()
+        && workflow.name() == target_name && workflow.inputs().contains_key(token.text()) {
             let scope = workflow.scope();
             if let Some(ident) = scope.lookup(token.text()) {
                 return Ok(Some(location_from_span(uri, ident.span(), lines)?));
             }
         }
-    }
 
     Ok(None)
 }

--- a/wdl-analysis/src/handlers/hover.rs
+++ b/wdl-analysis/src/handlers/hover.rs
@@ -113,8 +113,8 @@ fn resolve_hover_content(
     }
 
     // Finds hover information based on the scope.
-    if let Some(scope) = document.find_scope_by_position(token.span().start()) {
-        if let Some(name) = scope.lookup(token.text()) {
+    if let Some(scope) = document.find_scope_by_position(token.span().start())
+        && let Some(name) = scope.lookup(token.text()) {
             let (kind, documentation) = match name.ty() {
                 Type::Call(_) => ("call", None),
                 _ => {
@@ -130,7 +130,6 @@ fn resolve_hover_content(
 
             return Ok(Some(content));
         }
-    }
 
     // Finds hover information across global definitions.
     if let Some(content) = find_global_hover_in_doc(document, token)? {

--- a/wdl-analysis/src/handlers/hover.rs
+++ b/wdl-analysis/src/handlers/hover.rs
@@ -114,22 +114,23 @@ fn resolve_hover_content(
 
     // Finds hover information based on the scope.
     if let Some(scope) = document.find_scope_by_position(token.span().start())
-        && let Some(name) = scope.lookup(token.text()) {
-            let (kind, documentation) = match name.ty() {
-                Type::Call(_) => ("call", None),
-                _ => {
-                    let doc = find_parameter_meta_documentation(token);
-                    ("variable", doc)
-                }
-            };
-            let mut content = format!("```wdl\n({kind}) {}: {}\n```", token.text(), name.ty());
-            if let Some(doc) = documentation {
-                content.push_str("\n---\n");
-                content.push_str(&doc);
+        && let Some(name) = scope.lookup(token.text())
+    {
+        let (kind, documentation) = match name.ty() {
+            Type::Call(_) => ("call", None),
+            _ => {
+                let doc = find_parameter_meta_documentation(token);
+                ("variable", doc)
             }
-
-            return Ok(Some(content));
+        };
+        let mut content = format!("```wdl\n({kind}) {}: {}\n```", token.text(), name.ty());
+        if let Some(doc) = documentation {
+            content.push_str("\n---\n");
+            content.push_str(&doc);
         }
+
+        return Ok(Some(content));
+    }
 
     // Finds hover information across global definitions.
     if let Some(content) = find_global_hover_in_doc(document, token)? {

--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -110,9 +110,10 @@ impl SyntaxNodeExt for SyntaxNode {
     fn is_rule_excepted(&self, id: &str) -> bool {
         for comment in self.except_comments() {
             if let Some(ids) = comment.text().strip_prefix(EXCEPT_COMMENT_PREFIX)
-                && ids.split(',').any(|i| i.trim() == id) {
-                    return true;
-                }
+                && ids.split(',').any(|i| i.trim() == id)
+            {
+                return true;
+            }
         }
 
         false

--- a/wdl-analysis/src/lib.rs
+++ b/wdl-analysis/src/lib.rs
@@ -109,11 +109,10 @@ impl SyntaxNodeExt for SyntaxNode {
 
     fn is_rule_excepted(&self, id: &str) -> bool {
         for comment in self.except_comments() {
-            if let Some(ids) = comment.text().strip_prefix(EXCEPT_COMMENT_PREFIX) {
-                if ids.split(',').any(|i| i.trim() == id) {
+            if let Some(ids) = comment.text().strip_prefix(EXCEPT_COMMENT_PREFIX)
+                && ids.split(',').any(|i| i.trim() == id) {
                     return true;
                 }
-            }
         }
 
         false

--- a/wdl-analysis/src/stdlib.rs
+++ b/wdl-analysis/src/stdlib.rs
@@ -175,12 +175,11 @@ impl GenericType {
                 // Verify the type satisfies any constraint
                 let (param, _) = params.get(name).expect("should have parameter");
 
-                if !ignore_constraints {
-                    if let Some(constraint) = param.constraint() {
-                        if !constraint.satisfied(ty) {
-                            return;
-                        }
-                    }
+                if !ignore_constraints
+                    && let Some(constraint) = param.constraint()
+                    && !constraint.satisfied(ty)
+                {
+                    return;
                 }
 
                 params.set_inferred_type(name, ty.clone());
@@ -1096,10 +1095,10 @@ impl FunctionSignatureBuilder {
 
         // Ensure the number of required parameters doesn't exceed the number of
         // parameters
-        if let Some(required) = sig.required {
-            if required > sig.parameters.len() {
-                panic!("number of required parameters exceeds the number of parameters");
-            }
+        if let Some(required) = sig.required
+            && required > sig.parameters.len()
+        {
+            panic!("number of required parameters exceeds the number of parameters");
         }
 
         assert!(
@@ -5051,7 +5050,7 @@ mod test {
         // Check `Array[String?]+`
         let array: Type = ArrayType::non_empty(Type::from(PrimitiveType::String).optional()).into();
         let binding = f
-            .bind(SupportedVersion::V1(V1::Zero), &[array.clone()])
+            .bind(SupportedVersion::V1(V1::Zero), std::slice::from_ref(&array))
             .expect("binding should succeed");
         assert_eq!(binding.index(), 0);
         assert_eq!(binding.return_type().to_string(), "String");
@@ -5084,7 +5083,7 @@ mod test {
         // Check `Array[String?]`
         let array: Type = ArrayType::new(Type::from(PrimitiveType::String).optional()).into();
         let binding = f
-            .bind(SupportedVersion::V1(V1::Zero), &[array.clone()])
+            .bind(SupportedVersion::V1(V1::Zero), std::slice::from_ref(&array))
             .expect("binding should succeed");
         assert_eq!(binding.index(), 0);
         assert_eq!(binding.return_type().to_string(), "String");

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -303,9 +303,10 @@ impl Type {
 
         // Check for a compound type that might have a common type within it
         if let (Some(this), Some(other)) = (self.as_compound(), other.as_compound())
-            && let Some(ty) = this.common_type(other) {
-                return Some(Self::Compound(ty, self.is_optional()));
-            }
+            && let Some(ty) = this.common_type(other)
+        {
+            return Some(Self::Compound(ty, self.is_optional()));
+        }
 
         None
     }

--- a/wdl-analysis/src/types.rs
+++ b/wdl-analysis/src/types.rs
@@ -302,11 +302,10 @@ impl Type {
         }
 
         // Check for a compound type that might have a common type within it
-        if let (Some(this), Some(other)) = (self.as_compound(), other.as_compound()) {
-            if let Some(ty) = this.common_type(other) {
+        if let (Some(this), Some(other)) = (self.as_compound(), other.as_compound())
+            && let Some(ty) = this.common_type(other) {
                 return Some(Self::Compound(ty, self.is_optional()));
             }
-        }
 
         None
     }

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -797,8 +797,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                 // Ensure the remaining items types share common types
                 for item in items {
                     let (key, value) = item.key_value();
-                    if let Some(actual_key) = self.evaluate_expr(&key) {
-                        if let Some(actual_value) = self.evaluate_expr(&value) {
+                    if let Some(actual_key) = self.evaluate_expr(&key)
+                        && let Some(actual_value) = self.evaluate_expr(&value) {
                             match expected_key.common_type(&actual_key) {
                                 Some(ty) => {
                                     expected_key = ty;
@@ -829,7 +829,6 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                                 }
                             }
                         }
-                    }
                 }
 
                 MapType::new(expected_key, expected_value).into()
@@ -875,8 +874,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                     match ty.members.get_full(n.text()) {
                         Some((index, _, expected)) => {
                             present[index] = true;
-                            if let Some(actual) = self.evaluate_expr(&v) {
-                                if !actual.is_coercible_to(expected) {
+                            if let Some(actual) = self.evaluate_expr(&v)
+                                && !actual.is_coercible_to(expected) {
                                     self.context.add_diagnostic(type_mismatch(
                                         expected,
                                         n.span(),
@@ -884,7 +883,6 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                                         v.span(),
                                     ));
                                 }
-                            }
                         }
                         _ => {
                             // Not a struct member
@@ -950,8 +948,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
         if !self.evaluate_requirement(name, expr, &expr_ty) {
             // Always use object types for `runtime` section `inputs` and `outputs` keys as
             // only `hints` sections can use input/output hidden types
-            if let Some(expected) = task_hint_types(self.context.version(), name.text(), false) {
-                if !expected
+            if let Some(expected) = task_hint_types(self.context.version(), name.text(), false)
+                && !expected
                     .iter()
                     .any(|target| expr_ty.is_coercible_to(target))
                 {
@@ -962,7 +960,6 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                         expr.span(),
                     ));
                 }
-            }
         }
     }
 
@@ -1028,8 +1025,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
         expr: &Expr<N>,
     ) {
         let expr_ty = self.evaluate_expr(expr).unwrap_or(Type::Union);
-        if let Some(expected) = task_hint_types(self.context.version(), name.text(), true) {
-            if !expected
+        if let Some(expected) = task_hint_types(self.context.version(), name.text(), true)
+            && !expected
                 .iter()
                 .any(|target| expr_ty.is_coercible_to(target))
             {
@@ -1040,7 +1037,6 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                     expr.span(),
                 ));
             }
-        }
     }
 
     /// Evaluates the type of a literal input expression.
@@ -1490,8 +1486,7 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                         // above function expect the pattern as 2nd argument
                         if let Some(Expr::Literal(LiteralExpr::String(pattern_literal))) =
                             expr.arguments().nth(1)
-                        {
-                            if let Some(value) = pattern_literal.text() {
+                            && let Some(value) = pattern_literal.text() {
                                 let pattern = value.text().to_string();
                                 if let Err(e) = regex::Regex::new(&pattern) {
                                     self.context.add_diagnostic(invalid_regex_pattern(
@@ -1502,7 +1497,6 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                                     ));
                                 }
                             }
-                        }
                     }
                     _ => {}
                 }
@@ -1513,8 +1507,7 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                         Ok(binding) => {
                             if let Some(severity) =
                                 self.context.diagnostics_config().unnecessary_function_call
-                            {
-                                if !expr.inner().is_rule_excepted(UNNECESSARY_FUNCTION_CALL) {
+                                && !expr.inner().is_rule_excepted(UNNECESSARY_FUNCTION_CALL) {
                                     self.check_unnecessary_call(
                                         &target,
                                         arguments,
@@ -1522,7 +1515,6 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                                         severity,
                                     );
                                 }
-                            }
                             return Some(binding.return_type().clone());
                         }
                         Err(FunctionBindError::RequiresVersion(minimum)) => {

--- a/wdl-analysis/src/types/v1.rs
+++ b/wdl-analysis/src/types/v1.rs
@@ -798,37 +798,38 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                 for item in items {
                     let (key, value) = item.key_value();
                     if let Some(actual_key) = self.evaluate_expr(&key)
-                        && let Some(actual_value) = self.evaluate_expr(&value) {
-                            match expected_key.common_type(&actual_key) {
-                                Some(ty) => {
-                                    expected_key = ty;
-                                    expected_key_span = key.span();
-                                }
-                                _ => {
-                                    self.context.add_diagnostic(no_common_type(
-                                        &expected_key,
-                                        expected_key_span,
-                                        &actual_key,
-                                        key.span(),
-                                    ));
-                                }
+                        && let Some(actual_value) = self.evaluate_expr(&value)
+                    {
+                        match expected_key.common_type(&actual_key) {
+                            Some(ty) => {
+                                expected_key = ty;
+                                expected_key_span = key.span();
                             }
-
-                            match expected_value.common_type(&actual_value) {
-                                Some(ty) => {
-                                    expected_value = ty;
-                                    expected_value_span = value.span();
-                                }
-                                _ => {
-                                    self.context.add_diagnostic(no_common_type(
-                                        &expected_value,
-                                        expected_value_span,
-                                        &actual_value,
-                                        value.span(),
-                                    ));
-                                }
+                            _ => {
+                                self.context.add_diagnostic(no_common_type(
+                                    &expected_key,
+                                    expected_key_span,
+                                    &actual_key,
+                                    key.span(),
+                                ));
                             }
                         }
+
+                        match expected_value.common_type(&actual_value) {
+                            Some(ty) => {
+                                expected_value = ty;
+                                expected_value_span = value.span();
+                            }
+                            _ => {
+                                self.context.add_diagnostic(no_common_type(
+                                    &expected_value,
+                                    expected_value_span,
+                                    &actual_value,
+                                    value.span(),
+                                ));
+                            }
+                        }
+                    }
                 }
 
                 MapType::new(expected_key, expected_value).into()
@@ -875,14 +876,15 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                         Some((index, _, expected)) => {
                             present[index] = true;
                             if let Some(actual) = self.evaluate_expr(&v)
-                                && !actual.is_coercible_to(expected) {
-                                    self.context.add_diagnostic(type_mismatch(
-                                        expected,
-                                        n.span(),
-                                        &actual,
-                                        v.span(),
-                                    ));
-                                }
+                                && !actual.is_coercible_to(expected)
+                            {
+                                self.context.add_diagnostic(type_mismatch(
+                                    expected,
+                                    n.span(),
+                                    &actual,
+                                    v.span(),
+                                ));
+                            }
                         }
                         _ => {
                             // Not a struct member
@@ -952,14 +954,14 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                 && !expected
                     .iter()
                     .any(|target| expr_ty.is_coercible_to(target))
-                {
-                    self.context.add_diagnostic(multiple_type_mismatch(
-                        expected,
-                        name.span(),
-                        &expr_ty,
-                        expr.span(),
-                    ));
-                }
+            {
+                self.context.add_diagnostic(multiple_type_mismatch(
+                    expected,
+                    name.span(),
+                    &expr_ty,
+                    expr.span(),
+                ));
+            }
         }
     }
 
@@ -1029,14 +1031,14 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
             && !expected
                 .iter()
                 .any(|target| expr_ty.is_coercible_to(target))
-            {
-                self.context.add_diagnostic(multiple_type_mismatch(
-                    expected,
-                    name.span(),
-                    &expr_ty,
-                    expr.span(),
-                ));
-            }
+        {
+            self.context.add_diagnostic(multiple_type_mismatch(
+                expected,
+                name.span(),
+                &expr_ty,
+                expr.span(),
+            ));
+        }
     }
 
     /// Evaluates the type of a literal input expression.
@@ -1486,17 +1488,18 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                         // above function expect the pattern as 2nd argument
                         if let Some(Expr::Literal(LiteralExpr::String(pattern_literal))) =
                             expr.arguments().nth(1)
-                            && let Some(value) = pattern_literal.text() {
-                                let pattern = value.text().to_string();
-                                if let Err(e) = regex::Regex::new(&pattern) {
-                                    self.context.add_diagnostic(invalid_regex_pattern(
-                                        target.text(),
-                                        value.text(),
-                                        &e,
-                                        pattern_literal.span(),
-                                    ));
-                                }
+                            && let Some(value) = pattern_literal.text()
+                        {
+                            let pattern = value.text().to_string();
+                            if let Err(e) = regex::Regex::new(&pattern) {
+                                self.context.add_diagnostic(invalid_regex_pattern(
+                                    target.text(),
+                                    value.text(),
+                                    &e,
+                                    pattern_literal.span(),
+                                ));
                             }
+                        }
                     }
                     _ => {}
                 }
@@ -1507,14 +1510,15 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                         Ok(binding) => {
                             if let Some(severity) =
                                 self.context.diagnostics_config().unnecessary_function_call
-                                && !expr.inner().is_rule_excepted(UNNECESSARY_FUNCTION_CALL) {
-                                    self.check_unnecessary_call(
-                                        &target,
-                                        arguments,
-                                        expr.arguments().map(|e| e.span()),
-                                        severity,
-                                    );
-                                }
+                                && !expr.inner().is_rule_excepted(UNNECESSARY_FUNCTION_CALL)
+                            {
+                                self.check_unnecessary_call(
+                                    &target,
+                                    arguments,
+                                    expr.arguments().map(|e| e.span()),
+                                    severity,
+                                );
+                            }
                             return Some(binding.return_type().clone());
                         }
                         Err(FunctionBindError::RequiresVersion(minimum)) => {

--- a/wdl-analysis/src/validation/version.rs
+++ b/wdl-analysis/src/validation/version.rs
@@ -106,14 +106,15 @@ impl Visitor for VersionVisitor {
         }
 
         if let Some(version) = self.version
-            && version < SupportedVersion::V1(V1::Two) {
-                diagnostics.add(requirements_section(
-                    section
-                        .token::<RequirementsKeyword<_>>()
-                        .expect("should have keyword")
-                        .span(),
-                ));
-            }
+            && version < SupportedVersion::V1(V1::Two)
+        {
+            diagnostics.add(requirements_section(
+                section
+                    .token::<RequirementsKeyword<_>>()
+                    .expect("should have keyword")
+                    .span(),
+            ));
+        }
     }
 
     fn task_hints_section(
@@ -127,14 +128,15 @@ impl Visitor for VersionVisitor {
         }
 
         if let Some(version) = self.version
-            && version < SupportedVersion::V1(V1::Two) {
-                diagnostics.add(hints_section(
-                    section
-                        .token::<HintsKeyword<_>>()
-                        .expect("should have keyword")
-                        .span(),
-                ));
-            }
+            && version < SupportedVersion::V1(V1::Two)
+        {
+            diagnostics.add(hints_section(
+                section
+                    .token::<HintsKeyword<_>>()
+                    .expect("should have keyword")
+                    .span(),
+            ));
+        }
     }
 
     fn workflow_hints_section(
@@ -148,14 +150,15 @@ impl Visitor for VersionVisitor {
         }
 
         if let Some(version) = self.version
-            && version < SupportedVersion::V1(V1::Two) {
-                diagnostics.add(hints_section(
-                    section
-                        .token::<HintsKeyword<_>>()
-                        .expect("should have keyword")
-                        .span(),
-                ));
-            }
+            && version < SupportedVersion::V1(V1::Two)
+        {
+            diagnostics.add(hints_section(
+                section
+                    .token::<HintsKeyword<_>>()
+                    .expect("should have keyword")
+                    .span(),
+            ));
+        }
     }
 
     fn expr(&mut self, diagnostics: &mut Diagnostics, reason: VisitReason, expr: &v1::Expr) {
@@ -195,16 +198,17 @@ impl Visitor for VersionVisitor {
 
         if let Some(version) = self.version {
             if let Some(env) = decl.env()
-                && version < SupportedVersion::V1(V1::Two) {
-                    diagnostics.add(env_var_requirement(env.span()));
-                }
+                && version < SupportedVersion::V1(V1::Two)
+            {
+                diagnostics.add(env_var_requirement(env.span()));
+            }
 
             if let v1::Type::Primitive(ty) = decl.ty()
                 && version < SupportedVersion::V1(V1::Two)
-                    && ty.kind() == v1::PrimitiveTypeKind::Directory
-                {
-                    diagnostics.add(directory_type_requirement(ty.span()));
-                }
+                && ty.kind() == v1::PrimitiveTypeKind::Directory
+            {
+                diagnostics.add(directory_type_requirement(ty.span()));
+            }
         }
     }
 
@@ -220,16 +224,17 @@ impl Visitor for VersionVisitor {
 
         if let Some(version) = self.version {
             if let Some(env) = decl.env()
-                && version < SupportedVersion::V1(V1::Two) {
-                    diagnostics.add(env_var_requirement(env.span()));
-                }
+                && version < SupportedVersion::V1(V1::Two)
+            {
+                diagnostics.add(env_var_requirement(env.span()));
+            }
 
             if let v1::Type::Primitive(ty) = decl.ty()
                 && version < SupportedVersion::V1(V1::Two)
-                    && ty.kind() == v1::PrimitiveTypeKind::Directory
-                {
-                    diagnostics.add(directory_type_requirement(ty.span()));
-                }
+                && ty.kind() == v1::PrimitiveTypeKind::Directory
+            {
+                diagnostics.add(directory_type_requirement(ty.span()));
+            }
         }
     }
 
@@ -244,13 +249,15 @@ impl Visitor for VersionVisitor {
         }
 
         if let Some(version) = self.version
-            && version < SupportedVersion::V1(V1::Two) {
-                // Ensure there is a input keyword child token if there are inputs
-                if let Some(input) = stmt.inputs().next()
-                    && stmt.token::<InputKeyword<_>>().is_none() {
-                        diagnostics.add(input_keyword_requirement(input.span()));
-                    }
+            && version < SupportedVersion::V1(V1::Two)
+        {
+            // Ensure there is a input keyword child token if there are inputs
+            if let Some(input) = stmt.inputs().next()
+                && stmt.token::<InputKeyword<_>>().is_none()
+            {
+                diagnostics.add(input_keyword_requirement(input.span()));
             }
+        }
     }
 
     fn struct_definition(
@@ -264,26 +271,27 @@ impl Visitor for VersionVisitor {
         }
 
         if let Some(version) = self.version
-            && version < SupportedVersion::V1(V1::Two) {
-                if let Some(section) = def.metadata().next() {
-                    diagnostics.add(struct_metadata_requirement(
-                        "meta",
-                        section
-                            .token::<MetaKeyword<_>>()
-                            .expect("should have keyword")
-                            .span(),
-                    ));
-                }
-
-                if let Some(section) = def.parameter_metadata().next() {
-                    diagnostics.add(struct_metadata_requirement(
-                        "parameter_meta",
-                        section
-                            .token::<ParameterMetaKeyword<_>>()
-                            .expect("should have keyword")
-                            .span(),
-                    ));
-                }
+            && version < SupportedVersion::V1(V1::Two)
+        {
+            if let Some(section) = def.metadata().next() {
+                diagnostics.add(struct_metadata_requirement(
+                    "meta",
+                    section
+                        .token::<MetaKeyword<_>>()
+                        .expect("should have keyword")
+                        .span(),
+                ));
             }
+
+            if let Some(section) = def.parameter_metadata().next() {
+                diagnostics.add(struct_metadata_requirement(
+                    "parameter_meta",
+                    section
+                        .token::<ParameterMetaKeyword<_>>()
+                        .expect("should have keyword")
+                        .span(),
+                ));
+            }
+        }
     }
 }

--- a/wdl-analysis/src/validation/version.rs
+++ b/wdl-analysis/src/validation/version.rs
@@ -105,8 +105,8 @@ impl Visitor for VersionVisitor {
             return;
         }
 
-        if let Some(version) = self.version {
-            if version < SupportedVersion::V1(V1::Two) {
+        if let Some(version) = self.version
+            && version < SupportedVersion::V1(V1::Two) {
                 diagnostics.add(requirements_section(
                     section
                         .token::<RequirementsKeyword<_>>()
@@ -114,7 +114,6 @@ impl Visitor for VersionVisitor {
                         .span(),
                 ));
             }
-        }
     }
 
     fn task_hints_section(
@@ -127,8 +126,8 @@ impl Visitor for VersionVisitor {
             return;
         }
 
-        if let Some(version) = self.version {
-            if version < SupportedVersion::V1(V1::Two) {
+        if let Some(version) = self.version
+            && version < SupportedVersion::V1(V1::Two) {
                 diagnostics.add(hints_section(
                     section
                         .token::<HintsKeyword<_>>()
@@ -136,7 +135,6 @@ impl Visitor for VersionVisitor {
                         .span(),
                 ));
             }
-        }
     }
 
     fn workflow_hints_section(
@@ -149,8 +147,8 @@ impl Visitor for VersionVisitor {
             return;
         }
 
-        if let Some(version) = self.version {
-            if version < SupportedVersion::V1(V1::Two) {
+        if let Some(version) = self.version
+            && version < SupportedVersion::V1(V1::Two) {
                 diagnostics.add(hints_section(
                     section
                         .token::<HintsKeyword<_>>()
@@ -158,7 +156,6 @@ impl Visitor for VersionVisitor {
                         .span(),
                 ));
             }
-        }
     }
 
     fn expr(&mut self, diagnostics: &mut Diagnostics, reason: VisitReason, expr: &v1::Expr) {
@@ -197,19 +194,17 @@ impl Visitor for VersionVisitor {
         }
 
         if let Some(version) = self.version {
-            if let Some(env) = decl.env() {
-                if version < SupportedVersion::V1(V1::Two) {
+            if let Some(env) = decl.env()
+                && version < SupportedVersion::V1(V1::Two) {
                     diagnostics.add(env_var_requirement(env.span()));
                 }
-            }
 
-            if let v1::Type::Primitive(ty) = decl.ty() {
-                if version < SupportedVersion::V1(V1::Two)
+            if let v1::Type::Primitive(ty) = decl.ty()
+                && version < SupportedVersion::V1(V1::Two)
                     && ty.kind() == v1::PrimitiveTypeKind::Directory
                 {
                     diagnostics.add(directory_type_requirement(ty.span()));
                 }
-            }
         }
     }
 
@@ -224,19 +219,17 @@ impl Visitor for VersionVisitor {
         }
 
         if let Some(version) = self.version {
-            if let Some(env) = decl.env() {
-                if version < SupportedVersion::V1(V1::Two) {
+            if let Some(env) = decl.env()
+                && version < SupportedVersion::V1(V1::Two) {
                     diagnostics.add(env_var_requirement(env.span()));
                 }
-            }
 
-            if let v1::Type::Primitive(ty) = decl.ty() {
-                if version < SupportedVersion::V1(V1::Two)
+            if let v1::Type::Primitive(ty) = decl.ty()
+                && version < SupportedVersion::V1(V1::Two)
                     && ty.kind() == v1::PrimitiveTypeKind::Directory
                 {
                     diagnostics.add(directory_type_requirement(ty.span()));
                 }
-            }
         }
     }
 
@@ -250,16 +243,14 @@ impl Visitor for VersionVisitor {
             return;
         }
 
-        if let Some(version) = self.version {
-            if version < SupportedVersion::V1(V1::Two) {
+        if let Some(version) = self.version
+            && version < SupportedVersion::V1(V1::Two) {
                 // Ensure there is a input keyword child token if there are inputs
-                if let Some(input) = stmt.inputs().next() {
-                    if stmt.token::<InputKeyword<_>>().is_none() {
+                if let Some(input) = stmt.inputs().next()
+                    && stmt.token::<InputKeyword<_>>().is_none() {
                         diagnostics.add(input_keyword_requirement(input.span()));
                     }
-                }
             }
-        }
     }
 
     fn struct_definition(
@@ -272,8 +263,8 @@ impl Visitor for VersionVisitor {
             return;
         }
 
-        if let Some(version) = self.version {
-            if version < SupportedVersion::V1(V1::Two) {
+        if let Some(version) = self.version
+            && version < SupportedVersion::V1(V1::Two) {
                 if let Some(section) = def.metadata().next() {
                     diagnostics.add(struct_metadata_requirement(
                         "meta",
@@ -294,6 +285,5 @@ impl Visitor for VersionVisitor {
                     ));
                 }
             }
-        }
     }
 }

--- a/wdl-ast/src/v1/display.rs
+++ b/wdl-ast/src/v1/display.rs
@@ -84,27 +84,28 @@ pub fn write_input_section<N: TreeNode>(
     param_meta: Option<&ParameterMetadataSection<N>>,
 ) -> fmt::Result {
     if let Some(input) = input
-        && input.declarations().next().is_some() {
-            writeln!(f, "\n**Inputs**")?;
-            for decl in input.declarations() {
-                let name = decl.name();
-                let default = decl.expr().map(|e| e.text().to_string());
+        && input.declarations().next().is_some()
+    {
+        writeln!(f, "\n**Inputs**")?;
+        for decl in input.declarations() {
+            let name = decl.name();
+            let default = decl.expr().map(|e| e.text().to_string());
 
-                write!(f, "- **{}**: `{}`", name.text(), decl.ty().inner().text())?;
-                if let Some(val) = default {
-                    // default values
-                    write!(f, " = *`{}`*", val.trim_start_matches(" = "))?;
-                }
+            write!(f, "- **{}**: `{}`", name.text(), decl.ty().inner().text())?;
+            if let Some(val) = default {
+                // default values
+                write!(f, " = *`{}`*", val.trim_start_matches(" = "))?;
+            }
 
-                if let Some(meta_val) = get_param_meta(name.text(), param_meta) {
-                    writeln!(f)?;
-                    format_meta_value(f, &meta_val, 2)?;
-                    writeln!(f)?;
-                } else {
-                    writeln!(f)?;
-                }
+            if let Some(meta_val) = get_param_meta(name.text(), param_meta) {
+                writeln!(f)?;
+                format_meta_value(f, &meta_val, 2)?;
+                writeln!(f)?;
+            } else {
+                writeln!(f)?;
             }
         }
+    }
     Ok(())
 }
 
@@ -115,19 +116,20 @@ pub fn write_output_section<N: TreeNode>(
     param_meta: Option<&ParameterMetadataSection<N>>,
 ) -> fmt::Result {
     if let Some(output) = output
-        && output.declarations().next().is_some() {
-            writeln!(f, "\n**Outputs**")?;
-            for decl in output.declarations() {
-                let name = decl.name();
-                write!(f, "- **{}**: `{}`", name.text(), decl.ty().inner().text())?;
-                if let Some(meta_val) = get_param_meta(name.text(), param_meta) {
-                    writeln!(f)?;
-                    format_meta_value(f, &meta_val, 2)?;
-                    writeln!(f)?;
-                } else {
-                    writeln!(f)?;
-                }
+        && output.declarations().next().is_some()
+    {
+        writeln!(f, "\n**Outputs**")?;
+        for decl in output.declarations() {
+            let name = decl.name();
+            write!(f, "- **{}**: `{}`", name.text(), decl.ty().inner().text())?;
+            if let Some(meta_val) = get_param_meta(name.text(), param_meta) {
+                writeln!(f)?;
+                format_meta_value(f, &meta_val, 2)?;
+                writeln!(f)?;
+            } else {
+                writeln!(f)?;
             }
         }
+    }
     Ok(())
 }

--- a/wdl-ast/src/v1/display.rs
+++ b/wdl-ast/src/v1/display.rs
@@ -83,8 +83,8 @@ pub fn write_input_section<N: TreeNode>(
     input: Option<&InputSection<N>>,
     param_meta: Option<&ParameterMetadataSection<N>>,
 ) -> fmt::Result {
-    if let Some(input) = input {
-        if input.declarations().next().is_some() {
+    if let Some(input) = input
+        && input.declarations().next().is_some() {
             writeln!(f, "\n**Inputs**")?;
             for decl in input.declarations() {
                 let name = decl.name();
@@ -105,7 +105,6 @@ pub fn write_input_section<N: TreeNode>(
                 }
             }
         }
-    }
     Ok(())
 }
 
@@ -115,8 +114,8 @@ pub fn write_output_section<N: TreeNode>(
     output: Option<&OutputSection<N>>,
     param_meta: Option<&ParameterMetadataSection<N>>,
 ) -> fmt::Result {
-    if let Some(output) = output {
-        if output.declarations().next().is_some() {
+    if let Some(output) = output
+        && output.declarations().next().is_some() {
             writeln!(f, "\n**Outputs**")?;
             for decl in output.declarations() {
                 let name = decl.name();
@@ -130,6 +129,5 @@ pub fn write_output_section<N: TreeNode>(
                 }
             }
         }
-    }
     Ok(())
 }

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -1974,11 +1974,10 @@ impl<N: TreeNode> LiteralString<N> {
     /// span of text.
     pub fn text(&self) -> Option<StringText<N::Token>> {
         let mut parts = self.parts();
-        if let Some(StringPart::Text(text)) = parts.next() {
-            if parts.next().is_none() {
+        if let Some(StringPart::Text(text)) = parts.next()
+            && parts.next().is_none() {
                 return Some(text);
             }
-        }
 
         None
     }

--- a/wdl-ast/src/v1/expr.rs
+++ b/wdl-ast/src/v1/expr.rs
@@ -1975,9 +1975,10 @@ impl<N: TreeNode> LiteralString<N> {
     pub fn text(&self) -> Option<StringText<N::Token>> {
         let mut parts = self.parts();
         if let Some(StringPart::Text(text)) = parts.next()
-            && parts.next().is_none() {
-                return Some(text);
-            }
+            && parts.next().is_none()
+        {
+            return Some(text);
+        }
 
         None
     }

--- a/wdl-ast/src/v1/struct.rs
+++ b/wdl-ast/src/v1/struct.rs
@@ -66,15 +66,12 @@ impl<N: TreeNode> StructDefinition<N> {
         }
         writeln!(f, "}}\n```\n---")?;
 
-        if let Some(meta) = self.metadata().next() {
-            if let Some(desc) = meta.items().find(|i| i.name().text() == "description") {
-                if let MetadataValue::String(s) = desc.value() {
-                    if let Some(text) = s.text() {
+        if let Some(meta) = self.metadata().next()
+            && let Some(desc) = meta.items().find(|i| i.name().text() == "description")
+                && let MetadataValue::String(s) = desc.value()
+                    && let Some(text) = s.text() {
                         writeln!(f, "{}\n", text.text())?;
                     }
-                }
-            }
-        }
 
         let members: Vec<_> = self.members().collect();
         if !members.is_empty() {

--- a/wdl-ast/src/v1/struct.rs
+++ b/wdl-ast/src/v1/struct.rs
@@ -68,10 +68,11 @@ impl<N: TreeNode> StructDefinition<N> {
 
         if let Some(meta) = self.metadata().next()
             && let Some(desc) = meta.items().find(|i| i.name().text() == "description")
-                && let MetadataValue::String(s) = desc.value()
-                    && let Some(text) = s.text() {
-                        writeln!(f, "{}\n", text.text())?;
-                    }
+            && let MetadataValue::String(s) = desc.value()
+            && let Some(text) = s.text()
+        {
+            writeln!(f, "{}\n", text.text())?;
+        }
 
         let members: Vec<_> = self.members().collect();
         if !members.is_empty() {

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -388,15 +388,12 @@ impl<N: TreeNode> TaskDefinition<N> {
     pub fn markdown_description(&self, f: &mut impl fmt::Write) -> fmt::Result {
         writeln!(f, "```wdl\ntask {}\n```\n---", self.name().text())?;
 
-        if let Some(meta) = self.metadata() {
-            if let Some(desc) = meta.items().find(|i| i.name().text() == "description") {
-                if let MetadataValue::String(s) = desc.value() {
-                    if let Some(text) = s.text() {
+        if let Some(meta) = self.metadata()
+            && let Some(desc) = meta.items().find(|i| i.name().text() == "description")
+                && let MetadataValue::String(s) = desc.value()
+                    && let Some(text) = s.text() {
                         writeln!(f, "{}\n", text.text())?;
                     }
-                }
-            }
-        }
 
         write_input_section(f, self.input().as_ref(), self.parameter_metadata().as_ref())?;
         write_output_section(
@@ -1027,11 +1024,10 @@ impl<N: TreeNode> CommandSection<N> {
     /// cannot be represented as a single span of text.
     pub fn text(&self) -> Option<CommandText<N::Token>> {
         let mut parts = self.parts();
-        if let Some(CommandPart::Text(text)) = parts.next() {
-            if parts.next().is_none() {
+        if let Some(CommandPart::Text(text)) = parts.next()
+            && parts.next().is_none() {
                 return Some(text);
             }
-        }
 
         None
     }

--- a/wdl-ast/src/v1/task.rs
+++ b/wdl-ast/src/v1/task.rs
@@ -390,10 +390,11 @@ impl<N: TreeNode> TaskDefinition<N> {
 
         if let Some(meta) = self.metadata()
             && let Some(desc) = meta.items().find(|i| i.name().text() == "description")
-                && let MetadataValue::String(s) = desc.value()
-                    && let Some(text) = s.text() {
-                        writeln!(f, "{}\n", text.text())?;
-                    }
+            && let MetadataValue::String(s) = desc.value()
+            && let Some(text) = s.text()
+        {
+            writeln!(f, "{}\n", text.text())?;
+        }
 
         write_input_section(f, self.input().as_ref(), self.parameter_metadata().as_ref())?;
         write_output_section(
@@ -1025,9 +1026,10 @@ impl<N: TreeNode> CommandSection<N> {
     pub fn text(&self) -> Option<CommandText<N::Token>> {
         let mut parts = self.parts();
         if let Some(CommandPart::Text(text)) = parts.next()
-            && parts.next().is_none() {
-                return Some(text);
-            }
+            && parts.next().is_none()
+        {
+            return Some(text);
+        }
 
         None
     }

--- a/wdl-ast/src/v1/workflow.rs
+++ b/wdl-ast/src/v1/workflow.rs
@@ -146,15 +146,12 @@ impl<N: TreeNode> WorkflowDefinition<N> {
     pub fn markdown_description(&self, f: &mut impl fmt::Write) -> fmt::Result {
         writeln!(f, "```wdl\nworkflow {}\n```\n---", self.name().text())?;
 
-        if let Some(meta) = self.metadata() {
-            if let Some(desc) = meta.items().find(|i| i.name().text() == "description") {
-                if let MetadataValue::String(s) = desc.value() {
-                    if let Some(text) = s.text() {
+        if let Some(meta) = self.metadata()
+            && let Some(desc) = meta.items().find(|i| i.name().text() == "description")
+                && let MetadataValue::String(s) = desc.value()
+                    && let Some(text) = s.text() {
                         writeln!(f, "# {}\n", text.text())?;
                     }
-                }
-            }
-        }
 
         write_input_section(f, self.input().as_ref(), self.parameter_metadata().as_ref())?;
         write_output_section(

--- a/wdl-ast/src/v1/workflow.rs
+++ b/wdl-ast/src/v1/workflow.rs
@@ -148,10 +148,11 @@ impl<N: TreeNode> WorkflowDefinition<N> {
 
         if let Some(meta) = self.metadata()
             && let Some(desc) = meta.items().find(|i| i.name().text() == "description")
-                && let MetadataValue::String(s) = desc.value()
-                    && let Some(text) = s.text() {
-                        writeln!(f, "# {}\n", text.text())?;
-                    }
+            && let MetadataValue::String(s) = desc.value()
+            && let Some(text) = s.text()
+        {
+            writeln!(f, "# {}\n", text.text())?;
+        }
 
         write_input_section(f, self.input().as_ref(), self.parameter_metadata().as_ref())?;
         write_output_section(

--- a/wdl-cli/src/analysis/source.rs
+++ b/wdl-cli/src/analysis/source.rs
@@ -75,11 +75,10 @@ impl std::str::FromStr for Source {
 
         if path.is_dir() {
             return Ok(Source::Directory(path));
-        } else if path.is_file() {
-            if let Ok(url) = Url::from_file_path(&path) {
+        } else if path.is_file()
+            && let Ok(url) = Url::from_file_path(&path) {
                 return Ok(Source::File(url));
             }
-        }
 
         bail!("failed to convert `{s}` to a URI")
     }

--- a/wdl-cli/src/analysis/source.rs
+++ b/wdl-cli/src/analysis/source.rs
@@ -76,9 +76,10 @@ impl std::str::FromStr for Source {
         if path.is_dir() {
             return Ok(Source::Directory(path));
         } else if path.is_file()
-            && let Ok(url) = Url::from_file_path(&path) {
-                return Ok(Source::File(url));
-            }
+            && let Ok(url) = Url::from_file_path(&path)
+        {
+            return Ok(Source::File(url));
+        }
 
         bail!("failed to convert `{s}` to a URI")
     }

--- a/wdl-doc/src/docs_tree.rs
+++ b/wdl-doc/src/docs_tree.rs
@@ -478,10 +478,11 @@ impl DocsTree {
                     .expect("node should exist");
             }
             if let Some(next_component) = components.peek()
-                && next_component.as_os_str().to_string_lossy() == "index.html" {
-                    current_node.path = current_node.path().join("index.html");
-                    break;
-                }
+                && next_component.as_os_str().to_string_lossy() == "index.html"
+            {
+                current_node.path = current_node.path().join("index.html");
+                break;
+            }
         }
 
         current_node.page = Some(page);
@@ -532,23 +533,24 @@ impl DocsTree {
 
         for node in self.root().depth_first_traversal() {
             if let Some(page) = node.page()
-                && let PageType::Workflow(workflow) = page.page_type() {
-                    if node
-                        .path()
-                        .iter()
-                        .next()
-                        .expect("path should have a next component")
-                        .to_string_lossy()
-                        == "external"
-                    {
-                        categories.insert("External".to_string());
-                    } else if let Some(category) = workflow.category() {
-                        categories.insert(category);
-                    } else {
-                        categories.insert("Other".to_string());
-                    }
-                    nodes.push(node);
+                && let PageType::Workflow(workflow) = page.page_type()
+            {
+                if node
+                    .path()
+                    .iter()
+                    .next()
+                    .expect("path should have a next component")
+                    .to_string_lossy()
+                    == "external"
+                {
+                    categories.insert("External".to_string());
+                } else if let Some(category) = workflow.category() {
+                    categories.insert(category);
+                } else {
+                    categories.insert("Other".to_string());
                 }
+                nodes.push(node);
+            }
         }
         let sorted_categories = sort_workflow_categories(categories);
 

--- a/wdl-doc/src/docs_tree.rs
+++ b/wdl-doc/src/docs_tree.rs
@@ -477,12 +477,11 @@ impl DocsTree {
                     .get_mut(cur_name.as_ref())
                     .expect("node should exist");
             }
-            if let Some(next_component) = components.peek() {
-                if next_component.as_os_str().to_string_lossy() == "index.html" {
+            if let Some(next_component) = components.peek()
+                && next_component.as_os_str().to_string_lossy() == "index.html" {
                     current_node.path = current_node.path().join("index.html");
                     break;
                 }
-            }
         }
 
         current_node.page = Some(page);
@@ -532,8 +531,8 @@ impl DocsTree {
         let mut nodes = Vec::new();
 
         for node in self.root().depth_first_traversal() {
-            if let Some(page) = node.page() {
-                if let PageType::Workflow(workflow) = page.page_type() {
+            if let Some(page) = node.page()
+                && let PageType::Workflow(workflow) = page.page_type() {
                     if node
                         .path()
                         .iter()
@@ -550,7 +549,6 @@ impl DocsTree {
                     }
                     nodes.push(node);
                 }
-            }
         }
         let sorted_categories = sort_workflow_categories(categories);
 

--- a/wdl-doc/src/runnable.rs
+++ b/wdl-doc/src/runnable.rs
@@ -74,9 +74,10 @@ pub(crate) trait Runnable {
     fn inputs_in_group<'a>(&'a self, group: &'a Group) -> impl Iterator<Item = &'a Parameter> {
         self.inputs().iter().filter(move |param| {
             if let Some(param_group) = param.group()
-                && param_group == *group {
-                    return true;
-                }
+                && param_group == *group
+            {
+                return true;
+            }
             false
         })
     }

--- a/wdl-doc/src/runnable.rs
+++ b/wdl-doc/src/runnable.rs
@@ -73,11 +73,10 @@ pub(crate) trait Runnable {
     /// Get the inputs of the runnable that are part of `group`.
     fn inputs_in_group<'a>(&'a self, group: &'a Group) -> impl Iterator<Item = &'a Parameter> {
         self.inputs().iter().filter(move |param| {
-            if let Some(param_group) = param.group() {
-                if param_group == *group {
+            if let Some(param_group) = param.group()
+                && param_group == *group {
                     return true;
                 }
-            }
             false
         })
     }

--- a/wdl-doc/src/runnable/workflow.rs
+++ b/wdl-doc/src/runnable/workflow.rs
@@ -138,15 +138,16 @@ impl Workflow {
             .meta
             .get("allowNestedInputs")
             .or(self.meta.get("allow_nested_inputs"))
-            && b.value() {
-                return html! {
-                    div class="main__badge main__badge--success" {
-                        span class="main__badge-text" {
-                            "Nested Inputs Allowed"
-                        }
+            && b.value()
+        {
+            return html! {
+                div class="main__badge main__badge--success" {
+                    span class="main__badge-text" {
+                        "Nested Inputs Allowed"
                     }
-                };
-            }
+                }
+            };
+        }
         html! {
             div class="main__badge main__badge--disabled" {
                 span class="main__badge-text" {

--- a/wdl-doc/src/runnable/workflow.rs
+++ b/wdl-doc/src/runnable/workflow.rs
@@ -138,8 +138,7 @@ impl Workflow {
             .meta
             .get("allowNestedInputs")
             .or(self.meta.get("allow_nested_inputs"))
-        {
-            if b.value() {
+            && b.value() {
                 return html! {
                     div class="main__badge main__badge--success" {
                         span class="main__badge-text" {
@@ -148,7 +147,6 @@ impl Workflow {
                     }
                 };
             }
-        }
         html! {
             div class="main__badge main__badge--disabled" {
                 span class="main__badge-text" {

--- a/wdl-engine/src/backend/tes.rs
+++ b/wdl-engine/src/backend/tes.rs
@@ -138,12 +138,13 @@ impl TesTaskRequest {
         }
 
         if let Some(mount_point) = disks.keys().next()
-            && *mount_point != "/" {
-                bail!(
-                    "TES backend does not support a disk mount point other than `/` for the \
-                     `{TASK_REQUIREMENT_DISKS}` task requirement"
-                );
-            }
+            && *mount_point != "/"
+        {
+            bail!(
+                "TES backend does not support a disk mount point other than `/` for the \
+                 `{TASK_REQUIREMENT_DISKS}` task requirement"
+            );
+        }
 
         Ok(disks
             .values()
@@ -205,13 +206,14 @@ impl TaskManagerRequest for TesTaskRequest {
             if input.kind() == InputKind::Directory {
                 if let EvaluationPath::Local(path) = input.path()
                     && let Ok(mut entries) = path.read_dir()
-                        && entries.next().is_some() {
-                            bail!(
-                                "cannot upload contents of directory `{path}`: operation is not \
-                                 yet supported",
-                                path = path.display()
-                            );
-                        }
+                    && entries.next().is_some()
+                {
+                    bail!(
+                        "cannot upload contents of directory `{path}`: operation is not yet \
+                         supported",
+                        path = path.display()
+                    );
+                }
                 continue;
             }
 

--- a/wdl-engine/src/backend/tes.rs
+++ b/wdl-engine/src/backend/tes.rs
@@ -137,14 +137,13 @@ impl TesTaskRequest {
             );
         }
 
-        if let Some(mount_point) = disks.keys().next() {
-            if *mount_point != "/" {
+        if let Some(mount_point) = disks.keys().next()
+            && *mount_point != "/" {
                 bail!(
                     "TES backend does not support a disk mount point other than `/` for the \
                      `{TASK_REQUIREMENT_DISKS}` task requirement"
                 );
             }
-        }
 
         Ok(disks
             .values()
@@ -204,17 +203,15 @@ impl TaskManagerRequest for TesTaskRequest {
             // TODO: in the future, we should be uploading the entire contents to cloud
             // storage
             if input.kind() == InputKind::Directory {
-                if let EvaluationPath::Local(path) = input.path() {
-                    if let Ok(mut entries) = path.read_dir() {
-                        if entries.next().is_some() {
+                if let EvaluationPath::Local(path) = input.path()
+                    && let Ok(mut entries) = path.read_dir()
+                        && entries.next().is_some() {
                             bail!(
                                 "cannot upload contents of directory `{path}`: operation is not \
                                  yet supported",
                                 path = path.display()
                             );
                         }
-                    }
-                }
                 continue;
             }
 

--- a/wdl-engine/src/config.rs
+++ b/wdl-engine/src/config.rs
@@ -162,11 +162,10 @@ pub struct HttpConfig {
 impl HttpConfig {
     /// Validates the HTTP configuration.
     pub fn validate(&self) -> Result<()> {
-        if let Some(limit) = self.max_concurrent_downloads {
-            if limit == 0 {
+        if let Some(limit) = self.max_concurrent_downloads
+            && limit == 0 {
                 bail!("configuration value `http.max_concurrent_downloads` cannot be zero");
             }
-        }
         Ok(())
     }
 }
@@ -346,11 +345,10 @@ pub struct ScatterConfig {
 impl ScatterConfig {
     /// Validates the scatter configuration.
     pub fn validate(&self) -> Result<()> {
-        if let Some(concurrency) = self.concurrency {
-            if concurrency == 0 {
+        if let Some(concurrency) = self.concurrency
+            && concurrency == 0 {
                 bail!("configuration value `workflow.scatter.concurrency` cannot be zero");
             }
-        }
 
         Ok(())
     }

--- a/wdl-engine/src/config.rs
+++ b/wdl-engine/src/config.rs
@@ -163,9 +163,10 @@ impl HttpConfig {
     /// Validates the HTTP configuration.
     pub fn validate(&self) -> Result<()> {
         if let Some(limit) = self.max_concurrent_downloads
-            && limit == 0 {
-                bail!("configuration value `http.max_concurrent_downloads` cannot be zero");
-            }
+            && limit == 0
+        {
+            bail!("configuration value `http.max_concurrent_downloads` cannot be zero");
+        }
         Ok(())
     }
 }
@@ -346,9 +347,10 @@ impl ScatterConfig {
     /// Validates the scatter configuration.
     pub fn validate(&self) -> Result<()> {
         if let Some(concurrency) = self.concurrency
-            && concurrency == 0 {
-                bail!("configuration value `workflow.scatter.concurrency` cannot be zero");
-            }
+            && concurrency == 0
+        {
+            bail!("configuration value `workflow.scatter.concurrency` cannot be zero");
+        }
 
         Ok(())
     }

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -192,14 +192,13 @@ impl TaskInputs {
         // Check the types of the specified hints
         for (name, value) in &self.hints {
             let ty = value.ty();
-            if let Some(expected) = task_hint_types(version, name.as_str(), false) {
-                if !expected.iter().any(|target| ty.is_coercible_to(target)) {
+            if let Some(expected) = task_hint_types(version, name.as_str(), false)
+                && !expected.iter().any(|target| ty.is_coercible_to(target)) {
                     bail!(
                         "expected {expected} for hint `{name}`, but found type `{ty}`",
                         expected = display_types(expected),
                     );
                 }
-            }
         }
 
         Ok(())

--- a/wdl-engine/src/inputs.rs
+++ b/wdl-engine/src/inputs.rs
@@ -193,12 +193,13 @@ impl TaskInputs {
         for (name, value) in &self.hints {
             let ty = value.ty();
             if let Some(expected) = task_hint_types(version, name.as_str(), false)
-                && !expected.iter().any(|target| ty.is_coercible_to(target)) {
-                    bail!(
-                        "expected {expected} for hint `{name}`, but found type `{ty}`",
-                        expected = display_types(expected),
-                    );
-                }
+                && !expected.iter().any(|target| ty.is_coercible_to(target))
+            {
+                bail!(
+                    "expected {expected} for hint `{name}`, but found type `{ty}`",
+                    expected = display_types(expected),
+                );
+            }
         }
 
         Ok(())

--- a/wdl-engine/src/stdlib/write_tsv.rs
+++ b/wdl-engine/src/stdlib/write_tsv.rs
@@ -115,8 +115,8 @@ async fn write_array_tsv_file(
     // Write the rows
     for (index, row) in rows.as_slice().iter().enumerate() {
         let row = row.as_array().unwrap();
-        if let Some(column_count) = column_count {
-            if row.len() != column_count {
+        if let Some(column_count) = column_count
+            && row.len() != column_count {
                 return Err(function_call_failed(
                     FUNCTION_NAME,
                     format!(
@@ -128,7 +128,6 @@ async fn write_array_tsv_file(
                     call_site,
                 ));
             }
-        }
 
         for (i, column) in row.as_slice().iter().enumerate() {
             let column = column.as_string().unwrap();

--- a/wdl-engine/src/stdlib/write_tsv.rs
+++ b/wdl-engine/src/stdlib/write_tsv.rs
@@ -116,18 +116,19 @@ async fn write_array_tsv_file(
     for (index, row) in rows.as_slice().iter().enumerate() {
         let row = row.as_array().unwrap();
         if let Some(column_count) = column_count
-            && row.len() != column_count {
-                return Err(function_call_failed(
-                    FUNCTION_NAME,
-                    format!(
-                        "expected {column_count} column{s1} for every row but array at index \
-                         {index} has length {len}",
-                        s1 = if column_count == 1 { "s" } else { "" },
-                        len = row.len(),
-                    ),
-                    call_site,
-                ));
-            }
+            && row.len() != column_count
+        {
+            return Err(function_call_failed(
+                FUNCTION_NAME,
+                format!(
+                    "expected {column_count} column{s1} for every row but array at index {index} \
+                     has length {len}",
+                    s1 = if column_count == 1 { "s" } else { "" },
+                    len = row.len(),
+                ),
+                call_site,
+            ));
+        }
 
         for (i, column) in row.as_slice().iter().enumerate() {
             let column = column.as_string().unwrap();

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -141,11 +141,10 @@ impl SyntaxNode {
         let mut children = parent.children_with_tokens();
 
         while let Some(child) = children.next() {
-            if let Some(node) = child.as_node() {
-                if node.eq(self) {
+            if let Some(node) = child.as_node()
+                && node.eq(self) {
                     return children.next();
                 }
-            }
         }
 
         None
@@ -343,11 +342,10 @@ impl SyntaxToken {
         let mut children = parent.children_with_tokens();
 
         while let Some(child) = children.next() {
-            if let Some(token) = child.as_token() {
-                if token.eq(self) {
+            if let Some(token) = child.as_token()
+                && token.eq(self) {
                     return children.next();
                 }
-            }
         }
 
         None

--- a/wdl-engine/src/tree.rs
+++ b/wdl-engine/src/tree.rs
@@ -142,9 +142,10 @@ impl SyntaxNode {
 
         while let Some(child) = children.next() {
             if let Some(node) = child.as_node()
-                && node.eq(self) {
-                    return children.next();
-                }
+                && node.eq(self)
+            {
+                return children.next();
+            }
         }
 
         None
@@ -343,9 +344,10 @@ impl SyntaxToken {
 
         while let Some(child) = children.next() {
             if let Some(token) = child.as_token()
-                && token.eq(self) {
-                    return children.next();
-                }
+                && token.eq(self)
+            {
+                return children.next();
+            }
         }
 
         None

--- a/wdl-engine/src/value.rs
+++ b/wdl-engine/src/value.rs
@@ -2300,9 +2300,10 @@ impl CompoundValue {
                             .drain(..)
                             .map(|(mut k, mut v)| {
                                 if let Some(v) = &mut k
-                                    && !v.visit_paths_mut(key_optional, cb)? {
-                                        k = None;
-                                    }
+                                    && !v.visit_paths_mut(key_optional, cb)?
+                                {
+                                    k = None;
+                                }
 
                                 v.visit_paths_mut(value_optional, cb)?;
                                 Ok((k, v))

--- a/wdl-engine/src/value.rs
+++ b/wdl-engine/src/value.rs
@@ -2299,11 +2299,10 @@ impl CompoundValue {
                         let new = elements
                             .drain(..)
                             .map(|(mut k, mut v)| {
-                                if let Some(v) = &mut k {
-                                    if !v.visit_paths_mut(key_optional, cb)? {
+                                if let Some(v) = &mut k
+                                    && !v.visit_paths_mut(key_optional, cb)? {
                                         k = None;
                                     }
-                                }
 
                                 v.visit_paths_mut(value_optional, cb)?;
                                 Ok((k, v))

--- a/wdl-format/src/token/post.rs
+++ b/wdl-format/src/token/post.rs
@@ -359,9 +359,10 @@ impl Postprocessor {
                         Comment::Inline(value) => {
                             assert!(self.position == LinePosition::MiddleOfLine);
                             if let Some(next) = next
-                                && next != &PreToken::LineEnd {
-                                    self.interrupted = true;
-                                }
+                                && next != &PreToken::LineEnd
+                            {
+                                self.interrupted = true;
+                            }
                             self.trim_last_line(stream);
                             for token in INLINE_COMMENT_PRECEDING_TOKENS.iter() {
                                 stream.push(token.clone());
@@ -464,18 +465,19 @@ impl Postprocessor {
             );
 
             if let Some(cache) = cache
-                && post_buffer.last_line_width(config) > max_length {
-                    // The line is too long after the next step. Revert to the
-                    // cached state and insert a line break.
-                    post_buffer = cache;
-                    self.interrupted = true;
-                    self.end_line(&mut post_buffer);
-                    self.step(
-                        token.clone(),
-                        pre_buffer.peek().map(|(_, v)| &**v),
-                        &mut post_buffer,
-                    );
-                }
+                && post_buffer.last_line_width(config) > max_length
+            {
+                // The line is too long after the next step. Revert to the
+                // cached state and insert a line break.
+                post_buffer = cache;
+                self.interrupted = true;
+                self.end_line(&mut post_buffer);
+                self.step(
+                    token.clone(),
+                    pre_buffer.peek().map(|(_, v)| &**v),
+                    &mut post_buffer,
+                );
+            }
         }
 
         out_stream.extend(post_buffer);

--- a/wdl-format/src/token/post.rs
+++ b/wdl-format/src/token/post.rs
@@ -358,11 +358,10 @@ impl Postprocessor {
                         }
                         Comment::Inline(value) => {
                             assert!(self.position == LinePosition::MiddleOfLine);
-                            if let Some(next) = next {
-                                if next != &PreToken::LineEnd {
+                            if let Some(next) = next
+                                && next != &PreToken::LineEnd {
                                     self.interrupted = true;
                                 }
-                            }
                             self.trim_last_line(stream);
                             for token in INLINE_COMMENT_PRECEDING_TOKENS.iter() {
                                 stream.push(token.clone());
@@ -464,8 +463,8 @@ impl Postprocessor {
                 &mut post_buffer,
             );
 
-            if let Some(cache) = cache {
-                if post_buffer.last_line_width(config) > max_length {
+            if let Some(cache) = cache
+                && post_buffer.last_line_width(config) > max_length {
                     // The line is too long after the next step. Revert to the
                     // cached state and insert a line break.
                     post_buffer = cache;
@@ -477,7 +476,6 @@ impl Postprocessor {
                         &mut post_buffer,
                     );
                 }
-            }
         }
 
         out_stream.extend(post_buffer);

--- a/wdl-format/src/v1/expr.rs
+++ b/wdl-format/src/v1/expr.rs
@@ -161,26 +161,24 @@ pub fn format_literal_string(element: &FormatElement, stream: &mut TokenStream<P
                 while let Some(c) = chars.next() {
                     match c {
                         '\\' => {
-                            if let Some(next_c) = chars.peek() {
-                                if *next_c == '\'' {
+                            if let Some(next_c) = chars.peek()
+                                && *next_c == '\'' {
                                     // Do not write this backslash as single quotes don't need
                                     // escaping in a double-quoted string (and we format all
                                     // LiteralStrings as double-quoted strings).
                                     prev_c = Some(c);
                                     continue;
                                 }
-                            }
                             replacement.push(c);
                         }
                         '"' => {
-                            if let Some(pc) = prev_c {
-                                if pc != '\\' {
+                            if let Some(pc) = prev_c
+                                && pc != '\\' {
                                     // This double quote sign is not escaped, so we need to escape
                                     // it. This happens when a single quoted string is re-formatted
                                     // as a double quoted string.
                                     replacement.push('\\');
                                 }
-                            }
                             replacement.push(c);
                         }
                         _ => {

--- a/wdl-format/src/v1/expr.rs
+++ b/wdl-format/src/v1/expr.rs
@@ -162,23 +162,25 @@ pub fn format_literal_string(element: &FormatElement, stream: &mut TokenStream<P
                     match c {
                         '\\' => {
                             if let Some(next_c) = chars.peek()
-                                && *next_c == '\'' {
-                                    // Do not write this backslash as single quotes don't need
-                                    // escaping in a double-quoted string (and we format all
-                                    // LiteralStrings as double-quoted strings).
-                                    prev_c = Some(c);
-                                    continue;
-                                }
+                                && *next_c == '\''
+                            {
+                                // Do not write this backslash as single quotes don't need
+                                // escaping in a double-quoted string (and we format all
+                                // LiteralStrings as double-quoted strings).
+                                prev_c = Some(c);
+                                continue;
+                            }
                             replacement.push(c);
                         }
                         '"' => {
                             if let Some(pc) = prev_c
-                                && pc != '\\' {
-                                    // This double quote sign is not escaped, so we need to escape
-                                    // it. This happens when a single quoted string is re-formatted
-                                    // as a double quoted string.
-                                    replacement.push('\\');
-                                }
+                                && pc != '\\'
+                            {
+                                // This double quote sign is not escaped, so we need to escape
+                                // it. This happens when a single quoted string is re-formatted
+                                // as a double quoted string.
+                                replacement.push('\\');
+                            }
                             replacement.push(c);
                         }
                         _ => {

--- a/wdl-grammar/src/parser.rs
+++ b/wdl-grammar/src/parser.rs
@@ -640,21 +640,23 @@ where
             let marker = self.start();
             if let Err((marker, e)) = cb(self, marker) {
                 if let Some((Ok(token), _)) = lexer.as_mut().expect("should have a lexer").peek()
-                    && !recovery.contains(token.into_raw()) {
-                        // Determine if the token is recoverable in the parent recovery set
-                        // If so, we'll restart where we first attempted to parse this item
-                        if let Some(parent) = &parent
-                            && parent.contains(token.into_raw()) {
-                                // Truncate the event list and abandon the marker
-                                self.events.truncate(marker.0);
-                                marker.abandon(self);
+                    && !recovery.contains(token.into_raw())
+                {
+                    // Determine if the token is recoverable in the parent recovery set
+                    // If so, we'll restart where we first attempted to parse this item
+                    if let Some(parent) = &parent
+                        && parent.contains(token.into_raw())
+                    {
+                        // Truncate the event list and abandon the marker
+                        self.events.truncate(marker.0);
+                        marker.abandon(self);
 
-                                // Clear any buffered events and reset the lexer
-                                self.buffered.clear();
-                                self.lexer = lexer;
-                                break;
-                            }
+                        // Clear any buffered events and reset the lexer
+                        self.buffered.clear();
+                        self.lexer = lexer;
+                        break;
                     }
+                }
 
                 self.recover(e);
                 marker.abandon(self);
@@ -663,41 +665,41 @@ where
             next = self.peek();
 
             if let Some(delimiter) = delimiter
-                && let Some((token, _)) = next {
-                    if token == until {
-                        break;
-                    }
-
-                    if let Err(e) = self.expect(delimiter) {
-                        // Attach a label to the diagnostic hinting at where we expected the
-                        // delimiter to be; to do this, look back at the last non-trivia token event
-                        // in the parser events and use its span for the label.
-                        let e = if let Some(span) = self.events.iter().rev().find_map(|e| match e {
-                            Event::Token { kind, span }
-                                if *kind != SyntaxKind::Whitespace
-                                    && *kind != SyntaxKind::Comment =>
-                            {
-                                Some(*span)
-                            }
-                            _ => None,
-                        }) {
-                            e.with_label(
-                                format!(
-                                    "consider adding a {desc} after this",
-                                    desc = delimiter.describe()
-                                ),
-                                Span::new(span.end() - 1, 1),
-                            )
-                        } else {
-                            e
-                        };
-
-                        self.recover(e);
-                        self.next_if(delimiter);
-                    }
-
-                    next = self.peek();
+                && let Some((token, _)) = next
+            {
+                if token == until {
+                    break;
                 }
+
+                if let Err(e) = self.expect(delimiter) {
+                    // Attach a label to the diagnostic hinting at where we expected the
+                    // delimiter to be; to do this, look back at the last non-trivia token event
+                    // in the parser events and use its span for the label.
+                    let e = if let Some(span) = self.events.iter().rev().find_map(|e| match e {
+                        Event::Token { kind, span }
+                            if *kind != SyntaxKind::Whitespace && *kind != SyntaxKind::Comment =>
+                        {
+                            Some(*span)
+                        }
+                        _ => None,
+                    }) {
+                        e.with_label(
+                            format!(
+                                "consider adding a {desc} after this",
+                                desc = delimiter.describe()
+                            ),
+                            Span::new(span.end() - 1, 1),
+                        )
+                    } else {
+                        e
+                    };
+
+                    self.recover(e);
+                    self.next_if(delimiter);
+                }
+
+                next = self.peek();
+            }
         }
 
         self.recovery.pop();

--- a/wdl-grammar/src/parser.rs
+++ b/wdl-grammar/src/parser.rs
@@ -639,12 +639,12 @@ where
             let mut lexer = self.lexer.clone();
             let marker = self.start();
             if let Err((marker, e)) = cb(self, marker) {
-                if let Some((Ok(token), _)) = lexer.as_mut().expect("should have a lexer").peek() {
-                    if !recovery.contains(token.into_raw()) {
+                if let Some((Ok(token), _)) = lexer.as_mut().expect("should have a lexer").peek()
+                    && !recovery.contains(token.into_raw()) {
                         // Determine if the token is recoverable in the parent recovery set
                         // If so, we'll restart where we first attempted to parse this item
-                        if let Some(parent) = &parent {
-                            if parent.contains(token.into_raw()) {
+                        if let Some(parent) = &parent
+                            && parent.contains(token.into_raw()) {
                                 // Truncate the event list and abandon the marker
                                 self.events.truncate(marker.0);
                                 marker.abandon(self);
@@ -654,9 +654,7 @@ where
                                 self.lexer = lexer;
                                 break;
                             }
-                        }
                     }
-                }
 
                 self.recover(e);
                 marker.abandon(self);
@@ -664,8 +662,8 @@ where
 
             next = self.peek();
 
-            if let Some(delimiter) = delimiter {
-                if let Some((token, _)) = next {
+            if let Some(delimiter) = delimiter
+                && let Some((token, _)) = next {
                     if token == until {
                         break;
                     }
@@ -700,7 +698,6 @@ where
 
                     next = self.peek();
                 }
-            }
         }
 
         self.recovery.pop();

--- a/wdl-grammar/src/tree.rs
+++ b/wdl-grammar/src/tree.rs
@@ -735,8 +735,8 @@ impl SyntaxTokenExt for SyntaxToken {
                 break;
             }
             // Stop if a comment is not on its own line
-            if token.kind() == SyntaxKind::Comment {
-                if let Some(prev) = token.prev_token() {
+            if token.kind() == SyntaxKind::Comment
+                && let Some(prev) = token.prev_token() {
                     if prev.kind() == SyntaxKind::Whitespace {
                         let has_newlines = prev.text().chars().any(|c| c == '\n');
                         // If there are newlines in 'prev' then we know
@@ -752,7 +752,6 @@ impl SyntaxTokenExt for SyntaxToken {
                         break;
                     }
                 }
-            }
             // Filter out whitespace that is not substantial
             match token.kind() {
                 SyntaxKind::Whitespace

--- a/wdl-grammar/src/tree.rs
+++ b/wdl-grammar/src/tree.rs
@@ -736,22 +736,23 @@ impl SyntaxTokenExt for SyntaxToken {
             }
             // Stop if a comment is not on its own line
             if token.kind() == SyntaxKind::Comment
-                && let Some(prev) = token.prev_token() {
-                    if prev.kind() == SyntaxKind::Whitespace {
-                        let has_newlines = prev.text().chars().any(|c| c == '\n');
-                        // If there are newlines in 'prev' then we know
-                        // that the comment is on its own line.
-                        // The comment may still be on its own line if
-                        // 'prev' does not have newlines and nothing comes
-                        // before 'prev'.
-                        if !has_newlines && prev.prev_token().is_some() {
-                            break;
-                        }
-                    } else {
-                        // There is something else on this line before the comment.
+                && let Some(prev) = token.prev_token()
+            {
+                if prev.kind() == SyntaxKind::Whitespace {
+                    let has_newlines = prev.text().chars().any(|c| c == '\n');
+                    // If there are newlines in 'prev' then we know
+                    // that the comment is on its own line.
+                    // The comment may still be on its own line if
+                    // 'prev' does not have newlines and nothing comes
+                    // before 'prev'.
+                    if !has_newlines && prev.prev_token().is_some() {
                         break;
                     }
+                } else {
+                    // There is something else on this line before the comment.
+                    break;
                 }
+            }
             // Filter out whitespace that is not substantial
             match token.kind() {
                 SyntaxKind::Whitespace

--- a/wdl-grammar/src/tree/dive.rs
+++ b/wdl-grammar/src/tree/dive.rs
@@ -54,12 +54,11 @@ where
                 rowan::WalkEvent::Leave(_) => continue,
             };
 
-            if let rowan::SyntaxElement::Node(node) = &element {
-                if (self.ignore_predicate)(node) {
+            if let rowan::SyntaxElement::Node(node) = &element
+                && (self.ignore_predicate)(node) {
                     self.it.skip_subtree();
                     continue;
                 }
-            }
 
             return Some(element);
         }

--- a/wdl-grammar/src/tree/dive.rs
+++ b/wdl-grammar/src/tree/dive.rs
@@ -55,10 +55,11 @@ where
             };
 
             if let rowan::SyntaxElement::Node(node) = &element
-                && (self.ignore_predicate)(node) {
-                    self.it.skip_subtree();
-                    continue;
-                }
+                && (self.ignore_predicate)(node)
+            {
+                self.it.skip_subtree();
+                continue;
+            }
 
             return Some(element);
         }

--- a/wdl-lint/src/rules/call_input_spacing.rs
+++ b/wdl-lint/src/rules/call_input_spacing.rs
@@ -115,8 +115,7 @@ impl Visitor for CallInputSpacingRule {
             .inner()
             .children_with_tokens()
             .find(|c| c.kind() == SyntaxKind::InputKeyword)
-        {
-            if let Some(whitespace) = input_keyword.prev_sibling_or_token() {
+            && let Some(whitespace) = input_keyword.prev_sibling_or_token() {
                 if whitespace.kind() != SyntaxKind::Whitespace {
                     // If there is no whitespace before the input keyword
                     diagnostics.exceptable_add(
@@ -133,7 +132,6 @@ impl Visitor for CallInputSpacingRule {
                     );
                 }
             }
-        }
 
         call.inputs().for_each(|input| {
             // Check for assignment spacing

--- a/wdl-lint/src/rules/call_input_spacing.rs
+++ b/wdl-lint/src/rules/call_input_spacing.rs
@@ -115,23 +115,24 @@ impl Visitor for CallInputSpacingRule {
             .inner()
             .children_with_tokens()
             .find(|c| c.kind() == SyntaxKind::InputKeyword)
-            && let Some(whitespace) = input_keyword.prev_sibling_or_token() {
-                if whitespace.kind() != SyntaxKind::Whitespace {
-                    // If there is no whitespace before the input keyword
-                    diagnostics.exceptable_add(
-                        call_input_keyword_spacing(input_keyword.text_range().into()),
-                        SyntaxElement::from(call.inner().clone()),
-                        &self.exceptable_nodes(),
-                    );
-                } else if !whitespace.as_token().unwrap().text().eq(" ") {
-                    // If there is anything other than one space before the input keyword
-                    diagnostics.exceptable_add(
-                        call_input_incorrect_spacing(whitespace.text_range().into()),
-                        SyntaxElement::from(call.inner().clone()),
-                        &self.exceptable_nodes(),
-                    );
-                }
+            && let Some(whitespace) = input_keyword.prev_sibling_or_token()
+        {
+            if whitespace.kind() != SyntaxKind::Whitespace {
+                // If there is no whitespace before the input keyword
+                diagnostics.exceptable_add(
+                    call_input_keyword_spacing(input_keyword.text_range().into()),
+                    SyntaxElement::from(call.inner().clone()),
+                    &self.exceptable_nodes(),
+                );
+            } else if !whitespace.as_token().unwrap().text().eq(" ") {
+                // If there is anything other than one space before the input keyword
+                diagnostics.exceptable_add(
+                    call_input_incorrect_spacing(whitespace.text_range().into()),
+                    SyntaxElement::from(call.inner().clone()),
+                    &self.exceptable_nodes(),
+                );
             }
+        }
 
         call.inputs().for_each(|input| {
             // Check for assignment spacing

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -123,9 +123,9 @@ impl Visitor for CommentWhitespaceRule {
 
         if is_inline_comment(comment) {
             // check preceding whitespace for two spaces
-            if let Some(prior) = comment.inner().prev_sibling_or_token() {
-                if prior.kind() != SyntaxKind::Whitespace
-                    || prior.as_token().expect("should be a token").text() != "  "
+            if let Some(prior) = comment.inner().prev_sibling_or_token()
+                && (prior.kind() != SyntaxKind::Whitespace
+                    || prior.as_token().expect("should be a token").text() != "  ")
                 {
                     // Report a diagnostic if there are not two spaces before the comment delimiter
                     let span = Span::new(comment.span().start(), 1);
@@ -135,7 +135,6 @@ impl Visitor for CommentWhitespaceRule {
                         &self.exceptable_nodes(),
                     );
                 }
-            }
         } else {
             // Not an in-line comment, so check indentation level
             let ancestors = comment
@@ -222,11 +221,9 @@ fn filter_parent_ancestors(node: &SyntaxNode) -> bool {
     if let Some(prior) = node
         .prev_sibling_or_token()
         .and_then(SyntaxElement::into_token)
-    {
-        if prior.kind() == SyntaxKind::Whitespace && prior.text().contains('\n') {
+        && prior.kind() == SyntaxKind::Whitespace && prior.text().contains('\n') {
             return true;
         }
-    }
     // If a parenthesized expression has a prior sibling that contains a newline
     // before we get to a node, then this ancestor contributes to indentation.
     if node.kind() == SyntaxKind::ParenthesizedExprNode {

--- a/wdl-lint/src/rules/comment_whitespace.rs
+++ b/wdl-lint/src/rules/comment_whitespace.rs
@@ -126,15 +126,15 @@ impl Visitor for CommentWhitespaceRule {
             if let Some(prior) = comment.inner().prev_sibling_or_token()
                 && (prior.kind() != SyntaxKind::Whitespace
                     || prior.as_token().expect("should be a token").text() != "  ")
-                {
-                    // Report a diagnostic if there are not two spaces before the comment delimiter
-                    let span = Span::new(comment.span().start(), 1);
-                    diagnostics.exceptable_add(
-                        inline_preceding_whitespace(span),
-                        SyntaxElement::from(comment.inner().clone()),
-                        &self.exceptable_nodes(),
-                    );
-                }
+            {
+                // Report a diagnostic if there are not two spaces before the comment delimiter
+                let span = Span::new(comment.span().start(), 1);
+                diagnostics.exceptable_add(
+                    inline_preceding_whitespace(span),
+                    SyntaxElement::from(comment.inner().clone()),
+                    &self.exceptable_nodes(),
+                );
+            }
         } else {
             // Not an in-line comment, so check indentation level
             let ancestors = comment
@@ -221,9 +221,11 @@ fn filter_parent_ancestors(node: &SyntaxNode) -> bool {
     if let Some(prior) = node
         .prev_sibling_or_token()
         .and_then(SyntaxElement::into_token)
-        && prior.kind() == SyntaxKind::Whitespace && prior.text().contains('\n') {
-            return true;
-        }
+        && prior.kind() == SyntaxKind::Whitespace
+        && prior.text().contains('\n')
+    {
+        return true;
+    }
     // If a parenthesized expression has a prior sibling that contains a newline
     // before we get to a node, then this ancestor contributes to indentation.
     if node.kind() == SyntaxKind::ParenthesizedExprNode {

--- a/wdl-lint/src/rules/concise_input.rs
+++ b/wdl-lint/src/rules/concise_input.rs
@@ -99,17 +99,15 @@ impl Visitor for ConciseInputRule {
                 return;
             }
             stmt.inputs().for_each(|input| {
-                if let Some(expr) = input.expr() {
-                    if let Some(expr_name) = expr.as_name_ref() {
-                        if expr_name.name().text() == input.name().text() {
+                if let Some(expr) = input.expr()
+                    && let Some(expr_name) = expr.as_name_ref()
+                        && expr_name.name().text() == input.name().text() {
                             diagnostics.exceptable_add(
                                 redundant_input_assignment(input.span(), input.name().text()),
                                 SyntaxElement::from(input.inner().clone()),
                                 &self.exceptable_nodes(),
                             );
                         }
-                    }
-                }
             });
         }
     }

--- a/wdl-lint/src/rules/concise_input.rs
+++ b/wdl-lint/src/rules/concise_input.rs
@@ -101,13 +101,14 @@ impl Visitor for ConciseInputRule {
             stmt.inputs().for_each(|input| {
                 if let Some(expr) = input.expr()
                     && let Some(expr_name) = expr.as_name_ref()
-                        && expr_name.name().text() == input.name().text() {
-                            diagnostics.exceptable_add(
-                                redundant_input_assignment(input.span(), input.name().text()),
-                                SyntaxElement::from(input.inner().clone()),
-                                &self.exceptable_nodes(),
-                            );
-                        }
+                    && expr_name.name().text() == input.name().text()
+                {
+                    diagnostics.exceptable_add(
+                        redundant_input_assignment(input.span(), input.name().text()),
+                        SyntaxElement::from(input.inner().clone()),
+                        &self.exceptable_nodes(),
+                    );
+                }
             });
         }
     }

--- a/wdl-lint/src/rules/container_uri.rs
+++ b/wdl-lint/src/rules/container_uri.rs
@@ -158,8 +158,8 @@ impl Visitor for ContainerUriRule {
             return;
         }
 
-        if let Some(container) = section.container() {
-            if let Ok(value) = container.value() {
+        if let Some(container) = section.container()
+            && let Ok(value) = container.value() {
                 check_container_value(
                     diagnostics,
                     value,
@@ -167,7 +167,6 @@ impl Visitor for ContainerUriRule {
                     &self.exceptable_nodes(),
                 );
             }
-        }
     }
 
     fn requirements_section(
@@ -180,8 +179,8 @@ impl Visitor for ContainerUriRule {
             return;
         }
 
-        if let Some(container) = section.container() {
-            if let Ok(value) = container.value() {
+        if let Some(container) = section.container()
+            && let Ok(value) = container.value() {
                 check_container_value(
                     diagnostics,
                     value,
@@ -189,7 +188,6 @@ impl Visitor for ContainerUriRule {
                     &self.exceptable_nodes(),
                 );
             }
-        }
     }
 }
 

--- a/wdl-lint/src/rules/container_uri.rs
+++ b/wdl-lint/src/rules/container_uri.rs
@@ -159,14 +159,15 @@ impl Visitor for ContainerUriRule {
         }
 
         if let Some(container) = section.container()
-            && let Ok(value) = container.value() {
-                check_container_value(
-                    diagnostics,
-                    value,
-                    SyntaxElement::from(section.inner().clone()),
-                    &self.exceptable_nodes(),
-                );
-            }
+            && let Ok(value) = container.value()
+        {
+            check_container_value(
+                diagnostics,
+                value,
+                SyntaxElement::from(section.inner().clone()),
+                &self.exceptable_nodes(),
+            );
+        }
     }
 
     fn requirements_section(
@@ -180,14 +181,15 @@ impl Visitor for ContainerUriRule {
         }
 
         if let Some(container) = section.container()
-            && let Ok(value) = container.value() {
-                check_container_value(
-                    diagnostics,
-                    value,
-                    SyntaxElement::from(section.inner().clone()),
-                    &self.exceptable_nodes(),
-                );
-            }
+            && let Ok(value) = container.value()
+        {
+            check_container_value(
+                diagnostics,
+                value,
+                SyntaxElement::from(section.inner().clone()),
+                &self.exceptable_nodes(),
+            );
+        }
     }
 }
 

--- a/wdl-lint/src/rules/double_quotes.rs
+++ b/wdl-lint/src/rules/double_quotes.rs
@@ -78,14 +78,13 @@ impl Visitor for DoubleQuotesRule {
             return;
         }
 
-        if let Expr::Literal(LiteralExpr::String(s)) = expr {
-            if s.kind() == LiteralStringKind::SingleQuoted {
+        if let Expr::Literal(LiteralExpr::String(s)) = expr
+            && s.kind() == LiteralStringKind::SingleQuoted {
                 diagnostics.exceptable_add(
                     use_double_quotes(s.span()),
                     SyntaxElement::from(expr.inner().clone()),
                     &self.exceptable_nodes(),
                 );
             }
-        }
     }
 }

--- a/wdl-lint/src/rules/double_quotes.rs
+++ b/wdl-lint/src/rules/double_quotes.rs
@@ -79,12 +79,13 @@ impl Visitor for DoubleQuotesRule {
         }
 
         if let Expr::Literal(LiteralExpr::String(s)) = expr
-            && s.kind() == LiteralStringKind::SingleQuoted {
-                diagnostics.exceptable_add(
-                    use_double_quotes(s.span()),
-                    SyntaxElement::from(expr.inner().clone()),
-                    &self.exceptable_nodes(),
-                );
-            }
+            && s.kind() == LiteralStringKind::SingleQuoted
+        {
+            diagnostics.exceptable_add(
+                use_double_quotes(s.span()),
+                SyntaxElement::from(expr.inner().clone()),
+                &self.exceptable_nodes(),
+            );
+        }
     }
 }

--- a/wdl-lint/src/rules/element_spacing.rs
+++ b/wdl-lint/src/rules/element_spacing.rs
@@ -474,34 +474,29 @@ impl Visitor for ElementSpacingRule {
             .prev_sibling_or_token()
             .and_then(SyntaxElement::into_token);
         if let Some(p) = prior
-            && p.kind() == SyntaxKind::Whitespace {
-                let count = p.text().chars().filter(|c| *c == '\n').count();
-                // If we're in an `input` or `output`, we should have no blank lines, so only
-                // one `\n` is allowed.
-                if self.state == State::InputSection || self.state == State::OutputSection {
-                    if count > 1 {
-                        diagnostics.exceptable_add(
-                            excess_blank_line(p.text_range().into()),
-                            SyntaxElement::from(decl.inner().clone()),
-                            &self.exceptable_nodes(),
-                        );
-                    }
-                } else {
-                    let first = is_first_body(decl.inner());
+            && p.kind() == SyntaxKind::Whitespace
+        {
+            let count = p.text().chars().filter(|c| *c == '\n').count();
+            // If we're in an `input` or `output`, we should have no blank lines, so only
+            // one `\n` is allowed.
+            if self.state == State::InputSection || self.state == State::OutputSection {
+                if count > 1 {
+                    diagnostics.exceptable_add(
+                        excess_blank_line(p.text_range().into()),
+                        SyntaxElement::from(decl.inner().clone()),
+                        &self.exceptable_nodes(),
+                    );
+                }
+            } else {
+                let first = is_first_body(decl.inner());
 
-                    let prev = skip_preceding_comments(decl.inner());
+                let prev = skip_preceding_comments(decl.inner());
 
-                    if first {
-                        check_prior_spacing(
-                            &prev,
-                            diagnostics,
-                            true,
-                            false,
-                            &self.exceptable_nodes(),
-                        );
-                    }
+                if first {
+                    check_prior_spacing(&prev, diagnostics, true, false, &self.exceptable_nodes());
                 }
             }
+        }
     }
 
     fn bound_decl(&mut self, diagnostics: &mut Diagnostics, reason: VisitReason, decl: &BoundDecl) {
@@ -515,34 +510,29 @@ impl Visitor for ElementSpacingRule {
             .prev_sibling_or_token()
             .and_then(SyntaxElement::into_token);
         if let Some(p) = prior
-            && p.kind() == SyntaxKind::Whitespace {
-                let count = p.text().chars().filter(|c| *c == '\n').count();
-                // If we're in an `input` or `output`, we should have no blank lines, so only
-                // one `\n` is allowed.
-                if self.state == State::InputSection || self.state == State::OutputSection {
-                    if count > 1 {
-                        diagnostics.exceptable_add(
-                            excess_blank_line(p.text_range().into()),
-                            SyntaxElement::from(decl.inner().clone()),
-                            &self.exceptable_nodes(),
-                        );
-                    }
-                } else {
-                    let first = is_first_body(decl.inner());
+            && p.kind() == SyntaxKind::Whitespace
+        {
+            let count = p.text().chars().filter(|c| *c == '\n').count();
+            // If we're in an `input` or `output`, we should have no blank lines, so only
+            // one `\n` is allowed.
+            if self.state == State::InputSection || self.state == State::OutputSection {
+                if count > 1 {
+                    diagnostics.exceptable_add(
+                        excess_blank_line(p.text_range().into()),
+                        SyntaxElement::from(decl.inner().clone()),
+                        &self.exceptable_nodes(),
+                    );
+                }
+            } else {
+                let first = is_first_body(decl.inner());
 
-                    let prev = skip_preceding_comments(decl.inner());
+                let prev = skip_preceding_comments(decl.inner());
 
-                    if first {
-                        check_prior_spacing(
-                            &prev,
-                            diagnostics,
-                            true,
-                            false,
-                            &self.exceptable_nodes(),
-                        );
-                    }
+                if first {
+                    check_prior_spacing(&prev, diagnostics, true, false, &self.exceptable_nodes());
                 }
             }
+        }
     }
 
     fn conditional_statement(
@@ -708,16 +698,17 @@ fn check_last_token(
         .expect("node should have last token")
         .prev_token();
     if let Some(prev) = prev
-        && prev.kind() == SyntaxKind::Whitespace {
-            let count = prev.text().chars().filter(|c| *c == '\n').count();
-            if count > 1 {
-                diagnostics.exceptable_add(
-                    excess_blank_line(prev.text_range().into()),
-                    SyntaxElement::from(syntax.clone()),
-                    exceptable_nodes,
-                );
-            }
+        && prev.kind() == SyntaxKind::Whitespace
+    {
+        let count = prev.text().chars().filter(|c| *c == '\n').count();
+        if count > 1 {
+            diagnostics.exceptable_add(
+                excess_blank_line(prev.text_range().into()),
+                SyntaxElement::from(syntax.clone()),
+                exceptable_nodes,
+            );
         }
+    }
 }
 
 /// For a given node, walk background until a non-comment or blank line is

--- a/wdl-lint/src/rules/element_spacing.rs
+++ b/wdl-lint/src/rules/element_spacing.rs
@@ -473,8 +473,8 @@ impl Visitor for ElementSpacingRule {
             .inner()
             .prev_sibling_or_token()
             .and_then(SyntaxElement::into_token);
-        if let Some(p) = prior {
-            if p.kind() == SyntaxKind::Whitespace {
+        if let Some(p) = prior
+            && p.kind() == SyntaxKind::Whitespace {
                 let count = p.text().chars().filter(|c| *c == '\n').count();
                 // If we're in an `input` or `output`, we should have no blank lines, so only
                 // one `\n` is allowed.
@@ -502,7 +502,6 @@ impl Visitor for ElementSpacingRule {
                     }
                 }
             }
-        }
     }
 
     fn bound_decl(&mut self, diagnostics: &mut Diagnostics, reason: VisitReason, decl: &BoundDecl) {
@@ -515,8 +514,8 @@ impl Visitor for ElementSpacingRule {
         let prior = actual_start
             .prev_sibling_or_token()
             .and_then(SyntaxElement::into_token);
-        if let Some(p) = prior {
-            if p.kind() == SyntaxKind::Whitespace {
+        if let Some(p) = prior
+            && p.kind() == SyntaxKind::Whitespace {
                 let count = p.text().chars().filter(|c| *c == '\n').count();
                 // If we're in an `input` or `output`, we should have no blank lines, so only
                 // one `\n` is allowed.
@@ -544,7 +543,6 @@ impl Visitor for ElementSpacingRule {
                     }
                 }
             }
-        }
     }
 
     fn conditional_statement(
@@ -709,8 +707,8 @@ fn check_last_token(
         .last_token()
         .expect("node should have last token")
         .prev_token();
-    if let Some(prev) = prev {
-        if prev.kind() == SyntaxKind::Whitespace {
+    if let Some(prev) = prev
+        && prev.kind() == SyntaxKind::Whitespace {
             let count = prev.text().chars().filter(|c| *c == '\n').count();
             if count > 1 {
                 diagnostics.exceptable_add(
@@ -720,7 +718,6 @@ fn check_last_token(
                 );
             }
         }
-    }
 }
 
 /// For a given node, walk background until a non-comment or blank line is

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -297,40 +297,41 @@ impl Visitor for ExpressionSpacingRule {
                 // Opening parenthesis cannot be followed by a space, but can be followed by a
                 // newline. Except in the case of an in-line comment.
                 if let Some(open_next) = open.next_sibling_or_token()
-                    && open_next.kind() == SyntaxKind::Whitespace {
-                        let token = open_next.as_token().expect("should be a token");
-                        if token.text().starts_with(' ')
-                            && token
-                                .next_sibling_or_token()
-                                .is_some_and(|t| t.kind() != SyntaxKind::Comment)
-                        {
-                            // opening parens should not be followed by non-newline whitespace
-                            diagnostics.exceptable_add(
-                                disallowed_space(token.text_range().into()),
-                                SyntaxElement::from(expr.inner().clone()),
-                                &self.exceptable_nodes(),
-                            );
-                        }
+                    && open_next.kind() == SyntaxKind::Whitespace
+                {
+                    let token = open_next.as_token().expect("should be a token");
+                    if token.text().starts_with(' ')
+                        && token
+                            .next_sibling_or_token()
+                            .is_some_and(|t| t.kind() != SyntaxKind::Comment)
+                    {
+                        // opening parens should not be followed by non-newline whitespace
+                        diagnostics.exceptable_add(
+                            disallowed_space(token.text_range().into()),
+                            SyntaxElement::from(expr.inner().clone()),
+                            &self.exceptable_nodes(),
+                        );
                     }
+                }
 
                 // Closing parenthesis should not be preceded by a space, but can be preceded by
                 // a newline.
                 if let Some(close_prev) = close.prev_sibling_or_token()
                     && close_prev.kind() == SyntaxKind::Whitespace
-                        && !close_prev
-                            .as_token()
-                            .expect("should be a token")
-                            .text()
-                            .contains('\n')
-                    {
-                        // closing parenthesis should not be preceded by whitespace without a
-                        // newline
-                        diagnostics.exceptable_add(
-                            disallowed_space(close_prev.text_range().into()),
-                            SyntaxElement::from(expr.inner().clone()),
-                            &self.exceptable_nodes(),
-                        );
-                    }
+                    && !close_prev
+                        .as_token()
+                        .expect("should be a token")
+                        .text()
+                        .contains('\n')
+                {
+                    // closing parenthesis should not be preceded by whitespace without a
+                    // newline
+                    diagnostics.exceptable_add(
+                        disallowed_space(close_prev.text_range().into()),
+                        SyntaxElement::from(expr.inner().clone()),
+                        &self.exceptable_nodes(),
+                    );
+                }
             }
             Expr::LogicalAnd(_) | Expr::LogicalOr(_) => {
                 // find the operator

--- a/wdl-lint/src/rules/expression_spacing.rs
+++ b/wdl-lint/src/rules/expression_spacing.rs
@@ -296,8 +296,8 @@ impl Visitor for ExpressionSpacingRule {
 
                 // Opening parenthesis cannot be followed by a space, but can be followed by a
                 // newline. Except in the case of an in-line comment.
-                if let Some(open_next) = open.next_sibling_or_token() {
-                    if open_next.kind() == SyntaxKind::Whitespace {
+                if let Some(open_next) = open.next_sibling_or_token()
+                    && open_next.kind() == SyntaxKind::Whitespace {
                         let token = open_next.as_token().expect("should be a token");
                         if token.text().starts_with(' ')
                             && token
@@ -312,12 +312,11 @@ impl Visitor for ExpressionSpacingRule {
                             );
                         }
                     }
-                }
 
                 // Closing parenthesis should not be preceded by a space, but can be preceded by
                 // a newline.
-                if let Some(close_prev) = close.prev_sibling_or_token() {
-                    if close_prev.kind() == SyntaxKind::Whitespace
+                if let Some(close_prev) = close.prev_sibling_or_token()
+                    && close_prev.kind() == SyntaxKind::Whitespace
                         && !close_prev
                             .as_token()
                             .expect("should be a token")
@@ -332,7 +331,6 @@ impl Visitor for ExpressionSpacingRule {
                             &self.exceptable_nodes(),
                         );
                     }
-                }
             }
             Expr::LogicalAnd(_) | Expr::LogicalOr(_) => {
                 // find the operator

--- a/wdl-lint/src/rules/import_whitespace.rs
+++ b/wdl-lint/src/rules/import_whitespace.rs
@@ -124,22 +124,24 @@ impl Visitor for ImportWhitespaceRule {
             .and_then(SyntaxElement::into_token);
 
         if let Some(token) = prev_token
-            && token.kind() == SyntaxKind::Whitespace && !token.text().ends_with('\n') {
-                // Find the span of just the leading whitespace
-                let span: Span = token.text_range().into();
-                for (text, offset, _) in lines_with_offset(token.text()) {
-                    if !text.is_empty() {
-                        diagnostics.exceptable_add(
-                            improper_whitespace_before_import(Span::new(
-                                span.start() + offset,
-                                span.len() - offset,
-                            )),
-                            SyntaxElement::from(token.clone()),
-                            &self.exceptable_nodes(),
-                        );
-                    }
+            && token.kind() == SyntaxKind::Whitespace
+            && !token.text().ends_with('\n')
+        {
+            // Find the span of just the leading whitespace
+            let span: Span = token.text_range().into();
+            for (text, offset, _) in lines_with_offset(token.text()) {
+                if !text.is_empty() {
+                    diagnostics.exceptable_add(
+                        improper_whitespace_before_import(Span::new(
+                            span.start() + offset,
+                            span.len() - offset,
+                        )),
+                        SyntaxElement::from(token.clone()),
+                        &self.exceptable_nodes(),
+                    );
                 }
             }
+        }
 
         // Third, check for whitespace between imports.
         let between_imports = stmt

--- a/wdl-lint/src/rules/import_whitespace.rs
+++ b/wdl-lint/src/rules/import_whitespace.rs
@@ -123,8 +123,8 @@ impl Visitor for ImportWhitespaceRule {
             .prev_sibling_or_token()
             .and_then(SyntaxElement::into_token);
 
-        if let Some(token) = prev_token {
-            if token.kind() == SyntaxKind::Whitespace && !token.text().ends_with('\n') {
+        if let Some(token) = prev_token
+            && token.kind() == SyntaxKind::Whitespace && !token.text().ends_with('\n') {
                 // Find the span of just the leading whitespace
                 let span: Span = token.text_range().into();
                 for (text, offset, _) in lines_with_offset(token.text()) {
@@ -140,7 +140,6 @@ impl Visitor for ImportWhitespaceRule {
                     }
                 }
             }
-        }
 
         // Third, check for whitespace between imports.
         let between_imports = stmt

--- a/wdl-lint/src/rules/input_name.rs
+++ b/wdl-lint/src/rules/input_name.rs
@@ -142,29 +142,28 @@ fn check_decl_name(
     }
 
     let mut name = name.chars().peekable();
-    if let Some(c) = name.next() {
-        if c == 'i' || c == 'I' {
-            if let Some('n') = name.peek() {
-                name.next();
-                if let Some(c) = name.peek() {
-                    if c.is_ascii_uppercase() || c == &'_' {
-                        // name starts with "in"
-                        diagnostics.exceptable_add(
-                            decl_identifier_starts_with_in(decl.name().span()),
-                            SyntaxElement::from(decl.inner().clone()),
-                            exceptable_nodes,
-                        );
-                    } else {
-                        let s: String = name.take(3).collect();
-                        if s == "put" {
-                            // name starts with "input"
-                            diagnostics.exceptable_add(
-                                decl_identifier_starts_with_input(decl.name().span()),
-                                SyntaxElement::from(decl.inner().clone()),
-                                exceptable_nodes,
-                            );
-                        }
-                    }
+    if let Some(c) = name.next()
+        && (c == 'i' || c == 'I')
+        && let Some('n') = name.peek()
+    {
+        name.next();
+        if let Some(c) = name.peek() {
+            if c.is_ascii_uppercase() || c == &'_' {
+                // name starts with "in"
+                diagnostics.exceptable_add(
+                    decl_identifier_starts_with_in(decl.name().span()),
+                    SyntaxElement::from(decl.inner().clone()),
+                    exceptable_nodes,
+                );
+            } else {
+                let s: String = name.take(3).collect();
+                if s == "put" {
+                    // name starts with "input"
+                    diagnostics.exceptable_add(
+                        decl_identifier_starts_with_input(decl.name().span()),
+                        SyntaxElement::from(decl.inner().clone()),
+                        exceptable_nodes,
+                    );
                 }
             }
         }

--- a/wdl-lint/src/rules/lint_directive_valid.rs
+++ b/wdl-lint/src/rules/lint_directive_valid.rs
@@ -123,14 +123,15 @@ impl Visitor for LintDirectiveValidRule {
 
                 if let Some(elem) = &excepted_element
                     && let Some(Some(exceptable_nodes)) = RULE_MAP.get(trimmed)
-                        && !exceptable_nodes.contains(&elem.kind()) {
-                            diagnostics.add(misplaced_lint_directive(
-                                trimmed,
-                                Span::new(start + offset, trimmed.len()),
-                                elem,
-                                exceptable_nodes,
-                            ));
-                        }
+                    && !exceptable_nodes.contains(&elem.kind())
+                {
+                    diagnostics.add(misplaced_lint_directive(
+                        trimmed,
+                        Span::new(start + offset, trimmed.len()),
+                        elem,
+                        exceptable_nodes,
+                    ));
+                }
 
                 // Update the offset to account for the rule id and comma
                 offset += trimmed.len() + 1;

--- a/wdl-lint/src/rules/lint_directive_valid.rs
+++ b/wdl-lint/src/rules/lint_directive_valid.rs
@@ -121,9 +121,9 @@ impl Visitor for LintDirectiveValidRule {
                 // Update the offset to account for the whitespace that was removed
                 offset += id.len() - trimmed.len();
 
-                if let Some(elem) = &excepted_element {
-                    if let Some(Some(exceptable_nodes)) = RULE_MAP.get(trimmed) {
-                        if !exceptable_nodes.contains(&elem.kind()) {
+                if let Some(elem) = &excepted_element
+                    && let Some(Some(exceptable_nodes)) = RULE_MAP.get(trimmed)
+                        && !exceptable_nodes.contains(&elem.kind()) {
                             diagnostics.add(misplaced_lint_directive(
                                 trimmed,
                                 Span::new(start + offset, trimmed.len()),
@@ -131,8 +131,6 @@ impl Visitor for LintDirectiveValidRule {
                                 exceptable_nodes,
                             ));
                         }
-                    }
-                }
 
                 // Update the offset to account for the rule id and comma
                 offset += trimmed.len() + 1;

--- a/wdl-lint/src/rules/meta_key_value_formatting.rs
+++ b/wdl-lint/src/rules/meta_key_value_formatting.rs
@@ -164,13 +164,14 @@ impl Visitor for MetaKeyValueFormattingRule {
             .first_token()
             .expect("should have an opening delimiter");
         if let Some(open_ws) = open_delim.next_sibling_or_token()
-            && (open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n')) {
-                diagnostics.exceptable_add(
-                    missing_trailing_newline(open_delim.text_range().into()),
-                    SyntaxElement::from(item.inner().clone()),
-                    &self.exceptable_nodes(),
-                );
-            }
+            && (open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n'))
+        {
+            diagnostics.exceptable_add(
+                missing_trailing_newline(open_delim.text_range().into()),
+                SyntaxElement::from(item.inner().clone()),
+                &self.exceptable_nodes(),
+            );
+        }
 
         // Check if object is multi-line
         let close_delim = item
@@ -195,52 +196,55 @@ impl Visitor for MetaKeyValueFormattingRule {
             // Check indentation. If there is no prior whitespace, that will have been
             // reported already.
             if let Some(prior_ws) = child.inner().prev_sibling_or_token()
-                && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n')
-                {
-                    // If there was no newline, that is already reported
-                    let ws = prior_ws.to_string();
-                    let ws = ws
-                        .split('\n')
-                        .next_back()
-                        .expect("should have a last element");
-                    let expected_ws = parent_ws.to_owned() + INDENT;
+                && prior_ws.kind() == SyntaxKind::Whitespace
+                && prior_ws.to_string().contains('\n')
+            {
+                // If there was no newline, that is already reported
+                let ws = prior_ws.to_string();
+                let ws = ws
+                    .split('\n')
+                    .next_back()
+                    .expect("should have a last element");
+                let expected_ws = parent_ws.to_owned() + INDENT;
 
-                    if ws != expected_ws {
-                        diagnostics.exceptable_add(
-                            incorrect_indentation(prior_ws.text_range().into(), &expected_ws, ws),
-                            SyntaxElement::from(child.inner().clone()),
-                            &self.exceptable_nodes(),
-                        );
-                    }
+                if ws != expected_ws {
+                    diagnostics.exceptable_add(
+                        incorrect_indentation(prior_ws.text_range().into(), &expected_ws, ws),
+                        SyntaxElement::from(child.inner().clone()),
+                        &self.exceptable_nodes(),
+                    );
                 }
+            }
         }
 
         // No need to check the closing delimiter as the last element must have
         // a newline. But we should check the indentation of the closing delimiter.
         if let Some(prior_ws) = close_delim.prev_sibling_or_token()
-            && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n') {
-                let ws = prior_ws.to_string();
-                let ws = ws
-                    .split('\n')
-                    .next_back()
-                    .expect("there should be a last element");
-                let expected_ws = parent_ws.to_owned();
+            && prior_ws.kind() == SyntaxKind::Whitespace
+            && prior_ws.to_string().contains('\n')
+        {
+            let ws = prior_ws.to_string();
+            let ws = ws
+                .split('\n')
+                .next_back()
+                .expect("there should be a last element");
+            let expected_ws = parent_ws.to_owned();
 
-                if ws != expected_ws {
-                    diagnostics.exceptable_add(
-                        incorrect_indentation(
-                            Span::new(
-                                usize::from(close_delim.text_range().start()) - ws.len(),
-                                ws.len(),
-                            ),
-                            &expected_ws,
-                            ws,
+            if ws != expected_ws {
+                diagnostics.exceptable_add(
+                    incorrect_indentation(
+                        Span::new(
+                            usize::from(close_delim.text_range().start()) - ws.len(),
+                            ws.len(),
                         ),
-                        SyntaxElement::from(item.inner().clone()),
-                        &self.exceptable_nodes(),
-                    );
-                }
+                        &expected_ws,
+                        ws,
+                    ),
+                    SyntaxElement::from(item.inner().clone()),
+                    &self.exceptable_nodes(),
+                );
             }
+        }
     }
 
     fn metadata_array(
@@ -283,13 +287,14 @@ impl Visitor for MetaKeyValueFormattingRule {
             .first_token()
             .expect("should have an opening delimiter");
         if let Some(open_ws) = open_delim.next_sibling_or_token()
-            && (open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n')) {
-                diagnostics.exceptable_add(
-                    missing_trailing_newline(open_delim.text_range().into()),
-                    SyntaxElement::from(item.inner().clone()),
-                    &self.exceptable_nodes(),
-                );
-            }
+            && (open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n'))
+        {
+            diagnostics.exceptable_add(
+                missing_trailing_newline(open_delim.text_range().into()),
+                SyntaxElement::from(item.inner().clone()),
+                &self.exceptable_nodes(),
+            );
+        }
 
         // Metadata arrays should be one element per line
         let close_delim = item
@@ -314,52 +319,55 @@ impl Visitor for MetaKeyValueFormattingRule {
             // Check indentation. If there is no prior whitespace, that will have been
             // reported already.
             if let Some(prior_ws) = child.inner().prev_sibling_or_token()
-                && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n')
-                {
-                    // If there was no newline, that is already reported
-                    let ws = prior_ws.to_string();
-                    let ws = ws
-                        .split('\n')
-                        .next_back()
-                        .expect("there should be a last element");
-                    let expected_ws = parent_ws.to_owned() + INDENT;
-
-                    if ws != expected_ws {
-                        diagnostics.exceptable_add(
-                            incorrect_indentation(prior_ws.text_range().into(), &expected_ws, ws),
-                            SyntaxElement::from(child.inner().clone()),
-                            &self.exceptable_nodes(),
-                        );
-                    }
-                }
-        }
-
-        // No need to check the closing delimiter as the last element must have
-        // a newline. But we should check the indentation of the closing delimiter.
-        if let Some(prior_ws) = close_delim.prev_sibling_or_token()
-            && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n') {
+                && prior_ws.kind() == SyntaxKind::Whitespace
+                && prior_ws.to_string().contains('\n')
+            {
+                // If there was no newline, that is already reported
                 let ws = prior_ws.to_string();
                 let ws = ws
                     .split('\n')
                     .next_back()
                     .expect("there should be a last element");
-                let expected_ws = parent_ws.to_owned();
+                let expected_ws = parent_ws.to_owned() + INDENT;
 
                 if ws != expected_ws {
                     diagnostics.exceptable_add(
-                        incorrect_indentation(
-                            Span::new(
-                                usize::from(close_delim.text_range().start()) - ws.len(),
-                                ws.len(),
-                            ),
-                            &expected_ws,
-                            ws,
-                        ),
-                        SyntaxElement::from(item.inner().clone()),
+                        incorrect_indentation(prior_ws.text_range().into(), &expected_ws, ws),
+                        SyntaxElement::from(child.inner().clone()),
                         &self.exceptable_nodes(),
                     );
                 }
             }
+        }
+
+        // No need to check the closing delimiter as the last element must have
+        // a newline. But we should check the indentation of the closing delimiter.
+        if let Some(prior_ws) = close_delim.prev_sibling_or_token()
+            && prior_ws.kind() == SyntaxKind::Whitespace
+            && prior_ws.to_string().contains('\n')
+        {
+            let ws = prior_ws.to_string();
+            let ws = ws
+                .split('\n')
+                .next_back()
+                .expect("there should be a last element");
+            let expected_ws = parent_ws.to_owned();
+
+            if ws != expected_ws {
+                diagnostics.exceptable_add(
+                    incorrect_indentation(
+                        Span::new(
+                            usize::from(close_delim.text_range().start()) - ws.len(),
+                            ws.len(),
+                        ),
+                        &expected_ws,
+                        ws,
+                    ),
+                    SyntaxElement::from(item.inner().clone()),
+                    &self.exceptable_nodes(),
+                );
+            }
+        }
     }
 }
 

--- a/wdl-lint/src/rules/meta_key_value_formatting.rs
+++ b/wdl-lint/src/rules/meta_key_value_formatting.rs
@@ -163,15 +163,14 @@ impl Visitor for MetaKeyValueFormattingRule {
             .inner()
             .first_token()
             .expect("should have an opening delimiter");
-        if let Some(open_ws) = open_delim.next_sibling_or_token() {
-            if open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n') {
+        if let Some(open_ws) = open_delim.next_sibling_or_token()
+            && (open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n')) {
                 diagnostics.exceptable_add(
                     missing_trailing_newline(open_delim.text_range().into()),
                     SyntaxElement::from(item.inner().clone()),
                     &self.exceptable_nodes(),
                 );
             }
-        }
 
         // Check if object is multi-line
         let close_delim = item
@@ -195,8 +194,8 @@ impl Visitor for MetaKeyValueFormattingRule {
             }
             // Check indentation. If there is no prior whitespace, that will have been
             // reported already.
-            if let Some(prior_ws) = child.inner().prev_sibling_or_token() {
-                if prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n')
+            if let Some(prior_ws) = child.inner().prev_sibling_or_token()
+                && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n')
                 {
                     // If there was no newline, that is already reported
                     let ws = prior_ws.to_string();
@@ -214,13 +213,12 @@ impl Visitor for MetaKeyValueFormattingRule {
                         );
                     }
                 }
-            }
         }
 
         // No need to check the closing delimiter as the last element must have
         // a newline. But we should check the indentation of the closing delimiter.
-        if let Some(prior_ws) = close_delim.prev_sibling_or_token() {
-            if prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n') {
+        if let Some(prior_ws) = close_delim.prev_sibling_or_token()
+            && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n') {
                 let ws = prior_ws.to_string();
                 let ws = ws
                     .split('\n')
@@ -243,7 +241,6 @@ impl Visitor for MetaKeyValueFormattingRule {
                     );
                 }
             }
-        }
     }
 
     fn metadata_array(
@@ -285,15 +282,14 @@ impl Visitor for MetaKeyValueFormattingRule {
             .inner()
             .first_token()
             .expect("should have an opening delimiter");
-        if let Some(open_ws) = open_delim.next_sibling_or_token() {
-            if open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n') {
+        if let Some(open_ws) = open_delim.next_sibling_or_token()
+            && (open_ws.kind() != SyntaxKind::Whitespace || !open_ws.to_string().contains('\n')) {
                 diagnostics.exceptable_add(
                     missing_trailing_newline(open_delim.text_range().into()),
                     SyntaxElement::from(item.inner().clone()),
                     &self.exceptable_nodes(),
                 );
             }
-        }
 
         // Metadata arrays should be one element per line
         let close_delim = item
@@ -317,8 +313,8 @@ impl Visitor for MetaKeyValueFormattingRule {
             }
             // Check indentation. If there is no prior whitespace, that will have been
             // reported already.
-            if let Some(prior_ws) = child.inner().prev_sibling_or_token() {
-                if prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n')
+            if let Some(prior_ws) = child.inner().prev_sibling_or_token()
+                && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n')
                 {
                     // If there was no newline, that is already reported
                     let ws = prior_ws.to_string();
@@ -336,13 +332,12 @@ impl Visitor for MetaKeyValueFormattingRule {
                         );
                     }
                 }
-            }
         }
 
         // No need to check the closing delimiter as the last element must have
         // a newline. But we should check the indentation of the closing delimiter.
-        if let Some(prior_ws) = close_delim.prev_sibling_or_token() {
-            if prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n') {
+        if let Some(prior_ws) = close_delim.prev_sibling_or_token()
+            && prior_ws.kind() == SyntaxKind::Whitespace && prior_ws.to_string().contains('\n') {
                 let ws = prior_ws.to_string();
                 let ws = ws
                     .split('\n')
@@ -365,7 +360,6 @@ impl Visitor for MetaKeyValueFormattingRule {
                     );
                 }
             }
-        }
     }
 }
 

--- a/wdl-lint/src/rules/output_name.rs
+++ b/wdl-lint/src/rules/output_name.rs
@@ -141,31 +141,30 @@ fn check_decl_name(
     }
 
     let mut name = name.chars().peekable();
-    if let Some(c) = name.next() {
-        if c == 'o' || c == 'O' {
-            if let Some('u') = name.peek() {
-                name.next();
-                if let Some('t') = name.peek() {
-                    name.next();
-                    if let Some(c) = name.peek() {
-                        if c.is_ascii_uppercase() || c == &'_' {
-                            // name starts with "out"
-                            diagnostics.exceptable_add(
-                                decl_identifier_starts_with_out(decl.name().span()),
-                                SyntaxElement::from(decl.inner().clone()),
-                                exceptable_nodes,
-                            );
-                        } else {
-                            let s: String = name.take(3).collect();
-                            if s == "put" {
-                                // name starts with "output"
-                                diagnostics.exceptable_add(
-                                    decl_identifier_starts_with_output(decl.name().span()),
-                                    SyntaxElement::from(decl.inner().clone()),
-                                    exceptable_nodes,
-                                );
-                            }
-                        }
+    if let Some(c) = name.next()
+        && (c == 'o' || c == 'O')
+        && let Some('u') = name.peek()
+    {
+        name.next();
+        if let Some('t') = name.peek() {
+            name.next();
+            if let Some(c) = name.peek() {
+                if c.is_ascii_uppercase() || c == &'_' {
+                    // name starts with "out"
+                    diagnostics.exceptable_add(
+                        decl_identifier_starts_with_out(decl.name().span()),
+                        SyntaxElement::from(decl.inner().clone()),
+                        exceptable_nodes,
+                    );
+                } else {
+                    let s: String = name.take(3).collect();
+                    if s == "put" {
+                        // name starts with "output"
+                        diagnostics.exceptable_add(
+                            decl_identifier_starts_with_output(decl.name().span()),
+                            SyntaxElement::from(decl.inner().clone()),
+                            exceptable_nodes,
+                        );
                     }
                 }
             }

--- a/wdl-lint/src/rules/preamble_formatted.rs
+++ b/wdl-lint/src/rules/preamble_formatted.rs
@@ -284,6 +284,10 @@ impl Visitor for PreambleFormattedRule {
                         span.len() - offset,
                     )));
                 } else {
+                    // NOTE: this return should be kept in case future
+                    // iterations of the code add something after this `if`
+                    // statement.
+                    #[allow(clippy::needless_return)]
                     return;
                 }
             }

--- a/wdl-lint/src/rules/requirements_section.rs
+++ b/wdl-lint/src/rules/requirements_section.rs
@@ -113,8 +113,8 @@ impl Visitor for RequirementsSectionRule {
 
         // This rule should only be present for WDL v1.2 or later. Prior to that
         // version, the `runtime` section was recommended.
-        if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here") {
-            if minor_version >= V1::Two {
+        if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here")
+            && minor_version >= V1::Two {
                 match task.runtime() {
                     Some(runtime) => {
                         let name = task.name();
@@ -144,6 +144,5 @@ impl Visitor for RequirementsSectionRule {
                     }
                 }
             }
-        }
     }
 }

--- a/wdl-lint/src/rules/requirements_section.rs
+++ b/wdl-lint/src/rules/requirements_section.rs
@@ -114,35 +114,36 @@ impl Visitor for RequirementsSectionRule {
         // This rule should only be present for WDL v1.2 or later. Prior to that
         // version, the `runtime` section was recommended.
         if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here")
-            && minor_version >= V1::Two {
-                match task.runtime() {
-                    Some(runtime) => {
+            && minor_version >= V1::Two
+        {
+            match task.runtime() {
+                Some(runtime) => {
+                    let name = task.name();
+                    diagnostics.exceptable_add(
+                        deprecated_runtime_section(
+                            name.text(),
+                            runtime
+                                .inner()
+                                .first_token()
+                                .expect("runtime section should have tokens")
+                                .text_range()
+                                .into(),
+                        ),
+                        SyntaxElement::from(runtime.inner().clone()),
+                        &self.exceptable_nodes(),
+                    );
+                }
+                _ => {
+                    if task.requirements().is_none() {
                         let name = task.name();
                         diagnostics.exceptable_add(
-                            deprecated_runtime_section(
-                                name.text(),
-                                runtime
-                                    .inner()
-                                    .first_token()
-                                    .expect("runtime section should have tokens")
-                                    .text_range()
-                                    .into(),
-                            ),
-                            SyntaxElement::from(runtime.inner().clone()),
+                            missing_requirements_section(name.text(), name.span()),
+                            SyntaxElement::from(task.inner().clone()),
                             &self.exceptable_nodes(),
                         );
                     }
-                    _ => {
-                        if task.requirements().is_none() {
-                            let name = task.name();
-                            diagnostics.exceptable_add(
-                                missing_requirements_section(name.text(), name.span()),
-                                SyntaxElement::from(task.inner().clone()),
-                                &self.exceptable_nodes(),
-                            );
-                        }
-                    }
                 }
             }
+        }
     }
 }

--- a/wdl-lint/src/rules/runtime_section.rs
+++ b/wdl-lint/src/rules/runtime_section.rs
@@ -100,13 +100,15 @@ impl Visitor for RuntimeSectionRule {
         // This rule should only be present for WDL v1.1 or earlier, as the
         // `requirements` section replaces it in WDL v1.2.
         if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here")
-            && minor_version <= V1::One && task.runtime().is_none() {
-                let name = task.name();
-                diagnostics.exceptable_add(
-                    missing_runtime_section(name.text(), name.span()),
-                    SyntaxElement::from(task.inner().clone()),
-                    &self.exceptable_nodes(),
-                );
-            }
+            && minor_version <= V1::One
+            && task.runtime().is_none()
+        {
+            let name = task.name();
+            diagnostics.exceptable_add(
+                missing_runtime_section(name.text(), name.span()),
+                SyntaxElement::from(task.inner().clone()),
+                &self.exceptable_nodes(),
+            );
+        }
     }
 }

--- a/wdl-lint/src/rules/runtime_section.rs
+++ b/wdl-lint/src/rules/runtime_section.rs
@@ -99,8 +99,8 @@ impl Visitor for RuntimeSectionRule {
 
         // This rule should only be present for WDL v1.1 or earlier, as the
         // `requirements` section replaces it in WDL v1.2.
-        if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here") {
-            if minor_version <= V1::One && task.runtime().is_none() {
+        if let SupportedVersion::V1(minor_version) = self.0.expect("version should exist here")
+            && minor_version <= V1::One && task.runtime().is_none() {
                 let name = task.name();
                 diagnostics.exceptable_add(
                     missing_runtime_section(name.text(), name.span()),
@@ -108,6 +108,5 @@ impl Visitor for RuntimeSectionRule {
                     &self.exceptable_nodes(),
                 );
             }
-        }
     }
 }

--- a/wdl-lint/src/rules/version_statement_formatted.rs
+++ b/wdl-lint/src/rules/version_statement_formatted.rs
@@ -177,15 +177,14 @@ impl Visitor for VersionStatementFormattedRule {
         }
 
         // 3. Handle whitespace after the version statement
-        if let Some(next) = stmt.inner().next_sibling_or_token() {
-            if let Some(ws) = next.as_token().and_then(|s| Whitespace::cast(s.clone())) {
+        if let Some(next) = stmt.inner().next_sibling_or_token()
+            && let Some(ws) = next.as_token().and_then(|s| Whitespace::cast(s.clone())) {
                 let s = ws.text();
                 // Don't add diagnostic if there's nothing but whitespace after the version
                 // statement
                 if s != "\n\n" && s != "\r\n\r\n" && next.next_sibling_or_token().is_some() {
                     diagnostics.add(expected_blank_line_after_version(ws.span()));
                 }
-            }
-        } // else version is the last item in the document
+            } // else version is the last item in the document
     }
 }

--- a/wdl-lint/src/rules/version_statement_formatted.rs
+++ b/wdl-lint/src/rules/version_statement_formatted.rs
@@ -178,13 +178,14 @@ impl Visitor for VersionStatementFormattedRule {
 
         // 3. Handle whitespace after the version statement
         if let Some(next) = stmt.inner().next_sibling_or_token()
-            && let Some(ws) = next.as_token().and_then(|s| Whitespace::cast(s.clone())) {
-                let s = ws.text();
-                // Don't add diagnostic if there's nothing but whitespace after the version
-                // statement
-                if s != "\n\n" && s != "\r\n\r\n" && next.next_sibling_or_token().is_some() {
-                    diagnostics.add(expected_blank_line_after_version(ws.span()));
-                }
-            } // else version is the last item in the document
+            && let Some(ws) = next.as_token().and_then(|s| Whitespace::cast(s.clone()))
+        {
+            let s = ws.text();
+            // Don't add diagnostic if there's nothing but whitespace after the version
+            // statement
+            if s != "\n\n" && s != "\r\n\r\n" && next.next_sibling_or_token().is_some() {
+                diagnostics.add(expected_blank_line_after_version(ws.span()));
+            }
+        } // else version is the last item in the document
     }
 }

--- a/wdl-lsp/src/proto.rs
+++ b/wdl-lsp/src/proto.rs
@@ -92,12 +92,13 @@ pub fn diagnostic(
         .collect::<Result<_>>()?;
 
     if let Some(fix) = diagnostic.fix()
-        && let Some(span) = diagnostic.labels().next().map(|l| l.span()) {
-            related.push(DiagnosticRelatedInformation {
-                location: Location::new(uri.clone(), range_from_span(index, span)?),
-                message: format!("fix: {fix}"),
-            });
-        }
+        && let Some(span) = diagnostic.labels().next().map(|l| l.span())
+    {
+        related.push(DiagnosticRelatedInformation {
+            location: Location::new(uri.clone(), range_from_span(index, span)?),
+            message: format!("fix: {fix}"),
+        });
+    }
 
     Ok(Diagnostic::new(
         range.unwrap_or_default(),
@@ -188,23 +189,24 @@ pub fn workspace_diagnostic_report(
         }
 
         if let Some(previous) = ids.get(result.document().uri())
-            && previous == result.document().id().as_ref() {
-                debug!(
-                    "diagnostics for document `{uri}` have not changed (client has latest)",
-                    uri = result.document().uri(),
-                );
+            && previous == result.document().id().as_ref()
+        {
+            debug!(
+                "diagnostics for document `{uri}` have not changed (client has latest)",
+                uri = result.document().uri(),
+            );
 
-                items.push(WorkspaceDocumentDiagnosticReport::Unchanged(
-                    WorkspaceUnchangedDocumentDiagnosticReport {
-                        uri: result.document().uri().as_ref().clone(),
-                        version: result.version().map(|v| v as i64),
-                        unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
-                            result_id: result.document().id().as_ref().clone(),
-                        },
+            items.push(WorkspaceDocumentDiagnosticReport::Unchanged(
+                WorkspaceUnchangedDocumentDiagnosticReport {
+                    uri: result.document().uri().as_ref().clone(),
+                    version: result.version().map(|v| v as i64),
+                    unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
+                        result_id: result.document().id().as_ref().clone(),
                     },
-                ));
-                continue;
-            }
+                },
+            ));
+            continue;
+        }
 
         debug!(
             "diagnostics for document `{uri}` have changed since last client request",

--- a/wdl-lsp/src/proto.rs
+++ b/wdl-lsp/src/proto.rs
@@ -91,14 +91,13 @@ pub fn diagnostic(
         })
         .collect::<Result<_>>()?;
 
-    if let Some(fix) = diagnostic.fix() {
-        if let Some(span) = diagnostic.labels().next().map(|l| l.span()) {
+    if let Some(fix) = diagnostic.fix()
+        && let Some(span) = diagnostic.labels().next().map(|l| l.span()) {
             related.push(DiagnosticRelatedInformation {
                 location: Location::new(uri.clone(), range_from_span(index, span)?),
                 message: format!("fix: {fix}"),
             });
         }
-    }
 
     Ok(Diagnostic::new(
         range.unwrap_or_default(),
@@ -188,8 +187,8 @@ pub fn workspace_diagnostic_report(
             continue;
         }
 
-        if let Some(previous) = ids.get(result.document().uri()) {
-            if previous == result.document().id().as_ref() {
+        if let Some(previous) = ids.get(result.document().uri())
+            && previous == result.document().id().as_ref() {
                 debug!(
                     "diagnostics for document `{uri}` have not changed (client has latest)",
                     uri = result.document().uri(),
@@ -206,7 +205,6 @@ pub fn workspace_diagnostic_report(
                 ));
                 continue;
             }
-        }
 
         debug!(
             "diagnostics for document `{uri}` have changed since last client request",

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -356,12 +356,13 @@ impl LanguageServer for Server {
                 normalize_uri_path(&mut folder.uri);
                 self.folders.write().push(folder.clone());
                 if let Ok(path) = folder.uri.to_file_path()
-                    && let Err(e) = self.analyzer.add_directory(path).await {
-                        error!(
-                            "failed to add initial workspace directory {uri}: {e}",
-                            uri = folder.uri
-                        );
-                    }
+                    && let Err(e) = self.analyzer.add_directory(path).await
+                {
+                    error!(
+                        "failed to add initial workspace directory {uri}: {e}",
+                        uri = folder.uri
+                    );
+                }
             }
         }
 
@@ -598,9 +599,9 @@ impl LanguageServer for Server {
                         .collect(),
                 )
                 .await
-            {
-                error!("failed to remove documents from analyzer: {e}");
-            }
+        {
+            error!("failed to remove documents from analyzer: {e}");
+        }
 
         // Progress the added folders
         if !params.event.added.is_empty() {
@@ -622,9 +623,11 @@ impl LanguageServer for Server {
         /// Converts a URI into a WDL file path.
         fn to_wdl_file_path(uri: &Url) -> Option<PathBuf> {
             if let Ok(path) = uri.to_file_path()
-                && path.is_file() && path.extension().and_then(OsStr::to_str) == Some("wdl") {
-                    return Some(path);
-                }
+                && path.is_file()
+                && path.extension().and_then(OsStr::to_str) == Some("wdl")
+            {
+                return Some(path);
+            }
 
             None
         }
@@ -675,9 +678,10 @@ impl LanguageServer for Server {
 
         // Remove any documents from the analyzer
         if !deleted.is_empty()
-            && let Err(e) = self.analyzer.remove_documents(deleted).await {
-                error!("failed to remove documents from analyzer: {e}");
-            }
+            && let Err(e) = self.analyzer.remove_documents(deleted).await
+        {
+            error!("failed to remove documents from analyzer: {e}");
+        }
     }
 
     async fn formatting(

--- a/wdl-lsp/src/server.rs
+++ b/wdl-lsp/src/server.rs
@@ -355,14 +355,13 @@ impl LanguageServer for Server {
             for mut folder in folders {
                 normalize_uri_path(&mut folder.uri);
                 self.folders.write().push(folder.clone());
-                if let Ok(path) = folder.uri.to_file_path() {
-                    if let Err(e) = self.analyzer.add_directory(path).await {
+                if let Ok(path) = folder.uri.to_file_path()
+                    && let Err(e) = self.analyzer.add_directory(path).await {
                         error!(
                             "failed to add initial workspace directory {uri}: {e}",
                             uri = folder.uri
                         );
                     }
-                }
             }
         }
 
@@ -584,8 +583,8 @@ impl LanguageServer for Server {
         debug!("received `workspace/didChangeWorkspaceFolders` request: {params:#?}");
 
         // Process the removed folders
-        if !params.event.removed.is_empty() {
-            if let Err(e) = self
+        if !params.event.removed.is_empty()
+            && let Err(e) = self
                 .analyzer
                 .remove_documents(
                     params
@@ -602,7 +601,6 @@ impl LanguageServer for Server {
             {
                 error!("failed to remove documents from analyzer: {e}");
             }
-        }
 
         // Progress the added folders
         if !params.event.added.is_empty() {
@@ -623,11 +621,10 @@ impl LanguageServer for Server {
 
         /// Converts a URI into a WDL file path.
         fn to_wdl_file_path(uri: &Url) -> Option<PathBuf> {
-            if let Ok(path) = uri.to_file_path() {
-                if path.is_file() && path.extension().and_then(OsStr::to_str) == Some("wdl") {
+            if let Ok(path) = uri.to_file_path()
+                && path.is_file() && path.extension().and_then(OsStr::to_str) == Some("wdl") {
                     return Some(path);
                 }
-            }
 
             None
         }
@@ -677,11 +674,10 @@ impl LanguageServer for Server {
         }
 
         // Remove any documents from the analyzer
-        if !deleted.is_empty() {
-            if let Err(e) = self.analyzer.remove_documents(deleted).await {
+        if !deleted.is_empty()
+            && let Err(e) = self.analyzer.remove_documents(deleted).await {
                 error!("failed to remove documents from analyzer: {e}");
             }
-        }
     }
 
     async fn formatting(

--- a/wdl-lsp/tests/common.rs
+++ b/wdl-lsp/tests/common.rs
@@ -47,7 +47,7 @@ fn encode_message(message: &str) -> String {
 
 /// Gets a test workspace directory path
 fn get_workspace_path(name: &str) -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR",))
+    Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("workspace")
         .join(name)
@@ -195,12 +195,12 @@ impl TestContext {
 
             if let Ok(request) = serde_json::from_str::<jsonrpc::Request>(&content_str) {
                 let (method, id_opt, _params) = request.into_parts();
-                if method == "window/workDoneProgress/create" {
-                    if let Some(id) = id_opt {
-                        let response = jsonrpc::Response::from_ok(id, serde_json::Value::Null);
-                        let response_str = serde_json::to_string(&response).unwrap();
-                        self.send_raw(&response_str).await;
-                    }
+                if method == "window/workDoneProgress/create"
+                    && let Some(id) = id_opt
+                {
+                    let response = jsonrpc::Response::from_ok(id, serde_json::Value::Null);
+                    let response_str = serde_json::to_string(&response).unwrap();
+                    self.send_raw(&response_str).await;
                 }
                 continue;
             }


### PR DESCRIPTION
Rust 1.89 was released today and, with it, multiple clippy lints that need to be fixed.

For external contributors:

- [ ] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
