### PR TITLE
fix: use `IndexMap` in `Config`.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Use `IndexMap` for stable serialization of `Config` ([#602](https://github.com/stjude-rust-labs/wdl/pull/602)).
 * Fixed deserialization of `Object` to no longer require keys be WDL
   identifiers ([#586](https://github.com/stjude-rust-labs/wdl/pull/586)).
 * Fixed a panic caused by an incorrect type calculation of non-empty array

--- a/wdl-engine/src/config.rs
+++ b/wdl-engine/src/config.rs
@@ -1,7 +1,6 @@
 //! Implementation of engine configuration.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -10,6 +9,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
 use crankshaft::events::Event;
+use indexmap::IndexMap;
 use secrecy::ExposeSecret;
 use serde::Deserialize;
 use serde::Serialize;
@@ -165,8 +165,8 @@ pub struct Config {
     ///
     /// If the collection has exactly one entry and `backend` is not specified,
     /// the singular entry will be used.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub backends: HashMap<String, BackendConfig>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub backends: IndexMap<String, BackendConfig>,
     /// Storage configuration.
     #[serde(default)]
     pub storage: StorageConfig,
@@ -360,8 +360,8 @@ pub struct AzureStorageConfig {
     ///
     /// The value for the inner map is the SAS token to apply for requests to
     /// the Azure Storage container.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub auth: HashMap<String, HashMap<String, SecretString>>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub auth: IndexMap<String, IndexMap<String, SecretString>>,
 }
 
 impl AzureStorageConfig {


### PR DESCRIPTION
This PR fixes `Config` to use `IndexMap` internally rather than `HashMap` so that the output of `sprocket config` commands is stable.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
