### PR TITLE
fix: correct assertion for TES backend.

### DIFF
--- a/wdl-engine/CHANGELOG.md
+++ b/wdl-engine/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fixed incorrect assertion for the TES backend ([#606](https://github.com/stjude-rust-labs/wdl/pull/606)).
 * Fixed permissions issue in the Docker backend when a container runs with a
   different user ([#605](https://github.com/stjude-rust-labs/wdl/pull/605)).
 

--- a/wdl-engine/src/backend.rs
+++ b/wdl-engine/src/backend.rs
@@ -267,7 +267,7 @@ pub trait TaskExecutionBackend: Send + Sync {
     /// Returns `None` if no cleanup is required.
     fn cleanup<'a>(
         &'a self,
-        work_dir: &'a Path,
+        work_dir: &'a EvaluationPath,
         token: CancellationToken,
     ) -> Option<BoxFuture<'a, ()>> {
         let _ = work_dir;

--- a/wdl-engine/src/backend/docker.rs
+++ b/wdl-engine/src/backend/docker.rs
@@ -487,6 +487,7 @@ impl TaskExecutionBackend for DockerBackend {
         /// Amount of memory to reserve for the cleanup task.
         const CLEANUP_MEMORY: f64 = 0.05;
 
+        // SAFETY: the work directory is always local for the Docker backend
         let work_dir = work_dir.as_local().expect("path should be local");
         assert!(work_dir.is_absolute(), "work directory should be absolute");
 

--- a/wdl-engine/src/backend/docker.rs
+++ b/wdl-engine/src/backend/docker.rs
@@ -474,7 +474,7 @@ impl TaskExecutionBackend for DockerBackend {
     #[cfg(unix)]
     fn cleanup<'a>(
         &'a self,
-        work_dir: &'a std::path::Path,
+        work_dir: &'a EvaluationPath,
         token: CancellationToken,
     ) -> Option<futures::future::BoxFuture<'a, ()>> {
         use futures::FutureExt;
@@ -487,6 +487,7 @@ impl TaskExecutionBackend for DockerBackend {
         /// Amount of memory to reserve for the cleanup task.
         const CLEANUP_MEMORY: f64 = 0.05;
 
+        let work_dir = work_dir.as_local().expect("path should be local");
         assert!(work_dir.is_absolute(), "work directory should be absolute");
 
         let backend = self.inner.clone();

--- a/wdl-engine/src/eval/v1/task.rs
+++ b/wdl-engine/src/eval/v1/task.rs
@@ -1068,14 +1068,10 @@ impl TaskEvaluator {
         };
 
         // Perform backend cleanup before output evaluation
-        if let Some(cleanup) = self.backend.cleanup(
-            evaluated
-                .result
-                .work_dir
-                .as_local()
-                .expect("path should be local"),
-            self.token.clone(),
-        ) {
+        if let Some(cleanup) = self
+            .backend
+            .cleanup(&evaluated.result.work_dir, self.token.clone())
+        {
             cleanup.await;
         }
 


### PR DESCRIPTION
The changes in #605 made the assertion of the work directory being local in the wrong place, which impacted the TES backend and caused a panic.

The fix is to take cleanup by an `EvaluationPath` which may be local or remote; the assertion was moved to the Docker backend where the path should always be local.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.
- [x] Your PR title follows the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.1.0/
